### PR TITLE
usage_usec => user_usec

### DIFF
--- a/pkg/cgroup/stat_reader.go
+++ b/pkg/cgroup/stat_reader.go
@@ -55,7 +55,7 @@ var STANDARD_METRIC_NAME_MAPS = map[string][]CgroupFSReadMetric{
 	},
 	"cgroupfs_user_cpu_usage_us": []CgroupFSReadMetric{
 		CgroupFSReadMetric{Name: "cpuacct.usage_user", Converter: NanoToMicroConverter},
-		CgroupFSReadMetric{Name: "usage_usec", Converter: DefaultConverter},
+		CgroupFSReadMetric{Name: "user_usec", Converter: DefaultConverter},
 	},
 	"cgroupfs_ioread_bytes": []CgroupFSReadMetric{
 		CgroupFSReadMetric{Name: "rbytes", Converter: DefaultConverter},


### PR DESCRIPTION
from 

```
/sys/fs/cgroup# cat cpu.stat
usage_usec 8210530646
user_usec 5555530859
system_usec 2654999787
nr_periods 0
nr_throttled 0
throttled_usec 0

```

I think from context it should be user_usec instead of usage_usec, maybe it's a typo? 