### PR TITLE
Organize all metrics separately

### DIFF
--- a/manifests/keplerExporter-serviceMonitor.yaml
+++ b/manifests/keplerExporter-serviceMonitor.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: monitoring
 spec:
   endpoints:
-  - interval: 15s
+  - interval: 3s
     port: http
     relabelings:
     - action: replace

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -120,7 +120,6 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			[]string{
 				"pod_name",
 				"pod_namespace",
-				"command",
 			},
 			nil,
 		)
@@ -128,7 +127,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			de_total,
 			prometheus.CounterValue,
 			float64(v.EnergyInCore+v.EnergyInDram),
-			v.Pod, v.Namespace, v.Command,
+			v.Pod, v.Namespace,
 		)
 		ch <- desc_total
 
@@ -139,7 +138,6 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			[]string{
 				"pod_name",
 				"pod_namespace",
-				"command",
 			},
 			nil,
 		)
@@ -147,7 +145,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			de_current,
 			prometheus.CounterValue,
 			float64(v.EnergyInCore+v.EnergyInDram),
-			v.Pod, v.Namespace, v.Command,
+			v.Pod, v.Namespace,
 		)
 		ch <- desc_current
 
@@ -158,7 +156,6 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			[]string{
 				"pod_name",
 				"pod_namespace",
-				"command",
 			},
 			nil,
 		)
@@ -166,7 +163,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			de_cpu_current,
 			prometheus.CounterValue,
 			float64(v.EnergyInCore),
-			v.Pod, v.Namespace, v.Command,
+			v.Pod, v.Namespace,
 		)
 		ch <- desc_cpu_current
 
@@ -177,7 +174,6 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			[]string{
 				"pod_name",
 				"pod_namespace",
-				"command",
 			},
 			nil,
 		)
@@ -185,7 +181,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			de_cpu_total,
 			prometheus.CounterValue,
 			float64(v.LastEnergyInCore),
-			v.Pod, v.Namespace, v.Command,
+			v.Pod, v.Namespace,
 		)
 		ch <- desc_cpu_total
 
@@ -196,7 +192,6 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			[]string{
 				"pod_name",
 				"pod_namespace",
-				"command",
 			},
 			nil,
 		)
@@ -204,7 +199,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			de_dram_current,
 			prometheus.CounterValue,
 			float64(v.EnergyInDram),
-			v.Pod, v.Namespace, v.Command,
+			v.Pod, v.Namespace,
 		)
 		ch <- desc_dram_current
 
@@ -215,7 +210,6 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			[]string{
 				"pod_name",
 				"pod_namespace",
-				"command",
 			},
 			nil,
 		)
@@ -223,7 +217,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			de_dram_total,
 			prometheus.CounterValue,
 			float64(v.LastEnergyInDram),
-			v.Pod, v.Namespace, v.Command,
+			v.Pod, v.Namespace,
 		)
 		ch <- desc_dram_total
 	}

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -78,8 +78,8 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	defer lock.Unlock()
 	for _, v := range podEnergy {
 		de := prometheus.NewDesc(
-			"pod_energy_total",
-			"Pod total energy consumption",
+			"pod_energy_stat",
+			"Pod energy consumption stats",
 			[]string{
 				"pod_name",
 				"pod_namespace",
@@ -113,6 +113,26 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		)
 		ch <- desc
 
+		// de_total and desc_total give indexable values for total energy consumptions for all pods
+		de_total := prometheus.NewDesc(
+			"pod_energy_total",
+			"Pod current energy consumption",
+			[]string{
+				"pod_name",
+				"pod_namespace",
+				"command",
+			},
+			nil,
+		)
+		desc_total := prometheus.MustNewConstMetric(
+			de_total,
+			prometheus.CounterValue,
+			float64(v.EnergyInCore+v.EnergyInDram),
+			v.Pod, v.Namespace, v.Command,
+		)
+		ch <- desc_total
+
+		// de_current and desc_current give indexable values for current energy consumptions (in 3 seconds) for all pods
 		de_current := prometheus.NewDesc(
 			"pod_energy_current",
 			"Pod current energy consumption",
@@ -130,6 +150,82 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			v.Pod, v.Namespace, v.Command,
 		)
 		ch <- desc_current
+
+		// de_cpu_current and desc_cpu_current give indexable values for current CPU energy consumptions (in 3 seconds) for all pods
+		de_cpu_current := prometheus.NewDesc(
+			"pod_cpu_energy_current",
+			"Pod CPU energy consumption",
+			[]string{
+				"pod_name",
+				"pod_namespace",
+				"command",
+			},
+			nil,
+		)
+		desc_cpu_current := prometheus.MustNewConstMetric(
+			de_cpu_current,
+			prometheus.CounterValue,
+			float64(v.EnergyInCore),
+			v.Pod, v.Namespace, v.Command,
+		)
+		ch <- desc_cpu_current
+
+		// de_cpu_total and desc_cpu_total give indexable values for total CPU energy consumptions for all pods
+		de_cpu_total := prometheus.NewDesc(
+			"pod_cpu_energy_total",
+			"Pod CPU total energy consumption",
+			[]string{
+				"pod_name",
+				"pod_namespace",
+				"command",
+			},
+			nil,
+		)
+		desc_cpu_total := prometheus.MustNewConstMetric(
+			de_cpu_total,
+			prometheus.CounterValue,
+			float64(v.LastEnergyInCore),
+			v.Pod, v.Namespace, v.Command,
+		)
+		ch <- desc_cpu_total
+
+		// de_dram_current and desc_dram_current give indexable values for current DRAM energy consumptions (in 3 seconds) for all pods
+		de_dram_current := prometheus.NewDesc(
+			"pod_dram_energy_current",
+			"Pod DRAM energy consumption",
+			[]string{
+				"pod_name",
+				"pod_namespace",
+				"command",
+			},
+			nil,
+		)
+		desc_dram_current := prometheus.MustNewConstMetric(
+			de_dram_current,
+			prometheus.CounterValue,
+			float64(v.EnergyInDram),
+			v.Pod, v.Namespace, v.Command,
+		)
+		ch <- desc_dram_current
+
+		// de_dram_total and desc_dram_total give indexable values for total DRAM energy consumptions for all pods
+		de_dram_total := prometheus.NewDesc(
+			"pod_dram_energy_total",
+			"Pod DRAM total energy consumption",
+			[]string{
+				"pod_name",
+				"pod_namespace",
+				"command",
+			},
+			nil,
+		)
+		desc_dram_total := prometheus.MustNewConstMetric(
+			de_dram_total,
+			prometheus.CounterValue,
+			float64(v.LastEnergyInDram),
+			v.Pod, v.Namespace, v.Command,
+		)
+		ch <- desc_dram_total
 	}
 }
 


### PR DESCRIPTION
We have a list of metrics that can not be indexed by pod_namespace, pod_name, and command only, including
- pod_energy_total
- pod_energy_current
- pod_cpu_energy_current
- pod_cpu_energy_total
- pod_dram_energy_current
- pod_dram_energy_total

I also see the `command` field may change over time. I am not sure if that matters for users and I may just remove those.