### PR TITLE
Refactor the PackageEnergy to RAPLEnergy

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -445,7 +445,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		ch <- metric
 	}
 
-	// collect energy per package by RAPL mJ
+	// collect energy per RAPL components in mJ
 	for pkgID, energy := range pkgEnergy {
 		desc := c.getPackageEnergyDescription()
 		coreEnergy := strconv.FormatUint(energy.Core, 10)

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Test Collector Unit", func() {
 		sensorEnergy = map[string]float64{
 			"sensor0": sampleNodeEnergy,
 		}
-		pkgEnergy = map[int]source.PackageEnergy{
+		pkgEnergy = map[int]source.RAPLEnergy{
 			0: {
 				Pkg: samplePkgEnergy,
 			},
@@ -106,7 +106,7 @@ var _ = Describe("Test Collector Unit", func() {
 		sensorEnergy = map[string]float64{
 			"sensor0": sampleNodeEnergy * 2,
 		}
-		pkgEnergy = map[int]source.PackageEnergy{
+		pkgEnergy = map[int]source.RAPLEnergy{
 			0: {
 				Pkg: samplePkgEnergy * 2,
 			},

--- a/pkg/collector/node_energy.go
+++ b/pkg/collector/node_energy.go
@@ -80,7 +80,7 @@ func (v *NodeEnergy) ResetCurr() {
 	v.SensorEnergy.ResetCurr()
 }
 
-func (v *NodeEnergy) SetValues(sensorEnergy map[string]float64, pkgEnergy map[int]source.PackageEnergy, totalGPUDelta uint64, usage map[string]float64) {
+func (v *NodeEnergy) SetValues(sensorEnergy map[string]float64, pkgEnergy map[int]source.RAPLEnergy, totalGPUDelta uint64, usage map[string]float64) {
 	for sensorID, energy := range sensorEnergy {
 		v.SensorEnergy.AddStat(sensorID, uint64(energy))
 	}

--- a/pkg/collector/reader.go
+++ b/pkg/collector/reader.go
@@ -59,7 +59,7 @@ const (
 var (
 	// latest read energy
 	sensorEnergy = map[string]float64{}
-	pkgEnergy    = map[int]source.PackageEnergy{}
+	pkgEnergy    = map[int]source.RAPLEnergy{}
 	// latest process energy
 	podEnergy  = map[string]*PodEnergy{}
 	nodeEnergy = NewNodeEnergy()
@@ -76,7 +76,7 @@ var (
 // readEnergy reads sensor/pkg energies in mJ
 func (c *Collector) readEnergy() {
 	sensorEnergy, _ = acpiPowerMeter.GetEnergyFromHost()
-	pkgEnergy = rapl.GetPackageEnergy()
+	pkgEnergy = rapl.GetRAPLEnergy()
 }
 
 // resetCurrValue reset existing podEnergy previous curr value

--- a/pkg/power/rapl/power.go
+++ b/pkg/power/rapl/power.go
@@ -31,8 +31,8 @@ type powerInterface interface {
 	GetEnergyFromUncore() (uint64, error)
 	// GetEnergyFromDram returns mJ in package
 	GetEnergyFromPackage() (uint64, error)
-	// GetPackageEnergy returns set of mJ per package
-	GetPackageEnergy() map[int]source.PackageEnergy
+	// GetRAPLEnergy returns set of mJ per RAPL components
+	GetRAPLEnergy() map[int]source.RAPLEnergy
 	StopPower()
 	IsSupported() bool
 }
@@ -82,8 +82,8 @@ func GetEnergyFromPackage() (uint64, error) {
 	return powerImpl.GetEnergyFromPackage()
 }
 
-func GetPackageEnergy() map[int]source.PackageEnergy {
-	return powerImpl.GetPackageEnergy()
+func GetRAPLEnergy() map[int]source.RAPLEnergy {
+	return powerImpl.GetRAPLEnergy()
 }
 
 func StopPower() {

--- a/pkg/power/rapl/source/dummy.go
+++ b/pkg/power/rapl/source/dummy.go
@@ -41,6 +41,6 @@ func (r *PowerDummy) GetEnergyFromPackage() (uint64, error) {
 	return 0, nil
 }
 
-func (r *PowerDummy) GetPackageEnergy() map[int]PackageEnergy {
-	return map[int]PackageEnergy{}
+func (r *PowerDummy) GetRAPLEnergy() map[int]RAPLEnergy {
+	return map[int]RAPLEnergy{}
 }

--- a/pkg/power/rapl/source/estimate.go
+++ b/pkg/power/rapl/source/estimate.go
@@ -170,11 +170,11 @@ func (r *PowerEstimate) GetEnergyFromPackage() (uint64, error) {
 }
 
 // No package information, consider as 1 package
-func (r *PowerEstimate) GetPackageEnergy() map[int]PackageEnergy {
+func (r *PowerEstimate) GetRAPLEnergy() map[int]RAPLEnergy {
 	coreEnergy, _ := r.GetEnergyFromCore()
 	dramEnergy, _ := r.GetEnergyFromDram()
-	packageEnergies := make(map[int]PackageEnergy)
-	packageEnergies[0] = PackageEnergy{
+	packageEnergies := make(map[int]RAPLEnergy)
+	packageEnergies[0] = RAPLEnergy{
 		Core:   coreEnergy,
 		DRAM:   dramEnergy,
 		Uncore: 0,

--- a/pkg/power/rapl/source/msr.go
+++ b/pkg/power/rapl/source/msr.go
@@ -38,8 +38,8 @@ func (r *PowerMSR) GetEnergyFromPackage() (uint64, error) {
 	return ReadAllPower(ReadPkgPower)
 }
 
-func (r *PowerMSR) GetPackageEnergy() map[int]PackageEnergy {
-	return GetPackageEnergyByMSR(ReadCorePower, ReadDramPower, ReadUncorePower, ReadPkgPower)
+func (r *PowerMSR) GetRAPLEnergy() map[int]RAPLEnergy {
+	return GetRAPLEnergyByMSR(ReadCorePower, ReadDramPower, ReadUncorePower, ReadPkgPower)
 }
 
 func (r *PowerMSR) StopPower() {

--- a/pkg/power/rapl/source/msr_util.go
+++ b/pkg/power/rapl/source/msr_util.go
@@ -211,14 +211,14 @@ func ReadAllPower(f func(n int) (uint64, error)) (uint64, error) {
 	return energy, nil
 }
 
-func GetPackageEnergyByMSR(coreFunc, dramFunc, uncoreFunc, pkgFunc func(n int) (uint64, error)) map[int]PackageEnergy {
-	packageEnergies := make(map[int]PackageEnergy)
+func GetRAPLEnergyByMSR(coreFunc, dramFunc, uncoreFunc, pkgFunc func(n int) (uint64, error)) map[int]RAPLEnergy {
+	packageEnergies := make(map[int]RAPLEnergy)
 	for i := 0; i <= maxPackage; {
 		coreEnergy, _ := coreFunc(i)
 		dramEnergy, _ := dramFunc(i)
 		uncoreEnergy, _ := uncoreFunc(i)
 		pkgEnergy, _ := pkgFunc(i)
-		packageEnergies[i] = PackageEnergy{
+		packageEnergies[i] = RAPLEnergy{
 			Core:   coreEnergy,
 			DRAM:   dramEnergy,
 			Uncore: uncoreEnergy,

--- a/pkg/power/rapl/source/package_energy.go
+++ b/pkg/power/rapl/source/package_energy.go
@@ -16,8 +16,8 @@ limitations under the License.
 
 package source
 
-// PackageEnergy defines set of energy per package in mJ
-type PackageEnergy struct {
+// RAPLEnergy defines set of energy per RAPL components in mJ
+type RAPLEnergy struct {
 	Core   uint64
 	DRAM   uint64
 	Uncore uint64

--- a/pkg/power/rapl/source/sysfs.go
+++ b/pkg/power/rapl/source/sysfs.go
@@ -115,8 +115,8 @@ func (r *PowerSysfs) GetEnergyFromPackage() (uint64, error) {
 	return getEnergy(packageEvent)
 }
 
-func (r *PowerSysfs) GetPackageEnergy() map[int]PackageEnergy {
-	packageEnergies := make(map[int]PackageEnergy)
+func (r *PowerSysfs) GetRAPLEnergy() map[int]RAPLEnergy {
+	packageEnergies := make(map[int]RAPLEnergy)
 
 	pkgEnergies := readEventEnergy(packageEvent)
 	coreEnergies := readEventEnergy(coreEvent)
@@ -129,7 +129,7 @@ func (r *PowerSysfs) GetPackageEnergy() map[int]PackageEnergy {
 		uncoreEnergy := uncoreEnergies[pkgID]
 		splits := strings.Split(pkgID, "-")
 		i, _ := strconv.Atoi(splits[len(splits)-1])
-		packageEnergies[i] = PackageEnergy{
+		packageEnergies[i] = RAPLEnergy{
 			Core:   coreEnergy,
 			DRAM:   dramEnergy,
 			Uncore: uncoreEnergy,


### PR DESCRIPTION
The `PackageEnergy` structure and functions actually return not just the package energy, but all the energy of RAPL components such as core and dram....

To make this clearer, I'm renaming PackageEnergy to RAPLEnergy

Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>