### PR TITLE
s390x: build base image

### DIFF
--- a/.github/workflows/image-base.yml
+++ b/.github/workflows/image-base.yml
@@ -1,0 +1,38 @@
+name: base
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+            registry: quay.io/sustainable_computing_io
+            username: ${{ secrets.BOT_NAME }}
+            password: ${{ secrets.BOT_TOKEN }}
+      - name: Build and push amd64
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: {context}/build/Dockerfile.base
+          platforms: linux/amd64
+          push: true
+          tags: quay.io/sustainable_computing_io/kepler_base:latest-amd64
+      - name: Build and push s390x
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: {context}/build/Dockerfile.base.s390x
+          platforms: linux/s390x
+          push: true
+          tags: quay.io/sustainable_computing_io/kepler_base:latest-s390x

--- a/build/Dockerfile.base.s390x
+++ b/build/Dockerfile.base.s390x
@@ -1,0 +1,8 @@
+FROM --platform=linux/s390x registry.access.redhat.com/ubi8/ubi:8.4
+
+ARG ARCH=s390x
+
+RUN yum update -y && \
+    yum install -y https://rpmfind.net/linux/opensuse/distribution/leap/15.3/repo/oss/s390x/bcc-devel-0.19.0-1.1.s390x.rpm && \
+    yum install -y kmod xz python3 && yum clean all -y && \
+    pip3 install  --no-cache-dir archspec 


### PR DESCRIPTION
Build the amd64 and s390x base image, used separate Dockerfile.$arch file as it uses different packages to make it easy to maintain.

These base images will be used by kepler. We don't need a s390x builder as we can use the amd64 builder to build s390x images in future.

Signed-off-by: huoqifeng <huoqif@cn.ibm.com>