### PR TITLE
Improvement: Add tolerations to allow Kepler to spawn on unschedulable master nodes

### DIFF
--- a/manifests/openshift/kepler/01-kepler-install.yaml
+++ b/manifests/openshift/kepler/01-kepler-install.yaml
@@ -59,6 +59,9 @@ spec:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kepler-exporter
     spec:
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
       nodeSelector:
         sustainable-computing.io/kepler: ""
       serviceAccountName: kepler-sa


### PR DESCRIPTION
Multi-node OpenShift clusters can be configured to either allow the scheduler to launch user workloads on master (aka control plane) nodes or not. 

If Kepler is expected to be used for monitoring master nodes (and openshift-* namespaces) power usage in both schedulable and unschedulable master scenarioes, the proposed toleration is necessary in DaemonSet. It allows the scheduler to spawn Kepler Exporter pods despite master nodes being tainted as unschedulable for user workloads. It is not enough to label the master nodes with the "sustainable-computing.io/kepler" label.

It is open to discussion whether this is necessary.