### PR TITLE
Refactor pod_lister

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ Session.vim
 
 # test-bin
 test-bin
+
+vendor

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/sustainable-computing-io/kepler/pkg/collector"
+	"github.com/sustainable-computing-io/kepler/pkg/pod_lister"
 	"github.com/sustainable-computing-io/kepler/pkg/model"
 	"github.com/sustainable-computing-io/kepler/pkg/power/gpu"
 	"github.com/sustainable-computing-io/kepler/pkg/power/rapl"
@@ -64,8 +65,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to attach : %v", err)
 	}
+
 	defer collector.Destroy()
 	defer rapl.StopPower()
+	defer pod_lister.Destroy()
+	pod_lister.InitKeeper()
+	go pod_lister.Keeper.Run()
 
 	err = prometheus.Register(collector)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.16
 
 require (
 	github.com/NVIDIA/go-nvml v0.11.6-0
+	github.com/fsnotify/fsnotify v1.5.4 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/iovisor/gobpf v0.2.0
 	github.com/jszwec/csvutil v1.6.0
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
@@ -13,6 +15,11 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.34.0
 	github.com/stretchr/testify v1.7.1 // indirect
-	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6
-	k8s.io/api v0.24.0
+	golang.org/x/net v0.0.0-20220630215102-69896b714898 // indirect
+	golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b
+	google.golang.org/protobuf v1.28.0 // indirect
+	k8s.io/api v0.24.2
+	k8s.io/apimachinery v0.24.2
+	k8s.io/client-go v0.24.2
+	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/pkg/pod_lister/cgroup_stats.go
+++ b/pkg/pod_lister/cgroup_stats.go
@@ -50,6 +50,7 @@ func ReadCgroupIOStat(cGroupID uint64) (uint64, uint64, int, error) {
 	return 0, 0, 0, fmt.Errorf("no cgroup path found")
 }
 
+
 func readIOStat(cgroupPath string) (uint64, uint64, int, error) {
 	rBytes := uint64(0)
 	wBytes := uint64(0)

--- a/pkg/pod_lister/kubelet_pod_lister.go
+++ b/pkg/pod_lister/kubelet_pod_lister.go
@@ -18,7 +18,7 @@ package pod_lister
 
 import (
 	"crypto/tls"
-	"encoding/json"
+//	"encoding/json" // REPLACE WITH PodCacheKeeper
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -27,7 +27,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
-	corev1 "k8s.io/api/core/v1"
+//	corev1 "k8s.io/api/core/v1" // REPLACE WITH PodCacheKeeper
 )
 
 type KubeletPodLister struct{}
@@ -87,6 +87,9 @@ func httpGet(url string) (*http.Response, error) {
 	return resp, err
 }
 
+/*
+REPLACE WITH PodCacheKeeper
+
 // ListPods accesses Kubelet's metrics and obtain PodList
 func (k *KubeletPodLister) ListPods() (*[]corev1.Pod, error) {
 	resp, err := httpGet(podUrl)
@@ -108,6 +111,7 @@ func (k *KubeletPodLister) ListPods() (*[]corev1.Pod, error) {
 
 	return pods, nil
 }
+*/
 
 // ListMetrics accesses Kubelet's metrics and obtain pods and node metrics
 func (k *KubeletPodLister) ListMetrics() (containerCPU map[string]float64, containerMem map[string]float64, nodeCPU float64, nodeMem float64, retErr error) {

--- a/pkg/pod_lister/kubelet_pod_watcher.go
+++ b/pkg/pod_lister/kubelet_pod_watcher.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This pod_watcher is to cache pod info on creation.
+The cache will be deleted after the pod is deleted for a specific period of time. (scrape interval)
+*/
+
+package pod_lister
+
+ import (
+	 "context"
+ 
+	 v1 "k8s.io/api/core/v1"
+	 metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	 "k8s.io/apimachinery/pkg/util/wait"
+	 "k8s.io/client-go/informers"
+	 "k8s.io/client-go/kubernetes"
+	 "k8s.io/client-go/rest"
+	 "k8s.io/client-go/tools/cache"
+	 "k8s.io/client-go/tools/clientcmd"
+
+	 "log"
+	 "os"
+	 "time"
+	 "strings"
+ )
+
+ var Keeper *PodCacheKeeper
+ var PodCacheTime = 30
+
+ const (
+	MAX_QSIZE = 100
+ )
+
+ func InitKeeper() error {
+	var err error
+	Keeper, err = NewPodCacheKeeper()
+	if err != nil {
+		log.Println("cannot init PodCacheKeeper.")
+	}
+	return err
+}
+
+ func getConfig() (*rest.Config, error) {
+	var config *rest.Config
+	var err error
+	presentKube, ok := os.LookupEnv("KUBECONFIG_FILE")
+	if !ok && presentKube != "" {
+		log.Println("InCluster Config")
+		config, err = rest.InClusterConfig()
+	} else {
+		log.Printf("Config %s", presentKube)
+		config, err = clientcmd.BuildConfigFromFlags("", presentKube)
+	}
+	if err != nil {
+		log.Printf("Config Error: %v", err)
+	}
+	return config, err
+ }
+ 
+ // PodCacheKeeper watches pods and cache pod info
+ type PodCacheKeeper struct {
+	 *kubernetes.Clientset
+	 PodQueue chan *v1.Pod
+	 Quit     chan struct{}
+	 HostName string
+	 PodCgroupIDCache map[string]*ContainerInfo
+	 PodCache map[string]v1.Pod
+ }
+ 
+func isAllContainerReady(pod v1.Pod) bool {
+	totalContainer := len(pod.Spec.Containers) + len(pod.Spec.InitContainers)
+	totalCreatedContainer := len(pod.Status.ContainerStatuses) + len(pod.Status.InitContainerStatuses)
+	if totalContainer == totalCreatedContainer {
+		statuses := pod.Status.InitContainerStatuses
+		for _, status := range statuses {
+			if status.ContainerID == "" {
+				return false
+			}
+		}
+		statuses = pod.Status.ContainerStatuses
+		for _, status := range statuses {
+			if status.ContainerID == "" {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func getPodKey(pod *v1.Pod) string {
+	return pod.Namespace + "/" + pod.Name
+}
+
+ // NewPodCacheKeeper creates new cache keeper
+ func NewPodCacheKeeper() (*PodCacheKeeper, error) {
+	 config, err := getConfig()
+	 if err != nil {
+		return nil, err
+	 }
+	 clientset, err := kubernetes.NewForConfig(config)
+	 if err != nil {
+		return nil, err
+	 }
+	 hostName, err := os.Hostname()
+	 if err != nil {
+		return nil, err
+	 }
+
+	 quit := make(chan struct{})
+	 podQueue := make(chan *v1.Pod, MAX_QSIZE)
+
+	 keeper := &PodCacheKeeper{
+		 Clientset: clientset,
+		 PodQueue:  podQueue,
+		 Quit:      quit,
+		 HostName:  hostName,
+		 PodCgroupIDCache: make(map[string]*ContainerInfo),
+		 PodCache : make(map[string]v1.Pod),
+	 }
+
+	 factory := informers.NewSharedInformerFactory(clientset, 0)
+	 podInformer := factory.Core().V1().Pods()
+ 
+	 keeper.UpdateCurrentList()
+
+	 podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		 UpdateFunc: func(prevObj, obj interface{}) {
+			pod, ok := obj.(*v1.Pod)
+			prevPod, _ := prevObj.(*v1.Pod)
+			 if !ok {
+				 return
+			 }
+			 if pod.Spec.NodeName == hostName {
+				if !isAllContainerReady(*prevPod) && isAllContainerReady(*pod) {
+					keeper.PodQueue <- pod
+				}
+			 } 
+		 },
+		 DeleteFunc: func(obj interface{}) {
+			pod, ok := obj.(*v1.Pod)
+			if !ok {
+				return
+			}
+			if pod.Spec.NodeName == hostName {
+				keeper.PodQueue <- pod
+			}
+		},
+	 })
+	 factory.Start(keeper.Quit)
+ 
+	 return keeper, nil
+ }
+
+
+// UpdateCurrentList puts existing pods to the process queue
+func (w *PodCacheKeeper) UpdateCurrentList() error {
+	initialList, err := w.GetPods()
+	if err != nil {
+		return err
+	}
+	for _, pod := range initialList.Items {
+		w.PodQueue <- pod.DeepCopy()
+	}
+	return nil
+}
+
+ // getPods returns all daemon pod
+ func (w *PodCacheKeeper) GetPods() (*v1.PodList, error) {
+	 listOptions := metav1.ListOptions{
+		FieldSelector: "spec.nodeName=" + w.HostName,
+	 }
+	 return w.Clientset.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), listOptions)
+ }
+
+ // Run executes daemon watcher routine until get quit signal
+ func (w *PodCacheKeeper) Run() {
+	 defer close(w.PodQueue)
+	 log.Println("start watching pod")
+	 wait.Until(w.ProcessPodQueue, 0, w.Quit)
+ }
+ 
+ // ProcessPodQueue handle cache
+ func (w *PodCacheKeeper) ProcessPodQueue() {
+	 pod := <-w.PodQueue
+	 if pod.GetDeletionTimestamp() == nil {
+		// add case
+		w.addPodInfoToCache(*pod)
+		podKey := getPodKey(pod)
+		w.PodCache[podKey] = *pod
+	 } else {
+		// delete case
+		// remove pod info from cache after PodCacheTime seconds
+		podKey := getPodKey(pod)
+		cachedPod := w.PodCache[podKey]
+		time.AfterFunc(time.Duration(PodCacheTime) * time.Second, func(){w.removePodInfoFromCache(cachedPod)})
+		delete(w.PodCache, podKey)
+	 }
+ }
+
+ func (w *PodCacheKeeper) addPodInfoToCache(pod v1.Pod) {
+	statuses := pod.Status.ContainerStatuses
+	for _, status := range statuses {
+		info := &ContainerInfo{
+			PodName:       pod.Name,
+			Namespace:     pod.Namespace,
+			ContainerName: status.Name,
+		}
+		containerID := strings.Trim(status.ContainerID, containerIDPredix)
+		w.PodCgroupIDCache[containerID] = info
+	}
+	statuses = pod.Status.InitContainerStatuses
+	for _, status := range statuses {
+		info := &ContainerInfo{
+			PodName:       pod.Name,
+			Namespace:     pod.Namespace,
+			ContainerName: status.Name,
+		}
+		containerID := strings.Trim(status.ContainerID, containerIDPredix)
+		w.PodCgroupIDCache[containerID] = info
+	}
+	log.Printf("Add cache of pod %s\n", pod.Name)
+ }
+
+ func (w *PodCacheKeeper) removePodInfoFromCache(pod v1.Pod) {
+	statuses := pod.Status.ContainerStatuses
+	for _, status := range statuses {
+		containerID := strings.Trim(status.ContainerID, containerIDPredix)
+		delete(w.PodCgroupIDCache, containerID)
+	}
+	statuses = pod.Status.InitContainerStatuses
+	for _, status := range statuses {
+		containerID := strings.Trim(status.ContainerID, containerIDPredix)
+		delete(w.PodCgroupIDCache, containerID)
+	}
+	log.Printf("Remove cache of pod %s\n", pod.Name)
+ }
+
+ func Destroy() {
+	if Keeper != nil {
+		close(Keeper.Quit)
+	}	
+}

--- a/pkg/pod_lister/kubelet_pod_watcher_test.go
+++ b/pkg/pod_lister/kubelet_pod_watcher_test.go
@@ -1,0 +1,99 @@
+package pod_lister
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"context"
+	"fmt"
+)
+
+var testPod = &v1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "test-pod",
+		Namespace: "default",
+	},
+	Spec:  v1.PodSpec{
+		Containers: []v1.Container{
+			v1.Container{
+				Name: "test-container",
+				Image: "busybox",
+			},
+		},
+	},
+}
+
+func numContainers(podList *v1.PodList) int {
+	totalContainer := 0
+	for _, pod := range podList.Items {
+		totalContainer += len(pod.Spec.Containers) + len(pod.Spec.InitContainers)
+	}
+	return totalContainer
+}
+var _ = Describe("Test Pod Watcher", func() {
+	It("Properly load init list and update with added/deleted pod", func() {
+		podList, err := Keeper.GetPods()
+		Expect(err).NotTo(HaveOccurred())
+		initialPodNum := len(podList.Items)
+		expectedSize := numContainers(podList)
+		Expect(expectedSize).Should(BeNumerically(">", 0))
+		
+		maxWaitCount := 10
+		count := 0
+		for {
+			time.Sleep(2 * time.Second)
+			count += 1
+			size := len(Keeper.PodCgroupIDCache)
+			if size == expectedSize {
+				break
+			}
+			fmt.Printf("%d != %d\n", expectedSize, size)
+			Expect(count).Should(BeNumerically("<", maxWaitCount))
+		}
+		fmt.Printf("Initial cache size: %d\n", expectedSize)
+		defer Keeper.Clientset.CoreV1().Pods(testPod.Namespace).Delete(context.Background(), testPod.Name, metav1.DeleteOptions{})
+		_, err = Keeper.Clientset.CoreV1().Pods(testPod.Namespace).Create(context.Background(), testPod, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		count = 0
+		for {
+			time.Sleep(2 * time.Second)
+			count += 1
+			getPod, err := Keeper.Clientset.CoreV1().Pods(testPod.Namespace).Get(context.Background(), testPod.Name, metav1.GetOptions{})
+			if err == nil {
+				if isAllContainerReady(*getPod) {
+					break
+				} else {
+					fmt.Printf("%v \n", getPod.Status.ContainerStatuses)
+				}
+			}
+			Expect(count).Should(BeNumerically("<", maxWaitCount))
+		}
+		time.Sleep(5 * time.Second)
+		newSize := len(Keeper.PodCgroupIDCache)
+		Expect(newSize).To(Equal(expectedSize+1))
+
+		PodCacheTime = 1
+		err = Keeper.Clientset.CoreV1().Pods(testPod.Namespace).Delete(context.Background(), testPod.Name, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		count = 0
+		for {
+			time.Sleep(2 * time.Second)
+			count += 1
+			podList, _ := Keeper.GetPods()
+			size := len(podList.Items)
+			if size == initialPodNum {
+				break
+			}
+			fmt.Printf("%d != %d\n", initialPodNum, size)
+			Expect(count).Should(BeNumerically("<", maxWaitCount))
+		}
+		time.Sleep(5 * time.Second)
+		newSize = len(Keeper.PodCgroupIDCache)
+		Expect(newSize).To(Equal(expectedSize))
+	})
+
+})

--- a/pkg/pod_lister/resolve_container.go
+++ b/pkg/pod_lister/resolve_container.go
@@ -20,7 +20,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io/fs"
-	"log"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -56,7 +55,7 @@ var (
 func init() {
 	byteOrder = bpf.GetHostByteOrder()
 	podLister = KubeletPodLister{}
-	updateListPodCache("", false)
+	// updateListPodCache("", false)
 }
 
 func GetSystemProcessName() string {
@@ -90,24 +89,33 @@ func getContainerInfoFromcGgroupID(cGroupID uint64) (*ContainerInfo, error) {
 		Namespace: systemProcessNamespace,
 	}
 
-	if containerID, err = getContainerIDFromcGroupID(cGroupID); err != nil {
+	if containerID, err = GetContainerIDFromcGroupID(cGroupID); err != nil {
 		//TODO: print a warn with high verbosity
+		// systems (expect non-pod)
 		return info, nil
 	}
 
-	if i, ok := containerIDToContainerInfo[containerID]; ok {
+	if i, ok := Keeper.PodCgroupIDCache[containerID]; ok {
 		return i, nil
 	}
 
+	/* 
+	REPLACE WITH PodCacheKeeper
+	
 	// update cache info and stop loop if container id found
 	updateListPodCache(containerID, true)
 	if i, ok := containerIDToContainerInfo[containerID]; ok {
 		return i, nil
 	}
 
-	containerIDToContainerInfo[containerID] = info
-	return containerIDToContainerInfo[containerID], nil
+	*/
+
+	// systems (expect non-pod)
+	return info, nil
 }
+
+/* 
+REPLACE WITH PodCacheKeeper
 
 // updateListPodCache updates cache info with all pods and optionally
 // stops the loop when a given container ID is found
@@ -144,10 +152,10 @@ func updateListPodCache(targetContainerID string, stopWhenFound bool) {
 			}
 		}
 	}
-
 }
+*/
 
-func getContainerIDFromcGroupID(cGroupID uint64) (string, error) {
+func GetContainerIDFromcGroupID(cGroupID uint64) (string, error) {
 	if id, ok := cGroupIDToContainerIDCache[cGroupID]; ok {
 		return id, nil
 	}

--- a/pkg/pod_lister/suite_test.go
+++ b/pkg/pod_lister/suite_test.go
@@ -1,0 +1,26 @@
+package pod_lister
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"os"
+)
+
+func TestPodLoader(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Pod Lister Suite")
+}
+
+var _ = BeforeSuite(func() {
+	os.Setenv("KUBECONFIG_FILE", "/root/.kube/config")
+	InitKeeper()
+	go Keeper.Run()
+})
+
+var _ = AfterSuite(func() {
+	os.Unsetenv("KUBECONFIG_FILE")
+	Destroy()
+})
+


### PR DESCRIPTION
pod_lister
**issue:** Some short-lived pods cannot be detected at the time of ticker (as kubelet does not report deleted pods).
**proposal:** 
    1. Detect create/delete pod events from API server with kubernetes API
    2. Keep the pod/container info until x seconds after the pod is deleted. (now x is set to 30s but we might change it to ticker time).


**notices:**
   1.  Multiple changes to dependencies (vendors), Need to run go mod vendor to update
   2. Both take container ID as an input. So, It is still rely on `pod_lister.GetContainerIDFromcGroupID` function from previous implementation to convert cGroup ID to container ID. However, for older kernel version, we may need to handle Process ID in stead of cGroup ID.
   3. The modified code comes with unit test and is confirmed functionality on the experimental environment. Nevertheless, it causes relatively major changes, I believe discussion is needed.
   
Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>