### PR TITLE
Add gofmt as a prerequisite for PRs in CI

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -57,6 +57,16 @@ jobs:
     - name: Run 
       run: make test-verbose
 
+  gofmt_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: actions/setup-go@main
+        with:
+          go-version: 1.18
+      - name: run gofmt test
+        run: ./automation/presubmit-tests/gofmt.sh
+
   integration_test:
     runs-on: ubuntu-latest
     needs: unit_test_without_bcc

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ tidy-vendor:
 	go mod vendor
 
 
-_build_local:
+_build_local: format
 	@mkdir -p "$(CROSS_BUILD_BINDIR)/$(GOOS)_$(GOARCH)"
 	+@GOOS=$(GOOS) GOARCH=$(GOARCH) go build -tags ${GO_BUILD_TAGS} \
 		-o $(CROSS_BUILD_BINDIR)/$(GOOS)_$(GOARCH)/kepler ./cmd/exporter.go
@@ -78,7 +78,7 @@ cross-build: cross-build-linux-amd64 cross-build-linux-arm64
 .PHONY: cross-build
 
 
-_build_containerized:
+_build_containerized: format
 	@if [ -z '$(CTR_CMD)' ] ; then echo '!! ERROR: containerized builds require podman||docker CLI, none found $$PATH' >&2 && exit 1; fi
 	echo BIN_TIMESTAMP==$(BIN_TIMESTAMP)
 	$(CTR_CMD) build -t $(IMAGE_REPO):$(SOURCE_GIT_TAG)-linux-$(ARCH) \
@@ -134,7 +134,7 @@ test-verbose: ginkgo-set tidy-vendor
 	@go test $(GO_BUILD_FLAGS) -v ./... --race --bench=. -cover --count=1
 
 format:
-	go fmt ./...
+	gofmt -l -w pkg/ cmd/
 
 
 clean-cross-build:

--- a/automation/presubmit-tests/gofmt.sh
+++ b/automation/presubmit-tests/gofmt.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# This file is part of the Kepler project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 The Kepler Contributors.
+#
+
+set -e
+
+echo "Checking go format"
+sources="pkg/ cmd/"
+unformatted=$(gofmt -l $sources)
+if [ ! -z "$unformatted" ]; then
+    # Some files are not gofmt.
+    echo >&2 "The following Go files must be formatted with gofmt:"
+    for fn in $unformatted; do
+        echo >&2 "  $fn"
+    done
+    echo >&2 "Please run 'make format'."
+    exit 1
+fi
+
+exit 0

--- a/pkg/collector/metrics_test.go
+++ b/pkg/collector/metrics_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func clearPlatformDependentAvailability() {
-	availableCounters       = []string{}
-	availableCgroupMetrics  = []string{}
+	availableCounters = []string{}
+	availableCgroupMetrics = []string{}
 	availableKubeletMetrics = []string{}
 	uintFeatures = getUIntFeatures()
 	features = append(FLOAT_FEATURES, uintFeatures...)
@@ -27,7 +27,7 @@ var _ = Describe("Test Metric Unit", func() {
 
 	It("Test getUIntFeatures", func() {
 		clearPlatformDependentAvailability()
-		
+
 		exp := []string{"cpu_time", "bytes_read", "bytes_writes"}
 
 		cur := getUIntFeatures()


### PR DESCRIPTION
Add go fmt as a basic test case in CI.
If the code in the submitted PR is not well format, the test will fail and ask the developer to run `make format`.

This is the first step for testing the code quality, as describe in the issue #161

We will add later 
- [go vet](https://medium.com/a-journey-with-go/go-vet-command-is-more-powerful-than-you-think-563e9fdec2f5)
- [revive](https://blog.logrocket.com/linting-go-programs-improving-code-quality/)

Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>