### PR TITLE
Add panic handling when attaching the bpf program to do not termine kepler

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -30,3 +30,9 @@ jobs:
         env:
             CLUSTER_PROVIDER: ${{matrix.kube_provider}}
             CTR_CMD: docker
+
+      - name: test if kepler is still alive
+        run: |
+          sleep 60
+          kubectl logs $(kubectl -n kepler get pods -oname) -n kepler
+          kubectl get all -n kepler

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -79,7 +79,7 @@ func main() {
 	}
 	err = newCollector.Attach()
 	if err != nil {
-		klog.Fatalf("%s", fmt.Sprintf("failed to attach : %v", err))
+		klog.Infof("%s", fmt.Sprintf("failed to attach : %v", err))
 	}
 
 	err = prometheus.Register(newCollector)

--- a/pkg/attacher/bcc_attacher.go
+++ b/pkg/attacher/bcc_attacher.go
@@ -63,6 +63,11 @@ var (
 )
 
 func loadModule(objProg []byte, options []string) (*bpf.Module, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			klog.Infof("failed to attach the bpf program:", err)
+		}
+	}()
 	m := bpf.NewModule(string(objProg), options)
 	// TODO make all entrypoints yaml-declarable
 	sched_switch, err := m.LoadTracepoint("sched_switch")

--- a/pkg/attacher/bcc_attacher.go
+++ b/pkg/attacher/bcc_attacher.go
@@ -62,13 +62,14 @@ var (
 	EnableCPUFreq = true
 )
 
-func loadModule(objProg []byte, options []string) (*bpf.Module, error) {
+func loadModule(objProg []byte, options []string) (m *bpf.Module, err error) {
 	defer func() {
-		if err := recover(); err != nil {
-			klog.Infof("failed to attach the bpf program:", err)
+		if r := recover(); r != nil {
+			err = fmt.Errorf("failed to attach the bpf program: %v", err)
+			klog.Infoln(err)
 		}
 	}()
-	m := bpf.NewModule(string(objProg), options)
+	m = bpf.NewModule(string(objProg), options)
 	// TODO make all entrypoints yaml-declarable
 	sched_switch, err := m.LoadTracepoint("sched_switch")
 	if err != nil {


### PR DESCRIPTION
#### Why this PR is needed?
Kepler should work in the case that it could not attach a bpf program. We have the logic for this.
However, there are sometimes that it causes a panic and then terminates the program.

The PR #275 having this problem where the VM does not have the `Module kheaders`, details are [here](https://github.com/sustainable-computing-io/kepler/actions/runs/3201921603/jobs/5230372207#step:8:13).

This PR fix the issue #282

#### What this PR does?
Golang [recover](https://gobyexample.com/recover) function make it possible to recover from a panic.
Therefore, we use this when attaching the bpf program and instead of terminate the program we just log the error.

Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>