### PR TITLE
Update rapl sysfs event detection and measurement

### DIFF
--- a/pkg/power/sysfs_util.go
+++ b/pkg/power/sysfs_util.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package power
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
+
+func getNumCPUs() int {
+	data, err := ioutil.ReadFile(cpuInfoPath)
+	if err != nil {
+		fmt.Println(err)
+	}
+	return strings.Count(string(data), "processor")
+}
+
+func getNumPackage() int {
+	var numPackage int
+	pkgMap := map[int]bool{}
+	numCPUs := getNumCPUs()
+	for i := 0; i < numCPUs; i++ {
+		path := fmt.Sprintf(numPkgPathTemplate, i)
+		data, err := ioutil.ReadFile(path)
+		if err != nil {
+			break
+		}
+
+		if id, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil {
+			if _, exist := pkgMap[id]; !exist {
+				numPackage++
+				pkgMap[id] = true
+			}
+		}
+	}
+	return numPackage
+}
+
+func detectEventPaths() {
+	numPackage := getNumPackage()
+	for i := 0; i < numPackage; i++ {
+		packagePath := fmt.Sprintf(packageNamePathTemplate, i)
+		data, err := ioutil.ReadFile(packagePath + "name")
+		packageName := strings.TrimSpace(string(data))
+		if err != nil {
+			continue
+		}
+		eventPaths[string(packageName)] = map[string]string{}
+		eventPaths[string(packageName)][string(packageName)] = packagePath
+		for j := 0; j < numRAPLEvents; j++ {
+			eventNamePath := fmt.Sprintf(eventNamePathTemplate, i, i, j)
+			data, err := ioutil.ReadFile(eventNamePath + "name")
+			eventName := strings.TrimSpace(string(data))
+			if err != nil {
+				continue
+			}
+			eventPaths[string(packageName)][string(eventName)] = eventNamePath
+		}
+	}
+}
+
+func hasEvent(event string) bool {
+	for _, subTree := range eventPaths {
+		for e, _ := range subTree {
+			if e == event {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
**Why we need this PR:**
Before this PR, the logs were showing that the DRAM energy consumption was null.

<img width="1013" alt="image" src="https://user-images.githubusercontent.com/5133121/161425034-5a1d2b02-922c-40b2-a390-2ad7040ef6d8.png">
After this PR, we can see accurate cpu and dram energy consumption:
<img width="1065" alt="image" src="https://user-images.githubusercontent.com/5133121/161425796-d600dc9d-5c93-459e-9ffb-b2b76e2d1fa8.png">

**What this PR does:**
Investigating and analyzing both the [`rapl-read.c`](https://github.com/deater/uarch-configure/blob/master/rapl-read/rapl-read.c) code and the `sysfs` rapl sub-directory, the dram energy consumption file exist and the core energy consumption file that is missing in the measured system. Each `sysfs` rapl sub-directory has a file called `name` with the rapl event name.
<img width="708" alt="image" src="https://user-images.githubusercontent.com/5133121/161425157-ca020ead-fded-4881-9142-1300c6a4ec6b.png">

In the old Kepler logic, the rapl `sysfs` event path was defined regarding a sub-folder id:
<img width="943" alt="image" src="https://user-images.githubusercontent.com/5133121/161425490-001317ee-0549-45bd-aaf1-fc4a6e4aef77.png">
However, as we saw before, the ID varies. For example, in the old Kepler logic, `intel-rapl:%d:0/` is related to core power consumption, but looking at the sub-folder on the measured system, `intel-rapl:%d:0/` is related to dram power consumption.

Additionally, as the system is missing core power consumption, we calculate it from ` core = package - dram`.

**Special notes for your reviewer:**
Energy measurement is collected considering the CPU topology, ie., considering the packet id as we are planning to use this information in another PR.