### PR TITLE
Disable the kepler model server error for OSS demo

### DIFF
--- a/manifests/kubernetes/deployment.yaml
+++ b/manifests/kubernetes/deployment.yaml
@@ -11,10 +11,9 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-  - nodes/metrics
-  - nodes/proxy #access /pods
-  - nodes/stats
-  - nodes/metrics # access /metrics/resource  
+  - nodes/metrics # access /metrics/resource
+  - nodes/proxy # access /pods
+  - nodes/stats # access /pods
   verbs:
   - 'get'
   - 'watch'
@@ -69,9 +68,7 @@ spec:
         - -address
         - 0.0.0.0:9102
         - -enable-gpu
-        - "true"
-        - -model-server-endpoint
-        - http://127.0.0.1:8100/data
+        - "false"
         ports:
         - containerPort: 9102
           hostPort: 9102
@@ -86,9 +83,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-      - name: kepler-model-server
-        image: quay.io/sustainable_computing_io/kepler_model_server:latest
-        imagePullPolicy: Always
       volumes:
       - name: lib-modules
         hostPath:

--- a/manifests/openshift/kepler/01-kepler-install.yaml
+++ b/manifests/openshift/kepler/01-kepler-install.yaml
@@ -15,10 +15,9 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-  - nodes/metrics
-  - nodes/proxy #access /pods
-  - nodes/stats
   - nodes/metrics # access /metrics/resource
+  - nodes/proxy # access /pods
+  - nodes/stats # access /pods
   verbs:
   - 'get'
   - 'watch'
@@ -74,14 +73,10 @@ spec:
         - -address
         - 0.0.0.0:9102
         - -enable-gpu
-        - "true"
-        - -model-server-endpoint
-        - http://127.0.0.1:8100/data
+        - "false"
         ports:
         - containerPort: 9102
           name: kepler-exporter
-        - containerPort: 8100
-          name: model-server
         volumeMounts:
         - mountPath: /lib/modules
           name: lib-modules
@@ -96,9 +91,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-      - name: kepler-model-server
-        image: quay.io/sustainable_computing_io/kepler_model_server:latest
-        imagePullPolicy: Always
       volumes:
       - name: lib-modules
         hostPath:


### PR DESCRIPTION
This PR will
1) remove redundant `nodes/metrics` rbac rules.
2) disable the model server as it causes the following error.

```
Traceback (most recent call last):
  File "server.py", line 5, in <module>
    from kepler_model_trainer import archive_saved_model
  File "/kepler_model_trainer.py", line 1, in <module>
    import tensorflow as tf
  File "/usr/local/lib64/python3.8/site-packages/tensorflow/__init__.py", line 41, in <module>
    from tensorflow.python.tools import module_util as _module_util
  File "/usr/local/lib64/python3.8/site-packages/tensorflow/python/__init__.py", line 41, in <module>
    from tensorflow.python.eager import context
  File "/usr/local/lib64/python3.8/site-packages/tensorflow/python/eager/context.py", line 33, in <module>
    from tensorflow.core.framework import function_pb2
  File "/usr/local/lib64/python3.8/site-packages/tensorflow/core/framework/function_pb2.py", line 16, in <module>
    from tensorflow.core.framework import attr_value_pb2 as tensorflow_dot_core_dot_framework_dot_attr__value__pb2
  File "/usr/local/lib64/python3.8/site-packages/tensorflow/core/framework/attr_value_pb2.py", line 16, in <module>
    from tensorflow.core.framework import tensor_pb2 as tensorflow_dot_core_dot_framework_dot_tensor__pb2
  File "/usr/local/lib64/python3.8/site-packages/tensorflow/core/framework/tensor_pb2.py", line 16, in <module>
    from tensorflow.core.framework import resource_handle_pb2 as tensorflow_dot_core_dot_framework_dot_resource__handle__pb2
  File "/usr/local/lib64/python3.8/site-packages/tensorflow/core/framework/resource_handle_pb2.py", line 16, in <module>
    from tensorflow.core.framework import tensor_shape_pb2 as tensorflow_dot_core_dot_framework_dot_tensor__shape__pb2
  File "/usr/local/lib64/python3.8/site-packages/tensorflow/core/framework/tensor_shape_pb2.py", line 36, in <module>
    _descriptor.FieldDescriptor(
  File "/usr/local/lib64/python3.8/site-packages/google/protobuf/descriptor.py", line 560, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```