### PR TITLE
Fix dashboard typos for CPU and DRAM metrics on Total Pod Energy Consumption graph 

### DIFF
--- a/grafana-dashboards/Kepler-Exporter.json
+++ b/grafana-dashboards/Kepler-Exporter.json
@@ -359,7 +359,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum_over_time(pod_curr_energy_in_cpu_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
+          "expr": "sum_over_time(pod_curr_energy_in_core_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
           "hide": false,
           "legendFormat": "CPU",
           "range": true,

--- a/grafana-dashboards/Kepler-Exporter.json
+++ b/grafana-dashboards/Kepler-Exporter.json
@@ -371,7 +371,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum_over_time(pod_curr_energy_in_dram_millijoule{pod_namespace=\"monitoring\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
+          "expr": "sum_over_time(pod_curr_energy_in_dram_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
           "hide": false,
           "legendFormat": "DRAM",
           "range": true,


### PR DESCRIPTION
* Fixes typo in Total pod CPU energy consumption metric query which resulted in missing CPU Total Pod Energy Consumption
* Fixes typo in Total pod DRAM energy consumption metric query which resulted in missing DRAM Total Pod Energy Consumption on graph.

Both issues can be seen on dashboard posted in #118 PR. Now all of the metrics can be observed, as noted on screenshot below.
![Zrzut ekranu (103)](https://user-images.githubusercontent.com/43238042/187910150-d205a054-6d00-4a30-8592-03b4b707f691.png)
