### PR TITLE
Update kepler namespace from monitoring to kepler

### DIFF
--- a/grafana-dashboards/Kepler-Exporter.json
+++ b/grafana-dashboards/Kepler-Exporter.json
@@ -599,8 +599,8 @@
       {
         "current": {
           "selected": false,
-          "text": "monitoring",
-          "value": "monitoring"
+          "text": "kepler",
+          "value": "kepler"
         },
         "datasource": null,
         "definition": "label_values(pod_curr_energy_in_pkg_millijoule, pod_namespace)",

--- a/grafana-dashboards/legacy/Kepler-Exporter-Dashboard-openshift.json
+++ b/grafana-dashboards/legacy/Kepler-Exporter-Dashboard-openshift.json
@@ -439,8 +439,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "monitoring",
-          "value": "monitoring"
+          "text": "kepler",
+          "value": "kepler"
         },
         "datasource": null,
         "definition": "label_values(pod_energy_stat, pod_namespace)",

--- a/grafana-dashboards/legacy/Kepler-Exporter-Dashboard.json
+++ b/grafana-dashboards/legacy/Kepler-Exporter-Dashboard.json
@@ -417,12 +417,12 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "20*sum(rate(pod_energy_total{pod_namespace=\"monitoring\"}[24h]))/1000000000",
+          "expr": "20*sum(rate(pod_energy_total{pod_namespace=\"kepler\"}[24h]))/1000000000",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
-          "legendFormat": "monitoring",
+          "legendFormat": "kepler",
           "refId": "A"
         },
         {

--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -31,10 +31,10 @@ function main() {
 
     # Ignore errors because some clusters might not have prometheus operator
     kubectl apply -f ${MANIFESTS_OUT_DIR} || true
-    kubectl rollout status daemonset kepler-exporter -n monitoring --timeout 60s
+    kubectl rollout status daemonset kepler-exporter -n kepler --timeout 60s
 
     echo "Check the logs of the kepler-exporter with:"
-    echo "kubectl -n monitoring logs daemonset.apps/kepler-exporter"
+    echo "kubectl -n kepler logs daemonset.apps/kepler-exporter"
 }
 
 main "$@"

--- a/manifests/kubernetes/deployment.yaml
+++ b/manifests/kubernetes/deployment.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: monitoring
+  name: kepler
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kepler-clusterrole
-  namespace: monitoring
+  namespace: kepler
 rules:
 - apiGroups: [""]
   resources:
@@ -23,7 +23,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kepler-clusterrole-binding
-  namespace: monitoring
+  namespace: kepler
 roleRef:
   kind: ClusterRole
   name: kepler-clusterrole
@@ -31,19 +31,19 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kepler-sa
-  namespace: monitoring
+  namespace: kepler
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kepler-sa
-  namespace: monitoring
+  namespace: kepler
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kepler-exporter
-  namespace: monitoring
+  namespace: kepler
 spec:
   selector:
     matchLabels:
@@ -103,7 +103,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: kepler-exporter
-  namespace: monitoring
+  namespace: kepler
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kepler-exporter

--- a/manifests/openshift/kepler/00-kepler-scc.yaml
+++ b/manifests/openshift/kepler/00-kepler-scc.yaml
@@ -26,4 +26,4 @@ volumes:
   - emptyDir
   - hostPath
 users:
-  - system:serviceaccount:monitoring:kepler-sa # serviceaccount:namespace:sa
+  - system:serviceaccount:kepler:kepler-sa # serviceaccount:namespace:sa

--- a/manifests/openshift/kepler/01-kepler-install.yaml
+++ b/manifests/openshift/kepler/01-kepler-install.yaml
@@ -5,13 +5,13 @@ metadata:
   annotations:
     openshift.io/description: "Kepler exporter"
     openshift.io/display-name: ""
-  name: monitoring
+  name: kepler
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kepler-clusterrole
-  namespace: monitoring
+  namespace: kepler
 rules:
 - apiGroups: [""]
   resources:
@@ -27,7 +27,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kepler-clusterrole-binding
-  namespace: monitoring
+  namespace: kepler
 roleRef:
   kind: ClusterRole
   name: kepler-clusterrole
@@ -35,19 +35,19 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kepler-sa
-  namespace: monitoring
+  namespace: kepler
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kepler-sa
-  namespace: monitoring
+  namespace: kepler
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kepler-exporter
-  namespace: monitoring
+  namespace: kepler
 spec:
   selector:
     matchLabels:
@@ -123,7 +123,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: kepler-exporter
-  namespace: monitoring
+  namespace: kepler
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kepler-exporter


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR changes the kepler namespace from `monitoring` to its own namespace `kepler`.

When undeploying kepler using the `yml` file, it has the namespace definition. So just running `kubectl delete -f ${MANIFESTS_OUT_DIR}` will delete the `monitoring` namespace.
However, the `monitoring` namespace normally has other projects running like the prometheus stack and we shouldn't delete it when undeploying kepler...

#### Special notes for your reviewer:
Also, allowing kepler to have its own namespace has another advantage:
- Isolation. We don't need to worry about resource name collision.
- Permissions. Namespaces allow the use of Kubernetes RBAC specific to kepler only.
- Performance. The Kubernetes API will have fewer items to search for when performing operations, reducing latency and accelerating overall application performance. (even if we are not directly using the apiserver, the other projects in the monitoring namespace are using...)


Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>