### PR TITLE
clear platform-dependent metric before UT

### DIFF
--- a/pkg/collector/metrics_test.go
+++ b/pkg/collector/metrics_test.go
@@ -8,6 +8,14 @@ import (
 	"github.com/sustainable-computing-io/kepler/pkg/attacher"
 )
 
+func clearPlatformDependentAvailability() {
+	availableCounters       = []string{}
+	availableCgroupMetrics  = []string{}
+	availableKubeletMetrics = []string{}
+	uintFeatures = getUIntFeatures()
+	features = append(FLOAT_FEATURES, uintFeatures...)
+}
+
 var _ = Describe("Test Metric Unit", func() {
 	It("Check feature values", func() {
 		setPodStatProm()
@@ -18,13 +26,17 @@ var _ = Describe("Test Metric Unit", func() {
 	})
 
 	It("Test getUIntFeatures", func() {
+		clearPlatformDependentAvailability()
+		
 		exp := []string{"cpu_time", "bytes_read", "bytes_writes"}
-		// attacher/bcc_attacher_stub.go is used
+
 		cur := getUIntFeatures()
 		Expect(exp).To(Equal(cur))
 	})
 
 	It("Test getPrometheusMetrics", func() {
+		clearPlatformDependentAvailability()
+
 		exp := []string{"curr_cpu_time", "total_cpu_time", "curr_bytes_read", "total_bytes_read", "curr_bytes_writes", "total_bytes_writes", "block_devices_used"}
 		cur := getPrometheusMetrics()
 		Expect(exp).To(Equal(cur))
@@ -36,6 +48,8 @@ var _ = Describe("Test Metric Unit", func() {
 	})
 
 	It("Test getEstimatorMetrics", func() {
+		clearPlatformDependentAvailability()
+
 		exp := []string{"curr_cpu_time", "curr_bytes_read", "curr_bytes_writes", "block_devices_used"}
 		cur := getEstimatorMetrics()
 		Expect(exp).To(Equal(cur))


### PR DESCRIPTION
This PR adds function clearPlatformDependentAvailability to clear platform-dependent available metrics from each source and make this UT valid for any platform.

Example of potential test failure on the platform that cgroup metrics are available. 

```bash
2022/09/08 21:51:25 Available counter metrics: []
2022/09/08 21:51:25 Available cgroup metrics: [cgroupfs_user_cpu_usage_us cgroupfs_memory_usage_bytes cgroupfs_cpu_usage_us cgroupfs_system_cpu_usage_us]
2022/09/08 21:51:25 Available kubelet metrics: []

  Expected
      <[]string | len:3, cap:3>: ["cpu_time", "bytes_read", "bytes_writes"]
  to equal
      <[]string | len:7, cap:10>: [
          "cpu_time",
          "cgroupfs_user_cpu_usage_us",
          "cgroupfs_memory_usage_bytes",
          "cgroupfs_cpu_usage_us",
          "cgroupfs_system_cpu_usage_us",
          "bytes_read",
          "bytes_writes",
      ]
      pkg/collector/metrics_test.go:34
```


Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>