### PR TITLE
set pod prometheus label after attachment

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -56,8 +56,8 @@ var (
 	basicPodLabels []string = []string{
 		"pod_name", "pod_namespace", "command",
 	}
-	prometheusMetrics []string = getPrometheusMetrics()
-	podEnergyLabels   []string = append(basicPodLabels, prometheusMetrics...)
+	prometheusMetrics []string
+	podEnergyLabels   []string
 	basicNodeLabels   []string = []string{
 		"node_name", "cpu_architecture",
 	}
@@ -76,6 +76,11 @@ type Collector struct {
 	modules  *attacher.BpfModuleTables
 }
 
+func setPodStatProm() {
+	prometheusMetrics = getPrometheusMetrics()
+	podEnergyLabels = append(basicPodLabels, prometheusMetrics...)
+}
+
 func New() (*Collector, error) {
 	c := &Collector{}
 	c.setNodeDescriptionGroup()
@@ -84,6 +89,7 @@ func New() (*Collector, error) {
 
 func (c *Collector) Attach() error {
 	m, err := attacher.AttachBPFAssets()
+	setPodStatProm()
 	if err != nil {
 		return fmt.Errorf("failed to attach bpf assets: %v", err)
 	}

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -52,6 +52,7 @@ func convertPromToValue(body []byte, metric string) (int, error) {
 var _ = Describe("Test Collector Unit", func() {
 	It("Init and Run", func() {
 		newCollector, err := New()
+		setPodStatProm()
 		Expect(err).NotTo(HaveOccurred())
 		err = prometheus.Register(newCollector)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/collector/metrics_test.go
+++ b/pkg/collector/metrics_test.go
@@ -8,6 +8,7 @@ import (
 
 var _ = Describe("Test Metric Unit", func() {
 	It("Check feature values", func() {
+		setPodStatProm()
 		Expect(len(uintFeatures)).Should(BeNumerically(">", 0))
 		Expect(len(podEnergyLabels)).Should(BeNumerically(">", 0))
 		Expect(len(podEnergyLabels)).Should(BeNumerically(">", 0))
@@ -15,6 +16,7 @@ var _ = Describe("Test Metric Unit", func() {
 	})
 
 	It("Check convert values", func() {
+		setPodStatProm()
 		v := NewPodEnergy("podA", "default")
 		v.EnergyInCore = &UInt64Stat{
 			Curr: 10,


### PR DESCRIPTION
This PR set podEnergyLabels after calling AttachBPFAssets by attacher to support the case that `attacher.EnableCPUFreq` is changed to _false_ due to attachment failure.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>

fix #131 