### PR TITLE
add cgroup to collector with refactored code and unit test

### DIFF
--- a/pkg/cgroup/slice_handler_test.go
+++ b/pkg/cgroup/slice_handler_test.go
@@ -24,10 +24,6 @@ import (
 	"fmt"
 )
 
-const (
-	SLICE_SUFFIX = ".slice"
-	SCOPE_SUFFIX = ".scope"
-)
 
 var testPaths []string = []string {
 	"./test/hierarchypath", "./test/toppath/kubepod", "./test/toppath/system",
@@ -46,27 +42,6 @@ func initSliceHandler(basePath string) *SliceHandler {
 	sliceHandler := InitSliceHandler()
 	return sliceHandler
 
-}
-
-func findContainerScope(path string) string {
-	if strings.Contains(path, SCOPE_SUFFIX) {
-		return path
-	}
-	slicePath := SearchByContainerID(path, SLICE_SUFFIX)
-	if slicePath == "" {
-		return ""
-	}
-	return findContainerScope(slicePath)
-}
-
-func findExampleContainerID(slice *SliceHandler) string {
-	topPath := slice.GetCPUTopPath()
-	containerScopePath := findContainerScope(topPath)
-	pathSplits := strings.Split(containerScopePath, "/")
-	fileName := pathSplits[len(pathSplits) - 1]
-	scopeSplit := strings.Split(fileName, ".scope")[0]
-	partSplits := strings.Split(scopeSplit, "-")
-	return partSplits[len(partSplits)-1]
 }
 
 
@@ -91,6 +66,15 @@ var _ = Describe("Test Read Stat", func() {
 			stats := SliceHandlerInstance.GetStats(containerID)
 			fmt.Println(stats)
 			Expect(len(stats)).Should(BeNumerically(">", 0))
+		}
+	})
+
+	It("Properly get avilable stats", func() {
+		for _, testPath := range testPaths {
+			SliceHandlerInstance = initSliceHandler(testPath)
+			availableMetrics := GetAvailableCgroupMetrics()
+			Expect(len(availableMetrics)).Should(BeNumerically(">", 0))
+			fmt.Println("Available Metrics:", availableMetrics)
 		}
 	})
 

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -1,0 +1,101 @@
+package collector
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"net/http"
+	"net/http/httptest"
+	"io/ioutil"
+	"encoding/json"
+	"regexp"
+	"strings"
+	"strconv"
+)
+
+const (
+	CPU_USAGE_TOTAL_KEY = "cgroupfs_cpu_usage_us"
+	SAMPLE_CURR = 100
+	SAMPLE_AGGR = 1000
+	SAMPLE_NODE_ENERGY = 20000
+	SAMPLE_FREQ = 100000
+)
+ 
+
+func convertPromMetricToMap(body []byte, metric string) map[string]string {
+	regStr := fmt.Sprintf(`%s{[^{}]*}`, metric)
+	r := regexp.MustCompile(regStr)
+	match := r.FindString(string(body))
+	match = strings.Replace(match, metric, "", 1)
+	match = strings.ReplaceAll(match, "=", `"=`)
+	match = strings.ReplaceAll(match, ",", `,"`)
+	match = strings.ReplaceAll(match, "{", `{"`)
+	match = strings.ReplaceAll(match, "=", `:`)
+	var response map[string]string
+	json.Unmarshal([]byte(match), &response)
+	return response
+}
+
+func convertPromToValue(body []byte, metric string) (int, error) {
+	regStr := fmt.Sprintf(`%s{[^{}]*} [0-9]+`, metric)
+	r := regexp.MustCompile(regStr)
+	match := r.FindString(string(body))
+	splits := strings.Split(match, " ")
+	return strconv.Atoi(splits[1])
+}
+
+var _ = Describe("Test Collector Unit", func() {
+	It("Init and Run", func() {
+		podEnergy = map[string]*PodEnergy{
+			"abcd": &PodEnergy{
+				PodName: "podA",
+				Namespace: "default",
+				AggEnergyInCore: 10,
+				CgroupFSStats: map[string]*UInt64Stat{
+					CPU_USAGE_TOTAL_KEY: &UInt64Stat{
+						Curr: SAMPLE_CURR,
+						Aggr: SAMPLE_AGGR,
+					},	
+				},
+			},
+		}
+		nodeEnergy = map[string]float64{
+			"sensor0": SAMPLE_NODE_ENERGY,
+		}
+		cpuFrequency = map[int32]uint64{
+			0: SAMPLE_FREQ,
+		}
+
+		newCollector, err := New()
+		Expect(err).NotTo(HaveOccurred())
+		err = prometheus.Register(newCollector)
+		Expect(err).NotTo(HaveOccurred())
+		req, _ := http.NewRequest("GET", "", nil)
+		res := httptest.NewRecorder()
+		handler := http.Handler(promhttp.Handler())
+		handler.ServeHTTP(res, req)
+		body, _ := ioutil.ReadAll(res.Body)
+		Expect(len(body)).Should(BeNumerically(">", 0))
+		fmt.Printf("Result:\n %s\n", body)
+
+		// check sample pod energy stat
+		response := convertPromMetricToMap(body, POD_ENERGY_STAT_METRIC)
+		currSample, found := response["curr_" + CPU_USAGE_TOTAL_KEY]
+		Expect(found).To(Equal(true))
+		Expect(currSample).To(Equal(fmt.Sprintf("%d", SAMPLE_CURR)))
+		aggrSample, found := response["total_" + CPU_USAGE_TOTAL_KEY]
+		Expect(found).To(Equal(true))
+		Expect(aggrSample).To(Equal(fmt.Sprintf("%d", SAMPLE_AGGR)))
+		// check sample node energy
+		val, err := convertPromToValue(body, NODE_ENERGY_METRIC)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(val).To(Equal(int(SAMPLE_NODE_ENERGY/1000)))
+		// check sample frequency
+		val, err = convertPromToValue(body, FREQ_METRIC)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(val).To(Equal(int(SAMPLE_FREQ)))
+	})
+})

--- a/pkg/collector/suite_test.go
+++ b/pkg/collector/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCollector(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Collector Suite")
+}


### PR DESCRIPTION
This PR is to export cgroup metrics of pods to the prometheus format. 
In addition to that, I refactor the collector struct for properly add desc of each metric to prometheus desc channel. 

Also, I implement the unit test for the collector too.
To run the test independently, go into collector folder and run `../../test-bin/ginkgo`. 
> note: this must be run after ginkgo is installed by `make ginkgo-set`


Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>