### PR TITLE
cpu-model: Add Intel Xeon processor "Ice Lake"

### DIFF
--- a/data/cpu_model.csv
+++ b/data/cpu_model.csv
@@ -1,5 +1,7 @@
 Model,Architecture
 E3-1290,Sandy Bridge
+E3-1225,Sandy Bridge
+E3-1220,Sandy Bridge
 E3-1220L,Sandy Bridge
 E3-1280,Sandy Bridge
 E3-1275,Sandy Bridge
@@ -9,10 +11,8 @@ E3-1245,Sandy Bridge
 E3-1240,Sandy Bridge
 E3-1235,Sandy Bridge
 E3-1230,Sandy Bridge
-E3-1225,Sandy Bridge
-E3-1220,Sandy Bridge
-i3-2348M,Sandy Bridge
 i3-2375M,Sandy Bridge
+i3-2348M,Sandy Bridge
 i3-2328M,Sandy Bridge
 i3-2365M,Sandy Bridge
 i3-2377M,Sandy Bridge
@@ -22,77 +22,77 @@ i5-2450P,Sandy Bridge
 i3-2370M,Sandy Bridge
 i5-2450M,Sandy Bridge
 i7-2700K,Sandy Bridge
-i3-2367M,Sandy Bridge
-i7-2675QM,Sandy Bridge
-i7-2670QM,Sandy Bridge
-i5-2430M,Sandy Bridge
-i3-2350M,Sandy Bridge
 i5-2435M,Sandy Bridge
+i3-2367M,Sandy Bridge
+i3-2350M,Sandy Bridge
+i5-2430M,Sandy Bridge
+i7-2670QM,Sandy Bridge
+i7-2675QM,Sandy Bridge
+i7-2760QM,Sandy Bridge
 i7-2960XM,Sandy Bridge
 i7-2860QM,Sandy Bridge
-i7-2760QM,Sandy Bridge
-i3-2125,Sandy Bridge
+i5-2320,Sandy Bridge
 i7-2640M,Sandy Bridge
 i3-2130,Sandy Bridge
 i3-2120T,Sandy Bridge
-i5-2320,Sandy Bridge
-i3-2357M,Sandy Bridge
-i3-2340UE,Sandy Bridge
-i5-2557M,Sandy Bridge
+i3-2125,Sandy Bridge
 i5-2467M,Sandy Bridge
-i7-2637M,Sandy Bridge
-i7-2677M,Sandy Bridge
 i3-2330M,Sandy Bridge
 i3-2330E,Sandy Bridge
-i5-2310,Sandy Bridge
+i3-2340UE,Sandy Bridge
+i3-2357M,Sandy Bridge
+i5-2557M,Sandy Bridge
+i7-2677M,Sandy Bridge
+i7-2637M,Sandy Bridge
 i5-2405S,Sandy Bridge
+i5-2310,Sandy Bridge
+i3-2102,Sandy Bridge
 i3-2312M,Sandy Bridge
 i3-2105,Sandy Bridge
-i3-2102,Sandy Bridge
 i7-2655LE,Sandy Bridge
 i7-2610UE,Sandy Bridge
-i5-2540M,Sandy Bridge
 i5-2537M,Sandy Bridge
-i3-2310M,Sandy Bridge
-i5-2410M,Sandy Bridge
-i5-2520M,Sandy Bridge
-i7-2620M,Sandy Bridge
-i5-2510E,Sandy Bridge
-i5-2515E,Sandy Bridge
 i7-2617M,Sandy Bridge
 i7-2657M,Sandy Bridge
 i7-2649M,Sandy Bridge
+i5-2515E,Sandy Bridge
 i7-2629M,Sandy Bridge
-i3-2120,Sandy Bridge
+i5-2510E,Sandy Bridge
 i5-2390T,Sandy Bridge
-i3-2100T,Sandy Bridge
 i3-2100,Sandy Bridge
-i7-2720QM,Sandy Bridge
-i5-2300,Sandy Bridge
-i5-2400,Sandy Bridge
-i5-2400S,Sandy Bridge
-i5-2500,Sandy Bridge
-i5-2500K,Sandy Bridge
+i3-2100T,Sandy Bridge
+i3-2120,Sandy Bridge
+i5-2540M,Sandy Bridge
+i7-2620M,Sandy Bridge
+i5-2520M,Sandy Bridge
+i5-2410M,Sandy Bridge
+i3-2310M,Sandy Bridge
 i5-2500S,Sandy Bridge
 i5-2500T,Sandy Bridge
 i7-2600,Sandy Bridge
 i7-2600K,Sandy Bridge
 i7-2600S,Sandy Bridge
 i7-2630QM,Sandy Bridge
-i7-2715QE,Sandy Bridge
-i7-2635QM,Sandy Bridge
+i5-2500K,Sandy Bridge
+i5-2500,Sandy Bridge
 i7-2820QM,Sandy Bridge
+i5-2400S,Sandy Bridge
+i5-2400,Sandy Bridge
 i7-2920XM,Sandy Bridge
+i5-2300,Sandy Bridge
+i7-2720QM,Sandy Bridge
+i7-2715QE,Sandy Bridge
 i7-2710QE,Sandy Bridge
+i7-2635QM,Sandy Bridge
 i3-2310E,Sandy Bridge
 997,Sandy Bridge
 987,Sandy Bridge
 G645T,Sandy Bridge
 G645,Sandy Bridge
 B980,Sandy Bridge
-G860T,Sandy Bridge
-G870,Sandy Bridge
 G640T,Sandy Bridge
+G870,Sandy Bridge
+G860T,Sandy Bridge
 G640,Sandy Bridge
 977,Sandy Bridge
 B970,Sandy Bridge
@@ -102,63 +102,61 @@ G632,Sandy Bridge
 G630T,Sandy Bridge
 G630,Sandy Bridge
 G860,Sandy Bridge
-B940,Sandy Bridge
-B950,Sandy Bridge
 957,Sandy Bridge
-G850,Sandy Bridge
-G840,Sandy Bridge
-G622,Sandy Bridge
-G620T,Sandy Bridge
+B950,Sandy Bridge
+B940,Sandy Bridge
 G620,Sandy Bridge
+G620T,Sandy Bridge
+G622,Sandy Bridge
+G840,Sandy Bridge
+G850,Sandy Bridge
 G470,Sandy Bridge
 B830,Sandy Bridge
 887,Sandy Bridge
-G550T,Sandy Bridge
 G465,Sandy Bridge
 G555,Sandy Bridge
-877,Sandy Bridge
-807,Sandy Bridge
+G550T,Sandy Bridge
 B820,Sandy Bridge
+807,Sandy Bridge
+877,Sandy Bridge
 G550,Sandy Bridge
 G540T,Sandy Bridge
-797,Sandy Bridge
-867,Sandy Bridge
-B815,Sandy Bridge
 B720,Sandy Bridge
+B815,Sandy Bridge
+867,Sandy Bridge
+797,Sandy Bridge
 G460,Sandy Bridge
 807UE,Sandy Bridge
-G440,Sandy Bridge
-B840,Sandy Bridge
 G540,Sandy Bridge
 G530T,Sandy Bridge
 G530,Sandy Bridge
+B840,Sandy Bridge
+G440,Sandy Bridge
 787,Sandy Bridge
-B710,Sandy Bridge
 827E,Sandy Bridge
+B710,Sandy Bridge
 857,Sandy Bridge
 847,Sandy Bridge
-B810E,Sandy Bridge
-847E,Sandy Bridge
 B800,Sandy Bridge
+847E,Sandy Bridge
+B810E,Sandy Bridge
 B810,Sandy Bridge
-E5-4650,Sandy Bridge
 E5-4603,Sandy Bridge
+E5-4650,Sandy Bridge
 E5-4617,Sandy Bridge
 E5-4620,Sandy Bridge
 E5-4650L,Sandy Bridge
 E5-4607,Sandy Bridge
 E5-4640,Sandy Bridge
 E5-4610,Sandy Bridge
-E5-2670,Sandy Bridge
-E5-1620,Sandy Bridge
-E5-1660,Sandy Bridge
+E5-2630,Sandy Bridge
 E5-1650,Sandy Bridge
 E5-2637,Sandy Bridge
 E5-2665,Sandy Bridge
 E5-2690,Sandy Bridge
-E5-2648L,Sandy Bridge
+E5-2670,Sandy Bridge
 E5-2620,Sandy Bridge
-E5-2630,Sandy Bridge
+E5-2648L,Sandy Bridge
 E5-2603,Sandy Bridge
 E5-2640,Sandy Bridge
 E5-2650,Sandy Bridge
@@ -171,6 +169,8 @@ E5-2660,Sandy Bridge
 E5-2680,Sandy Bridge
 E5-2687W,Sandy Bridge
 E5-2658,Sandy Bridge
+E5-1660,Sandy Bridge
+E5-1620,Sandy Bridge
 E5-2450L,Sandy Bridge
 E5-2450,Sandy Bridge
 E5-2440,Sandy Bridge
@@ -185,29 +185,29 @@ E5-2428L,Sandy Bridge
 E5-2418L,Sandy Bridge
 E5-1428L,Sandy Bridge
 1405,Sandy Bridge
-E7-8870,Ivy Bridge
-E7-2870,Ivy Bridge
-E7-2880,Ivy Bridge
-E7-2890,Ivy Bridge
-E7-4809,Ivy Bridge
-E7-4820,Ivy Bridge
-E7-4830,Ivy Bridge
 E7-4850,Ivy Bridge
-E7-4860,Ivy Bridge
-E7-4870,Ivy Bridge
-E7-4890,Ivy Bridge
-E7-8850,Ivy Bridge
-E7-8857,Ivy Bridge
-E7-8880L,Ivy Bridge
-E7-8880,Ivy Bridge
-E7-8890,Ivy Bridge
-E7-8891,Ivy Bridge
-E7-8893,Ivy Bridge
 E7-4880,Ivy Bridge
+E7-8893,Ivy Bridge
+E7-8891,Ivy Bridge
+E7-8890,Ivy Bridge
+E7-8880,Ivy Bridge
+E7-8880L,Ivy Bridge
+E7-8870,Ivy Bridge
+E7-8857,Ivy Bridge
+E7-8850,Ivy Bridge
+E7-4890,Ivy Bridge
+E7-4870,Ivy Bridge
+E7-4860,Ivy Bridge
+E7-4830,Ivy Bridge
+E7-4820,Ivy Bridge
+E7-4809,Ivy Bridge
+E7-2890,Ivy Bridge
+E7-2880,Ivy Bridge
+E7-2870,Ivy Bridge
 E7-2850,Ivy Bridge
-E3-1225,Ivy Bridge
-E3-1220L,Ivy Bridge
 E3-1220,Ivy Bridge
+E3-1220L,Ivy Bridge
+E3-1225,Ivy Bridge
 E3-1230,Ivy Bridge
 E3-1240,Ivy Bridge
 E3-1245,Ivy Bridge
@@ -220,137 +220,130 @@ i7-3940XM,Ivy Bridge
 i7-3920XM,Ivy Bridge
 i5-3340,Ivy Bridge
 i5-3340S,Ivy Bridge
-i3-3250,Ivy Bridge
-i3-3250T,Ivy Bridge
 i3-3245,Ivy Bridge
+i3-3250T,Ivy Bridge
+i3-3250,Ivy Bridge
+i5-3230M,Ivy Bridge
+i3-3130M,Ivy Bridge
+i3-3227U,Ivy Bridge
+i5-3230M,Ivy Bridge
+i5-3337U,Ivy Bridge
+i7-3537U,Ivy Bridge
+i5-3380M,Ivy Bridge
 i5-3437U,Ivy Bridge
 i7-3687U,Ivy Bridge
 i5-3340M,Ivy Bridge
-i5-3380M,Ivy Bridge
-i7-3540M,Ivy Bridge
 i3-3210,Ivy Bridge
-i7-3537U,Ivy Bridge
-i5-3337U,Ivy Bridge
-i5-3230M,Ivy Bridge
-i3-3227U,Ivy Bridge
-i3-3130M,Ivy Bridge
-i5-3230M,Ivy Bridge
+i7-3540M,Ivy Bridge
 i7-3689Y,Ivy Bridge
 i5-3439Y,Ivy Bridge
 i5-3339Y,Ivy Bridge
 i3-3229Y,Ivy Bridge
-i7-3840QM,Ivy Bridge
 i7-3632QM,Ivy Bridge
-i3-3120M,Ivy Bridge
-i7-3635QM,Ivy Bridge
 i7-3630QM,Ivy Bridge
+i7-3635QM,Ivy Bridge
+i3-3120M,Ivy Bridge
 i7-3632QM,Ivy Bridge
 i7-3740QM,Ivy Bridge
-i3-3225,Ivy Bridge
+i7-3840QM,Ivy Bridge
 i5-3350P,Ivy Bridge
-i5-3330S,Ivy Bridge
-i5-3330,Ivy Bridge
 i3-3240T,Ivy Bridge
 i3-3240,Ivy Bridge
-i3-3220T,Ivy Bridge
+i3-3225,Ivy Bridge
 i3-3220,Ivy Bridge
-i3-3120ME,Ivy Bridge
+i3-3220T,Ivy Bridge
+i5-3330,Ivy Bridge
+i5-3330S,Ivy Bridge
 i3-3217UE,Ivy Bridge
-i3-3110M,Ivy Bridge
+i3-3120ME,Ivy Bridge
 i3-3217U,Ivy Bridge
-i5-3610ME,Ivy Bridge
+i3-3110M,Ivy Bridge
 i7-3517UE,Ivy Bridge
 i7-3555LE,Ivy Bridge
-i5-3475S,Ivy Bridge
-i5-3427U,Ivy Bridge
+i5-3610ME,Ivy Bridge
 i5-3570S,Ivy Bridge
-i5-3570,Ivy Bridge
-i5-3470T,Ivy Bridge
-i5-3317U,Ivy Bridge
 i5-3210M,Ivy Bridge
-i7-3667U,Ivy Bridge
-i5-3360M,Ivy Bridge
-i7-3517U,Ivy Bridge
-i7-3520M,Ivy Bridge
+i5-3317U,Ivy Bridge
+i5-3470T,Ivy Bridge
+i5-3570,Ivy Bridge
 i5-3470,Ivy Bridge
 i5-3470S,Ivy Bridge
 i5-3210M,Ivy Bridge
+i7-3517U,Ivy Bridge
+i7-3520M,Ivy Bridge
+i5-3360M,Ivy Bridge
 i5-3320M,Ivy Bridge
-i7-3720QM,Ivy Bridge
-i7-3610QM,Ivy Bridge
-i7-3615QM,Ivy Bridge
+i7-3667U,Ivy Bridge
+i5-3427U,Ivy Bridge
+i5-3475S,Ivy Bridge
 i7-3612QM,Ivy Bridge
-i5-3450,Ivy Bridge
-i7-3820QM,Ivy Bridge
-i5-3450S,Ivy Bridge
-i5-3550,Ivy Bridge
-i5-3550S,Ivy Bridge
-i5-3570K,Ivy Bridge
-i5-3570T,Ivy Bridge
+i7-3770,Ivy Bridge
 i7-3770K,Ivy Bridge
-i7-3770S,Ivy Bridge
-i7-3770T,Ivy Bridge
+i5-3570T,Ivy Bridge
+i5-3570K,Ivy Bridge
+i5-3550S,Ivy Bridge
+i5-3550,Ivy Bridge
+i5-3450S,Ivy Bridge
+i5-3450,Ivy Bridge
+i7-3612QM,Ivy Bridge
+i7-3615QM,Ivy Bridge
+i7-3610QM,Ivy Bridge
+i7-3720QM,Ivy Bridge
+i7-3820QM,Ivy Bridge
 i7-3615QE,Ivy Bridge
 i7-3612QE,Ivy Bridge
 i7-3610QE,Ivy Bridge
-i7-3770,Ivy Bridge
-i7-3612QM,Ivy Bridge
+i7-3770S,Ivy Bridge
+i7-3770T,Ivy Bridge
 G2030T,Ivy Bridge
-G2120T,Ivy Bridge
 G2140,Ivy Bridge
+G2120T,Ivy Bridge
 G2030,Ivy Bridge
 G2130,Ivy Bridge
 G2010,Ivy Bridge
 G2020,Ivy Bridge
 G2020T,Ivy Bridge
-G2120,Ivy Bridge
 G2100T,Ivy Bridge
+G2120,Ivy Bridge
 2127U,Ivy Bridge
 2030M,Ivy Bridge
 2129Y,Ivy Bridge
-2117U,Ivy Bridge
 2020M,Ivy Bridge
+2117U,Ivy Bridge
 1405,Ivy Bridge
 A1018,Ivy Bridge
 G1630,Ivy Bridge
 G1620T,Ivy Bridge
 G1610T,Ivy Bridge
-G1610,Ivy Bridge
 G1620,Ivy Bridge
-1017U,Ivy Bridge
+G1610,Ivy Bridge
 1005M,Ivy Bridge
+1017U,Ivy Bridge
 1019Y,Ivy Bridge
-1020M,Ivy Bridge
-1037U,Ivy Bridge
-1000M,Ivy Bridge
-1007U,Ivy Bridge
-1020E,Ivy Bridge
 1047UE,Ivy Bridge
+1020E,Ivy Bridge
+1007U,Ivy Bridge
+1000M,Ivy Bridge
+1037U,Ivy Bridge
+1020M,Ivy Bridge
 927UE,Ivy Bridge
+E5-4603,Ivy Bridge
+E5-4607,Ivy Bridge
 E5-4624L,Ivy Bridge
 E5-4657L,Ivy Bridge
 E5-4650,Ivy Bridge
-E5-4607,Ivy Bridge
-E5-4603,Ivy Bridge
 E5-4640,Ivy Bridge
-E5-4627,Ivy Bridge
 E5-4610,Ivy Bridge
 E5-4620,Ivy Bridge
-E5-2618L,Ivy Bridge
-E5-1620,Ivy Bridge
-E5-2620,Ivy Bridge
+E5-4627,Ivy Bridge
 E5-2630,Ivy Bridge
-E5-2630L,Ivy Bridge
-E5-2637,Ivy Bridge
-E5-2603,Ivy Bridge
-E5-2628L,Ivy Bridge
-E5-2648L,Ivy Bridge
-E5-2658,Ivy Bridge
-E5-2687W,Ivy Bridge
+E5-2640,Ivy Bridge
+E5-2620,Ivy Bridge
+E5-2618L,Ivy Bridge
 E5-2609,Ivy Bridge
 E5-1660,Ivy Bridge
 E5-1650,Ivy Bridge
-E5-2640,Ivy Bridge
+E5-1620,Ivy Bridge
 E5-2697,Ivy Bridge
 E5-2695,Ivy Bridge
 E5-2690,Ivy Bridge
@@ -361,149 +354,156 @@ E5-2660,Ivy Bridge
 E5-2650L,Ivy Bridge
 E5-2650,Ivy Bridge
 E5-2643,Ivy Bridge
+E5-2630L,Ivy Bridge
+E5-2637,Ivy Bridge
+E5-2603,Ivy Bridge
+E5-2628L,Ivy Bridge
+E5-2648L,Ivy Bridge
+E5-2658,Ivy Bridge
+E5-2687W,Ivy Bridge
+E7-8870,Haswell
+E7-8893,Haswell
+E7-8891,Haswell
 E7-8890,Haswell
-E7-4830,Haswell
 E7-8880L,Haswell
 E7-8880,Haswell
-E7-8870,Haswell
 E7-8867,Haswell
 E7-8860,Haswell
 E7-4850,Haswell
-E7-8891,Haswell
-E7-8893,Haswell
+E7-4830,Haswell
 E7-4820,Haswell
 E7-4809,Haswell
-E5-4610,Haswell
-E5-4620,Haswell
-E5-4627,Haswell
-E5-4640,Haswell
-E5-4648,Haswell
 E5-4669,Haswell
 E5-4667,Haswell
 E5-4660,Haswell
 E5-4655,Haswell
 E5-4650,Haswell
+E5-4648,Haswell
+E5-4610,Haswell
+E5-4620,Haswell
+E5-4627,Haswell
+E5-4640,Haswell
 E5-2658A,Haswell
 E5-2438L,Haswell
 E5-2428L,Haswell
 E5-2418L,Haswell
 E5-2408L,Haswell
 E5-1428L,Haswell
-E5-2609,Haswell
-E5-1630,Haswell
-E5-2643,Haswell
-E5-2648L,Haswell
-E5-2650L,Haswell
-E5-2658,Haswell
-E5-2680,Haswell
-E5-2687W,Haswell
-E5-1620,Haswell
-E5-2690,Haswell
-E5-2670,Haswell
-E5-2660,Haswell
-E5-2650,Haswell
-E5-2628L,Haswell
-E5-2697,Haswell
-E5-2699,Haswell
-E5-2698,Haswell
-E5-2695,Haswell
-E5-2683,Haswell
-E5-1660,Haswell
+E5-2620,Haswell
 E5-2667,Haswell
 E5-2640,Haswell
 E5-2637,Haswell
 E5-2630L,Haswell
 E5-2630,Haswell
 E5-2623,Haswell
-E5-2620,Haswell
 E5-2618L,Haswell
+E5-2650L,Haswell
 E5-2608L,Haswell
 E5-2603,Haswell
 E5-1680,Haswell
+E5-1660,Haswell
 E5-1650,Haswell
-E3-1281,Haswell
-E3-1240L,Haswell
-E3-1231,Haswell
-E3-1271,Haswell
+E5-1630,Haswell
+E5-1620,Haswell
+E5-2687W,Haswell
+E5-2680,Haswell
+E5-2658,Haswell
+E5-2698,Haswell
+E5-2648L,Haswell
+E5-2643,Haswell
+E5-2609,Haswell
+E5-2690,Haswell
+E5-2670,Haswell
+E5-2660,Haswell
+E5-2650,Haswell
+E5-2628L,Haswell
+E5-2699,Haswell
+E5-2697,Haswell
+E5-2695,Haswell
+E5-2683,Haswell
 E3-1241,Haswell
-E3-1286L,Haswell
+E3-1271,Haswell
+E3-1281,Haswell
 E3-1275L,Haswell
-E3-1286,Haswell
-E3-1276,Haswell
-E3-1246,Haswell
+E3-1240L,Haswell
 E3-1226,Haswell
+E3-1246,Haswell
+E3-1276,Haswell
+E3-1286L,Haswell
+E3-1286,Haswell
+E3-1231,Haswell
 E3-1220L,Haswell
+E3-1268L,Haswell
+E3-1285L,Haswell
+E3-1285,Haswell
+E3-1275,Haswell
+E3-1265L,Haswell
+E3-1245,Haswell
+E3-1225,Haswell
+E3-1230L,Haswell
+E3-1220,Haswell
+E3-1230,Haswell
 E3-1280,Haswell
 E3-1270,Haswell
 E3-1240,Haswell
-E3-1230,Haswell
-E3-1230L,Haswell
-E3-1220,Haswell
-E3-1245,Haswell
-E3-1225,Haswell
-E3-1275,Haswell
-E3-1285,Haswell
-E3-1265L,Haswell
-E3-1285L,Haswell
-E3-1268L,Haswell
 i7-4940MX,Haswell
 i7-4930MX,Haswell
-i7-4720HQ,Haswell
 i7-4722HQ,Haswell
+i7-4720HQ,Haswell
 i7-4578U,Haswell
 i7-4785T,Haswell
-i7-4790,Haswell
-i7-4790S,Haswell
 i7-4790T,Haswell
-i7-4510U,Haswell
+i7-4790S,Haswell
+i7-4790,Haswell
 i7-4712MQ,Haswell
 i7-4712HQ,Haswell
 i7-4710MQ,Haswell
 i7-4710HQ,Haswell
+i7-4510U,Haswell
 i7-4702EC,Haswell
 i7-4700EC,Haswell
 i7-4610M,Haswell
 i7-4910MQ,Haswell
 i7-4810MQ,Haswell
 i7-4600M,Haswell
-i7-4610Y,Haswell
-i7-4600U,Haswell
 i7-4771,Haswell
+i7-4600U,Haswell
+i7-4610Y,Haswell
+i7-4558U,Haswell
 i7-4550U,Haswell
 i7-4650U,Haswell
 i7-4500U,Haswell
-i7-4558U,Haswell
+i7-4700EQ,Haswell
 i7-4770TE,Haswell
-i7-4770K,Haswell
+i7-4700HQ,Haswell
 i7-4900MQ,Haswell
 i7-4800MQ,Haswell
 i7-4770T,Haswell
 i7-4770S,Haswell
+i7-4770K,Haswell
 i7-4770,Haswell
 i7-4765T,Haswell
 i7-4702MQ,Haswell
 i7-4702HQ,Haswell
-i7-4700HQ,Haswell
-i7-4700EQ,Haswell
 i7-4700MQ,Haswell
-i5-4210H,Haswell
 i5-4278U,Haswell
 i5-4308U,Haswell
+i5-4210H,Haswell
+i5-4690,Haswell
 i5-4460S,Haswell
 i5-4460,Haswell
-i5-4590T,Haswell
-i5-4460T,Haswell
 i5-4590S,Haswell
 i5-4590,Haswell
-i5-4690,Haswell
-i5-4690S,Haswell
 i5-4690T,Haswell
-i5-4410E,Haswell
+i5-4690S,Haswell
+i5-4590T,Haswell
+i5-4460T,Haswell
 i5-4422E,Haswell
-i5-4210U,Haswell
-i5-4220Y,Haswell
+i5-4410E,Haswell
 i5-4260U,Haswell
 i5-4210M,Haswell
+i5-4210U,Haswell
+i5-4220Y,Haswell
 i5-4402EC,Haswell
 i5-4310M,Haswell
 i5-4340M,Haswell
@@ -517,17 +517,18 @@ i5-4200M,Haswell
 i5-4300M,Haswell
 i5-4300U,Haswell
 i5-4402E,Haswell
-i5-4200H,Haswell
 i5-4400E,Haswell
+i5-4200H,Haswell
 i5-4440,Haswell
 i5-4440S,Haswell
 i5-4330M,Haswell
-i5-4350U,Haswell
-i5-4250U,Haswell
-i5-4200U,Haswell
-i5-4200Y,Haswell
-i5-4258U,Haswell
 i5-4288U,Haswell
+i5-4250U,Haswell
+i5-4350U,Haswell
+i5-4200U,Haswell
+i5-4258U,Haswell
+i5-4200Y,Haswell
+i5-4570TE,Haswell
 i5-4670T,Haswell
 i5-4670S,Haswell
 i5-4670K,Haswell
@@ -536,35 +537,34 @@ i5-4570T,Haswell
 i5-4570S,Haswell
 i5-4570,Haswell
 i5-4430S,Haswell
-i5-4570TE,Haswell
 i5-4430,Haswell
-i3-4170,Haswell
 i3-4370T,Haswell
 i3-4170T,Haswell
-i3-4360T,Haswell
+i3-4170,Haswell
 i3-4370,Haswell
+i3-4360T,Haswell
 i3-4160T,Haswell
 i3-4160,Haswell
-i3-4150,Haswell
-i3-4150T,Haswell
-i3-4350,Haswell
-i3-4350T,Haswell
-i3-4360,Haswell
 i3-4340TE,Haswell
+i3-4360,Haswell
+i3-4350T,Haswell
+i3-4350,Haswell
+i3-4150T,Haswell
+i3-4150,Haswell
 i3-4112E,Haswell
-i3-4025U,Haswell
-i3-4030U,Haswell
 i3-4110E,Haswell
 i3-4110M,Haswell
 i3-4120U,Haswell
+i3-4030U,Haswell
+i3-4025U,Haswell
 i3-4030Y,Haswell
-i3-4102E,Haswell
-i3-4020Y,Haswell
-i3-4012Y,Haswell
-i3-4100M,Haswell
-i3-4100E,Haswell
 i3-4000M,Haswell
 i3-4005U,Haswell
+i3-4100M,Haswell
+i3-4020Y,Haswell
+i3-4012Y,Haswell
+i3-4102E,Haswell
+i3-4100E,Haswell
 i3-4330TE,Haswell
 i3-4340,Haswell
 i3-4330T,Haswell
@@ -573,22 +573,22 @@ i3-4130T,Haswell
 i3-4130,Haswell
 i3-4010U,Haswell
 i3-4100U,Haswell
-i3-4010Y,Haswell
 i3-4158U,Haswell
+i3-4010Y,Haswell
 G3460T,Haswell
-G3470,Haswell
 G3260,Haswell
 G3260T,Haswell
+G3470,Haswell
 G3250,Haswell
-G3460,Haswell
 G3250T,Haswell
+G3460,Haswell
 G3450T,Haswell
 G3258,Haswell
 G3450,Haswell
 G3440,Haswell
-G3440T,Haswell
-G3240,Haswell
 G3240T,Haswell
+G3240,Haswell
+G3440T,Haswell
 G3320TE,Haswell
 G3430,Haswell
 G3420T,Haswell
@@ -596,166 +596,163 @@ G3420,Haswell
 G3220T,Haswell
 G3220,Haswell
 3560M,Haswell
-3558U,Haswell
 3561Y,Haswell
-3556U,Haswell
-3560Y,Haswell
+3558U,Haswell
 3550M,Haswell
-G1850,Haswell
-G1840,Haswell
+3560Y,Haswell
+3556U,Haswell
 G1840T,Haswell
+G1840,Haswell
+G1850,Haswell
 G1820TE,Haswell
 G1820T,Haswell
 G1820,Haswell
 G1830,Haswell
 2970M,Haswell
-2002E,Haswell
 2000E,Haswell
+2002E,Haswell
 2981U,Haswell
 2961Y,Haswell
 2957U,Haswell
 2955U,Haswell
-2980U,Haswell
 2950M,Haswell
+2980U,Haswell
 D-1513N,Broadwell
 D-1543N,Broadwell
 D-1523N,Broadwell
 D-1553N,Broadwell
 D-1533N,Broadwell
-D-1529,Broadwell
 D-1559,Broadwell
 D-1539,Broadwell
-D-1567,Broadwell
+D-1529,Broadwell
 D-1557,Broadwell
-D-1577,Broadwell
+D-1567,Broadwell
 D-1571,Broadwell
+D-1577,Broadwell
 D-1527,Broadwell
-D-1537,Broadwell
-D-1528,Broadwell
-D-1541,Broadwell
-D-1518,Broadwell
-D-1521,Broadwell
-D-1531,Broadwell
 D-1548,Broadwell
-D-1520,Broadwell
+D-1531,Broadwell
+D-1521,Broadwell
+D-1518,Broadwell
+D-1541,Broadwell
+D-1528,Broadwell
+D-1537,Broadwell
 D-1540,Broadwell
+D-1520,Broadwell
 E7-8894,Broadwell
+E7-8891,Broadwell
 E7-4809,Broadwell
+E7-8860,Broadwell
+E7-8880,Broadwell
 E7-8890,Broadwell
 E7-8893,Broadwell
-E7-8880,Broadwell
-E7-8860,Broadwell
-E7-8891,Broadwell
-E7-4820,Broadwell
 E7-8870,Broadwell
-E7-4850,Broadwell
 E7-8867,Broadwell
+E7-4850,Broadwell
 E7-4830,Broadwell
-E5-2699R,Broadwell
+E7-4820,Broadwell
 E5-2699A,Broadwell
-E5-4650,Broadwell
-E5-4660,Broadwell
-E5-4640,Broadwell
-E5-4627,Broadwell
-E5-4620,Broadwell
+E5-2699R,Broadwell
 E5-4628L,Broadwell
+E5-4669,Broadwell
 E5-4667,Broadwell
 E5-4655,Broadwell
+E5-4650,Broadwell
 E5-4610,Broadwell
-E5-4669,Broadwell
+E5-4660,Broadwell
+E5-4620,Broadwell
+E5-4627,Broadwell
+E5-4640,Broadwell
 E5-1660,Broadwell
-E5-1630,Broadwell
-E5-1620,Broadwell
-E5-1680,Broadwell
 E5-1650,Broadwell
-E5-2648L,Broadwell
+E5-1680,Broadwell
+E5-1620,Broadwell
+E5-1630,Broadwell
+E5-2699,Broadwell
+E5-2695,Broadwell
+E5-2620,Broadwell
+E5-2603,Broadwell
+E5-2609,Broadwell
+E5-2643,Broadwell
+E5-2608L,Broadwell
+E5-2650,Broadwell
+E5-2640,Broadwell
+E5-2637,Broadwell
+E5-2618L,Broadwell
+E5-2630,Broadwell
+E5-2623,Broadwell
+E5-2667,Broadwell
+E5-2630L,Broadwell
+E5-2628L,Broadwell
 E5-2660,Broadwell
 E5-2658,Broadwell
 E5-2690,Broadwell
 E5-2697A,Broadwell
-E5-2650,Broadwell
 E5-2683,Broadwell
-E5-2630L,Broadwell
+E5-2648L,Broadwell
 E5-2697,Broadwell
-E5-2695,Broadwell
-E5-2699,Broadwell
 E5-2680,Broadwell
 E5-2698,Broadwell
 E5-2650L,Broadwell
 E5-2687W,Broadwell
-E5-2628L,Broadwell
-E5-2667,Broadwell
-E5-2623,Broadwell
-E5-2630,Broadwell
-E5-2618L,Broadwell
-E5-2637,Broadwell
-E5-2640,Broadwell
-E5-2620,Broadwell
-E5-2608L,Broadwell
-E5-2643,Broadwell
-E5-2609,Broadwell
-E5-2603,Broadwell
-E3-1265L,Broadwell
-E3-1285L,Broadwell
-E3-1285,Broadwell
-E3-1258L,Broadwell
 E3-1278L,Broadwell
-i7-5700HQ,Broadwell
-i7-5750HQ,Broadwell
-i7-5775R,Broadwell
+E3-1258L,Broadwell
+E3-1285,Broadwell
+E3-1285L,Broadwell
+E3-1265L,Broadwell
 i7-5850HQ,Broadwell
+i7-5775R,Broadwell
+i7-5750HQ,Broadwell
+i7-5700HQ,Broadwell
 i7-5950HQ,Broadwell
-i7-5775C,Broadwell
-i7-5700EQ,Broadwell
 i7-5850EQ,Broadwell
-i7-5650U,Broadwell
+i7-5700EQ,Broadwell
+i7-5775C,Broadwell
 i7-5600U,Broadwell
 i7-5500U,Broadwell
-i7-5550U,Broadwell
+i7-5650U,Broadwell
 i7-5557U,Broadwell
-i5-5350H,Broadwell
-i5-5575R,Broadwell
+i7-5550U,Broadwell
 i5-5675R,Broadwell
+i5-5575R,Broadwell
+i5-5350H,Broadwell
 i5-5675C,Broadwell
-i5-5300U,Broadwell
-i5-5250U,Broadwell
-i5-5257U,Broadwell
 i5-5287U,Broadwell
-i5-5350U,Broadwell
+i5-5300U,Broadwell
 i5-5200U,Broadwell
-i3-5015U,Broadwell
+i5-5350U,Broadwell
+i5-5257U,Broadwell
+i5-5250U,Broadwell
 i3-5020U,Broadwell
-i3-5005U,Broadwell
-i3-5010U,Broadwell
+i3-5015U,Broadwell
 i3-5157U,Broadwell
-M-5Y51,Broadwell
+i3-5010U,Broadwell
+i3-5005U,Broadwell
 M-5Y71,Broadwell
+M-5Y51,Broadwell
 M-5Y31,Broadwell
 M-5Y10,Broadwell
 M-5Y70,Broadwell
 D1519,Broadwell
-D1509,Broadwell
-D1507,Broadwell
 D1517,Broadwell
+D1507,Broadwell
+D1509,Broadwell
 D1508,Broadwell
 3825U,Broadwell
 3805U,Broadwell
 3765U,Broadwell
 3215U,Broadwell
-3205U,Broadwell
 3755U,Broadwell
+3205U,Broadwell
 6138P,Sky Lake
-6148F,Sky Lake
-6146,Sky Lake
-6144,Sky Lake
-5120,Sky Lake
-6126F,Sky Lake
-8176F,Sky Lake
-4114T,Sky Lake
-5119T,Sky Lake
 4116T,Sky Lake
-5118,Sky Lake
+5119T,Sky Lake
+6146,Sky Lake
+4114T,Sky Lake
+8176F,Sky Lake
+6144,Sky Lake
 6148,Sky Lake
+8164,Sky Lake
 8160,Sky Lake
 8158,Sky Lake
 8156,Sky Lake
@@ -766,7 +763,7 @@ D1508,Broadwell
 6130,Sky Lake
 6152,Sky Lake
 6150,Sky Lake
-8160F,Sky Lake
+5118,Sky Lake
 6142,Sky Lake
 6140,Sky Lake
 5115,Sky Lake
@@ -777,8 +774,12 @@ D1508,Broadwell
 5120T,Sky Lake
 6138,Sky Lake
 5122,Sky Lake
-8168,Sky Lake
+5120,Sky Lake
+8170,Sky Lake
+6148F,Sky Lake
+6126F,Sky Lake
 6130F,Sky Lake
+8160F,Sky Lake
 6138F,Sky Lake
 6142F,Sky Lake
 4112,Sky Lake
@@ -794,50 +795,49 @@ D1508,Broadwell
 6132,Sky Lake
 3106,Sky Lake
 8176,Sky Lake
-8170,Sky Lake
-8164,Sky Lake
+8168,Sky Lake
 W-3175X,Sky Lake
-W-2123,Sky Lake
-W-2155,Sky Lake
-W-2133,Sky Lake
 W-2145,Sky Lake
 W-2125,Sky Lake
 W-2135,Sky Lake
 W-2195,Sky Lake
 W-2175,Sky Lake
-D-2161I,Sky Lake
+W-2155,Sky Lake
+W-2133,Sky Lake
+W-2123,Sky Lake
+D-2177NT,Sky Lake
+D-2183IT,Sky Lake
 D-2187NT,Sky Lake
+D-2166NT,Sky Lake
+D-2173IT,Sky Lake
+D-2163IT,Sky Lake
+D-2161I,Sky Lake
 D-2146NT,Sky Lake
 D-2145NT,Sky Lake
 D-2142IT,Sky Lake
 D-2143IT,Sky Lake
 D-2141I,Sky Lake
 D-2123IT,Sky Lake
-D-2177NT,Sky Lake
-D-2163IT,Sky Lake
-D-2173IT,Sky Lake
-D-2166NT,Sky Lake
-D-2183IT,Sky Lake
-E3-1565L,Sky Lake
-E3-1585L,Sky Lake
-E3-1585,Sky Lake
-E3-1558L,Sky Lake
 E3-1578L,Sky Lake
+E3-1558L,Sky Lake
+E3-1585,Sky Lake
+E3-1585L,Sky Lake
+E3-1565L,Sky Lake
+E3-1575M,Sky Lake
 E3-1545M,Sky Lake
 E3-1515M,Sky Lake
-E3-1575M,Sky Lake
-E3-1235L,Sky Lake
-E3-1240L,Sky Lake
 E3-1225,Sky Lake
-E3-1220,Sky Lake
+E3-1240L,Sky Lake
+E3-1235L,Sky Lake
 E3-1280,Sky Lake
-E3-1230,Sky Lake
-E3-1268L,Sky Lake
-E3-1275,Sky Lake
-E3-1240,Sky Lake
-E3-1270,Sky Lake
+E3-1220,Sky Lake
 E3-1245,Sky Lake
+E3-1270,Sky Lake
 E3-1260L,Sky Lake
+E3-1275,Sky Lake
+E3-1268L,Sky Lake
+E3-1240,Sky Lake
+E3-1230,Sky Lake
 E3-1505L,Sky Lake
 E3-1535M,Sky Lake
 E3-1505M,Sky Lake
@@ -846,83 +846,83 @@ i9-9980XE,Sky Lake
 i9-9940X,Sky Lake
 i9-9900X,Sky Lake
 i9-9960X,Sky Lake
-i7-9800X,Sky Lake
 i9-9820X,Sky Lake
-i9-7940X,Sky Lake
+i7-9800X,Sky Lake
 i9-7980XE,Sky Lake
 i9-7960X,Sky Lake
+i9-7940X,Sky Lake
 i9-7920X,Sky Lake
 i7-7800X,Sky Lake
 i9-7900X,Sky Lake
 i7-7820X,Sky Lake
 i7-6785R,Sky Lake
 i7-6660U,Sky Lake
-i7-6970HQ,Sky Lake
 i7-6770HQ,Sky Lake
 i7-6870HQ,Sky Lake
+i7-6970HQ,Sky Lake
+i7-6820EQ,Sky Lake
 i7-6822EQ,Sky Lake
 i7-6700TE,Sky Lake
-i7-6820EQ,Sky Lake
+i7-6920HQ,Sky Lake
 i7-6820HQ,Sky Lake
-i7-6560U,Sky Lake
-i7-6650U,Sky Lake
-i7-6500U,Sky Lake
-i7-6600U,Sky Lake
 i7-6820HK,Sky Lake
 i7-6700HQ,Sky Lake
-i7-6920HQ,Sky Lake
-i7-6700,Sky Lake
+i7-6500U,Sky Lake
+i7-6600U,Sky Lake
+i7-6650U,Sky Lake
+i7-6560U,Sky Lake
 i7-6700T,Sky Lake
+i7-6700,Sky Lake
 i7-6700K,Sky Lake
 i7-6567U,Sky Lake
-i5-6685R,Sky Lake
 i5-6585R,Sky Lake
+i5-6685R,Sky Lake
 i5-6350HQ,Sky Lake
 i5-6402P,Sky Lake
-i5-6442EQ,Sky Lake
 i5-6500TE,Sky Lake
 i5-6440EQ,Sky Lake
+i5-6442EQ,Sky Lake
+i5-6440HQ,Sky Lake
+i5-6300HQ,Sky Lake
+i5-6200U,Sky Lake
+i5-6300U,Sky Lake
 i5-6360U,Sky Lake
 i5-6260U,Sky Lake
 i5-6287U,Sky Lake
 i5-6267U,Sky Lake
-i5-6200U,Sky Lake
-i5-6300U,Sky Lake
-i5-6440HQ,Sky Lake
-i5-6300HQ,Sky Lake
-i5-6500T,Sky Lake
-i5-6500,Sky Lake
 i5-6400,Sky Lake
 i5-6400T,Sky Lake
 i5-6600,Sky Lake
 i5-6600T,Sky Lake
+i5-6500,Sky Lake
+i5-6500T,Sky Lake
 i5-6600K,Sky Lake
 i3-6006U,Sky Lake
 i3-6157U,Sky Lake
 i3-6098P,Sky Lake
-i3-6102E,Sky Lake
-i3-6100E,Sky Lake
 i3-6100TE,Sky Lake
-i3-6167U,Sky Lake
-i3-6100U,Sky Lake
+i3-6100E,Sky Lake
+i3-6102E,Sky Lake
 i3-6100H,Sky Lake
-i3-6300,Sky Lake
+i3-6100U,Sky Lake
+i3-6167U,Sky Lake
 i3-6320,Sky Lake
 i3-6100T,Sky Lake
+i3-6300,Sky Lake
 i3-6100,Sky Lake
 i3-6300T,Sky Lake
+m5-6Y54,Sky Lake
+m7-6Y75,Sky Lake
 m3-6Y30,Sky Lake
 m5-6Y57,Sky Lake
-m7-6Y75,Sky Lake
-m5-6Y54,Sky Lake
 G4400TE,Sky Lake
+G4400T,Sky Lake
 G4400,Sky Lake
 G4520,Sky Lake
-G4500T,Sky Lake
-G4400T,Sky Lake
 G4500,Sky Lake
-4405Y,Sky Lake
+G4500T,Sky Lake
 4405U,Sky Lake
+4405Y,Sky Lake
 G3900E,Sky Lake
 G3902E,Sky Lake
 G3900TE,Sky Lake
@@ -931,39 +931,61 @@ G3900T,Sky Lake
 G3920,Sky Lake
 3955U,Sky Lake
 3855U,Sky Lake
+6230R,Cascade Lake
 6250L,Cascade Lake
+5220R,Cascade Lake
+6246R,Cascade Lake
+6242R,Cascade Lake
+6248R,Cascade Lake
+6258R,Cascade Lake
+4215R,Cascade Lake
+6208U,Cascade Lake
+6226R,Cascade Lake
+6238R,Cascade Lake
+4210T,Cascade Lake
+6240R,Cascade Lake
+5218R,Cascade Lake
+6256,Cascade Lake
+6250,Cascade Lake
 3206R,Cascade Lake
 4214R,Cascade Lake
 4210R,Cascade Lake
-6250,Cascade Lake
-6256,Cascade Lake
-5218R,Cascade Lake
-6240R,Cascade Lake
-4210T,Cascade Lake
-6238R,Cascade Lake
-6230R,Cascade Lake
-6226R,Cascade Lake
-6208U,Cascade Lake
-4215R,Cascade Lake
-6258R,Cascade Lake
-6248R,Cascade Lake
-6242R,Cascade Lake
-6246R,Cascade Lake
-5220R,Cascade Lake
 9222,Cascade Lake
 9221,Cascade Lake
+6230T,Cascade Lake
+4209T,Cascade Lake
+6252N,Cascade Lake
+5220S,Cascade Lake
+6238,Cascade Lake
+5218B,Cascade Lake
+4214Y,Cascade Lake
+5218N,Cascade Lake
+5217,Cascade Lake
+4216,Cascade Lake
+5215L,Cascade Lake
+5215,Cascade Lake
+4208,Cascade Lake
+4215,Cascade Lake
+5220,Cascade Lake
+4214,Cascade Lake
+4210,Cascade Lake
+5218T,Cascade Lake
+9282,Cascade Lake
+9242,Cascade Lake
+6262V,Cascade Lake
+6209U,Cascade Lake
+5220T,Cascade Lake
 6246,Cascade Lake
 6222V,Cascade Lake
 6240L,Cascade Lake
 6238L,Cascade Lake
 6226,Cascade Lake
-5220T,Cascade Lake
-6209U,Cascade Lake
-6262V,Cascade Lake
-9242,Cascade Lake
-9282,Cascade Lake
-6238,Cascade Lake
-6254,Cascade Lake
+6234,Cascade Lake
+6212U,Cascade Lake
+3204,Cascade Lake
+8270,Cascade Lake
+8268,Cascade Lake
+8260Y,Cascade Lake
 8280,Cascade Lake
 8260L,Cascade Lake
 8276L,Cascade Lake
@@ -972,9 +994,9 @@ G3920,Sky Lake
 8276,Cascade Lake
 8256,Cascade Lake
 8253,Cascade Lake
-6212U,Cascade Lake
+6230,Cascade Lake
 6210U,Cascade Lake
-8260Y,Cascade Lake
+6254,Cascade Lake
 6230N,Cascade Lake
 6240Y,Cascade Lake
 6252,Cascade Lake
@@ -985,36 +1007,15 @@ G3920,Sky Lake
 6244,Cascade Lake
 6242,Cascade Lake
 6238T,Cascade Lake
-5215L,Cascade Lake
-5218T,Cascade Lake
-6230T,Cascade Lake
-6252N,Cascade Lake
-5220S,Cascade Lake
-6230,Cascade Lake
-5218B,Cascade Lake
-4214Y,Cascade Lake
-5218N,Cascade Lake
-5217,Cascade Lake
-4216,Cascade Lake
-6234,Cascade Lake
-5215,Cascade Lake
-4208,Cascade Lake
-4215,Cascade Lake
-5220,Cascade Lake
-4214,Cascade Lake
-4210,Cascade Lake
-4209T,Cascade Lake
-3204,Cascade Lake
-8270,Cascade Lake
-8268,Cascade Lake
-W-2275,Cascade Lake
-W-2295,Cascade Lake
-W-2265,Cascade Lake
-W-2255,Cascade Lake
 W-2223,Cascade Lake
+W-2255,Cascade Lake
+W-2265,Cascade Lake
+W-2295,Cascade Lake
+W-2275,Cascade Lake
 W-2235,Cascade Lake
-W-2245,Cascade Lake
 W-2225,Cascade Lake
+W-2245,Cascade Lake
+W-3275M,Cascade Lake
 W-3245,Cascade Lake
 W-3275,Cascade Lake
 W-3245M,Cascade Lake
@@ -1023,20 +1024,17 @@ W-3235,Cascade Lake
 W-3225,Cascade Lake
 W-3265,Cascade Lake
 W-3223,Cascade Lake
-W-3275M,Cascade Lake
-i9-10920X,Cascade Lake
-i9-10940X,Cascade Lake
-i9-10980XE,Cascade Lake
 i9-10900X,Cascade Lake
-E-2278GE,Coffee Lake
-E-2254ME,Coffee Lake
-E-2276ME,Coffee Lake
+i9-10980XE,Cascade Lake
+i9-10940X,Cascade Lake
+i9-10920X,Cascade Lake
 E-2254ML,Coffee Lake
+E-2276ME,Coffee Lake
+E-2254ME,Coffee Lake
+E-2278GE,Coffee Lake
 E-2276ML,Coffee Lake
-E-2278GEL,Coffee Lake
 E-2226GE,Coffee Lake
-E-2274G,Coffee Lake
-E-2246G,Coffee Lake
+E-2278GEL,Coffee Lake
 E-2286G,Coffee Lake
 E-2276G,Coffee Lake
 E-2224,Coffee Lake
@@ -1045,192 +1043,211 @@ E-2226G,Coffee Lake
 E-2234,Coffee Lake
 E-2236,Coffee Lake
 E-2244G,Coffee Lake
+E-2274G,Coffee Lake
+E-2246G,Coffee Lake
 E-2278G,Coffee Lake
 E-2288G,Coffee Lake
 E-2286M,Coffee Lake
 E-2276M,Coffee Lake
-E-2176G,Coffee Lake
+E-2136,Coffee Lake
 E-2146G,Coffee Lake
 E-2174G,Coffee Lake
 E-2126G,Coffee Lake
 E-2144G,Coffee Lake
-E-2124G,Coffee Lake
-E-2136,Coffee Lake
+E-2176G,Coffee Lake
 E-2134,Coffee Lake
-E-2186G,Coffee Lake
 E-2124,Coffee Lake
+E-2186G,Coffee Lake
+E-2124G,Coffee Lake
 E-2186M,Coffee Lake
 E-2176M,Coffee Lake
 i9-9900KS,Coffee Lake
-i9-9880H,Coffee Lake
 i9-9900T,Coffee Lake
+i9-9880H,Coffee Lake
 i9-9980HK,Coffee Lake
 i9-9900,Coffee Lake
 i9-9900KF,Coffee Lake
 i9-9900K,Coffee Lake
 i9-8950HK,Coffee Lake
-i7-9700E,Coffee Lake
-i7-9850HE,Coffee Lake
 i7-9850HL,Coffee Lake
 i7-9700TE,Coffee Lake
+i7-9850HE,Coffee Lake
+i7-9700E,Coffee Lake
 i7-9700T,Coffee Lake
 i7-9850H,Coffee Lake
 i7-9750HF,Coffee Lake
 i7-9750H,Coffee Lake
-i7-9700F,Coffee Lake
 i7-9700,Coffee Lake
+i7-9700F,Coffee Lake
 i7-9700KF,Coffee Lake
 i7-9700K,Coffee Lake
 i7-8557U,Coffee Lake
 i7-8569U,Coffee Lake
 i7-8086K,Coffee Lake
-i7-8700T,Coffee Lake
 i7-8559U,Coffee Lake
-i7-8750H,Coffee Lake
-i7-8700B,Coffee Lake
+i7-8700T,Coffee Lake
 i7-8850H,Coffee Lake
-i7-8700K,Coffee Lake
+i7-8700B,Coffee Lake
+i7-8750H,Coffee Lake
 i7-8700,Coffee Lake
-i5-9500E,Coffee Lake
+i7-8700K,Coffee Lake
 i5-9500TE,Coffee Lake
-i5-9400H,Coffee Lake
-i5-9300H,Coffee Lake
+i5-9500E,Coffee Lake
 i5-9500T,Coffee Lake
 i5-9600T,Coffee Lake
 i5-9500F,Coffee Lake
 i5-9600,Coffee Lake
 i5-9500,Coffee Lake
 i5-9400T,Coffee Lake
+i5-9400H,Coffee Lake
+i5-9300H,Coffee Lake
 i5-9300HF,Coffee Lake
-i5-9400,Coffee Lake
-i5-9400F,Coffee Lake
 i5-9600KF,Coffee Lake
+i5-9400F,Coffee Lake
+i5-9400,Coffee Lake
 i5-9600K,Coffee Lake
 i5-8260U,Coffee Lake
 i5-8257U,Coffee Lake
 i5-8279U,Coffee Lake
-i5-8500T,Coffee Lake
-i5-8400T,Coffee Lake
-i5-8500,Coffee Lake
-i5-8600T,Coffee Lake
-i5-8600,Coffee Lake
 i5-8269U,Coffee Lake
 i5-8259U,Coffee Lake
-i5-8500B,Coffee Lake
+i5-8500,Coffee Lake
+i5-8500T,Coffee Lake
+i5-8400T,Coffee Lake
+i5-8600T,Coffee Lake
+i5-8600,Coffee Lake
 i5-8400B,Coffee Lake
+i5-8500B,Coffee Lake
 i5-8400H,Coffee Lake
 i5-8300H,Coffee Lake
-i5-8600K,Coffee Lake
 i5-8400,Coffee Lake
-i3-9100E,Coffee Lake
-i3-9100HL,Coffee Lake
+i5-8600K,Coffee Lake
 i3-9100TE,Coffee Lake
-i3-9350K,Coffee Lake
+i3-9100HL,Coffee Lake
+i3-9100E,Coffee Lake
 i3-9100F,Coffee Lake
-i3-9100,Coffee Lake
-i3-9100T,Coffee Lake
+i3-9350K,Coffee Lake
 i3-9300T,Coffee Lake
 i3-9300,Coffee Lake
+i3-9100T,Coffee Lake
 i3-9320,Coffee Lake
+i3-9100,Coffee Lake
 i3-9350KF,Coffee Lake
 i3-8140U,Coffee Lake
 i3-8100B,Coffee Lake
 i3-8100H,Coffee Lake
+i3-8109U,Coffee Lake
 i3-8100T,Coffee Lake
 i3-8300T,Coffee Lake
 i3-8300,Coffee Lake
-i3-8109U,Coffee Lake
-i3-8100,Coffee Lake
 i3-8350K,Coffee Lake
-G5600T,Coffee Lake
-G5420T,Coffee Lake
+i3-8100,Coffee Lake
 G5420,Coffee Lake
 G5620,Coffee Lake
-G5600,Coffee Lake
-G5400,Coffee Lake
+G5420T,Coffee Lake
+G5600T,Coffee Lake
 G5400T,Coffee Lake
 G5500T,Coffee Lake
 G5500,Coffee Lake
-G4932E,Coffee Lake
+G5600,Coffee Lake
+G5400,Coffee Lake
 G4930E,Coffee Lake
-G4930T,Coffee Lake
+G4932E,Coffee Lake
 G4950,Coffee Lake
 G4930,Coffee Lake
-G4900T,Coffee Lake
-G4920,Coffee Lake
+G4930T,Coffee Lake
 G4900,Coffee Lake
-i9-12900HK,Alder Lake
-i9-12900H,Alder Lake
-i9-12900E,Alder Lake
-i9-12900TE,Alder Lake
-i9-12900,Alder Lake
-i9-12900T,Alder Lake
-i9-12900F,Alder Lake
-i9-12900KF,Alder Lake
-i9-12900K,Alder Lake
-i7-1260U,Alder Lake
-i7-1250U,Alder Lake
-i7-1255U,Alder Lake
-i7-1265U,Alder Lake
-i7-1270P,Alder Lake
-i7-1260P,Alder Lake
-i7-1280P,Alder Lake
-i7-12650H,Alder Lake
-i7-12800H,Alder Lake
-i7-12700T,Alder Lake
-i7-12700F,Alder Lake
-i7-12700,Alder Lake
-i7-12700H,Alder Lake
-i7-12700E,Alder Lake
-i7-12700TE,Alder Lake
-i7-12800HE,Alder Lake
-i7-12700K,Alder Lake
-i7-12700KF,Alder Lake
-i5-1230U,Alder Lake
-i5-1240U,Alder Lake
-i5-1235U,Alder Lake
-i5-1235U,Alder Lake
-i5-1245U,Alder Lake
-i5-1250P,Alder Lake
-i5-1240P,Alder Lake
-i5-12500T,Alder Lake
-i5-12500H,Alder Lake
-i5-12500TE,Alder Lake
-i5-12500E,Alder Lake
-i5-12500,Alder Lake
-i5-12600,Alder Lake
-i5-12600T,Alder Lake
-i5-12600H,Alder Lake
-i5-12600HE,Alder Lake
-i5-12400F,Alder Lake
-i5-12400,Alder Lake
-i5-12450H,Alder Lake
-i5-12400T,Alder Lake
-i5-12600K,Alder Lake
-i5-12600KF,Alder Lake
-i3-1210U,Alder Lake
-i3-1215U,Alder Lake
-i3-1215U,Alder Lake
-i3-1220P,Alder Lake
-i3-12100T,Alder Lake
-i3-12100E,Alder Lake
-i3-12100,Alder Lake
-i3-12300HE,Alder Lake
-i3-12100TE,Alder Lake
-i3-12100F,Alder Lake
-i3-12300T,Alder Lake
-i3-12300,Alder Lake
-G7400T,Alder Lake
-G7400,Alder Lake
-G7400TE,Alder Lake
-G7400E,Alder Lake
-8505,Alder Lake
-8500,Alder Lake
-8505,Alder Lake
-G6900,Alder Lake
-G6900T,Alder Lake
-G6900TE,Alder Lake
-G6900E,Alder Lake
-7300,Alder Lake
-7305,Alder Lake
-8255C,Cascade Lake
+G4920,Coffee Lake
+G4900T,Coffee Lake
+5315Y,Ice Lake
+8362,Ice Lake
+8352M,Ice Lake
+6334,Ice Lake
+5320,Ice Lake
+5320T,Ice Lake
+4310T,Ice Lake
+6312U,Ice Lake
+5318N,Ice Lake
+6336Y,Ice Lake
+5318S,Ice Lake
+6338T,Ice Lake
+4310,Ice Lake
+6342,Ice Lake
+4309Y,Ice Lake
+6326,Ice Lake
+8368,Ice Lake
+5317,Ice Lake
+5318Y,Ice Lake
+4316,Ice Lake
+4314,Ice Lake
+6338N,Ice Lake
+6314U,Ice Lake
+6354,Ice Lake
+8360Y,Ice Lake
+6330,Ice Lake
+6346,Ice Lake
+6348,Ice Lake
+8352V,Ice Lake
+8358P,Ice Lake
+8352S,Ice Lake
+8368Q,Ice Lake
+8351N,Ice Lake
+8380,Ice Lake
+6330N,Ice Lake
+6338,Ice Lake
+8352Y,Ice Lake
+8358,Ice Lake
+W-3323,Ice Lake
+W-3375,Ice Lake
+W-3345,Ice Lake
+W-3335,Ice Lake
+W-3365,Ice Lake
+D-2779,Ice Lake
+D-2786NTE,Ice Lake
+D-2796TE,Ice Lake
+D-2775TE,Ice Lake
+D-2796NT,Ice Lake
+D-2752TER,Ice Lake
+D-2752NTE,Ice Lake
+D-2798NT,Ice Lake
+D-2799,Ice Lake
+D-2795NT,Ice Lake
+D-1702,Ice Lake
+D-2766NT,Ice Lake
+D-2776NT,Ice Lake
+D-2753NT,Ice Lake
+D-2738,Ice Lake
+D-2733NT,Ice Lake
+D-2712T,Ice Lake
+D-1748TE,Ice Lake
+D-1747NTE,Ice Lake
+D-1713NT,Ice Lake
+D-1734NT,Ice Lake
+D-1722NE,Ice Lake
+D-1726,Ice Lake
+D-1736,Ice Lake
+D-1739,Ice Lake
+D-1714,Ice Lake
+D-1712TR,Ice Lake
+D-1718T,Ice Lake
+D-1732TE,Ice Lake
+D-1715TER,Ice Lake
+D-1713NTE,Ice Lake
+D-1735TR,Ice Lake
+D-1749NT,Ice Lake
+D-1746TER,Ice Lake
+D-1733NT,Ice Lake
+D-1736NT,Ice Lake
+i7-1068NG7,Ice Lake
+i7-1060G7,Ice Lake
+i7-1065G7,Ice Lake
+i5-1038NG7,Ice Lake
+i5-1030G4,Ice Lake
+i5-1030G7,Ice Lake
+i5-1035G1,Ice Lake
+i5-1035G7,Ice Lake
+i5-1035G4,Ice Lake
+i3-1000G4,Ice Lake
+i3-1005G1,Ice Lake
+i3-1000G1,Ice Lake
+6805,Ice Lake

--- a/data/download_intel_cpu_models.sh
+++ b/data/download_intel_cpu_models.sh
@@ -11,6 +11,7 @@ skylake="https://ark.intel.com/content/www/us/en/ark/products/codename/37572/pro
 cascade="https://ark.intel.com/content/www/us/en/ark/products/codename/124664/products-formerly-cascade-lake.html#@nofilter"
 coffee="https://ark.intel.com/content/www/us/en/ark/products/codename/97787/products-formerly-coffee-lake.html#@nofilter"
 alder="https://ark.intel.com/content/www/us/en/ark/products/codename/147470/products-formerly-alder-lake.html#@nofilter"
+icelake="https://ark.intel.com/content/www/us/en/ark/products/codename/74979/products-formerly-ice-lake.html#@nofilter"
 
 download_arch() {
    url=$1
@@ -19,18 +20,22 @@ download_arch() {
    for m in $models; do
 	   echo $m,$arch >> $file
    done
-}	
+}
+
+[[ "$(command -v pup)" ]] || { echo "Please install pup from github.com/ericchiang/pup first." 1>&2 ; exit 1; }
+
 file="cpu_model.csv"
 echo "Model,Architecture" > $file
-# go get github.com/ericchiang/pup
-download_arch $sandy "Sandy Bridge" 
-download_arch $sandy_ep "Sandy Bridge" 
-download_arch $sandy_en "Sandy Bridge" 
-download_arch $ivy "Ivy Bridge" 
-download_arch $ivy_ep "Ivy Bridge" 
-download_arch $haswell "Haswell" 
-download_arch $broadwell "Broadwell" 
-download_arch $skylake "Sky Lake" 
-download_arch $cascade "Cascade Lake" 
-download_arch $coffee "Coffee Lake" 
-download_arch $alder "Alder Lake" 
+
+download_arch $sandy "Sandy Bridge"
+download_arch $sandy_ep "Sandy Bridge"
+download_arch $sandy_en "Sandy Bridge"
+download_arch $ivy "Ivy Bridge"
+download_arch $ivy_ep "Ivy Bridge"
+download_arch $haswell "Haswell"
+download_arch $broadwell "Broadwell"
+download_arch $skylake "Sky Lake"
+download_arch $cascade "Cascade Lake"
+download_arch $coffee "Coffee Lake"
+download_arch $alder "Alder Lake"
+download_arch $icelake "Ice Lake"


### PR DESCRIPTION
1. download_intel_cpu_models.sh
   - check whether pup command exists firstly.
   - add product web link for Intel processor Ice Lake
2. cpu-model.csv:
   - refresh generated by updated script download_intel_cpu_models.sh

Signed-off-by: Lu Ken <ken.lu@intel.com>