### PR TITLE
remove the dram energy from rapl pkg energy calculation

### DIFF
--- a/pkg/collector/node_energy.go
+++ b/pkg/collector/node_energy.go
@@ -17,9 +17,10 @@ package collector
 
 import (
 	"fmt"
-	"github.com/sustainable-computing-io/kepler/pkg/power/rapl/source"
 	"os"
 	"strconv"
+
+	"github.com/sustainable-computing-io/kepler/pkg/power/rapl/source"
 )
 
 var (
@@ -130,42 +131,17 @@ func (v *NodeEnergy) getEnergyValue(ekey string) (val uint64) {
 }
 
 func (v *NodeEnergy) GetPrometheusEnergyValue(ekey string) (val uint64) {
-	val = v.getEnergyValue(ekey)
-
-	// the core, dram, uncore domains may not always be present
-	// in this case, derive the missing values by using pkg and other domains
-	// note, this indirection gives priority core > dram > uncore
-	//       if both core and dram does not exist, all delta energy is considered as core energy
-	if val == 0 {
-		uncoreVal := v.EnergyInUncore.Curr()
-		switch ekey {
-		case "core":
-			val = v.EnergyInPkg.Curr() - v.EnergyInDRAM.Curr() - uncoreVal
-		case "dram":
-			coreVal := v.EnergyInCore.Curr()
-			if coreVal > 0 {
-				val = v.EnergyInPkg.Curr() - coreVal - uncoreVal
-			}
-		}
-	}
-	return
+	return v.getEnergyValue(ekey)
 }
 
 func (v *NodeEnergy) Curr() uint64 {
 	return v.EnergyInPkg.Curr() + v.EnergyInGPU + v.EnergyInOther
 }
 
-func (v *NodeEnergy) GetCurrPerPkg(pkgIDKey string) (coreDelta, dramDelta, uncoreDelta uint64) {
-	pkgDelta := v.EnergyInPkg.Stat[pkgIDKey].Curr
+func (v *NodeEnergy) GetCurrEnergyPerPkgID(pkgIDKey string) (coreDelta, dramDelta, uncoreDelta uint64) {
 	coreDelta = v.EnergyInCore.Stat[pkgIDKey].Curr
 	dramDelta = v.EnergyInDRAM.Stat[pkgIDKey].Curr
 	uncoreDelta = v.EnergyInUncore.Stat[pkgIDKey].Curr
-	// handle missing domains giving priority core > dram > uncore
-	if coreDelta == 0 {
-		coreDelta = pkgDelta - dramDelta - uncoreDelta
-	} else if dramDelta == 0 {
-		dramDelta = pkgDelta - coreDelta - uncoreDelta
-	}
 	return
 }
 

--- a/pkg/collector/reader.go
+++ b/pkg/collector/reader.go
@@ -289,7 +289,7 @@ func (c *Collector) reader() {
 				sumUsage := model.GetSumUsageMap(metricNames, podMetricValues)
 				nodeEnergy.SetValues(sensorEnergy, pkgEnergy, totalGPUPower, sumUsage)
 				for pkgIDKey, pkgStat := range nodeEnergy.EnergyInPkg.Stat {
-					coreDelta, dramDelta, uncoreDelta := nodeEnergy.GetCurrPerPkg(pkgIDKey)
+					coreDelta, dramDelta, uncoreDelta := nodeEnergy.GetCurrEnergyPerPkgID(pkgIDKey)
 					pkgDelta := pkgStat.Curr
 					coreNDelta = append(coreNDelta, float64(coreDelta))
 					dramNDelta = append(dramNDelta, float64(dramDelta))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,7 +40,7 @@ var (
 	CoreUsageMetric       = "curr_cpu_cycles"
 	DRAMUsageMetric       = "curr_cache_miss"
 	UncoreUsageMetric     = ""                // no metric (evenly divided)
-	GeneralUsageMetric    = "curr_cpu_cycles" // for uncategorized energy; pkg - core - dram - uncore
+	GeneralUsageMetric    = "curr_cpu_cycles" // for uncategorized energy; pkg - core - uncore
 )
 
 // EnableEBPFCgroupID enables the eBPF code to collect cgroup id if the system has kernel version > 4.18
@@ -85,7 +85,7 @@ func isCGroupV2() bool {
 func GetCGroupVersion() int {
 	if isCGroupV2() {
 		return 2
-	} else{
+	} else {
 		return 1
 	}
 }

--- a/pkg/model/estimate.go
+++ b/pkg/model/estimate.go
@@ -2,10 +2,11 @@ package model
 
 import (
 	"encoding/json"
-	"github.com/sustainable-computing-io/kepler/pkg/config"
 	"log"
 	"math"
 	"net"
+
+	"github.com/sustainable-computing-io/kepler/pkg/config"
 )
 
 const (
@@ -98,7 +99,9 @@ func GetPowerFromUsageRatio(podMetricValues [][]float64, totalCorePower, totalDR
 	totalUncoreUsage := sumUsage[config.UncoreUsageMetric]
 	totalUsage := sumUsage[config.GeneralUsageMetric]
 
-	unknownValue := totalPkgPower - totalCorePower - totalDRAMPower - totalUncorePower
+	//Package (PKG) domain measures the energy consumption of the entire socket, including the consumption of all the cores, integrated graphics and
+	//also the "unknown" components such as last level caches and memory controllers
+	unknownValue := totalPkgPower - totalCorePower - totalUncorePower
 
 	// find ratio power
 	for _, podMetricValue := range podMetricValues {
@@ -106,7 +109,7 @@ func GetPowerFromUsageRatio(podMetricValues [][]float64, totalCorePower, totalDR
 		dramValue := getRatio(podMetricValue, dramMetricIndex, totalDRAMUsage, totalDRAMPower, podNumber)
 		uncoreValue := getRatio(podMetricValue, uncoreMetricIndex, totalUncoreUsage, totalUncorePower, podNumber)
 		unknownValue := getRatio(podMetricValue, generalMetricIndex, totalUsage, unknownValue, podNumber)
-		pkgValue := coreValue + dramValue + uncoreValue + unknownValue
+		pkgValue := coreValue + uncoreValue + unknownValue
 		podCore = append(podCore, coreValue)
 		podDRAM = append(podDRAM, dramValue)
 		podUncore = append(podUncore, uncoreValue)

--- a/pkg/power/rapl/source/estimate.go
+++ b/pkg/power/rapl/source/estimate.go
@@ -179,7 +179,7 @@ func (r *PowerEstimate) GetPackageEnergy() map[int]PackageEnergy {
 		Core:   coreEnergy,
 		DRAM:   dramEnergy,
 		Uncore: 0,
-		Pkg:    coreEnergy + dramEnergy,
+		Pkg:    coreEnergy,
 	}
 	return packageEnergies
 }

--- a/pkg/power/rapl/source/sysfs.go
+++ b/pkg/power/rapl/source/sysfs.go
@@ -60,26 +60,7 @@ func getEnergy(event string) (uint64, error) {
 			energy += e
 		}
 		return energy, nil
-	} else {
-		switch event {
-		case coreEvent:
-			packageEnergy := readEventEnergy(packageEvent)
-			dramEnergy := readEventEnergy(dramEvent)
-			for id, e := range packageEnergy {
-				energy += e - dramEnergy[id]
-			}
-			return energy, nil
-
-		case dramEvent:
-			packageEnergy := readEventEnergy(packageEvent)
-			coreEnergy := readEventEnergy(coreEvent)
-			for id, e := range packageEnergy {
-				energy += e - coreEnergy[id]
-			}
-			return energy, nil
-		}
 	}
-
 	return energy, fmt.Errorf("could not read RAPL energy for %s", event)
 }
 


### PR DESCRIPTION
#### Why we need this PR:
We have some logic to calculate missing core energy consumption using rapl pkg and dram energy consumption. However, package energy consumption does not include dram energy....

The official documentation is [Intel® 64 and IA-32 Architectures Software Developer's Manual: Volume 3](https://www.intel.com/content/www/us/en/architecture-and-technology/64-ia-32-architectures-software-developer-system-programming-manual-325384.html). See page 499+ for RAPL details.


Also, consider the image from the paper [RAPL in Action: Experiences in Using RAPL for Power Measurements](https://dl.acm.org/doi/pdf/10.1145/3177754):
<img width="207" alt="image" src="https://user-images.githubusercontent.com/5133121/189361910-9f7ef8ef-cc17-43ad-945f-93f673030611.png">

- **Package**: The Package domain (PKG) measures the energy consumption of the entire socket. It includes consumption of all cores, integrated graphics and also uncore components (last level caches, memory controller).
- **Power Plane 0**: The Power Plane 0 (PP0) domain measures the energy consumption of all processor **cores** in the socket.
- **Power Plane 1**: The Power Plane 1 (PP1) domain measures the energy consumption of the processor graphics (**GPU**) in the socket (desktop models only).
- **DRAM**: The DRAM domain measures the energy consumption of random access memory (RAM) connected to the integrated memory controller.
- **PSys**: Intel Skylake introduced a new RAPL domain called PSys. It monitors and controls the thermal and power specifications of the entire **SoC** and is especially useful when the source of energy consumption is not the CPU or GPU. As Figure 1 suggests, PSys includes packet energy consumption.

#### What this PR does:
This PR removes dram energy from rapl package or core energy calculation.

#### Special notes for your reviewer:
There is some discussion in other PRs, such as in PR #120 that the eCore Pod is reported as 0.
We have two directions here, some works (e.g., smartwatts) use package energy as the core energy, or we can just keep it as 0.

I think this might be counter-intuitive to use the pkg energy as the core energy. If there is no rapl core energy, we should not report it, and just report the package energy... Otherwise, one can mislead the meaning of the metric, especially since the packet (socket) energy will be much higher than the energy of the core and may not have energy consumption fully and related to CPU usage (other components might also impact the pkg energy consumption).

Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>