### PR TITLE
Revert back the logic to extract container id from path

### DIFF
--- a/pkg/pod_lister/resolve_container.go
+++ b/pkg/pod_lister/resolve_container.go
@@ -55,13 +55,12 @@ var (
 	containerIDToContainerInfo = map[string]*ContainerInfo{}
 	cGroupIDToPath             = map[uint64]string{}
 
-
 	//regex to extract container ID from path, default value is for cgroup v2
-	regexFindContainerIDPath = regexp.MustCompile(`.*-(.*?)\.scope`)
+	regexFindContainerIDPath          = regexp.MustCompile(`.*-(.*?)\.scope`)
 	regexReplaceContainerIDPathPrefix = regexp.MustCompile(`.*-`)
 
-	regexReplaceContainerIDPathSufix  = regexp.MustCompile(`\..*`)
-	regexReplaceContainerIDPrefix     = regexp.MustCompile(`.*//`)
+	regexReplaceContainerIDPathSufix = regexp.MustCompile(`\..*`)
+	regexReplaceContainerIDPrefix    = regexp.MustCompile(`.*//`)
 )
 
 func init() {
@@ -259,10 +258,6 @@ func getPathFromcGroupID(cgroupId uint64) (string, error) {
 // Get containerID from path. cgroup v1 and cgroup v2 will use different regex
 func extractPodContainerIDfromPath(path string) (string, error) {
 	cgroup := config.GetCGroupVersion()
-	if cgroup == 1 {
-		regexFindContainerIDPath = regexp.MustCompile(`[0-9]*:.+slice.+`)
-		regexReplaceContainerIDPathPrefix = regexp.MustCompile(`.*:`)
-	}
 	if regexFindContainerIDPath.MatchString(path) {
 		sub := regexFindContainerIDPath.FindAllString(path, -1)
 		for _, element := range sub {


### PR DESCRIPTION
#### Why we need this PR:
Previous PR #138 updated the logic to extract the container ID from a cgroup path.

Unfortunately, I wrongly revised the PR #138 as it had a problem. With the changes, Kepler stopped collecting the container IDs in my environment....

My system has cgroup v1 and the OS is ubuntu, and after creating a kepler deployment, the cgroup path is as follows:
```
11:blkio:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod481c0ae9_7d40_46dd_b6ca_ba27cb64f87e.slice/docker-28a5e57257f81fcd6d592647dde27e06b53944d58af4fa546ad77a12ce8b41c2.scope
```

Note that the chunk that has `.slice` is actually the pod id and not the container id. The container id is in the chunk that has `.scope`. The previous PR introduced the logic to extract the id from the `.slice` chunk.
Also, in the previous PR, the regex is not extracting an ID but is matching the entire string for that given cgroup path in my environment. You can test the regex using this site [here](https://regex101.com/).

#### What this PR does:
Revert back the logic to extract container id from the cgroup path

#### Special notes for your reviewer:
@rootfs I suggest reverting the changes now and work on another PR with @ruomengh to make it work in his environment.
Actually @ruomengh, could you share the cgroup path of a kubernetes container running in your environment?


Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>