### PR TITLE
Add support to deploy Kepler in a cluster in development mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ Create the namespace and CRDs, and then wait for them to be available before cre
 ## Sample Grafana dashboard
 
  ![Sample Grafana dashboard](doc/dashboard.png)
+
+
+## To start developing Kepler
+To set up a development environment please read our ![Getting Started Guide](dev/README.md)

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,12 +1,53 @@
-# Local Dev Env Setup
+# Getting Started
 
-This quick tutorial is for developing and testing Kepler locally
+A quick start guide to get Kepler up and running inside your container-based development cluster.
 
-# Install bcc-devel and kernel-devel 
+## I just want it built and run it on my cluster
+
+First, point the `Makefile` to the container registry of your choice:
+
+```bash
+export IMAGE_REPO=index.docker.io/myrepo
+export IMAGE_TAG=mybuild
+```
+
+We assume that you have logged in your container registry
+
+Then point the `Makefile` to cluster provider to build the right manifests:
+```bash
+export CLUSTER_PROVIDER=kubernetes
+```
+
+By default we use the IMAGE_TAG=`devel` and CLUSTER_PROVIDER=`kubernetes`
+
+After that, build the manifests and images:
+```bash
+make build-manifest
+make _build_containerized
+make push-image
+```
+
+If successful, the manifests are at `_output/manifest/$CLUSTER_PROVIDER/`
+
+Finally, push the manifests to your cluster:
+```bash
+make cluster-deploy
+```
+
+Or just simply build and deploy with:
+```bash
+make cluster-sync
+```
+
+## To run kepler externally to the cluster
+
+This quick tutorial is for developing and testing Kepler locally but with access to kubelet
+
+### Install bcc-devel and kernel-devel 
 
 Refer to the [builder Dockerfile](https://github.com/sustainable-computing-io/kepler/blob/main/build/Dockerfile.builder)
 
-# Compile 
+### Compile 
 Go to the root of the repo and do the following:
 
 ```bash
@@ -15,12 +56,12 @@ Go to the root of the repo and do the following:
 
 If successful, the binary is at `_output/bin/_/kepler`
 
-# Test
+### Test
 
 Create the k8s role and token, this is only needed once.
 ```bash
+cd dev/
 ./create_k8s_token.sh
 ```
 
 Then run the Kepler binary at `_output/bin/_/kepler`
-

--- a/hack/build-manifest.sh
+++ b/hack/build-manifest.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# This file is part of the Kepler project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 IBM, Inc.
+#
+
+set -ex
+
+CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
+IMAGE_TAG=${IMAGE_TAG:-devel}
+IMAGE_REPO=${IMAGE_REPO:-quay.io/sustainable_computing_io/kepler}
+
+MANIFESTS_OUT_DIR=${MANIFESTS_OUT_DIR:-"_output/manifests/${CLUSTER_PROVIDER}/generated"}
+
+
+echo "Building manifests..."
+
+rm -rf ${MANIFESTS_OUT_DIR}
+mkdir -p ${MANIFESTS_OUT_DIR}
+cp -r manifests/${CLUSTER_PROVIDER}/* ${MANIFESTS_OUT_DIR}/
+
+if [[ $CLUSTER_PROVIDER == "openshift" ]]; then
+    cat manifests/${CLUSTER_PROVIDER}/kepler/01-kepler-install.yaml | sed "s|image:.*|image: $IMAGE_REPO:$IMAGE_TAG|" > ${MANIFESTS_OUT_DIR}/kepler/01-kepler-install.yaml
+else
+    cat manifests/${CLUSTER_PROVIDER}/deployment.yaml | sed "s|image:.*|image: $IMAGE_REPO:$IMAGE_TAG|" > ${MANIFESTS_OUT_DIR}/deployment.yaml
+fi
+
+echo "Done $0"

--- a/hack/cluster-clean.sh
+++ b/hack/cluster-clean.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# This file is part of the Kepler project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 IBM, Inc.
+#
+
+set -e
+
+CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
+MANIFESTS_OUT_DIR=${MANIFESTS_OUT_DIR:-"_output/manifests/${CLUSTER_PROVIDER}/generated"}
+
+function main() {
+    echo "Cleaning up ..."
+
+    if [ ! -d "${MANIFESTS_OUT_DIR}" ]; then
+        echo "Directory ${MANIFESTS_OUT_DIR} DOES NOT exists. Run make generate first."
+        exit
+    fi
+
+    kubectl delete --ignore-not-found=true -f ${MANIFESTS_OUT_DIR}
+
+    sleep 2
+
+    echo "Done $0"
+}
+
+main "$@"

--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# This file is part of the Kepler project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 IBM, Inc.
+#
+
+set -ex pipefail
+
+CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
+MANIFESTS_OUT_DIR=${MANIFESTS_OUT_DIR:-"_output/manifests/${CLUSTER_PROVIDER}/generated"}
+
+function main() {
+    [ ! -d "${MANIFESTS_OUT_DIR}" ] && echo "Directory ${MANIFESTS_OUT_DIR} DOES NOT exists. Run make generate first."
+    
+    kubectl apply -f ${MANIFESTS_OUT_DIR}
+    kubectl rollout status daemonset kepler-exporter -n monitoring --timeout 60s
+
+    echo "Check the logs of the kepler-exporter with:"
+    echo "kubectl -n monitoring logs daemonset.apps/kepler-exporter"
+}
+
+main "$@"

--- a/hack/cluster-sync.sh
+++ b/hack/cluster-sync.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# This file is part of the Kepler project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 IBM, Inc.
+#
+
+set -e
+
+export IMAGE_TAG=${IMAGE_TAG:-devel}
+export IMAGE_REPO=${IMAGE_REPO:-quay.io/sustainable_computing_io/kepler}
+export CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
+
+# we do not use `make cluster-clean` and `make cluster-deploy` because they trigger other actions
+function main() {
+    make build-manifest
+    
+    ./hack/cluster-clean.sh &
+    CLEAN_PID=$!
+
+    make _build_containerized
+    make push-image
+
+    echo "waiting for cluster-clean to finish"
+    if ! wait $CLEAN_PID; then
+        echo "cluster-clean failed, output was:"
+        cat $TEMP_FILE
+        exit 1
+    fi
+
+    ./hack/cluster-deploy.sh
+}
+
+main "$@"


### PR DESCRIPTION
#### Why we need this PR:
When extending Kepler, the developer needs an easy way to build and deploy Kepler in its cluster. 

#### What this PR does:
This PR adds support to:
- build a docker image with custom container registry and tag using environment variables
- push the new image to the container registry
- generate the manifests using the custom image
- clean up the cluster (undeploy kepler)
- deploy kepler to the given cluster

Testing kepler will be as simple as running `make cluster-sync`

#### Special notes for your reviewer:
This is the typical workflow in other k8s bases systems