### PR TITLE
mount host /proc in the kind cluster to resolve pod name

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -165,6 +165,11 @@ function _prepare_config() {
     cp $KIND_MANIFESTS_DIR/local-registry.yml ${CONFIG_OUT_DIR}/local-registry.yml
     sed -i -e "s/$_registry_name/${REGISTRY_NAME}/g" ${CONFIG_OUT_DIR}/local-registry.yml
     sed -i -e "s/$_registry_port/${REGISTRY_PORT}/g" ${CONFIG_OUT_DIR}/local-registry.yml
+
+    # make cluster-sync overwrite the CONFIG_OUT_DIR, so that we update the manifest dir directly.
+    # TODO: configure the kepler yaml in the CONFIG_OUT_DIR, not in the MANIFEST DIR.
+    echo "WARN: we are changing the file manifests/kubernetes/deployment.yaml"
+    sed -i -e "s/path: \/proc/path: \/proc-host/g" manifests/kubernetes/deployment.yaml
 }
 
 function _get_nodes() {

--- a/cluster-up/cluster/kind/manifests/kind.yml
+++ b/cluster-up/cluster/kind/manifests/kind.yml
@@ -8,3 +8,6 @@ containerdConfigPatches:
     endpoint = ["http://kind-registry:5000"]
 nodes:
   - role: control-plane
+    extraMounts:
+      - hostPath: /proc
+        containerPath: /proc-host


### PR DESCRIPTION
#### Why do we need this PR:
On my Kind cluster, some pod names weren't being resolved
Actually the errors were related to no read access to `/proc/pid`

This is because when we create a `kind` cluster, the host directory `/proc` is not mounted in the `kind` worker node container

#### What this PR does:

We mount the host directory `/proc` in the kind container as `/proc-host`
Unfortunately, we can't use the same directory name `/proc` -> `/proc`
So since the host proc directory has a different name, we also updated the kepler manifest to mount the correct directory

Signed by: Marcelo Amaral <marcelo.amaral1@ibm.com>