### PR TITLE
Update go test to run all go vet checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,10 +128,10 @@ ginkgo-set: tidy-vendor
 	  cp $(GOBIN)/ginkgo $(ENVTEST_ASSETS_DIR)/ginkgo)
 	
 test: ginkgo-set tidy-vendor
-	@go test $(GO_BUILD_FLAGS) ./... --race --bench=. -cover --count=1
+	@go test $(GO_BUILD_FLAGS) ./... --race --bench=. -cover --count=1 --vet=all
 
 test-verbose: ginkgo-set tidy-vendor
-	@go test $(GO_BUILD_FLAGS) -v ./... --race --bench=. -cover --count=1
+	@go test $(GO_BUILD_FLAGS) -v ./... --race --bench=. -cover --count=1 --vet=all
 
 format:
 	gofmt -l -w pkg/ cmd/


### PR DESCRIPTION
Add all go vet checks as a basic test case in CI.

As part of building a test binary, go test runs go vet on the package and its test source files to identify significant problems. To run all go vet checks, we can use the -vet=all flag. More info [here](https://manpages.debian.org/testing/golang-go/go-test.1.en.html).

This is PR is part of the effort for testing the code quality, as describe in the issue #161

Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>