### PR TITLE
export package energy and CPU time per CPU core of each pod

### DIFF
--- a/pkg/power/rapl/power.go
+++ b/pkg/power/rapl/power.go
@@ -31,6 +31,8 @@ type powerInterface interface {
 	GetEnergyFromUncore() (uint64, error)
 	// GetEnergyFromDram returns mJ in package
 	GetEnergyFromPackage() (uint64, error)
+	// GetPackageEnergy returns set of mJ per package 
+	GetPackageEnergy() map[int]source.PackageEnergy
 	StopPower()
 	IsSupported() bool
 }
@@ -79,6 +81,11 @@ func GetEnergyFromUncore() (uint64, error) {
 func GetEnergyFromPackage() (uint64, error) {
 	return powerImpl.GetEnergyFromPackage()
 }
+
+func GetPackageEnergy() map[int]source.PackageEnergy {
+	return powerImpl.GetPackageEnergy()
+}
+
 
 func StopPower() {
 	powerImpl.StopPower()

--- a/pkg/power/rapl/source/estimate.go
+++ b/pkg/power/rapl/source/estimate.go
@@ -168,3 +168,7 @@ func (r *PowerEstimate) GetEnergyFromUncore() (uint64, error) {
 func (r *PowerEstimate) GetEnergyFromPackage() (uint64, error) {
 	return 0, nil
 }
+
+func (r *PowerEstimate) GetPackageEnergy() map[int]PackageEnergy {
+	return map[int]PackageEnergy{}
+}

--- a/pkg/power/rapl/source/msr.go
+++ b/pkg/power/rapl/source/msr.go
@@ -38,6 +38,10 @@ func (r *PowerMSR) GetEnergyFromPackage() (uint64, error) {
 	return ReadAllPower(ReadPkgPower)
 }
 
+func (r *PowerMSR) GetPackageEnergy() map[int]PackageEnergy {
+	return GetPackageEnergyByMSR(ReadCorePower, ReadDramPower, ReadUncorePower, ReadPkgPower)
+}
+
 func (r *PowerMSR) StopPower() {
 	CloseAllMSR()
 }

--- a/pkg/power/rapl/source/msr_util.go
+++ b/pkg/power/rapl/source/msr_util.go
@@ -210,3 +210,21 @@ func ReadAllPower(f func(n int) (uint64, error)) (uint64, error) {
 	}
 	return energy, nil
 }
+
+func GetPackageEnergyByMSR(coreFunc, dramFunc, uncoreFunc, pkgFunc func(n int) (uint64, error)) map[int]PackageEnergy {
+	packageEnergies := make(map[int]PackageEnergy)
+	for i := 0; i <= maxPackage; {
+		coreEnergy, _ := coreFunc(i)
+		dramEnergy, _ := dramFunc(i)
+		uncoreEnergy, _ := uncoreFunc(i)
+		pkgEnergy, _ := pkgFunc(i)
+		packageEnergies[i] = PackageEnergy{
+			Core: coreEnergy,
+			DRAM: dramEnergy,
+			Uncore: uncoreEnergy,
+			Pkg: pkgEnergy,
+		}
+		i = i + 1
+	}
+	return packageEnergies
+}

--- a/pkg/power/rapl/source/package_energy.go
+++ b/pkg/power/rapl/source/package_energy.go
@@ -16,31 +16,11 @@ limitations under the License.
 
 package source
 
-type PowerDummy struct{}
-
-func (r *PowerDummy) IsSupported() bool {
-	return true
+// PackageEnergy defines set of energy per package in mJ
+type PackageEnergy struct {
+	Core   uint64
+	DRAM   uint64
+	Uncore uint64
+	Pkg    uint64	
 }
 
-func (r *PowerDummy) StopPower() {
-}
-
-func (r *PowerDummy) GetEnergyFromDram() (uint64, error) {
-	return 0, nil
-}
-
-func (r *PowerDummy) GetEnergyFromCore() (uint64, error) {
-	return 0, nil
-}
-
-func (r *PowerDummy) GetEnergyFromUncore() (uint64, error) {
-	return 0, nil
-}
-
-func (r *PowerDummy) GetEnergyFromPackage() (uint64, error) {
-	return 0, nil
-}
-
-func (r *PowerDummy) GetPackageEnergy() map[int]PackageEnergy {
-	return map[int]PackageEnergy{}
-}

--- a/pkg/power/rapl/source/sysfs.go
+++ b/pkg/power/rapl/source/sysfs.go
@@ -60,7 +60,6 @@ func getEnergy(event string) (uint64, error) {
 			energy += e
 		}
 		return energy, nil
-
 	} else {
 		switch event {
 		case coreEvent:
@@ -131,6 +130,30 @@ func (r *PowerSysfs) GetEnergyFromUncore() (uint64, error) {
 
 func (r *PowerSysfs) GetEnergyFromPackage() (uint64, error) {
 	return getEnergy(packageEvent)
+}
+
+func (r *PowerSysfs) GetPackageEnergy() map[int]PackageEnergy {
+	packageEnergies := make(map[int]PackageEnergy)
+
+	pkgEnergies := readEventEnergy(packageEvent)
+	coreEnergies := readEventEnergy(coreEvent)
+	dramEnergies := readEventEnergy(dramEvent)
+	uncoreEnergies := readEventEnergy(uncoreEvent)
+	for pkgId, pkgEnergy := range pkgEnergies {
+		coreEnergy, _ := coreEnergies[pkgId]
+		dramEnergy, _ := dramEnergies[pkgId]
+		uncoreEnergy, _ := uncoreEnergies[pkgId]
+		splits := strings.Split(pkgId, "-")
+		i, _ := strconv.Atoi(splits[len(splits)-1])
+		packageEnergies[i] = PackageEnergy{
+			Core: coreEnergy,
+			DRAM: dramEnergy,
+			Uncore: uncoreEnergy,
+			Pkg: pkgEnergy,
+		}
+	}
+
+	return packageEnergies
 }
 
 func (r *PowerSysfs) StopPower() {


### PR DESCRIPTION
This PR is composed of two commits to
1.  defines PackageEnergy struct to keep RAPL energy per package and add GetPackageEnergy() function in the powerInterface for getting RAPL energy per package.  
2. add two new metrics to collector module. These values can be further used in model training.
    - node_package_energy_joule: Current package energy by RAPL in joules
    - pod_cpu_cpu_time_us:           Current CPU time per CPU of each Pod

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>