### PR TITLE
Add golint test to CI

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,22 @@
+name: golangci-lint
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@main
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.49


### PR DESCRIPTION
Before merging this PR, we need the PR #168 that adds support for golint with the revive package.

This action will highlight golint issues as the ones described in the issue #169.

This is PR is part of the effort for testing the code quality, as describe in the issue https://github.com/sustainable-computing-io/kepler/issues/161

Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>