### PR TITLE
Generalize Grafana dashboard

### DIFF
--- a/grafana-dashboards/Kepler-Exporter.json
+++ b/grafana-dashboards/Kepler-Exporter.json
@@ -1,82 +1,9 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    },
-    {
-      "name": "VAR_COAL",
-      "type": "constant",
-      "label": "coal",
-      "value": "2.23",
-      "description": ""
-    },
-    {
-      "name": "VAR_NATURAL_GAS",
-      "type": "constant",
-      "label": "natural_gas",
-      "value": "0.91",
-      "description": ""
-    },
-    {
-      "name": "VAR_PETROLEUM",
-      "type": "constant",
-      "label": "petroleum",
-      "value": "2.13",
-      "description": ""
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "panel",
-      "id": "bargauge",
-      "name": "Bar gauge",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "gauge",
-      "name": "Gauge",
-      "version": ""
-    },
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "9.0.4"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
         "builtIn": 1,
-        "datasource": {
-          "type": "datasource",
-          "uid": "grafana"
-        },
+        "datasource": "-- Grafana --",
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -95,16 +22,13 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
+  "id": 28,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "collapsed": false,
-      "datasource": {
-        "type": "datasource",
-        "uid": "grafana"
-      },
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -117,10 +41,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": null,
       "description": "Using CO2 emissions  by power generation type as reported by US Energy Information Administration https://www.eia.gov/tools/faqs/faq.php?id=74&t=11",
       "fieldConfig": {
         "defaults": {
@@ -132,8 +53,7 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "#EAB839",
@@ -171,10 +91,6 @@
       "pluginVersion": "9.0.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
           "editorMode": "code",
           "expr": "sum(rate(pod_curr_energy_in_pkg_millijoule{pod_namespace='$namespace'}[24h])/3600000000*$coal)",
           "legendFormat": "CO2 Coal",
@@ -182,10 +98,6 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
           "editorMode": "code",
           "expr": "sum(rate(pod_curr_energy_in_pkg_millijoule{pod_namespace='$namespace'}[24h])/3600000000*$petroleum)",
           "hide": false,
@@ -194,10 +106,6 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
           "editorMode": "code",
           "expr": "sum(rate(pod_curr_energy_in_pkg_millijoule{pod_namespace='$namespace'}[24h])/3600000000*$natural_gas)",
           "hide": false,
@@ -212,10 +120,7 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "datasource",
-        "uid": "grafana"
-      },
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -228,10 +133,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": null,
       "description": "The mW per second",
       "fieldConfig": {
         "defaults": {
@@ -272,8 +174,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -367,10 +268,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": null,
       "description": "Total W*s Consumed",
       "fieldConfig": {
         "defaults": {
@@ -411,8 +309,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -510,10 +407,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": null,
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -580,10 +474,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": null,
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -706,12 +597,13 @@
   "templating": {
     "list": [
       {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+        "current": {
+          "selected": false,
+          "text": "monitoring",
+          "value": "monitoring"
         },
-        "definition": "label_values(pod_curr_energy_pkg_dram_millijoule, pod_namespace)",
+        "datasource": null,
+        "definition": "label_values(pod_curr_energy_in_pkg_millijoule, pod_namespace)",
         "description": "Namespace for pods to choose",
         "hide": 0,
         "includeAll": false,
@@ -733,11 +625,12 @@
         "useTags": false
       },
       {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+        "current": {
+          "selected": false,
+          "text": "alertmanager-main-2",
+          "value": "alertmanager-main-2"
         },
+        "datasource": null,
         "definition": "label_values(pod_curr_energy_in_pkg_millijoule{pod_namespace=\"$namespace\"}, pod_name)",
         "hide": 0,
         "includeAll": false,
@@ -761,59 +654,23 @@
       {
         "hide": 2,
         "name": "coal",
-        "query": "${VAR_COAL}",
+        "query": "2.23",
         "skipUrlSync": false,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_COAL}",
-          "text": "${VAR_COAL}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_COAL}",
-            "text": "${VAR_COAL}",
-            "selected": false
-          }
-        ]
+        "type": "constant"
       },
       {
         "hide": 2,
         "name": "natural_gas",
-        "query": "${VAR_NATURAL_GAS}",
+        "query": "0.91",
         "skipUrlSync": false,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_NATURAL_GAS}",
-          "text": "${VAR_NATURAL_GAS}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_NATURAL_GAS}",
-            "text": "${VAR_NATURAL_GAS}",
-            "selected": false
-          }
-        ]
+        "type": "constant"
       },
       {
         "hide": 2,
         "name": "petroleum",
-        "query": "${VAR_PETROLEUM}",
+        "query": "2.13",
         "skipUrlSync": false,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_PETROLEUM}",
-          "text": "${VAR_PETROLEUM}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_PETROLEUM}",
-            "text": "${VAR_PETROLEUM}",
-            "selected": false
-          }
-        ]
+        "type": "constant"
       }
     ]
   },
@@ -825,6 +682,6 @@
   "timezone": "browser",
   "title": "Kepler Exporter Dashboard",
   "uid": "NhnADUW4z",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/grafana-dashboards/Kepler-Exporter.json
+++ b/grafana-dashboards/Kepler-Exporter.json
@@ -3,10 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": {
-          "type": "datasource",
-          "uid": "grafana"
-        },
+        "datasource": "-- Grafana --",
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -31,10 +28,7 @@
   "panels": [
     {
       "collapsed": false,
-      "datasource": {
-        "type": "datasource",
-        "uid": "grafana"
-      },
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -47,10 +41,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": null,
       "description": "Using CO2 emissions  by power generation type as reported by US Energy Information Administration https://www.eia.gov/tools/faqs/faq.php?id=74&t=11",
       "fieldConfig": {
         "defaults": {
@@ -100,10 +91,6 @@
       "pluginVersion": "9.0.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
-          },
           "editorMode": "code",
           "expr": "sum(rate(pod_curr_energy_in_pkg_millijoule{pod_namespace='$namespace'}[24h])/3600000000*$coal)",
           "legendFormat": "CO2 Coal",
@@ -111,10 +98,6 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
-          },
           "editorMode": "code",
           "expr": "sum(rate(pod_curr_energy_in_pkg_millijoule{pod_namespace='$namespace'}[24h])/3600000000*$petroleum)",
           "hide": false,
@@ -123,10 +106,6 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
-          },
           "editorMode": "code",
           "expr": "sum(rate(pod_curr_energy_in_pkg_millijoule{pod_namespace='$namespace'}[24h])/3600000000*$natural_gas)",
           "hide": false,
@@ -141,10 +120,7 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "datasource",
-        "uid": "grafana"
-      },
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -157,10 +133,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": null,
       "description": "The mW per second",
       "fieldConfig": {
         "defaults": {
@@ -234,7 +207,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(pod_curr_energy_in_pkg_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1m])/3",
@@ -245,7 +218,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(pod_curr_energy_in_core_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1m])/3",
@@ -257,7 +230,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(pod_curr_energy_in_dram_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1m])/3",
@@ -269,7 +242,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(pod_curr_energy_in_gpu_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1m])/3",
@@ -281,7 +254,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(pod_curr_energy_in_other_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1m])/3",
@@ -295,10 +268,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": null,
       "description": "Total W*s Consumed",
       "fieldConfig": {
         "defaults": {
@@ -373,7 +343,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -386,7 +356,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum_over_time(pod_curr_energy_in_cpu_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
@@ -398,7 +368,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum_over_time(pod_curr_energy_in_dram_millijoule{pod_namespace=\"monitoring\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
@@ -410,7 +380,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum_over_time(pod_curr_energy_in_gpu_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
@@ -422,7 +392,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum_over_time(pod_curr_energy_in_other_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
@@ -437,10 +407,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": null,
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -494,7 +461,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum_over_time(pod_curr_energy_in_pkg_millijoule{pod_namespace=\"$namespace\"}[24h])*15/3/3600000000",
@@ -507,10 +474,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
-      },
+      "datasource": null,
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -613,7 +577,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum by (pod_namespace) (sum_over_time(pod_curr_energy_in_pkg_millijoule[24h])*15/3/3600000000)",
@@ -638,11 +602,8 @@
           "text": "monitoring",
           "value": "monitoring"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P1809F7CD0C75ACF3"
-        },
-        "definition": "label_values(pod_curr_energy_pkg_dram_millijoule, pod_namespace)",
+        "datasource": null,
+        "definition": "label_values(pod_curr_energy_in_pkg_millijoule, pod_namespace)",
         "description": "Namespace for pods to choose",
         "hide": 0,
         "includeAll": false,
@@ -669,10 +630,7 @@
           "text": "alertmanager-main-2",
           "value": "alertmanager-main-2"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P1809F7CD0C75ACF3"
-        },
+        "datasource": null,
         "definition": "label_values(pod_curr_energy_in_pkg_millijoule{pod_namespace=\"$namespace\"}, pod_name)",
         "hide": 0,
         "includeAll": false,

--- a/grafana-dashboards/Kepler-Exporter.json
+++ b/grafana-dashboards/Kepler-Exporter.json
@@ -680,7 +680,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Kepler Exporter Dashboard Copy",
+  "title": "Kepler Exporter Dashboard",
   "uid": "NhnADUW4z",
   "version": 2,
   "weekStart": ""

--- a/grafana-dashboards/Kepler-Exporter.json
+++ b/grafana-dashboards/Kepler-Exporter.json
@@ -1,9 +1,82 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    },
+    {
+      "name": "VAR_COAL",
+      "type": "constant",
+      "label": "coal",
+      "value": "2.23",
+      "description": ""
+    },
+    {
+      "name": "VAR_NATURAL_GAS",
+      "type": "constant",
+      "label": "natural_gas",
+      "value": "0.91",
+      "description": ""
+    },
+    {
+      "name": "VAR_PETROLEUM",
+      "type": "constant",
+      "label": "petroleum",
+      "value": "2.13",
+      "description": ""
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.0.4"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -22,13 +95,16 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 28,
+  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -41,7 +117,10 @@
       "type": "row"
     },
     {
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Using CO2 emissions  by power generation type as reported by US Energy Information Administration https://www.eia.gov/tools/faqs/faq.php?id=74&t=11",
       "fieldConfig": {
         "defaults": {
@@ -53,7 +132,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "#EAB839",
@@ -91,6 +171,10 @@
       "pluginVersion": "9.0.4",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "editorMode": "code",
           "expr": "sum(rate(pod_curr_energy_in_pkg_millijoule{pod_namespace='$namespace'}[24h])/3600000000*$coal)",
           "legendFormat": "CO2 Coal",
@@ -98,6 +182,10 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "editorMode": "code",
           "expr": "sum(rate(pod_curr_energy_in_pkg_millijoule{pod_namespace='$namespace'}[24h])/3600000000*$petroleum)",
           "hide": false,
@@ -106,6 +194,10 @@
           "refId": "B"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "editorMode": "code",
           "expr": "sum(rate(pod_curr_energy_in_pkg_millijoule{pod_namespace='$namespace'}[24h])/3600000000*$natural_gas)",
           "hide": false,
@@ -120,7 +212,10 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -133,7 +228,10 @@
       "type": "row"
     },
     {
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "The mW per second",
       "fieldConfig": {
         "defaults": {
@@ -174,7 +272,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -268,7 +367,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Total W*s Consumed",
       "fieldConfig": {
         "defaults": {
@@ -309,7 +411,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -407,7 +510,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -474,7 +580,10 @@
       "type": "bargauge"
     },
     {
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -597,13 +706,12 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "monitoring",
-          "value": "monitoring"
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
         },
-        "datasource": null,
-        "definition": "label_values(pod_curr_energy_in_pkg_millijoule, pod_namespace)",
+        "definition": "label_values(pod_curr_energy_pkg_dram_millijoule, pod_namespace)",
         "description": "Namespace for pods to choose",
         "hide": 0,
         "includeAll": false,
@@ -625,12 +733,11 @@
         "useTags": false
       },
       {
-        "current": {
-          "selected": false,
-          "text": "alertmanager-main-2",
-          "value": "alertmanager-main-2"
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
         },
-        "datasource": null,
         "definition": "label_values(pod_curr_energy_in_pkg_millijoule{pod_namespace=\"$namespace\"}, pod_name)",
         "hide": 0,
         "includeAll": false,
@@ -654,23 +761,59 @@
       {
         "hide": 2,
         "name": "coal",
-        "query": "2.23",
+        "query": "${VAR_COAL}",
         "skipUrlSync": false,
-        "type": "constant"
+        "type": "constant",
+        "current": {
+          "value": "${VAR_COAL}",
+          "text": "${VAR_COAL}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_COAL}",
+            "text": "${VAR_COAL}",
+            "selected": false
+          }
+        ]
       },
       {
         "hide": 2,
         "name": "natural_gas",
-        "query": "0.91",
+        "query": "${VAR_NATURAL_GAS}",
         "skipUrlSync": false,
-        "type": "constant"
+        "type": "constant",
+        "current": {
+          "value": "${VAR_NATURAL_GAS}",
+          "text": "${VAR_NATURAL_GAS}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_NATURAL_GAS}",
+            "text": "${VAR_NATURAL_GAS}",
+            "selected": false
+          }
+        ]
       },
       {
         "hide": 2,
         "name": "petroleum",
-        "query": "2.13",
+        "query": "${VAR_PETROLEUM}",
         "skipUrlSync": false,
-        "type": "constant"
+        "type": "constant",
+        "current": {
+          "value": "${VAR_PETROLEUM}",
+          "text": "${VAR_PETROLEUM}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_PETROLEUM}",
+            "text": "${VAR_PETROLEUM}",
+            "selected": false
+          }
+        ]
       }
     ]
   },
@@ -682,6 +825,6 @@
   "timezone": "browser",
   "title": "Kepler Exporter Dashboard",
   "uid": "NhnADUW4z",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
Kepler-Exporter.json dashboard has been generalized taking OpenShift Carbon USA legacy dashboard as an example. This PR partially addresses #119 issue.

Dashboard is now possible to import by hand and opens up correctly, not throwing any errors. This change doesn't include the URL changes necessary in manifests/openshift/04-grafana-dashboard.yaml.