### PR TITLE
Prometheus->prometheus to fix grafana dashboard

### DIFF
--- a/manifests/openshift/dashboard/03-grafana-datasource-UPDATETHIS.yaml
+++ b/manifests/openshift/dashboard/03-grafana-datasource-UPDATETHIS.yaml
@@ -16,7 +16,7 @@ spec:
         httpHeaderName1: 'Authorization'
         timeInterval: 5s
         tlsSkipVerify: true
-      name: Prometheus
+      name: prometheus
       secureJsonData:
         # Update bearer token to match your environment
         httpHeaderValue1: 'Bearer ${BEARER_TOKEN}'


### PR DESCRIPTION
resolves https://github.com/sustainable-computing-io/kepler/issues/262

Hardcodes the name of the GrafanaDatasource to `prometheus` rather than `Prometheus`. 
The OpenShift manifests have been broken since https://github.com/sustainable-computing-io/kepler/pull/201 merged, since GrafanaDataSource names are case-sensitive. This quickly gets things back to working.