### PR TITLE
fill core/dram curr energy from delta instead of aggregated value

### DIFF
--- a/pkg/collector/reader.go
+++ b/pkg/collector/reader.go
@@ -286,9 +286,7 @@ func (c *Collector) reader() {
 				sumUsage := model.GetSumUsageMap(metricNames, podMetricValues)
 				nodeEnergy.SetValues(sensorEnergy, pkgEnergy, totalGPUPower, sumUsage)
 				for pkgIDKey, pkgStat := range nodeEnergy.EnergyInPkg.Stat {
-					coreDelta := nodeEnergy.EnergyInCore.Stat[pkgIDKey].Curr
-					dramDelta := nodeEnergy.EnergyInDRAM.Stat[pkgIDKey].Curr
-					uncoreDelta := nodeEnergy.EnergyInUncore.Stat[pkgIDKey].Curr
+					coreDelta, dramDelta, uncoreDelta := nodeEnergy.GetCurrPerPkg(pkgIDKey)
 					pkgDelta := pkgStat.Curr
 					coreNDelta = append(coreNDelta, float64(coreDelta))
 					dramNDelta = append(dramNDelta, float64(dramDelta))

--- a/pkg/power/rapl/source/sysfs.go
+++ b/pkg/power/rapl/source/sysfs.go
@@ -139,15 +139,7 @@ func (r *PowerSysfs) GetPackageEnergy() map[int]PackageEnergy {
 	coreEnergies := readEventEnergy(coreEvent)
 	dramEnergies := readEventEnergy(dramEvent)
 	uncoreEnergies := readEventEnergy(uncoreEvent)
-	// the core, dram, uncore domains may not always be present
-	// in this case, derive the missing values by using pkg and other domains
-	// note, this indirection ignores uncore domain
-	if len(coreEnergies) == 0 && len(dramEnergies) > 0 {
-		coreEnergies = getEnergyFromDelta(pkgEnergies, dramEnergies)
-	}
-	if len(dramEnergies) == 0 && len(coreEnergies) > 0 {
-		dramEnergies = getEnergyFromDelta(pkgEnergies, coreEnergies)
-	}
+
 	for pkgId, pkgEnergy := range pkgEnergies {
 		coreEnergy, _ := coreEnergies[pkgId]
 		dramEnergy, _ := dramEnergies[pkgId]
@@ -155,10 +147,10 @@ func (r *PowerSysfs) GetPackageEnergy() map[int]PackageEnergy {
 		splits := strings.Split(pkgId, "-")
 		i, _ := strconv.Atoi(splits[len(splits)-1])
 		packageEnergies[i] = PackageEnergy{
-			Core: coreEnergy,
-			DRAM: dramEnergy,
+			Core:   coreEnergy,
+			DRAM:   dramEnergy,
 			Uncore: uncoreEnergy,
-			Pkg: pkgEnergy,
+			Pkg:    pkgEnergy,
 		}
 	}
 

--- a/pkg/power/rapl/source/sysfs_util.go
+++ b/pkg/power/rapl/source/sysfs_util.go
@@ -85,12 +85,3 @@ func hasEvent(event string) bool {
 	}
 	return false
 }
-
-func getEnergyFromDelta(pkg, other map[string]uint64) map[string]uint64 {
-	result := make(map[string]uint64)
-	for pkgId, pkgEnergy := range pkg {
-		otherEnergy, _ := other[pkgId]
-		result[pkgId] = pkgEnergy - otherEnergy
-	}
-	return result
-}


### PR DESCRIPTION
This PR changes filling up the missing core or dram energy from (processed) current value instead of aggregated value to avoid overflow issue.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>