### PR TITLE
Fix issue 107 in cgroup v1 environment

### DIFF
--- a/bpf_assets/perf_event/perf_event.c
+++ b/bpf_assets/perf_event/perf_event.c
@@ -88,7 +88,7 @@ static void safe_array_add(u32 idx, u16 *array, u16 value)
 
 int sched_switch(switch_args *ctx)
 {
-    u64 pid = bpf_get_current_pid_tgid();
+    u64 pid = bpf_get_current_pid_tgid() >> 32;
 #ifdef SET_GROUP_ID
     u64 cgroup_id = bpf_get_current_cgroup_id();
 #else

--- a/pkg/bpf_assets/perf_event_bindata.go
+++ b/pkg/bpf_assets/perf_event_bindata.go
@@ -135,7 +135,7 @@ static void safe_array_add(u32 idx, u16 *array, u16 value)
 
 int sched_switch(switch_args *ctx)
 {
-    u64 pid = bpf_get_current_pid_tgid();
+    u64 pid = bpf_get_current_pid_tgid() >> 32;
 #ifdef SET_GROUP_ID
     u64 cgroup_id = bpf_get_current_cgroup_id();
 #else

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -81,6 +81,15 @@ func isCGroupV2() bool {
 	return true
 }
 
+// Get cgroup version, return 1 or 2
+func GetCGroupVersion() int {
+	if isCGroupV2() {
+		return 2
+	} else{
+		return 1
+	}
+}
+
 func SetEstimatorConfig(modelName string, selectFilter string) {
 	EstimatorModel = modelName
 	EstimatorSelectFilter = selectFilter

--- a/pkg/pod_lister/resolve_container.go
+++ b/pkg/pod_lister/resolve_container.go
@@ -56,9 +56,11 @@ var (
 	containerIDToContainerInfo = map[string]*ContainerInfo{}
 	cGroupIDToPath             = map[uint64]string{}
 
-	//regex to extract container ID from path
-	regexFindContainerIDPath          = regexp.MustCompile(`.*-(.*?)\.scope`)
+
+	//regex to extract container ID from path, default value is for cgroup v2
+	regexFindContainerIDPath = regexp.MustCompile(`.*-(.*?)\.scope`)
 	regexReplaceContainerIDPathPrefix = regexp.MustCompile(`.*-`)
+
 	regexReplaceContainerIDPathSufix  = regexp.MustCompile(`\..*`)
 	regexReplaceContainerIDPrefix     = regexp.MustCompile(`.*//`)
 )
@@ -255,11 +257,17 @@ func getPathFromcGroupID(cgroupId uint64) (string, error) {
 	return cGroupIDToPath[cgroupId], nil
 }
 
+// Get containerID from path. cgroup v1 and cgroup v2 will use different regex
 func extractPodContainerIDfromPath(path string) (string, error) {
+	cgroup := config.GetCGroupVersion()
+	if cgroup == 1 {
+		regexFindContainerIDPath = regexp.MustCompile(`[0-9]*:.+slice.+`)
+		regexReplaceContainerIDPathPrefix = regexp.MustCompile(`.*:`)
+	}
 	if regexFindContainerIDPath.MatchString(path) {
 		sub := regexFindContainerIDPath.FindAllString(path, -1)
 		for _, element := range sub {
-			if strings.Contains(element, "-conmon-") || strings.Contains(element, ".service") {
+			if cgroup == 2 && (strings.Contains(element, "-conmon-") || strings.Contains(element, ".service")) {
 				return "", fmt.Errorf("process is not in a kubernetes pod")
 				//TODO: we need to extend this to include other runtimes
 			} else if strings.Contains(element, "crio") || strings.Contains(element, "docker") || strings.Contains(element, "containerd") {


### PR DESCRIPTION
1. User space PID should take upper 32 bit of bpf_get_current_pid_tgid(). Please refer to https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#4-bpf_get_current_pid_tgid
2. Update path regex and containerID regex for cgroup v1 env. Note that this has only been tested with cgroup v1 + containerd

Signed-off-by: Hao, Ruomeng <ruomeng.hao@intel.com>