### PR TITLE
initial baseline for OCP/OKD native prometheus and grafana operator

### DIFF
--- a/manifests/openshift/dashboard/00-openshift-monitoring-user-projects.yaml
+++ b/manifests/openshift/dashboard/00-openshift-monitoring-user-projects.yaml
@@ -1,0 +1,10 @@
+---
+# https://docs.openshift.com/container-platform/4.10/monitoring/enabling-monitoring-for-user-defined-projects.html
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true

--- a/manifests/openshift/dashboard/01-grafana-operator.yaml
+++ b/manifests/openshift/dashboard/01-grafana-operator.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: grafana-operator
+  namespace: monitoring
+spec:
+  channel: v4
+  installPlanApproval: Automatic
+  name: grafana-operator
+  source: operatorhubio-catalog
+  sourceNamespace: openshift-marketplace

--- a/manifests/openshift/dashboard/02-grafana-instance.yaml
+++ b/manifests/openshift/dashboard/02-grafana-instance.yaml
@@ -1,0 +1,25 @@
+apiVersion: integreatly.org/v1alpha1
+kind: Grafana
+metadata:
+  name: kepler-grafana
+  namespace: monitoring
+spec:
+  ingress:
+    enabled: true
+  config:
+    auth:
+      disable_signout_menu: true
+    auth.anonymous:
+      enabled: true
+    log:
+      level: warn
+      mode: console
+    security:
+      admin_password: "kepler"
+      admin_user: "kepler"
+  dashboardLabelSelector:
+    - matchExpressions:
+        - key: app
+          operator: In
+          values:
+            - grafana

--- a/manifests/openshift/dashboard/03-grafana-datasource-UPDATETHIS.yaml
+++ b/manifests/openshift/dashboard/03-grafana-datasource-UPDATETHIS.yaml
@@ -1,0 +1,25 @@
+# 1. Grant `cluster-monitoring-view` role to the `grafana-serviceaccount`
+#  oc adm policy add-cluster-role-to-user cluster-monitoring-view -z grafana-serviceaccount
+# 2. Get bearer token for `grafana-serviceaccount`. Update manifest.
+#  oc serviceaccounts get-token grafana-serviceaccount -n monitoring
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDataSource
+metadata:
+  name: prometheus-grafanadatasource
+  namespace: monitoring
+spec:
+  datasources:
+    - access: proxy
+      editable: true
+      isDefault: true
+      jsonData:
+        httpHeaderName1: 'Authorization'
+        timeInterval: 5s
+        tlsSkipVerify: true
+      name: Prometheus
+      secureJsonData:
+        # Update bearer token to match your environment
+        httpHeaderValue1: 'Bearer ${BEARER_TOKEN}'
+      type: prometheus
+      url: 'https://thanos-querier.openshift-monitoring.svc.cluster.local:9091'
+  name: prometheus-grafanadatasource.yaml

--- a/manifests/openshift/dashboard/04-grafana-dashboard.yaml
+++ b/manifests/openshift/dashboard/04-grafana-dashboard.yaml
@@ -1,0 +1,9 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: kepler-dashboard
+  namespace: monitoring
+#  labels:
+#    app: kepler
+spec:
+  url: https://raw.githubusercontent.com/sustainable-computing-io/kepler/main/grafana-dashboards/Kepler-Exporter-Dashboard.json


### PR DESCRIPTION
Manifests for:
- Configuration to enable OCP/OKD native Prometheus for user workloads
- Installing Red Hat Grafana Operator
- Setup Grafana instance in Kepler's `monitoring` namespace
- Template for defining local Prometheus as GrafanaDataSource