### PR TITLE
dev: create secret manually

### DIFF
--- a/dev/create_k8s_token.sh
+++ b/dev/create_k8s_token.sh
@@ -2,8 +2,7 @@
 kubectl apply -f role.yaml
 
 SERVICE_ACCOUNT=kubelet-visitor
-# Get the ServiceAccount's token Secret's name
-SECRET=$(kubectl get serviceaccount ${SERVICE_ACCOUNT} -o json | jq -Mr '.secrets[].name | select(contains("token"))')
+SECRET=kubelet-visitor-token
 # Extract the Bearer token from the Secret and decode
 TOKEN=$(kubectl get secret ${SECRET} -o json | jq -Mr '.data.token' | base64 -d)
 echo -n ${TOKEN} > /tmp/token

--- a/dev/role.yaml
+++ b/dev/role.yaml
@@ -24,3 +24,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kubelet-visitor
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubelet-visitor-token
+  annotations:
+    kubernetes.io/service-account.name: kubelet-visitor
+type: kubernetes.io/service-account-token


### PR DESCRIPTION
From Kubernetes 1.24, secret will not be create automatically with service account. Thus create_k8s_token.sh would fail due to no secret is created.
Create secret manually to fix the issue.

Signed-off-by: Hao, Ruomeng <ruomeng.hao@intel.com>