### PR TITLE
Adding support to easily create local kubernetes cluster for testing purposes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,3 +161,11 @@ cluster-deploy: cluster-clean
 cluster-sync:
 	./hack/cluster-sync.sh
 .PHONY: cluster-sync
+
+cluster-up:
+	./hack/cluster-up.sh
+.PHONY: cluster-up
+
+cluster-down:
+	./hack/cluster-down.sh
+.PHONY: cluster-down

--- a/cluster-up/README.md
+++ b/cluster-up/README.md
@@ -1,0 +1,35 @@
+# How to use cluster-up
+
+This directory provides the scripts to create a local kubernetes cluster to used for development or integration tests. The scripts are the source for the kepler cluster commands like `make cluster-up` and `make cluster-down`.
+
+## Docker registry
+
+There's a docker registry available which is exposed at `localhost:5001`.
+
+## Choosing a cluster version
+
+The env variable `CLUSTER_PROVIDER` tells keplerci what cluster version to spin up.
+
+Therefore, before calling one of the make targets, the environment variable `CLUSTER_PROVIDER` must be exported to set the name of the tool that will create the kubernetes cluster. Currently, we only support the type `kind`. In the future, we will support other types such as `microshift`.
+
+## Bringing the cluster up
+```bash
+export CLUSTER_PROVIDER=`kind`
+make cluster-up
+```
+
+## Bringing the cluster down
+
+```bash
+export CLUSTER_PROVIDER=`kind`
+make cluster-down
+```
+This destroys the whole cluster.
+
+## Deploying kepler in the cluster
+
+```bash
+export CLUSTER_PROVIDER=`kind`
+make cluster-sync
+```
+This removes a running kepler deployment, creates a new docker image, pushes it to the local cluster registry, deploys kepler with the newly created image, and waits for the kepler container to be in the running state.

--- a/cluster-up/cluster-down.sh
+++ b/cluster-up/cluster-down.sh
@@ -17,27 +17,10 @@
 # Copyright 2022 The Kepler Contributors
 #
 
-set -e
+if [ -z "$CLUSTER_PROVIDER" ]; then
+    echo 'You must define a cluster provider (e.g. CLUSTER_PROVIDER="kind")'
+    exit 1
+fi
 
-source cluster-up/common.sh
-
-CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
-MANIFESTS_OUT_DIR=${MANIFESTS_OUT_DIR:-"_output/manifests/${CLUSTER_PROVIDER}/generated"}
-
-function main() {
-    echo "Cleaning up ..."
-
-    if [ ! -d "${MANIFESTS_OUT_DIR}" ]; then
-        echo "Directory ${MANIFESTS_OUT_DIR} DOES NOT exists. Run make generate first."
-        exit
-    fi
-
-    # Ignore errors because some clusters might not have prometheus operator
-    kubectl delete --ignore-not-found=true -f ${MANIFESTS_OUT_DIR} || true
-
-    sleep 2
-
-    echo "Done $0"
-}
-
-main "$@"
+source cluster-up/cluster/$CLUSTER_PROVIDER/common.sh
+down

--- a/cluster-up/cluster-up.sh
+++ b/cluster-up/cluster-up.sh
@@ -17,27 +17,10 @@
 # Copyright 2022 The Kepler Contributors
 #
 
-set -e
+if [ -z "$CLUSTER_PROVIDER" ]; then
+    echo 'You must define a cluster provider (e.g. CLUSTER_PROVIDER="kind")'
+    exit 1
+fi
 
-source cluster-up/common.sh
-
-CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
-MANIFESTS_OUT_DIR=${MANIFESTS_OUT_DIR:-"_output/manifests/${CLUSTER_PROVIDER}/generated"}
-
-function main() {
-    echo "Cleaning up ..."
-
-    if [ ! -d "${MANIFESTS_OUT_DIR}" ]; then
-        echo "Directory ${MANIFESTS_OUT_DIR} DOES NOT exists. Run make generate first."
-        exit
-    fi
-
-    # Ignore errors because some clusters might not have prometheus operator
-    kubectl delete --ignore-not-found=true -f ${MANIFESTS_OUT_DIR} || true
-
-    sleep 2
-
-    echo "Done $0"
-}
-
-main "$@"
+source cluster-up/cluster/$CLUSTER_PROVIDER/common.sh
+up

--- a/cluster-up/cluster/kind/README.md
+++ b/cluster-up/cluster/kind/README.md
@@ -1,0 +1,11 @@
+# K8S in a Kind cluster
+
+This folder serves as base to spin a k8s cluster up using [kind](https://github.com/kubernetes-sigs/kind). The cluster is completely ephemeral and is recreated on every cluster restart. 
+The Kepler container is built on the local machine and is then pushed to a registry which is exposed at `localhost:5001` (we use port 5001 to work on [macOS](https://github.com/kubernetes-sigs/kind/pull/2621)). 
+
+A kind cluster must specify:
+* CLUSTER_NAME representing the cluster name (default: `kind`)
+* IMAGE_REPO representing the image name with the local repository (default: `localhost:5001/kepler`)
+* IMAGE_TAG with the current git tag (`git describe --tags`)
+
+The provider is supposed to copy a valid `kind.yaml` file under `cluster-up/cluster/${CLUSTER_PROVIDER}/manifests/kind.yaml`

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#
+# This file is part of the Kepler project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 The Kepler Contributors
+#
+
+set -ex pipefail
+
+_registry_port="5001"
+_registry_name="kind-registry"
+
+CONFIG_PATH="cluster-up/cluster"
+KIND_VERSION=${KIND_VERSION:-0.12.0}
+KIND_MANIFESTS_DIR="$CONFIG_PATH/${CLUSTER_PROVIDER}/manifests"
+CLUSTER_NAME=${KIND_CLUSTER_NAME:-kind}
+REGISTRY_NAME=${REGISTRY_NAME:-kind-registry}
+REGISTRY_PORT=${REGISTRY_PORT:-5001}
+KIND_DEFAULT_NETWORK="kind"
+
+IMAGE_REPO=${IMAGE_REPO:-localhost:5001/kepler}
+IMAGE_TAG=${IMAGE_TAG:-$(git describe --tags | head -1)}
+
+CONFIG_OUT_DIR=${CONFIG_OUT_DIR:-"_output/manifests/${CLUSTER_PROVIDER}/generated"}
+rm -rf ${CONFIG_OUT_DIR}
+mkdir -p ${CONFIG_OUT_DIR}
+
+# check CPU arch
+PLATFORM=$(uname -m)
+case ${PLATFORM} in
+x86_64* | i?86_64* | amd64*)
+    ARCH="amd64"
+    ;;
+ppc64le)
+    ARCH="ppc64le"
+    ;;
+aarch64* | arm64*)
+    ARCH="arm64"
+    ;;
+*)
+    echo "invalid Arch, only support x86_64, ppc64le, aarch64"
+    exit 1
+    ;;
+esac
+
+function _wait_kind_up {
+    echo "Waiting for kind to be ready ..."
+    
+    while [ -z "$(docker exec --privileged ${CLUSTER_NAME}-control-plane kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes -o=jsonpath='{.items..status.conditions[-1:].status}' | grep True)" ]; do
+        echo "Waiting for kind to be ready ..."
+        sleep 10
+    done
+    echo "Waiting for dns to be ready ..."
+    kubectl wait -n kube-system --timeout=12m --for=condition=Ready -l k8s-app=kube-dns pods
+}
+
+function _wait_containers_ready {
+    echo "Waiting for all containers to become ready ..."
+    kubectl wait --for=condition=Ready pod --all -n kube-system --timeout 12m
+}
+
+function _fetch_kind() {
+    mkdir -p ${CONFIG_OUT_DIR}
+    KIND="${CONFIG_OUT_DIR}"/.kind
+    if [ -f $KIND ]; then
+        current_kind_version=$($KIND --version |& awk '{print $3}')
+    fi
+    if [[ $current_kind_version != $KIND_VERSION ]]; then
+        echo "Downloading kind v$KIND_VERSION"
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            curl -LSs https://github.com/kubernetes-sigs/kind/releases/download/v$KIND_VERSION/kind-darwin-${ARCH} -o "$KIND"
+        else
+            curl -LSs https://github.com/kubernetes-sigs/kind/releases/download/v$KIND_VERSION/kind-linux-${ARCH} -o "$KIND"
+        fi
+        chmod +x "$KIND"
+    fi
+}
+
+function _run_registry() {
+    until [ -z "$(docker ps -a | grep ${REGISTRY_NAME})" ]; do
+        docker stop ${REGISTRY_NAME} || true
+        docker rm ${REGISTRY_NAME} || true
+        sleep 5
+    done
+
+    docker run \
+        -d --restart=always \
+        -p "127.0.0.1:${REGISTRY_PORT}:5000" \
+        --name "${REGISTRY_NAME}" \
+        registry:2
+
+    # connect the registry to the cluster network if not already connected
+    docker network connect "${KIND_DEFAULT_NETWORK}" "${REGISTRY_NAME}" || true
+
+    kubectl apply -f ${CONFIG_OUT_DIR}/local-registry.yml
+}
+
+function _prepare_config() {
+    echo "Building manifests..."
+
+    cp $KIND_MANIFESTS_DIR/kind.yml ${CONFIG_OUT_DIR}/kind.yml
+    sed -i -e "s/$_registry_name/${REGISTRY_NAME}/g" ${CONFIG_OUT_DIR}/kind.yml
+    sed -i -e "s/$_registry_port/${REGISTRY_PORT}/g" ${CONFIG_OUT_DIR}/kind.yml
+    
+    cp $KIND_MANIFESTS_DIR/local-registry.yml ${CONFIG_OUT_DIR}/local-registry.yml
+    sed -i -e "s/$_registry_name/${REGISTRY_NAME}/g" ${CONFIG_OUT_DIR}/local-registry.yml
+    sed -i -e "s/$_registry_port/${REGISTRY_PORT}/g" ${CONFIG_OUT_DIR}/local-registry.yml
+}
+
+function _get_nodes() {
+    kubectl get nodes --no-headers
+}
+
+function _get_pods() {
+    kubectl get pods --all-namespaces --no-headers
+}
+
+function _setup_kind() {
+     echo "Starting kind with cluster name \"${CLUSTER_NAME}\""
+
+    $KIND create cluster -v=6 --name=${CLUSTER_NAME} --config=${CONFIG_OUT_DIR}/kind.yml
+    $KIND get kubeconfig --name=${CLUSTER_NAME} > ${CONFIG_OUT_DIR}/.kubeconfig
+
+    _wait_kind_up
+    kubectl cluster-info
+
+    # wait until k8s pods are running
+    while [ -n "$(_get_pods | grep -v Running)" ]; do
+        echo "Waiting for all pods to enter the Running state ..."
+        _get_pods | >&2 grep -v Running || true
+        sleep 10
+    done
+
+    _wait_containers_ready
+    _run_registry
+}
+
+function _kind_up() {
+    _fetch_kind
+    _prepare_config
+    _setup_kind
+}
+
+function up() {
+    _kind_up
+
+    echo "${CLUSTER_PROVIDER} cluster '$CLUSTER_NAME' is ready"
+}
+
+function down() {
+    _fetch_kind
+    if [ -z "$($KIND get clusters | grep ${CLUSTER_NAME})" ]; then
+        return
+    fi
+    # Avoid failing an entire test run just because of a deletion error
+    $KIND delete cluster --name=${CLUSTER_NAME} || "true"
+    docker rm -f ${REGISTRY_NAME} >> /dev/null
+    rm -f ${CONFIG_PATH}/${CLUSTER_PROVIDER}/kind.yml
+}

--- a/cluster-up/cluster/kind/manifests/kind.yml
+++ b/cluster-up/cluster/kind/manifests/kind.yml
@@ -1,0 +1,10 @@
+---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+# create a cluster with the local registry enabled in containerd
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
+    endpoint = ["http://kind-registry:5000"]
+nodes:
+  - role: control-plane

--- a/cluster-up/cluster/kind/manifests/local-registry.yml
+++ b/cluster-up/cluster/kind/manifests/local-registry.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:5001"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"

--- a/cluster-up/common.sh
+++ b/cluster-up/common.sh
@@ -19,25 +19,7 @@
 
 set -e
 
-source cluster-up/common.sh
-
-CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
-MANIFESTS_OUT_DIR=${MANIFESTS_OUT_DIR:-"_output/manifests/${CLUSTER_PROVIDER}/generated"}
-
-function main() {
-    echo "Cleaning up ..."
-
-    if [ ! -d "${MANIFESTS_OUT_DIR}" ]; then
-        echo "Directory ${MANIFESTS_OUT_DIR} DOES NOT exists. Run make generate first."
-        exit
-    fi
-
-    # Ignore errors because some clusters might not have prometheus operator
-    kubectl delete --ignore-not-found=true -f ${MANIFESTS_OUT_DIR} || true
-
-    sleep 2
-
-    echo "Done $0"
-}
-
-main "$@"
+# the cluster kind is a kubernetes cluster
+if [ ${CLUSTER_PROVIDER} = "kind" ]; then
+    CLUSTER_PROVIDER="kubernetes"
+fi

--- a/dev/README.md
+++ b/dev/README.md
@@ -2,7 +2,16 @@
 
 A quick start guide to get Kepler up and running inside your container-based development cluster.
 
-## I just want it built and run it on my cluster
+## To create a new emphemeral local kubernetes cluster
+You can bring the cluster up with:
+```bash
+export CLUSTER_PROVIDER=`kind`
+make cluster-up
+```
+
+For more information please read our ![How to use cluster-up](cluster-up/README.md)
+
+## Then build and run kepler on your cluster
 
 First, point the `Makefile` to the container registry of your choice:
 

--- a/hack/build-manifest.sh
+++ b/hack/build-manifest.sh
@@ -14,10 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2022 IBM, Inc.
+# Copyright 2022 The Kepler Contributors
 #
 
 set -ex
+
+source cluster-up/common.sh
 
 CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
 IMAGE_TAG=${IMAGE_TAG:-devel}

--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -14,10 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2022 IBM, Inc.
+# Copyright 2022 The Kepler Contributors
 #
 
 set -ex pipefail
+
+source cluster-up/common.sh
 
 CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
 MANIFESTS_OUT_DIR=${MANIFESTS_OUT_DIR:-"_output/manifests/${CLUSTER_PROVIDER}/generated"}
@@ -25,7 +27,10 @@ MANIFESTS_OUT_DIR=${MANIFESTS_OUT_DIR:-"_output/manifests/${CLUSTER_PROVIDER}/ge
 function main() {
     [ ! -d "${MANIFESTS_OUT_DIR}" ] && echo "Directory ${MANIFESTS_OUT_DIR} DOES NOT exists. Run make generate first."
     
-    kubectl apply -f ${MANIFESTS_OUT_DIR}
+    echo "Deploying manifests..."
+
+    # Ignore errors because some clusters might not have prometheus operator
+    kubectl apply -f ${MANIFESTS_OUT_DIR} || true
     kubectl rollout status daemonset kepler-exporter -n monitoring --timeout 60s
 
     echo "Check the logs of the kepler-exporter with:"

--- a/hack/cluster-down.sh
+++ b/hack/cluster-down.sh
@@ -16,28 +16,4 @@
 #
 # Copyright 2022 The Kepler Contributors
 #
-
-set -e
-
-source cluster-up/common.sh
-
-CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
-MANIFESTS_OUT_DIR=${MANIFESTS_OUT_DIR:-"_output/manifests/${CLUSTER_PROVIDER}/generated"}
-
-function main() {
-    echo "Cleaning up ..."
-
-    if [ ! -d "${MANIFESTS_OUT_DIR}" ]; then
-        echo "Directory ${MANIFESTS_OUT_DIR} DOES NOT exists. Run make generate first."
-        exit
-    fi
-
-    # Ignore errors because some clusters might not have prometheus operator
-    kubectl delete --ignore-not-found=true -f ${MANIFESTS_OUT_DIR} || true
-
-    sleep 2
-
-    echo "Done $0"
-}
-
-main "$@"
+./cluster-up/cluster-down.sh

--- a/hack/cluster-sync.sh
+++ b/hack/cluster-sync.sh
@@ -14,14 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2022 IBM, Inc.
+# Copyright 2022 The Kepler Contributors
 #
 
 set -e
+export CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
+source cluster-up/cluster/$CLUSTER_PROVIDER/common.sh
+# set the CLUSTER_PROVIDER to kubernetes or openshift kind
+source cluster-up/common.sh
 
 export IMAGE_TAG=${IMAGE_TAG:-devel}
 export IMAGE_REPO=${IMAGE_REPO:-quay.io/sustainable_computing_io/kepler}
-export CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
 
 # we do not use `make cluster-clean` and `make cluster-deploy` because they trigger other actions
 function main() {
@@ -35,9 +38,7 @@ function main() {
 
     echo "waiting for cluster-clean to finish"
     if ! wait $CLEAN_PID; then
-        echo "cluster-clean failed, output was:"
-        cat $TEMP_FILE
-        exit 1
+        echo "cluster-clean failed"
     fi
 
     ./hack/cluster-deploy.sh

--- a/hack/cluster-up.sh
+++ b/hack/cluster-up.sh
@@ -16,28 +16,4 @@
 #
 # Copyright 2022 The Kepler Contributors
 #
-
-set -e
-
-source cluster-up/common.sh
-
-CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
-MANIFESTS_OUT_DIR=${MANIFESTS_OUT_DIR:-"_output/manifests/${CLUSTER_PROVIDER}/generated"}
-
-function main() {
-    echo "Cleaning up ..."
-
-    if [ ! -d "${MANIFESTS_OUT_DIR}" ]; then
-        echo "Directory ${MANIFESTS_OUT_DIR} DOES NOT exists. Run make generate first."
-        exit
-    fi
-
-    # Ignore errors because some clusters might not have prometheus operator
-    kubectl delete --ignore-not-found=true -f ${MANIFESTS_OUT_DIR} || true
-
-    sleep 2
-
-    echo "Done $0"
-}
-
-main "$@"
+./cluster-up/cluster-up.sh


### PR DESCRIPTION
### What this PR does / why we need it:

After making changes to a kepler code, you should test it locally and the github should also trigger integration tests.

This PR introduce the code to provision and start containerized Kubernetes clusters in order to test Kepler on different Kubernetes configurations.

Currently, there is only support for creating a k8s cluster using the `kind` tool, but we will add support for other tools later such as `microshift`.

The developer will be able to simply run:
```bash
export CLUSTER_PROVIDER=`kind`
make cluster-up
```

### Special notes for your reviewer:
After this PR, we will be able to update the github workflow that runs the integration test.
This PR is related to the PR #157.