### PR TITLE
update integration test to use cluster up and sync

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,0 +1,29 @@
+name: Integration test
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  integration_test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        kube_provider: [kind]
+    steps:
+      - uses: actions/checkout@main
+      - uses: actions/setup-go@main
+        with:
+          go-version: 1.18
+      - name: install kubectl
+        run: curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+      - name: start local k8s cluster
+        run: make cluster-up
+        env:
+            CLUSTER_PROVIDER: ${{matrix.kube_provider}}
+      - name: simple test - deploy kepler
+        run: make cluster-sync
+        env:
+            CLUSTER_PROVIDER: ${{matrix.kube_provider}}
+            CTR_CMD: docker

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -66,25 +66,3 @@ jobs:
           go-version: 1.18
       - name: run gofmt test
         run: ./automation/presubmit-tests/gofmt.sh
-
-  integration_test:
-    runs-on: ubuntu-latest
-    needs: unit_test_without_bcc
-    strategy:
-      matrix:
-        kube_provider: [kind]
-    steps:
-      - uses: actions/checkout@main
-      - uses: actions/setup-go@main
-        with:
-          go-version: 1.18
-      - name: install kubectl
-        run: curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-      - name: build image locally
-        run: export CTR_CMD=docker && make
-      - name: infra up
-        run: ./hack/integration_cluster.sh ${{matrix.kube_provider}}
-      - name: deploy test
-        run: kubectl create -f manifests/kubernetes/deployment.yaml 
-      - name: checking
-        run: until kubectl get svc --all-namespaces ; do date; sleep 1; echo ""; done  

--- a/cluster-up/cluster/kind/README.md
+++ b/cluster-up/cluster/kind/README.md
@@ -6,6 +6,5 @@ The Kepler container is built on the local machine and is then pushed to a regis
 A kind cluster must specify:
 * CLUSTER_NAME representing the cluster name (default: `kind`)
 * IMAGE_REPO representing the image name with the local repository (default: `localhost:5001/kepler`)
-* IMAGE_TAG with the current git tag (`git describe --tags`)
 
 The provider is supposed to copy a valid `kind.yaml` file under `cluster-up/cluster/${CLUSTER_PROVIDER}/manifests/kind.yaml`

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -31,7 +31,7 @@ REGISTRY_PORT=${REGISTRY_PORT:-5001}
 KIND_DEFAULT_NETWORK="kind"
 
 IMAGE_REPO=${IMAGE_REPO:-localhost:5001/kepler}
-IMAGE_TAG=${IMAGE_TAG:-$(git describe --tags | head -1)}
+IMAGE_TAG=${IMAGE_TAG:-devel}
 
 CONFIG_OUT_DIR=${CONFIG_OUT_DIR:-"_output/manifests/${CLUSTER_PROVIDER}/generated"}
 rm -rf ${CONFIG_OUT_DIR}


### PR DESCRIPTION
### What this PR does / why we need it:
This PR updates the way that the integration test creates the local kubernetes cluster by using the scripts introduced in the PR #164.

### Special notes for your reviewer:
This PR depends on the PR #164 be merged first.


Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>