### PR TITLE
Add support for golint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,91 @@
+linters-settings:
+  dupl:
+    threshold: 100
+  funlen:
+    lines: 100
+    statements: 50
+  goconst:
+    min-len: 2
+    min-occurrences: 3
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+  gocyclo:
+    min-complexity: 15
+  goimports:
+    local-prefixes: github.com/golangci/golangci-lint
+
+  govet:
+    check-shadowing: true
+    settings:
+      printf:
+        funcs:
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+  lll:
+    line-length: 140
+  misspell:
+    locale: US
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - funlen
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
+    - varcheck
+
+  # don't enable:
+  # - lll
+  # - asciicheck
+  # - scopelint
+  # - gochecknoglobals
+  # - gocognit
+  # - godot
+  # - godox
+  # - goerr113
+  # - interfacer
+  # - maligned
+  # - nestif
+  # - prealloc
+  # - testpackage
+  # - revive
+  # - wsl
+
+run:
+  timeout: 5m

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,9 @@ test-verbose: ginkgo-set tidy-vendor
 format:
 	gofmt -l -w pkg/ cmd/
 
+golint:
+	./hack/golint.sh
+
 
 clean-cross-build:
 	$(RM) -r '$(CROSS_BUILD_BINDIR)'

--- a/hack/golint.sh
+++ b/hack/golint.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# This file is part of the Kepler project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 The Kepler Contributors.
+#
+
+set -e
+
+IMAGE_VERSION="v1.49.0"
+CACHE_DIR="/tmp/golint-docker-$USER"
+mkdir -p "$CACHE_DIR"
+
+docker run \
+    --rm -t \
+    --user "$(id -u):$(id -g)" \
+    -v "$CACHE_DIR:/.cache" \
+    -v "$(go env GOPATH)/pkg:/go/pkg" \
+    -v "$PWD:/app" \
+    --env GO111MODULE=on \
+    --workdir /app \
+    golangci/golangci-lint:${IMAGE_VERSION} \
+    golangci-lint run


### PR DESCRIPTION
Using linters improves the code quality and readability by highlighting problems before they are executed, and it helps with the standardization of the codebase.

This PR enables golint. But, fixing the issues is out of the scope of this PR and will be done in another PR.

Additionally, this is PR is part of the effort for testing the code quality, as describe in the issue https://github.com/sustainable-computing-io/kepler/issues/161

Signed-off-by: Marcelo Amaral [marcelo.amaral1@ibm.com](mailto:marcelo.amaral1@ibm.com)