### PR TITLE
fix kernel version parsing position

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 
@@ -39,12 +38,12 @@ var (
 
 // EnableEBPFCgroupID enables the eBPF code to collect cgroup id if the system has kernel version > 4.18
 func EnableEBPFCgroupID(enabled bool) {
-	fmt.Println("config EnabledEBPFCgroupID ", EnabledEBPFCgroupID)
-	fmt.Println("config enabled ", enabled)
-	fmt.Println("config getKernelVersion ", getKernelVersion())
+	fmt.Println("config EnabledEBPFCgroupID enabled: ", enabled)
+	fmt.Println("config getKernelVersion: ", getKernelVersion())
 	if (enabled == true) && (getKernelVersion() >= CGROUP_ID_MIN_KERNEL_VERSION) && (isCGroupV2()) {
 		EnabledEBPFCgroupID = true
 	}
+	fmt.Println("config set EnabledEBPFCgroupID to ", EnabledEBPFCgroupID)
 }
 
 func getKernelVersion() float32 {
@@ -53,18 +52,18 @@ func getKernelVersion() float32 {
 	si.GetSysInfo()
 
 	data, err := json.MarshalIndent(&si, "", "  ")
-	if err != nil {
-		log.Fatal(err)
-	}
+	if err == nil {
+		var result map[string]map[string]string
+		json.Unmarshal([]byte(data), &result)
 
-	var result map[string]map[string]string
-	json.Unmarshal([]byte(data), &result)
-	val, err := strconv.ParseFloat(result["kernel"]["release"][:3], 32)
-	if err != nil {
-		log.Fatal(err)
+		if release, ok := result["kernel"]["release"]; ok {
+			val, err := strconv.ParseFloat(release[:4], 32)
+			if err == nil {
+				return float32(val)
+			}
+		}
 	}
-
-	return float32(val)
+	return -1
 }
 
 func isCGroupV2() bool {


### PR DESCRIPTION
This PR fixes the missing position when getting kernel release version to second decimal number (from x.x to x.xx). 
Additionally, to avoid unnecessary fatal failure when it cannot detect the kernel version from the system info, this PR returns -1 value instead.

_note: the current minimum kernel version check is down to second decimal number (4.18)._

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>