### PR TITLE
fix exported metrics, handle energy overflow to use latest valid value

### DIFF
--- a/pkg/collector/metrics_test.go
+++ b/pkg/collector/metrics_test.go
@@ -20,8 +20,8 @@ var _ = Describe("Test Metric Unit", func() {
 			Curr: 10,
 			Aggr: 10,
 		}
-		v.CgroupFSStats = map[string]*ContainerUInt64Stat{
-			CPU_USAGE_TOTAL_KEY: &ContainerUInt64Stat{
+		v.CgroupFSStats = map[string]*UInt64StatCollection{
+			CPU_USAGE_TOTAL_KEY: &UInt64StatCollection{
 				Stat: map[string]*UInt64Stat{
 					"cA": &UInt64Stat{
 						Curr: SAMPLE_CURR,

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -1,0 +1,90 @@
+package collector
+
+import (
+	"fmt"
+	"math"
+)
+
+type UInt64Stat struct {
+	Curr     uint64
+	Aggr     uint64
+	PrevCurr uint64
+}
+
+func (s UInt64Stat) String() string {
+	return fmt.Sprintf("%d (%d)", s.Curr, s.Aggr)
+}
+
+// ResetCurr resets current value and keep previous curr value for filling negative value
+func (s *UInt64Stat) ResetCurr() {
+	s.PrevCurr = s.Curr
+	s.Curr = uint64(0)
+}
+
+// AddNewCurr adds new read current value (e.g., from bpf table that is reset, computed delta energy)
+func (s *UInt64Stat) AddNewCurr(newCurr uint64) error {
+	s.Curr += newCurr
+	if math.MaxUint64-newCurr < s.Aggr {
+		// overflow
+		s.Aggr = s.Curr
+		return fmt.Errorf("Aggr value overflow %d < %d, reset", s.Aggr+newCurr, s.Aggr)
+	}
+	s.Aggr += newCurr
+	return nil
+}
+
+// SetNewAggr set new read aggregated value (e.g., from cgroup, energy files)
+func (s *UInt64Stat) SetNewAggr(newAggr uint64) error {
+	oldAggr := s.Aggr
+	s.Aggr = newAggr
+	if newAggr < oldAggr {
+		// overflow: set to prev value
+		s.Curr = s.PrevCurr
+		return fmt.Errorf("Aggr value overflow %d < %d", newAggr, oldAggr)
+	}
+	if oldAggr == 0 {
+		// new value
+		s.Curr = 0
+	} else {
+		s.Curr = newAggr - oldAggr
+	}
+	return nil
+}
+
+// UInt64StatCollection keeps a collection of UInt64Stat
+type UInt64StatCollection struct {
+	Stat map[string]*UInt64Stat
+}
+
+func (s *UInt64StatCollection) AddStat(key string, newAggr uint64) {
+	if _, found := s.Stat[key]; !found {
+		s.Stat[key] = &UInt64Stat{}
+	}
+	s.Stat[key].SetNewAggr(newAggr)
+}
+
+func (s *UInt64StatCollection) Curr() uint64 {
+	sum := uint64(0)
+	for _, stat := range s.Stat {
+		sum += stat.Curr
+	}
+	return sum
+}
+
+func (s *UInt64StatCollection) Aggr() uint64 {
+	sum := uint64(0)
+	for _, stat := range s.Stat {
+		sum += stat.Aggr
+	}
+	return sum
+}
+
+func (s *UInt64StatCollection) ResetCurr() {
+	for _, stat := range s.Stat {
+		stat.ResetCurr()
+	}
+}
+
+func (s UInt64StatCollection) String() string {
+	return fmt.Sprintf("%d (%d)", s.Curr(), s.Aggr())
+}

--- a/pkg/model/estimate_test.go
+++ b/pkg/model/estimate_test.go
@@ -1,10 +1,8 @@
 package model
 
 import (
-	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sustainable-computing-io/kepler/pkg/config"
 )
 
 var (
@@ -12,29 +10,12 @@ var (
 	LR_NAME          string      = "Linear Regression_10"
 	RATIO_MODEL_NAME string      = "CorrRatio"
 	METRICS          []string    = []string{"curr_bytes_read", "curr_bytes_writes", "curr_cache_miss", "curr_cgroupfs_cpu_usage_us", "curr_cgroupfs_memory_usage_bytes", "curr_cgroupfs_system_cpu_usage_us", "curr_cgroupfs_user_cpu_usage_us", "curr_cpu_cycles", "curr_cpu_instr", "curr_cpu_time"}
-	VALUES           [][]float32 = [][]float32{[]float32{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, []float32{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}}
-	FAIL_VALUES      [][]float32 = [][]float32{[]float32{1, 1, 1, 1, 1, 1}}
+	VALUES           [][]float64 = [][]float64{[]float64{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, []float64{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}}
+	FAIL_VALUES      [][]float64 = [][]float64{[]float64{1, 1, 1, 1, 1, 1}}
 	empty            []float64   = []float64{}
 )
 
 var _ = Describe("Test Estimator Unit", func() {
-	It("Get Dynamic Power", func() {
-		// should power of each pods
-		config.EstimatorModel = MODEL_NAME
-		powers := GetDynamicPower(METRICS, VALUES, empty, empty, empty, empty, empty)
-		Expect(len(powers)).To(Equal(len(VALUES)))
-		config.EstimatorModel = LR_NAME
-		powers = GetDynamicPower(METRICS, VALUES, empty, empty, empty, empty, empty)
-		Expect(len(powers)).To(Equal(len(VALUES)))
-		config.EstimatorModel = RATIO_MODEL_NAME
-		powers = GetDynamicPower(METRICS, VALUES, []float64{10, 10}, []float64{5, 5}, []float64{0, 0}, []float64{0, 0}, []float64{0, 0})
-		Expect(len(powers)).To(Equal(len(VALUES)))
-		fmt.Println(powers)
-		// should safely return empty list if fails
-		config.EstimatorModel = MODEL_NAME
-		powers = GetDynamicPower(METRICS, FAIL_VALUES, empty, empty, empty, empty, empty)
-		Expect(len(powers)).To(Equal(0))
-	})
 	It("Get Ratio Power", func() {
 		corePower := []float64{10, 10}
 		dramPower := []float64{2, 2}


### PR DESCRIPTION
**What's included in this PR:**
- define _UInt64StatCollection_ type for collections of any aggregated stat
   _previous_: _ContainerUInt64Stat_ keeps collection of containers in a single pod
   _this PR_: _UInt64StatCollection_ keeps collection of containers in a pod, package/sensor energy of the node
   **objective**: to handle energy aggregated stat in the same way of other aggregated stat such as cgroup
- keep _PrevCurr_ stat when resetting _Curr_ value of _UInt64Stat_ and use if meeting overflow condition
  _previous_: `s.Curr = newAggr + (math.MaxUint64 - oldAggr)`
  _this PR_: `s.Curr = s.PrevCurr`
  **objective**: to avoid uncertainty of maximum number of aggregated value for each stat
  **related PR comment:**: https://github.com/sustainable-computing-io/kepler/pull/112#discussion_r957854026
- rename _CurrNodeEnergy_, _currNodeEnergy_ and _nodeEnergy_ to _NodeEnergy_, _nodeEnergy_ and _sensorEnergy_ respectively.
   **objective**: to avoid confusion
- use float64 instead of float32 for estimating dynamic power
  **objective**: to cover larger value
- update node-energy-related metrics and additionally export the following metrics
   - `node_curr_energy_joule`
   - `pod_curr_energy_millijoule` 
   - `pod_total_energy_millijoule`
    
   **objective**: to export value `pkg + GPU + others` when `others = sensor - pkg - GPU` if sensor energy is available
   **related issue**: https://github.com/sustainable-computing-io/kepler/issues/113#issuecomment-1229932614

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>