### PR TITLE
fix the pod_total_energy 0 value issues

### DIFF
--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: monitoring
----  
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -126,7 +126,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		desc_total := prometheus.MustNewConstMetric(
 			de_total,
 			prometheus.CounterValue,
-			float64(v.EnergyInCore+v.EnergyInDram),
+			float64(v.LastEnergyInCore+v.LastEnergyInDram),
 			v.Pod, v.Namespace,
 		)
 		ch <- desc_total


### PR DESCRIPTION
This PR fix the following issue:
1. Do not create monitoring ns for kepler deployment as Prometheus will also need that namespace.
2. The pod_total_energy was wrong.