### PR TITLE
Add support to deploy prometheus operator via make cluster-up

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -16,25 +16,23 @@ jobs:
       - uses: actions/setup-go@main
         with:
           go-version: 1.18
+          
       - name: install kubectl
         run: curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+
       - name: start local k8s cluster
         run: make cluster-up
         env:
             CLUSTER_PROVIDER: ${{matrix.kube_provider}}
-      - name: Checkout kube-operator repo
-        uses: actions/checkout@v3
-        with:
-          repository: prometheus-operator/kube-prometheus
-          path: kube-prometheus
-      - name: deploy kube operator
-        run:  ls && kubectl create -f manifests/setup && until kubectl get servicemonitors --all-namespaces ; do date; sleep 1; echo ""; done && kubectl create -f manifests/
-        working-directory: kube-prometheus
+            PROMETHEUS_ENABLE: "true"
+            GRAFANA_ENABLE: "false"
+
       - name: simple test - deploy kepler
         run: make cluster-sync
         env:
             CLUSTER_PROVIDER: ${{matrix.kube_provider}}
             CTR_CMD: docker
+
       - name: Login to Quay
         if: github.event_name == 'push'
         uses: docker/login-action@v1


### PR DESCRIPTION
#### What this PR does / why we need it:
The current integration test tries to deploy the prometheus operator, but it doesn't work because the cluster doesn't have the docker images.
We don't see errors in the test because the test is not verifying if all containers were created successfully....

To deploy the prometheus operator on the kind cluster, we need to load the images into the cluster.

This PR adds that logic and wait all containers to be ready.
Also, I applied logic to deploy the minimum version of the prometheus operator to speed up the test execution.

After this PR anyone can create a kind cluster with prometheus using:
```
CLUSTER_PROVIDER="kind" PROMETHEUS_ENABLE="true" cluster-up
```

#### Special notes for your reviewer:
I don't think pushed a new image to quay should be part of an integration test.
We need to fix this in another PR.


Signed-off-by: Marcelo Amaral [marcelo.amaral1@ibm.com](mailto:marcelo.amaral1@ibm.com)