### PR TITLE
add metrics.go to get available metrics dynamically

### DIFF
--- a/pkg/attacher/bcc_attacher.go
+++ b/pkg/attacher/bcc_attacher.go
@@ -41,11 +41,17 @@ type BpfModuleTables struct {
 	Table  *bpf.Table
 }
 
+const (
+	CPU_CYCLE_LABEL = "cpu_cycles"
+	CPU_INSTRUCTION_LABEL = "cpu_instr"
+	CACHE_MISS_LABEL = "cache_miss"
+)
+
 var (
 	Counters = map[string]perfCounter{
-		"cpu_cycles": {unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CPU_CYCLES, true},
-		"cpu_instr":  {unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_INSTRUCTIONS, true},
-		"cache_miss": {unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CACHE_MISSES, true},
+		CPU_CYCLE_LABEL: {unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CPU_CYCLES, true},
+		CPU_INSTRUCTION_LABEL:  {unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_INSTRUCTIONS, true},
+		CACHE_MISS_LABEL: {unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CACHE_MISSES, true},
 	}
 	EnableCPUFreq = true
 )
@@ -118,4 +124,14 @@ func AttachBPFAssets() (*BpfModuleTables, error) {
 func DetachBPFModules(bpfModules *BpfModuleTables) {
 	closePerfEvent()
 	bpfModules.Module.Close()
+}
+
+func GetEnabledCounters() []string {
+	var metrics []string
+	for metric, counter := range Counters {
+		if counter.enabled {
+			metrics = append(metrics, metric)
+		}
+	}
+	return metrics
 }

--- a/pkg/cgroup/slice_handler.go
+++ b/pkg/cgroup/slice_handler.go
@@ -165,8 +165,7 @@ func GetAvailableCgroupMetrics() []string {
 	TryInitStatReaders(containerID)
 	stats := GetStandardStat(containerID)
 	for metric, _ := range stats {
-		availableMetrics = append(availableMetrics, "curr_" + metric)
-		availableMetrics = append(availableMetrics, "total_" + metric)
+		availableMetrics = append(availableMetrics, metric)
 	}
 	return availableMetrics
 }

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -19,29 +19,18 @@ package collector
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/sustainable-computing-io/kepler/pkg/attacher"
-	"github.com/sustainable-computing-io/kepler/pkg/cgroup"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 var basicStatLabels []string = []string{
 	"pod_name", "pod_namespace", "command",
-	"total_cpu_time", "curr_cpu_time",
-	"total_cpu_cycles", "curr_cpu_cycles",
-	"total_cpu_instructions", "curr_cpu_instructions",
-	"total_cache_misses", "curr_cache_misses",
-	"total_energy_in_core", "curr_energy_in_core",
-	"total_energy_in_dram", "curr_energy_in_dram",
-	"total_energy_in_gpu", "curr_energy_in_gpu",
-	"total_energy_in_other", "curr_energy_in_other",
-	"avg_cpu_frequency",
-	"block_devices_used",
-	"total_bytes_read", "curr_bytes_read",
-	"total_bytes_writes","curr_bytes_writes",
 }
-var cgroupStatLabels []string = cgroup.GetAvailableCgroupMetrics()
+
+var uintFeatures []string = GetUIntFeatures()
+var collectedLabel []string = getCollectedLabels(FLOAT_FEATURES, uintFeatures)
+var podEnergyLabels []string = append(basicStatLabels, collectedLabel...)
 
 const (
 	NODE_ENERGY_STAT_METRRIC = "node_energy_stat"
@@ -107,7 +96,7 @@ func (c *Collector) getPodDescription() *PodMetric {
 	fullStat := prometheus.NewDesc(
 		POD_ENERGY_STAT_METRIC,
 		"Pod energy consumption status",
-		append(basicStatLabels, cgroupStatLabels...),
+		podEnergyLabels,
 		nil,
 	)
 	allCurr := prometheus.NewDesc(
@@ -285,46 +274,10 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 
 	for _, v := range podEnergy {
 		podDesc := c.getPodDescription()
-		aggCPU := fmt.Sprintf("%f", v.AggCPUTime)
-		currCPU := fmt.Sprintf("%f", v.CurrCPUTime)
-		avgFreq := fmt.Sprintf("%f", float64(v.AvgCPUFreq))
-		disks := fmt.Sprintf("%d", v.Disks)
 
-		basicStatValues := []string{
-			v.PodName, v.Namespace, v.Command,
-			aggCPU, currCPU,
-			strconv.FormatUint(v.AggCPUCycles, 10), strconv.FormatUint(v.CurrCPUCycles, 10),
-			strconv.FormatUint(v.AggCPUInstr, 10), strconv.FormatUint(v.CurrCPUInstr, 10),
-			strconv.FormatUint(v.AggCacheMisses, 10), strconv.FormatUint(v.CurrCacheMisses, 10),
-			strconv.FormatUint(v.AggEnergyInCore, 10), strconv.FormatUint(v.CurrEnergyInCore, 10),
-			strconv.FormatUint(v.AggEnergyInDram, 10), strconv.FormatUint(v.CurrEnergyInDram, 10),
-			strconv.FormatUint(v.AggEnergyInGPU, 10), strconv.FormatUint(v.CurrEnergyInGPU, 10),
-			strconv.FormatUint(v.AggEnergyInOther, 10), strconv.FormatUint(v.CurrEnergyInOther, 10),
-			avgFreq, 
-			disks,
-			strconv.FormatUint(v.AggBytesRead, 10), strconv.FormatUint(v.CurrBytesRead, 10),
-			strconv.FormatUint(v.AggBytesWrite, 10), strconv.FormatUint(v.CurrBytesWrite, 10),
-		}
-	
-		var podEnergyVals []string
-		podEnergyVals = append(podEnergyVals, basicStatValues...)
-		
-		for _, fullStatLabel := range cgroupStatLabels {
-			splitIndex := strings.Index(fullStatLabel, "_")
-			valType := fullStatLabel[0:splitIndex]
-			statLabel := fullStatLabel[splitIndex+1 : len(fullStatLabel)]
-			statValue, exist := v.CgroupFSStats[statLabel]
-			if exist {
-				switch valType {
-				case "curr":
-					podEnergyVals = append(podEnergyVals, strconv.FormatUint(statValue.Curr, 10))
-				case "total":
-					podEnergyVals = append(podEnergyVals, strconv.FormatUint(statValue.Aggr, 10))
-				}
-			} else {
-				podEnergyVals = append(podEnergyVals, "-1")
-			}
-		}
+		basicStatValues := []string{ v.PodName, v.Namespace, v.Command, }
+		collectedValues := convertCollectedValues(FLOAT_FEATURES, uintFeatures, v)
+		podEnergyVals := append(basicStatValues, collectedValues...)
 
 		desc := prometheus.MustNewConstMetric(
 			podDesc.FullStat,

--- a/pkg/collector/metrics.go
+++ b/pkg/collector/metrics.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package collector
+
+import (
+	"github.com/sustainable-computing-io/kepler/pkg/attacher"
+	"github.com/sustainable-computing-io/kepler/pkg/cgroup"
+	"fmt"
+	"log"
+	"strconv"
+)
+
+const (
+	FREQ_METRIC_LABEL = "avg_cpu_frequency"
+	CURR_PREFIX = "curr_"
+	AGGR_PREFIX = "total_"
+
+	// TO-DO: merge to cgroup stat
+	BYTE_READ_LABEL = "bytes_read"
+	BYTE_WRITE_LABEL = "bytes_writes"
+	BLOCK_DEVICE_LABEL = "block_devices_used"
+
+	CPU_TIME_LABEL = "cpu_time"
+	
+)
+// TO-DO: merge to cgroup stat and remove hard-code metric list
+var IOSTAT_METRICS []string = []string {BYTE_READ_LABEL, BYTE_WRITE_LABEL}
+var FLOAT_FEATURES []string = []string {CPU_TIME_LABEL}
+
+func GetUIntFeatures() []string {
+	var metrics []string
+	// counter metric
+	metrics = append(metrics, attacher.GetEnabledCounters()...)
+	// cgroup metric
+	metrics = append(metrics, cgroup.GetAvailableCgroupMetrics()...)
+	metrics = append(metrics, IOSTAT_METRICS...)
+	return metrics
+}
+
+func getCollectedLabels(floatFeatures, uintFeatures []string) []string {
+	var labels []string
+	features := append(floatFeatures, uintFeatures...)
+	for _, feature := range features {
+		labels = append(labels, CURR_PREFIX + feature)
+		labels = append(labels, AGGR_PREFIX + feature)
+	}
+	if attacher.EnableCPUFreq {
+		labels = append(labels, FREQ_METRIC_LABEL)
+	}
+	// TO-DO: remove this hard code metric 
+	labels = append(labels, BLOCK_DEVICE_LABEL)
+	return labels
+}
+
+func convertCollectedValues(floatFeatures, uintFeatures []string, podEnergy *PodEnergy) []string{
+	var values []string
+
+	for _, metric := range floatFeatures {
+		curr, aggr, err := converFloatCurrAggr(metric, podEnergy)
+		if err != nil {
+			log.Printf("convertCollectedValues: %v", err)
+		}
+		values = append(values, fmt.Sprintf("%f", curr))
+		values = append(values, fmt.Sprintf("%f", aggr))
+	}
+
+	for _, metric := range uintFeatures {
+		curr, aggr, err := convertUIntCurrAggr(metric, podEnergy)
+		if err != nil {
+			log.Printf("convertCollectedValues: %v", err)
+		}
+		values = append(values, strconv.FormatUint(curr, 10))
+		values = append(values, strconv.FormatUint(aggr, 10))
+	}
+
+	if attacher.EnableCPUFreq {
+		avgFreq := fmt.Sprintf("%f", float64(podEnergy.AvgCPUFreq))
+		values = append(values, avgFreq)
+	}
+
+	// TO-DO: remove this hard code metric 
+	disks := fmt.Sprintf("%d", podEnergy.Disks)
+	values = append(values, disks)
+	return values
+}
+
+// convertUIntCurrAggr return curr, aggr values of specific uint metric
+func convertUIntCurrAggr(metric string, podEnergy *PodEnergy) (uint64, uint64, error) {
+	// cgroup metrics
+	if statValue, exists := podEnergy.CgroupFSStats[metric]; exists {
+		return statValue.Curr, statValue.Aggr, nil
+	}
+	// hardcode cgroup metrics
+	// TO-DO: merge to cgroup stat
+	if metric == BYTE_READ_LABEL {
+		return podEnergy.CurrBytesRead, podEnergy.AggBytesRead, nil
+	}
+	if metric == BYTE_WRITE_LABEL {
+		return podEnergy.CurrBytesWrite, podEnergy.AggBytesWrite, nil
+	}
+	// counter metrics
+	switch metric {
+	case attacher.CPU_CYCLE_LABEL:
+		return podEnergy.CurrCacheMisses, podEnergy.AggCacheMisses, nil
+	case attacher.CPU_INSTRUCTION_LABEL:
+		return podEnergy.CurrCPUInstr, podEnergy.AggCPUInstr, nil
+	case attacher.CACHE_MISS_LABEL:
+		return podEnergy.CurrCacheMisses, podEnergy.AggCacheMisses, nil
+	default:
+		return 0, 0, fmt.Errorf("cannot extract metric %s", metric)
+	}
+}
+
+func converFloatCurrAggr(metric string, podEnergy *PodEnergy) (float64, float64, error) {
+	// TO-DO: remove hard code
+	if metric == CPU_TIME_LABEL {
+		return float64(podEnergy.CurrCPUTime), float64(podEnergy.AggCPUTime), nil
+	}
+	return 0, 0, fmt.Errorf("cannot extract metric %s", metric)
+}
+
+
+
+

--- a/pkg/collector/metrics_test.go
+++ b/pkg/collector/metrics_test.go
@@ -1,0 +1,34 @@
+package collector
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"fmt"
+)
+
+
+
+var _ = Describe("Test Metric Unit", func() {
+	It("Check feature values", func() {
+		Expect(len(uintFeatures)).Should(BeNumerically(">", 0))
+		Expect(len(collectedLabel)).Should(BeNumerically(">", 0))
+		Expect(len(podEnergyLabels)).Should(BeNumerically(">", 0))
+		fmt.Printf("%v\n%v\n%v\n", uintFeatures, collectedLabel, podEnergyLabels)
+	})
+
+
+	It("Check convert values", func() {
+
+		podEnergy := &PodEnergy{
+			PodName: "podA",
+			Namespace: "default",
+			AggEnergyInCore: 10,
+			CgroupFSStats: map[string]*UInt64Stat{},
+		}
+
+		collectedValues := convertCollectedValues(FLOAT_FEATURES, uintFeatures, podEnergy)
+		Expect(len(collectedValues)).To(Equal(len(collectedLabel)))
+		fmt.Printf("%v\n", collectedValues)
+	})
+
+})


### PR DESCRIPTION
This PR introduce metric.go in collector module to add flexibility to list available metrics and convert corresponding values from PodEnergy object.

- With this PR, counter metrics are detected by enabled attribute in perfCounter object from attacher module and cgroup metrics are detected by previously-implemented function GetAvailableCgroupMetrics() from cgroup module. 
- The future introduced metrics should implement the conversion in convertUIntCurrAggr() or converFloatCurrAggr().

_notes:_ there are still some hard-code metrics to update such as bytes_read, bytes_write, block_devices.


Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>