### PR TITLE
copy files for dev local build

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -58,10 +58,11 @@ If successful, the binary is at `_output/bin/_/kepler`
 
 ### Test
 
-Create the k8s role and token, this is only needed once.
+Create the k8s role and token, copy data files, this is only needed once.
 ```bash
 cd dev/
 ./create_k8s_token.sh
+./prepare_dev_env.sh
 ```
 
 Then run the Kepler binary at `_output/bin/_/kepler`

--- a/dev/prepare_dev_env.sh
+++ b/dev/prepare_dev_env.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "copy data files"
+
+DATAPATH="/var/lib/kepler/data/"
+mkdir -p ${DATAPATH}
+
+cp ../data/normalized_cpu_arch.csv ${DATAPATH}
+cp ../data/power_data.csv          ${DATAPATH}
+cp ../data/power_model.csv         ${DATAPATH}
+


### PR DESCRIPTION
After local build for keper and run it, there will an error reports that `normalized_cpu_arch.csv` deson't exist:

Here is the message
```
[root@xxx kepler]# ./_output/bin/_/kepler
2022/09/06 00:58:56 InitSliceHandler: &{map[] /sys/fs/cgroup/cpu /sys/fs/cgroup/memory /sys/fs/cgroup/blkio}
no cpu info: open /var/lib/kepler/data/normalized_cpu_arch.csv: no such file or directory
power not supported
```

To resolve this issue, this pull request will:
1. Add a script named `dev/prepare_dev_env.sh` to copy the needed files for local build to the target folder
2. Update readme to remind developer to run this script
