### PR TITLE
multi-arch: create kepler_base multi-arch image

### DIFF
--- a/.github/workflows/image-base.yml
+++ b/.github/workflows/image-base.yml
@@ -3,9 +3,7 @@ name: base
 on:
   push:
     branches: 
-      - 'main'
-    tags:
-      - 'v*'
+      - 'base'
 
 jobs:
   docker:
@@ -47,9 +45,4 @@ jobs:
           push: true
           tags: quay.io/sustainable_computing_io/kepler_base:latest-arm64
       - name: Create and upload multi-arch image
-        run: |
-            docker pull --platform=linux/s390x quay.io/sustainable_computing_io/kepler_base:latest-s390x
-            docker pull --platform=linux/amd64 quay.io/sustainable_computing_io/kepler_base:latest-amd64
-            docker manifest create quay.io/sustainable_computing_io/kepler_base:latest quay.io/sustainable_computing_io/kepler_base:latest-s390x quay.io/sustainable_computing_io/kepler_base:latest-amd64 quay.io/sustainable_computing_io/kepler_base:latest-arm64
-            docker manifest annotate --arch s390x quay.io/sustainable_computing_io/kepler_base:latest quay.io/sustainable_computing_io/kepler_base:latest-s390x
-            docker push quay.io/sustainable_computing_io/kepler_base:latest
+        run: make multi-arch-image-base

--- a/.github/workflows/image-base.yml
+++ b/.github/workflows/image-base.yml
@@ -2,7 +2,10 @@ name: base
 
 on:
   push:
-    branches: [ main ]
+    branches: 
+      - 'main'
+    tags:
+      - 'v*'
 
 jobs:
   docker:
@@ -24,7 +27,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: {context}/build/Dockerfile.base
+          file: ./build/Dockerfile.base
           platforms: linux/amd64
           push: true
           tags: quay.io/sustainable_computing_io/kepler_base:latest-amd64
@@ -32,7 +35,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: {context}/build/Dockerfile.base.s390x
+          file: ./build/Dockerfile.base.s390x
           platforms: linux/s390x
           push: true
           tags: quay.io/sustainable_computing_io/kepler_base:latest-s390x

--- a/.github/workflows/image-base.yml
+++ b/.github/workflows/image-base.yml
@@ -36,3 +36,10 @@ jobs:
           platforms: linux/s390x
           push: true
           tags: quay.io/sustainable_computing_io/kepler_base:latest-s390x
+      - name: Create and upload multi-arch image
+        run: |
+            docker pull --platform=linux/s390x quay.io/sustainable_computing_io/kepler_base:latest-s390x
+            docker pull --platform=linux/amd64 quay.io/sustainable_computing_io/kepler_base:latest-amd64
+            docker manifest create quay.io/sustainable_computing_io/kepler_base:latest quay.io/sustainable_computing_io/kepler_base:latest-s390x quay.io/sustainable_computing_io/kepler_base:latest-amd64
+            docker manifest annotate --arch s390x quay.io/sustainable_computing_io/kepler_base:latest quay.io/sustainable_computing_io/kepler_base:latest-s390x
+            docker push quay.io/sustainable_computing_io/kepler_base:latest

--- a/.github/workflows/image-base.yml
+++ b/.github/workflows/image-base.yml
@@ -39,10 +39,17 @@ jobs:
           platforms: linux/s390x
           push: true
           tags: quay.io/sustainable_computing_io/kepler_base:latest-s390x
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./build/Dockerfile.base.arm64
+          platforms: linux/arm64
+          push: true
+          tags: quay.io/sustainable_computing_io/kepler_base:latest-arm64
       - name: Create and upload multi-arch image
         run: |
             docker pull --platform=linux/s390x quay.io/sustainable_computing_io/kepler_base:latest-s390x
             docker pull --platform=linux/amd64 quay.io/sustainable_computing_io/kepler_base:latest-amd64
-            docker manifest create quay.io/sustainable_computing_io/kepler_base:latest quay.io/sustainable_computing_io/kepler_base:latest-s390x quay.io/sustainable_computing_io/kepler_base:latest-amd64
+            docker manifest create quay.io/sustainable_computing_io/kepler_base:latest quay.io/sustainable_computing_io/kepler_base:latest-s390x quay.io/sustainable_computing_io/kepler_base:latest-amd64 quay.io/sustainable_computing_io/kepler_base:latest-arm64
             docker manifest annotate --arch s390x quay.io/sustainable_computing_io/kepler_base:latest quay.io/sustainable_computing_io/kepler_base:latest-s390x
             docker push quay.io/sustainable_computing_io/kepler_base:latest

--- a/Makefile
+++ b/Makefile
@@ -111,11 +111,11 @@ push-image:
 .PHONY: push-image
 
 multi-arch-image-base:	
-	docker pull --platform=linux/s390x quay.io/sustainable_computing_io/kepler_base:latest-s390x; \
-	docker pull --platform=linux/amd64 quay.io/sustainable_computing_io/kepler_base:latest-amd64; \
-	docker manifest create quay.io/sustainable_computing_io/kepler_base:latest quay.io/sustainable_computing_io/kepler_base:latest-s390x quay.io/sustainable_computing_io/kepler_base:latest-amd64 quay.io/sustainable_computing_io/kepler_base:latest-arm64; \
-	docker manifest annotate --arch s390x quay.io/sustainable_computing_io/kepler_base:latest quay.io/sustainable_computing_io/kepler_base:latest-s390x; \
-	docker push quay.io/sustainable_computing_io/kepler_base:latest
+	$(CTR_CMD) pull --platform=linux/s390x quay.io/sustainable_computing_io/kepler_base:latest-s390x; \
+	$(CTR_CMD) pull --platform=linux/amd64 quay.io/sustainable_computing_io/kepler_base:latest-amd64; \
+	$(CTR_CMD) manifest create quay.io/sustainable_computing_io/kepler_base:latest quay.io/sustainable_computing_io/kepler_base:latest-s390x quay.io/sustainable_computing_io/kepler_base:latest-amd64 quay.io/sustainable_computing_io/kepler_base:latest-arm64; \
+	$(CTR_CMD) manifest annotate --arch s390x quay.io/sustainable_computing_io/kepler_base:latest quay.io/sustainable_computing_io/kepler_base:latest-s390x; \
+	$(CTR_CMD) push quay.io/sustainable_computing_io/kepler_base:latest
 .PHONY: multi-arch-image-base
 
 # for testsuite

--- a/Makefile
+++ b/Makefile
@@ -110,12 +110,12 @@ push-image:
 	$(CTR_CMD) push $(IMAGE_REPO):$(IMAGE_TAG)
 .PHONY: push-image
 
-multi-arch-image-base:
-    docker pull --platform=linux/s390x quay.io/sustainable_computing_io/kepler_base:latest-s390x
-    docker pull --platform=linux/amd64 quay.io/sustainable_computing_io/kepler_base:latest-amd64
-    docker manifest create quay.io/sustainable_computing_io/kepler_base:latest quay.io/sustainable_computing_io/kepler_base:latest-s390x quay.io/sustainable_computing_io/kepler_base:latest-amd64 quay.io/sustainable_computing_io/kepler_base:latest-arm64
-    docker manifest annotate --arch s390x quay.io/sustainable_computing_io/kepler_base:latest quay.io/sustainable_computing_io/kepler_base:latest-s390x
-    docker push quay.io/sustainable_computing_io/kepler_base:latest
+multi-arch-image-base:	
+	docker pull --platform=linux/s390x quay.io/sustainable_computing_io/kepler_base:latest-s390x; \
+	docker pull --platform=linux/amd64 quay.io/sustainable_computing_io/kepler_base:latest-amd64; \
+	docker manifest create quay.io/sustainable_computing_io/kepler_base:latest quay.io/sustainable_computing_io/kepler_base:latest-s390x quay.io/sustainable_computing_io/kepler_base:latest-amd64 quay.io/sustainable_computing_io/kepler_base:latest-arm64; \
+	docker manifest annotate --arch s390x quay.io/sustainable_computing_io/kepler_base:latest quay.io/sustainable_computing_io/kepler_base:latest-s390x; \
+	docker push quay.io/sustainable_computing_io/kepler_base:latest
 .PHONY: multi-arch-image-base
 
 # for testsuite

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,14 @@ push-image:
 	$(CTR_CMD) push $(IMAGE_REPO):$(IMAGE_TAG)
 .PHONY: push-image
 
+multi-arch-image-base:
+    docker pull --platform=linux/s390x quay.io/sustainable_computing_io/kepler_base:latest-s390x
+    docker pull --platform=linux/amd64 quay.io/sustainable_computing_io/kepler_base:latest-amd64
+    docker manifest create quay.io/sustainable_computing_io/kepler_base:latest quay.io/sustainable_computing_io/kepler_base:latest-s390x quay.io/sustainable_computing_io/kepler_base:latest-amd64 quay.io/sustainable_computing_io/kepler_base:latest-arm64
+    docker manifest annotate --arch s390x quay.io/sustainable_computing_io/kepler_base:latest quay.io/sustainable_computing_io/kepler_base:latest-s390x
+    docker push quay.io/sustainable_computing_io/kepler_base:latest
+.PHONY: multi-arch-image-base
+
 # for testsuite
 PWD=$(shell pwd)
 ENVTEST_ASSETS_DIR=./test-bin

--- a/build/Dockerfile.base.arm64
+++ b/build/Dockerfile.base.arm64
@@ -1,0 +1,7 @@
+FROM --platform=linux/arm64 registry.access.redhat.com/ubi8/ubi:8.4
+
+ARG ARCH=arm64
+
+RUN yum update -y && \
+    yum install -y kmod xz python3 && yum clean all -y && \
+    pip3 install  --no-cache-dir archspec 


### PR DESCRIPTION
- Cross-platform `kepler_base` image comes from different Dockerfile for different `arch` for maintain purpose. 
- It's a nightmare to maintain all arches in a single `Docekerfile`, so we build arch specific images first and then create a manifest then.
- arm64 base image is just a base, some necessary RPM might be needed in future
- Trigger it when there is a tag generated.

Signed-off-by: huoqifeng <huoqif@cn.ibm.com>