### PR TITLE
Remove the dram energy from the host other components energy consumption

### DIFF
--- a/pkg/collector/node_energy.go
+++ b/pkg/collector/node_energy.go
@@ -95,8 +95,9 @@ func (v *NodeEnergy) SetValues(sensorEnergy map[string]float64, pkgEnergy map[in
 	fmt.Printf("node energy stat core %v dram %v uncore %v pkg %v gpu %v sensor %v\n", v.EnergyInCore, v.EnergyInDRAM, v.EnergyInUncore, v.EnergyInPkg, v.EnergyInGPU, v.SensorEnergy)
 	totalSensorDelta := v.SensorEnergy.Curr()
 	totalPkgDelta := v.EnergyInPkg.Curr()
+	totalDramDelta := v.EnergyInDRAM.Curr()
 	if totalSensorDelta > (totalPkgDelta + totalGPUDelta) {
-		v.EnergyInOther = totalSensorDelta - (totalPkgDelta + totalGPUDelta)
+		v.EnergyInOther = totalSensorDelta - (totalPkgDelta + totalGPUDelta + totalDramDelta)
 	}
 	v.Usage = usage
 }


### PR DESCRIPTION
Power consumption of other host components is related to node cooling system, power supply, bus connection, etc, except RAPL (CPU Package and DRAM) and GPU power consumption.

Signed by: Marcelo Amaral <marcelo.amaral1@ibm.com>