### PR TITLE
init podEnergy of inactive pods (e.g., nginx)

### DIFF
--- a/pkg/collector/reader.go
+++ b/pkg/collector/reader.go
@@ -75,6 +75,19 @@ var (
 	systemProcessNamespace = podlister.GetSystemProcessNamespace()
 )
 
+func init() {
+	pods, err := podlister.Init()
+	if err != nil {
+		klog.V(5).Infoln(err)
+		return
+	}
+	for i := 0; i < len(*pods); i++ {
+		podName := (*pods)[i].Name
+		podNamespace := (*pods)[i].Namespace
+		podEnergy[podName] = NewPodEnergy(podName, podNamespace)
+	}
+}
+
 // readEnergy reads sensor/pkg energies in mJ
 func (c *Collector) readEnergy() {
 	sensorEnergy, _ = acpiPowerMeter.GetEnergyFromHost()

--- a/pkg/podlister/suite_test.go
+++ b/pkg/podlister/suite_test.go
@@ -27,3 +27,7 @@ func TestPodLoader(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "PodLister Suite")
 }
+
+var _ = BeforeSuite(func() {
+	_, _ = Init()
+})


### PR DESCRIPTION
This PR is to add initial inactive pods (e.g. nginx) at the beginning of collector package relating to this comment of the previous PR https://github.com/sustainable-computing-io/kepler/pull/268#issuecomment-1263694217.

This is supposed to solve the issue by also passing the result of podlister init function to the collector package and the podEnergy.  



Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>