### PR TITLE
acpi power sensordon't continue if the power meter doesn't exist

### DIFF
--- a/pkg/power/acpi/acpi.go
+++ b/pkg/power/acpi/acpi.go
@@ -174,14 +174,14 @@ func getPowerFromSensor() (map[string]float64, error) {
 		path := fmt.Sprintf(powerPath, i)
 		data, err := os.ReadFile(path)
 		if err != nil {
-			return power, err
+			break
 		}
 		// currPower is in microWatt
 		currPower, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
 		if err == nil {
 			power[fmt.Sprintf("%s%d", sensorIDPrefix, i)] = float64(currPower) / 1000 /*miliWatts*/
 		} else {
-			log.Fatal(err)
+			return power, err
 		}
 	}
 


### PR DESCRIPTION
fix the regression in https://github.com/sustainable-computing-io/kepler/commit/75f60857a022410fb03f6488c6a137527cae785f#diff-01d4e5e0e8a39b2a514a24ebfd7524d6d692272ef2c75a615bd7435f1b097931L177