### PR TITLE
Update GH Action on push for new image tag operate-first

### DIFF
--- a/.github/workflows/push_to_quay.yml
+++ b/.github/workflows/push_to_quay.yml
@@ -24,3 +24,6 @@ jobs:
 
     - name: push to quay
       run: podman push quay.io/sustainable_computing_io/kepler:latest
+
+    - name: push to operate-first quay
+      run: podman push quay.io/sustainable_computing_io/kepler:operate-first


### PR DESCRIPTION
This PR updates the exisiting GH action `on push to main branch` to push image under tags `latest` as well `operate-first` to quay.io 
Signed-off-by: Parul <parsingh@redhat.com>