### PR TITLE
make conditional build for bcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,14 @@ endif
 
 GO_LD_FLAGS := $(GC_FLAGS) -ldflags "-X $(LD_FLAGS)" $(CFLAGS)
 
-GO_BUILD_FLAGS :=-tags 'include_gcs include_oss containers_image_openpgp gssapi providerless netgo osusergo'
+GO_BUILD_TAGS := 'include_gcs include_oss containers_image_openpgp gssapi providerless netgo osusergo'
+ifneq ($(shell command -v ldconfig),)
+  ifneq ($(shell ldconfig -p|grep bcc),)
+     GO_BUILD_TAGS = 'include_gcs include_oss containers_image_openpgp gssapi providerless netgo osusergo bcc'
+  endif
+endif
+
+GO_BUILD_FLAGS :=-tags ${GO_BUILD_TAGS}
 
 OS := $(shell go env GOOS)
 ARCH := $(shell go env GOARCH)

--- a/pkg/attacher/bcc_attacher.go
+++ b/pkg/attacher/bcc_attacher.go
@@ -1,3 +1,6 @@
+//go:build bcc
+// +build bcc
+
 /*
 Copyright 2021.
 

--- a/pkg/attacher/bcc_attacher_stub.go
+++ b/pkg/attacher/bcc_attacher_stub.go
@@ -1,0 +1,78 @@
+//go:build !bcc
+// +build !bcc
+
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package attacher
+
+import (
+	"fmt"
+)
+
+const (
+	CPU_CYCLE_LABEL       = "cpu_cycles"
+	CPU_INSTRUCTION_LABEL = "cpu_instr"
+	CACHE_MISS_LABEL      = "cache_miss"
+)
+
+type perfCounter struct{}
+
+type ModuleStub struct{}
+
+type Table struct {
+}
+type TableIterator struct {
+	leaf []byte
+}
+
+func (table *Table) Iter() *TableIterator {
+	return &TableIterator{}
+}
+
+func (it *TableIterator) Next() bool {
+	return false
+}
+
+func (it *TableIterator) Leaf() []byte {
+	return it.leaf
+}
+
+func (table *Table) DeleteAll() {
+	return
+}
+
+type BpfModuleTables struct {
+	Module    ModuleStub
+	Table     *Table
+	TimeTable *Table
+}
+
+var (
+	Counters      = map[string]perfCounter{}
+	EnableCPUFreq = false
+)
+
+func AttachBPFAssets() (*BpfModuleTables, error) {
+	return nil, fmt.Errorf("no bcc build tag")
+}
+
+func DetachBPFModules(bpfModules *BpfModuleTables) {
+}
+
+func GetEnabledCounters() []string {
+	return []string{}
+}

--- a/pkg/attacher/bpf_perf.go
+++ b/pkg/attacher/bpf_perf.go
@@ -1,3 +1,6 @@
+//go:build bcc
+// +build bcc
+
 /*
 Copyright 2021.
 

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -117,12 +117,14 @@ var _ = Describe("Test Collector Unit", func() {
 
 		// check sample pod energy stat
 		response := convertPromMetricToMap(body, POD_ENERGY_STAT_METRIC)
-		currSample, found := response["curr_"+CPU_USAGE_TOTAL_KEY]
-		Expect(found).To(Equal(true))
-		Expect(currSample).To(Equal(fmt.Sprintf("%d", SAMPLE_CURR)))
-		aggrSample, found := response["total_"+CPU_USAGE_TOTAL_KEY]
-		Expect(found).To(Equal(true))
-		Expect(aggrSample).To(Equal(fmt.Sprintf("%d", SAMPLE_AGGR)))
+		if len(availableCgroupMetrics) > 0 {
+			currSample, found := response["curr_"+CPU_USAGE_TOTAL_KEY]
+			Expect(found).To(Equal(true))
+			Expect(currSample).To(Equal(fmt.Sprintf("%d", SAMPLE_CURR)))
+			aggrSample, found := response["total_"+CPU_USAGE_TOTAL_KEY]
+			Expect(found).To(Equal(true))
+			Expect(aggrSample).To(Equal(fmt.Sprintf("%d", SAMPLE_AGGR)))
+		}
 		// check sample node energy
 		val, err := convertPromToValue(body, NODE_ENERGY_METRIC)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/collector/reader.go
+++ b/pkg/collector/reader.go
@@ -103,6 +103,9 @@ func (c *Collector) resetBPFTables() {
 func (c *Collector) readBPFEvent() (pidPodName map[uint32]string, containerIDPodName map[string]string) {
 	pidPodName = make(map[uint32]string)
 	containerIDPodName = make(map[string]string)
+	if c.modules == nil {
+		return
+	}
 	foundPod := make(map[string]bool)
 	var ct CgroupTime
 	for it := c.modules.Table.Iter(); it.Next(); {

--- a/pkg/pod_lister/byte_order.go
+++ b/pkg/pod_lister/byte_order.go
@@ -1,0 +1,18 @@
+package pod_lister
+
+import (
+	"encoding/binary"
+	"unsafe"
+)
+
+func determineHostByteOrder() binary.ByteOrder {
+	var i int32 = 0x01020304
+	u := unsafe.Pointer(&i)
+	pb := (*byte)(u)
+	b := *pb
+	if b == 0x04 {
+		return binary.LittleEndian
+	}
+
+	return binary.BigEndian
+}

--- a/pkg/pod_lister/resolve_container.go
+++ b/pkg/pod_lister/resolve_container.go
@@ -28,7 +28,6 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	bpf "github.com/iovisor/gobpf/bcc"
 	"github.com/sustainable-computing-io/kepler/pkg/config"
 )
 
@@ -48,7 +47,7 @@ const (
 )
 
 var (
-	byteOrder binary.ByteOrder = bpf.GetHostByteOrder()
+	byteOrder binary.ByteOrder = determineHostByteOrder()
 	podLister KubeletPodLister = KubeletPodLister{}
 
 	//map to cache data to speedup lookups


### PR DESCRIPTION
This PR removes static dependency to bcc library.
With this decoupling, we can make a quick test on collector package without need of bcc installation. 
Furthermore, in some system where bcc library cannot be installed in the host, we can still provide the other stat such as node energy and can provide other approach to export pod-level metrics such as using only kubelet and cgroup.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>