### PR TITLE
Added CPU testing load and update dashboard for legents

### DIFF
--- a/grafana-dashboards/Kepler-Exporter-Dashboard-OSS-Demo.json
+++ b/grafana-dashboards/Kepler-Exporter-Dashboard-OSS-Demo.json
@@ -96,7 +96,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1655361413094,
+  "iteration": 1655434182129,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -347,7 +347,7 @@
           "editorMode": "code",
           "expr": "rate(pod_gpu_energy_current{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1m])/3",
           "hide": false,
-          "legendFormat": "DRAM",
+          "legendFormat": "GPU",
           "range": true,
           "refId": "D"
         },
@@ -451,7 +451,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum_over_time(pod_energy_current{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1h])/3/3600000000",
+          "expr": "sum_over_time(pod_energy_current{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
           "instant": false,
           "legendFormat": "Total",
           "range": true,
@@ -463,7 +463,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum_over_time(pod_cpu_energy_current{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1h])/3/3600000000",
+          "expr": "sum_over_time(pod_cpu_energy_current{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
           "hide": false,
           "legendFormat": "CPU",
           "range": true,
@@ -475,7 +475,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum_over_time(pod_dram_energy_current{pod_namespace=\"monitoring\", pod_name=\"$pod\"}[1h])/3/3600000000",
+          "expr": "sum_over_time(pod_dram_energy_current{pod_namespace=\"monitoring\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
           "hide": false,
           "legendFormat": "DRAM",
           "range": true,
@@ -487,7 +487,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum_over_time(pod_gpu_energy_current{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1h])/3/3600000000",
+          "expr": "sum_over_time(pod_gpu_energy_current{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
           "hide": false,
           "legendFormat": "GPU",
           "range": true,
@@ -499,7 +499,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum_over_time(pod_other_energy_joule_current{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1h])/3/3600000000",
+          "expr": "sum_over_time(pod_other_energy_joule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
           "hide": false,
           "legendFormat": "Other",
           "range": true,
@@ -572,13 +572,13 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum_over_time(pod_energy_current{pod_namespace=\"$namespace\"}[1h])/3/3600000000",
+          "expr": "sum_over_time(pod_energy_current{pod_namespace=\"$namespace\"}[24h])*15/3/3600000000",
           "legendFormat": "{{pod_name}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Total Pod Energy Consumption (kW*h) in $namespace",
+      "title": "Total Pod Energy Consumption (kW*h) in $namespace in 24 hours",
       "type": "bargauge"
     },
     {
@@ -676,7 +676,12 @@
         },
         "frameIndex": 0,
         "showHeader": true,
-        "sortBy": []
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "kW*h"
+          }
+        ]
       },
       "pluginVersion": "8.5.5",
       "repeatDirection": "h",
@@ -687,13 +692,13 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by (pod_namespace) (sum_over_time(pod_energy_current[1h])/3/3600000000)",
+          "expr": "sum by (pod_namespace) (sum_over_time(pod_energy_current[24h])*15/3/3600000000)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Total Energy Consumption (kW*h) by Namespace in 1 hour",
+      "title": "Total Energy Consumption (kW*h) by Namespace in 24 hours",
       "type": "table"
     }
   ],
@@ -819,13 +824,13 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "Kepler Exporter Dashboard",
   "uid": "feedc0ffee",
-  "version": 22,
+  "version": 5,
   "weekStart": ""
 }

--- a/manifests/kubernetes/deployment.yaml
+++ b/manifests/kubernetes/deployment.yaml
@@ -68,7 +68,7 @@ spec:
         - -address
         - 0.0.0.0:9102
         - -enable-gpu
-        - "false"
+        - "true"
         ports:
         - containerPort: 9102
           hostPort: 9102

--- a/manifests/tests/cpu/random.yaml
+++ b/manifests/tests/cpu/random.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: random
+spec:
+  selector:
+    matchLabels:
+      app: random
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: random
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
+      containers:
+        - name: hamster
+          image: k8s.gcr.io/ubuntu-slim:0.1
+          resources:
+            requests:
+              cpu: 1
+              memory: 500Mi
+          command: ["/bin/sh"]
+          args:
+            - "-c"
+            - "cat /dev/random"


### PR DESCRIPTION
This PR adds:
1) a random testing pod for CPU load
2) fix legend and sum_over_time errors to consider the 15-second sampling interval.
3) enable GPU for OSS demo