### PR TITLE
Update log lib to klog to enable log verbosity support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/prometheus/common v0.37.0
 	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261
 	k8s.io/api v0.25.0
+	k8s.io/klog/v2 v2.70.1
 )
 
 require (
@@ -38,7 +39,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apimachinery v0.25.0 // indirect
-	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect

--- a/manifests/kubernetes/deployment.yaml
+++ b/manifests/kubernetes/deployment.yaml
@@ -69,6 +69,7 @@ spec:
         - 0.0.0.0:9102
         - -enable-gpu=true
         - -enable-cgroup-id=true
+        - -v=1
         ports:
         - containerPort: 9102
           hostPort: 9102

--- a/pkg/attacher/bcc_attacher.go
+++ b/pkg/attacher/bcc_attacher.go
@@ -31,6 +31,8 @@ import (
 	"github.com/sustainable-computing-io/kepler/pkg/model"
 
 	bpf "github.com/iovisor/gobpf/bcc"
+
+	"k8s.io/klog/v2"
 )
 
 type perfCounter struct {
@@ -81,7 +83,7 @@ func loadModule(objProg []byte, options []string) (*bpf.Module, error) {
 		perfErr := openPerfEvent(t, counter.evType, counter.evConfig)
 		if perfErr != nil {
 			// some hypervisors don't expose perf counters
-			fmt.Printf("failed to attach perf event %s: %v\n", arrayName, perfErr)
+			klog.Infof("failed to attach perf event %s: %v\n", arrayName, perfErr)
 			counter.enabled = false
 			// if perf counters are not available, it is likely running on a VM
 			model.SetVMCoeff()
@@ -106,12 +108,12 @@ func AttachBPFAssets() (*BpfModuleTables, error) {
 	}
 	m, err := loadModule(objProg, options)
 	if err != nil {
-		fmt.Printf("failed to attach perf module with options %v: %v\n", options, err)
+		klog.Infof("failed to attach perf module with options %v: %v\n", options, err)
 		options = []string{"-DNUM_CPUS=" + strconv.Itoa(runtime.NumCPU())}
 		EnableCPUFreq = false
 		m, err = loadModule(objProg, options)
 		if err != nil {
-			fmt.Printf("failed to attach perf module with options %v: %v\n", options, err)
+			klog.Infof("failed to attach perf module with options %v: %v\n", options, err)
 			// at this time, there is not much we can do with the eBPF module
 			return nil, err
 		}

--- a/pkg/bpfassets/perf_event_bindata.go
+++ b/pkg/bpfassets/perf_event_bindata.go
@@ -45,7 +45,7 @@ func (fi bindataFileInfo) Sys() interface{} {
 	return nil
 }
 
-var _bpf_assetsPerf_eventPerf_eventC = []byte(`/*
+var _bpfassetsPerf_eventPerf_eventC = []byte(`/*
 Copyright 2021.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -235,12 +235,12 @@ int sched_switch(switch_args *ctx)
 }
 `)
 
-func bpf_assetsPerf_eventPerf_eventCBytes() ([]byte, error) {
-	return _bpf_assetsPerf_eventPerf_eventC, nil
+func bpfassetsPerf_eventPerf_eventCBytes() ([]byte, error) {
+	return _bpfassetsPerf_eventPerf_eventC, nil
 }
 
-func bpf_assetsPerf_eventPerf_eventC() (*asset, error) {
-	bytes, err := bpf_assetsPerf_eventPerf_eventCBytes()
+func bpfassetsPerf_eventPerf_eventC() (*asset, error) {
+	bytes, err := bpfassetsPerf_eventPerf_eventCBytes()
 	if err != nil {
 		return nil, err
 	}
@@ -302,7 +302,7 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"bpfassets/perf_event/perf_event.c": bpf_assetsPerf_eventPerf_eventC,
+	"bpfassets/perf_event/perf_event.c": bpfassetsPerf_eventPerf_eventC,
 }
 
 // AssetDir returns the file names below a certain
@@ -348,7 +348,7 @@ type bintree struct {
 var _bintree = &bintree{nil, map[string]*bintree{
 	"bpfassets": {nil, map[string]*bintree{
 		"perf_event": {nil, map[string]*bintree{
-			"perf_event.c": {bpf_assetsPerf_eventPerf_eventC, map[string]*bintree{}},
+			"perf_event.c": {bpfassetsPerf_eventPerf_eventC, map[string]*bintree{}},
 		}},
 	}},
 }}

--- a/pkg/cgroup/slice_handler.go
+++ b/pkg/cgroup/slice_handler.go
@@ -26,10 +26,11 @@ This file is a main file of cgroup module containing
 package cgroup
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -112,7 +113,7 @@ func InitSliceHandler() *SliceHandler {
 		}
 	}
 	handler.Init()
-	log.Printf("InitSliceHandler: %v", handler)
+	klog.V(3).Infof("InitSliceHandler: %v", handler)
 	return handler
 }
 

--- a/pkg/collector/metrics.go
+++ b/pkg/collector/metrics.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sustainable-computing-io/kepler/pkg/model"
 	"github.com/sustainable-computing-io/kepler/pkg/podlister"
 
-	"log"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -59,9 +59,9 @@ func getUIntFeatures() []string {
 	// kubelet metric
 	metrics = append(metrics, availableKubeletMetrics...)
 	metrics = append(metrics, iostatMetrics...)
-	log.Printf("Available counter metrics: %v", availableCounters)
-	log.Printf("Available cgroup metrics: %v", availableCgroupMetrics)
-	log.Printf("Available kubelet metrics: %v", availableKubeletMetrics)
+	klog.V(3).Infof("Available counter metrics: %v", availableCounters)
+	klog.V(3).Infof("Available cgroup metrics: %v", availableCgroupMetrics)
+	klog.V(3).Infof("Available kubelet metrics: %v", availableKubeletMetrics)
 	return metrics
 }
 

--- a/pkg/collector/node_energy.go
+++ b/pkg/collector/node_energy.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 
 	"github.com/sustainable-computing-io/kepler/pkg/power/rapl/source"
+	"k8s.io/klog/v2"
 )
 
 var (
@@ -80,7 +81,6 @@ func (v *NodeEnergy) ResetCurr() {
 }
 
 func (v *NodeEnergy) SetValues(sensorEnergy map[string]float64, pkgEnergy map[int]source.PackageEnergy, totalGPUDelta uint64, usage map[string]float64) {
-	fmt.Printf("%v %v\n", sensorEnergy, pkgEnergy)
 	for sensorID, energy := range sensorEnergy {
 		v.SensorEnergy.AddStat(sensorID, uint64(energy))
 	}
@@ -92,7 +92,7 @@ func (v *NodeEnergy) SetValues(sensorEnergy map[string]float64, pkgEnergy map[in
 		v.EnergyInPkg.AddStat(key, energy.Pkg)
 	}
 	v.EnergyInGPU = totalGPUDelta
-	fmt.Printf("node energy stat core %v dram %v uncore %v pkg %v gpu %v sensor %v\n", v.EnergyInCore, v.EnergyInDRAM, v.EnergyInUncore, v.EnergyInPkg, v.EnergyInGPU, v.SensorEnergy)
+	klog.V(3).Infof("node energy stat core %v dram %v uncore %v pkg %v gpu %v sensor %v\n", v.EnergyInCore, v.EnergyInDRAM, v.EnergyInUncore, v.EnergyInPkg, v.EnergyInGPU, v.SensorEnergy)
 	totalSensorDelta := v.SensorEnergy.Curr()
 	totalPkgDelta := v.EnergyInPkg.Curr()
 	if totalSensorDelta > (totalPkgDelta + totalGPUDelta) {

--- a/pkg/collector/pod_energy.go
+++ b/pkg/collector/pod_energy.go
@@ -18,10 +18,10 @@ package collector
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 
 	"github.com/sustainable-computing-io/kepler/pkg/attacher"
+	"k8s.io/klog/v2"
 )
 
 type PodEnergy struct {
@@ -156,7 +156,7 @@ func (v *PodEnergy) extractUIntCurrAggr(metric string) (curr, aggr uint64) {
 		return v.BytesWrite.Curr(), v.BytesWrite.Aggr()
 	}
 
-	log.Printf("cannot extract: %s", metric)
+	klog.V(4).Infof("cannot extract: %s", metric)
 	return 0, 0
 }
 

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -2,8 +2,9 @@ package collector
 
 import (
 	"fmt"
-	"log"
 	"math"
+
+	"k8s.io/klog/v2"
 )
 
 type UInt64Stat struct {
@@ -62,7 +63,7 @@ func (s *UInt64StatCollection) AddStat(key string, newAggr uint64) {
 		s.Stat[key] = &UInt64Stat{}
 	}
 	if err := s.Stat[key].SetNewAggr(newAggr); err != nil {
-		log.Println(err)
+		klog.V(3).Infoln(err)
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 
 	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -58,12 +59,12 @@ var (
 
 // EnableEBPFCgroupID enables the eBPF code to collect cgroup id if the system has kernel version > 4.18
 func EnableEBPFCgroupID(enabled bool) {
-	fmt.Println("config EnabledEBPFCgroupID enabled: ", enabled)
-	fmt.Println("config getKernelVersion: ", getKernelVersion(c))
+	klog.V(1).Infoln("config EnabledEBPFCgroupID enabled: ", enabled)
+	klog.V(1).Infoln("config getKernelVersion: ", getKernelVersion(c))
 	if (enabled) && (getKernelVersion(c) >= cGroupIDMinKernelVersion) && (isCGroupV2(c)) {
 		EnabledEBPFCgroupID = true
 	}
-	fmt.Println("config set EnabledEBPFCgroupID to ", EnabledEBPFCgroupID)
+	klog.V(1).Infoln("config set EnabledEBPFCgroupID to ", EnabledEBPFCgroupID)
 }
 
 func (c config) getUnixName() (unix.Utsname, error) {
@@ -80,7 +81,7 @@ func getKernelVersion(c Client) float32 {
 	utsname, err := c.getUnixName()
 
 	if err != nil {
-		fmt.Println("Failed to parse unix name")
+		klog.V(4).Infoln("Failed to parse unix name")
 		return -1
 	}
 	// per https://github.com/google/cadvisor/blob/master/machine/info.go#L164
@@ -88,24 +89,24 @@ func getKernelVersion(c Client) float32 {
 
 	versionParts := versionRegex.FindStringSubmatch(string(kv))
 	if len(versionParts) < 2 {
-		fmt.Printf("got invalid release version %q (expected format '4.3-1 or 4.3.2-1')\n", kv)
+		klog.V(1).Infof("got invalid release version %q (expected format '4.3-1 or 4.3.2-1')\n", kv)
 		return -1
 	}
 	major, err := strconv.Atoi(versionParts[1])
 	if err != nil {
-		fmt.Printf("got invalid release major version %q\n", major)
+		klog.V(1).Infof("got invalid release major version %q\n", major)
 		return -1
 	}
 
 	minor, err := strconv.Atoi(versionParts[2])
 	if err != nil {
-		fmt.Printf("got invalid release minor version %q\n", minor)
+		klog.V(1).Infof("got invalid release minor version %q\n", minor)
 		return -1
 	}
 
 	v, err := strconv.ParseFloat(fmt.Sprintf("%d.%d", major, minor), 32)
 	if err != nil {
-		fmt.Printf("parse %d.%d got issue: %v", major, minor, err)
+		klog.V(1).Infof("parse %d.%d got issue: %v", major, minor, err)
 		return -1
 	}
 	return float32(v)

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -21,7 +21,6 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"math"
 	"net/http"
@@ -29,6 +28,7 @@ import (
 	"time"
 
 	"github.com/sustainable-computing-io/kepler/pkg/power/rapl/source"
+	"k8s.io/klog/v2"
 
 	"github.com/jszwec/csvutil"
 )
@@ -146,7 +146,7 @@ func SetBMCoeff() {
 						break
 					}
 					if p.Architecture == cpuArch {
-						fmt.Printf("use model %v\n", p)
+						klog.V(3).Infof("use model %v\n", p)
 						RunTimeCoeff = p
 					}
 				}

--- a/pkg/podlister/resolve_container.go
+++ b/pkg/podlister/resolve_container.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
 
 	"github.com/sustainable-computing-io/kepler/pkg/config"
 )
@@ -131,7 +132,7 @@ func getContainerInfo(cGroupID, pid uint64) (*ContainerInfo, error) {
 func updateListPodCache(targetContainerID string, stopWhenFound bool) {
 	pods, err := podLister.ListPods()
 	if err != nil {
-		fmt.Printf("%v", err)
+		klog.V(4).Infof("%v", err)
 		return
 	}
 	for i := 0; i < len(*pods); i++ {

--- a/pkg/power/acpi/acpi.go
+++ b/pkg/power/acpi/acpi.go
@@ -18,13 +18,14 @@ package acpi
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -87,7 +88,7 @@ func (a *ACPI) Run() {
 						}
 						a.mu.Unlock()
 					} else {
-						log.Fatal(err)
+						klog.Fatal(err)
 					}
 				}
 
@@ -114,7 +115,7 @@ func (a *ACPI) GetCPUCoreFrequency() map[int32]uint64 {
 func getCPUCoreFrequency() map[int32]uint64 {
 	files, err := os.ReadDir(freqPathDir)
 	if err != nil {
-		log.Fatal(err)
+		klog.Fatal(err)
 	}
 
 	ch := make(chan []uint64)
@@ -141,7 +142,7 @@ func getCPUCoreFrequency() map[int32]uint64 {
 				cpuCoreFrequency[int32(val[0])] = val[1]
 			}
 		case <-time.After(1 * time.Minute):
-			log.Println("timeout reading cpu core frequency files")
+			klog.V(1).Infoln("timeout reading cpu core frequency files")
 		}
 	}
 

--- a/pkg/power/gpu/gpu_nvml.go
+++ b/pkg/power/gpu/gpu_nvml.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"k8s.io/klog/v2"
 )
 
 var (
@@ -40,7 +41,7 @@ func Init() error {
 		nvml.Shutdown()
 		return fmt.Errorf("failed to get nvml device count: %v", nvml.ErrorString(ret))
 	}
-	fmt.Printf("found %d gpu devices\n", count)
+	klog.V(1).Infof("found %d gpu devices\n", count)
 	devices = make([]nvml.Device, count)
 	for i := 0; i < count; i++ {
 		device, ret := nvml.DeviceGetHandleByIndex(i)
@@ -62,7 +63,7 @@ func GetGpuEnergy() []uint32 {
 	for i, device := range devices {
 		power, ret := device.GetPowerUsage()
 		if ret != nvml.SUCCESS {
-			fmt.Printf("failed to get power usage on device %v: %v\n", device, nvml.ErrorString(ret))
+			klog.V(2).Infof("failed to get power usage on device %v: %v\n", device, nvml.ErrorString(ret))
 			continue
 		}
 		e[i] = power
@@ -76,12 +77,12 @@ func GetCurrGpuEnergyPerPid() (map[uint32]float64, error) {
 	for _, device := range devices {
 		power, ret := device.GetPowerUsage()
 		if ret != nvml.SUCCESS {
-			fmt.Printf("failed to get power usage on device %v: %v\n", device, nvml.ErrorString(ret))
+			klog.V(2).Infof("failed to get power usage on device %v: %v\n", device, nvml.ErrorString(ret))
 			continue
 		}
 		pids, ret := device.GetComputeRunningProcesses()
 		if ret != nvml.SUCCESS {
-			fmt.Printf("failed to get compute processes on device %v: %v", device, nvml.ErrorString(ret))
+			klog.V(2).Infof("failed to get compute processes on device %v: %v", device, nvml.ErrorString(ret))
 			continue
 		}
 		totalMem := uint64(0)
@@ -94,7 +95,7 @@ func GetCurrGpuEnergyPerPid() (map[uint32]float64, error) {
 		}
 		// use per pid used memory/total used memory to estimate per pid energy
 		for _, p := range pm {
-			fmt.Printf("pid %v power %v total mem %v mem %v\n", p.pid, power, totalMem, p.mem)
+			klog.V(5).Infof("pid %v power %v total mem %v mem %v\n", p.pid, power, totalMem, p.mem)
 			m[p.pid] = float64(uint64(power) * p.mem / totalMem)
 		}
 	}

--- a/pkg/power/rapl/power.go
+++ b/pkg/power/rapl/power.go
@@ -17,7 +17,7 @@ limitations under the License.
 package rapl
 
 import (
-	"fmt"
+	"k8s.io/klog/v2"
 
 	"github.com/sustainable-computing-io/kepler/pkg/power/rapl/source"
 )
@@ -48,18 +48,18 @@ var (
 
 func init() {
 	if sysfsImpl.IsSupported() /*&& false*/ {
-		fmt.Println("use sysfs to obtain power")
+		klog.V(1).Infoln("use sysfs to obtain power")
 		powerImpl = sysfsImpl
 	} else {
 		if msrImpl.IsSupported() && useMSR {
-			fmt.Println("use MSR to obtain power")
+			klog.V(1).Infoln("use MSR to obtain power")
 			powerImpl = msrImpl
 		} else {
 			if estimateImpl.IsSupported() {
-				fmt.Println("use power estimate to obtain power")
+				klog.V(1).Infoln("use power estimate to obtain power")
 				powerImpl = estimateImpl
 			} else {
-				fmt.Println("power not supported")
+				klog.V(1).Infoln("power not supported")
 				powerImpl = dummyImpl
 			}
 		}

--- a/pkg/power/rapl/source/estimate.go
+++ b/pkg/power/rapl/source/estimate.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/jszwec/csvutil"
+	"k8s.io/klog/v2"
 )
 
 type PowerEstimate struct{}
@@ -127,17 +128,17 @@ func getCPUPowerEstimate(cpu string) (perThreadMinPowerEstimate, perThreadMaxPow
 func (r *PowerEstimate) IsSupported() bool {
 	cpu, err := GetCPUArchitecture()
 	if err != nil {
-		fmt.Printf("no cpu info: %v\n", err)
+		klog.V(2).Infof("no cpu info: %v\n", err)
 		return false
 	}
 	dramInGB, err = getDram()
 	if err != nil {
-		fmt.Printf("no dram info: %v\n", err)
+		klog.V(2).Infof("no dram info: %v\n", err)
 		return false
 	}
 	perThreadMinPowerEstimate, perThreadMaxPowerEstimate, perGBPowerEstimate, err = getCPUPowerEstimate(cpu)
 	startTime = time.Now()
-	fmt.Printf("cpu architecture %v, dram in GB %v\n", cpu, dramInGB)
+	klog.V(4).Infof("cpu architecture %v, dram in GB %v\n", cpu, dramInGB)
 	return err == nil
 }
 

--- a/pkg/power/rapl/source/sysfs.go
+++ b/pkg/power/rapl/source/sysfs.go
@@ -18,10 +18,11 @@ package source
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 	"strings"
+
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -76,11 +77,11 @@ func readEventEnergy(eventName string) map[string]uint64 {
 			var data []byte
 
 			if data, err = os.ReadFile(path + energyFile); err != nil {
-				log.Println(err)
+				klog.V(3).Infoln(err)
 				continue
 			}
 			if e, err = strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64); err != nil {
-				log.Println(err)
+				klog.V(3).Infoln(err)
 				continue
 			}
 			e /= 1000 /*mJ*/

--- a/pkg/power/rapl/source/sysfs_util.go
+++ b/pkg/power/rapl/source/sysfs_util.go
@@ -21,12 +21,14 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"k8s.io/klog/v2"
 )
 
 func getNumCPUs() int {
 	data, err := os.ReadFile(cpuInfoPath)
 	if err != nil {
-		fmt.Println(err)
+		klog.V(2).Infoln(err)
 	}
 	return strings.Count(string(data), "processor")
 }


### PR DESCRIPTION
There are a lot of prints currently in the code generating a lot of log data.
To fix this, we must use a different log verbosity.

Also, as indicated in #212, we should standardize the use of fmt and log prints to just one way.

This PR is moving all prints from fmt or log to klog.

Klog was developed by the Kubernetes community and has some advantages over glog as described [here](https://pkg.go.dev/k8s.io/klog).


Signed by: Marcelo Amaral <marcelo.amaral1@ibm.com>