### PR TITLE
set config values from configmap or environment vars

### DIFF
--- a/pkg/attacher/bcc_attacher.go
+++ b/pkg/attacher/bcc_attacher.go
@@ -48,9 +48,9 @@ type BpfModuleTables struct {
 }
 
 const (
-	CPUCycleLable       = "cpu_cycles"
-	CPUInstructionLabel = "cpu_instr"
-	CacheMissLabel      = "cache_miss"
+	CPUCycleLable       = config.CPUCycle
+	CPUInstructionLabel = config.CPUInstruction
+	CacheMissLabel      = config.CacheMiss
 )
 
 var (

--- a/pkg/cgroup/stat_reader.go
+++ b/pkg/cgroup/stat_reader.go
@@ -18,6 +18,8 @@ package cgroup
 
 import (
 	"path/filepath"
+
+	"github.com/sustainable-computing-io/kepler/pkg/config"
 )
 
 var MemUsageFiles = []string{
@@ -39,32 +41,32 @@ var ioUsageFiles = []string{
 }
 
 var standardMetricName = map[string][]CgroupFSReadMetric{
-	"cgroupfs_memory_usage_bytes": {
+	config.CgroupfsMemory: {
 		{Name: "memory.current", Converter: DefaultConverter},
 		{Name: "memory.usage_in_bytes", Converter: DefaultConverter},
 	},
-	"cgroupfs_kernel_memory_usage_bytes": {
+	config.CgroupfsKernelMemory: {
 		{Name: "memory.kmem.usage_in_bytes", Converter: DefaultConverter},
 	},
-	"cgroupfs_tcp_memory_usage_bytes": {
+	config.CgroupfsTCPMemory: {
 		{Name: "memory.kmem.tcp.usage_in_bytes", Converter: DefaultConverter},
 	},
-	"cgroupfs_cpu_usage_us": {
+	config.CgroupfsCPU: {
 		{Name: "cpuacct.usage", Converter: NanoToMicroConverter},
 		{Name: "usage_usec", Converter: DefaultConverter},
 	},
-	"cgroupfs_system_cpu_usage_us": {
+	config.CgroupfsSystemCPU: {
 		{Name: "cpuacct.usage_sys", Converter: NanoToMicroConverter},
 		{Name: "system_usec", Converter: DefaultConverter},
 	},
-	"cgroupfs_user_cpu_usage_us": {
+	config.CgroupfsUserCPU: {
 		{Name: "cpuacct.usage_user", Converter: NanoToMicroConverter},
 		{Name: "user_usec", Converter: DefaultConverter},
 	},
-	"cgroupfs_ioread_bytes": {
+	config.CgroupfsReadIO: {
 		{Name: "rbytes", Converter: DefaultConverter},
 	},
-	"cgroupfs_iowrite_bytes": {
+	config.CgroupfsWriteIO: {
 		{Name: "wbytes", Converter: DefaultConverter},
 	},
 }

--- a/pkg/collector/metrics.go
+++ b/pkg/collector/metrics.go
@@ -19,6 +19,7 @@ package collector
 import (
 	"github.com/sustainable-computing-io/kepler/pkg/attacher"
 	"github.com/sustainable-computing-io/kepler/pkg/cgroup"
+	"github.com/sustainable-computing-io/kepler/pkg/config"
 	"github.com/sustainable-computing-io/kepler/pkg/model"
 	"github.com/sustainable-computing-io/kepler/pkg/podlister"
 
@@ -26,14 +27,14 @@ import (
 )
 
 const (
-	freqMetricLabel = "avg_cpu_frequency"
+	freqMetricLabel = config.CPUFrequency
 
 	// TO-DO: merge to cgroup stat
-	ByteReadLabel    = "bytes_read"
-	ByteWriteLabel   = "bytes_writes"
-	blockDeviceLabel = "block_devices_used"
+	ByteReadLabel    = config.BytesReadIO
+	ByteWriteLabel   = config.BytesWriteIO
+	blockDeviceLabel = config.BlockDevicesIO
 
-	CPUTimeLabel = "cpu_time"
+	CPUTimeLabel = config.CPUTime
 )
 
 var (

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 
@@ -44,18 +45,40 @@ type config struct {
 
 var c config
 
+const (
+	defaultMetricValue = ""
+)
+
 var (
 	EnabledEBPFCgroupID = false
 
-	EstimatorModel        = "" // auto-select
-	EstimatorSelectFilter = "" // no filter
-	CoreUsageMetric       = "curr_cpu_cycles"
-	DRAMUsageMetric       = "curr_cache_miss"
-	UncoreUsageMetric     = ""                // no metric (evenly divided)
-	GeneralUsageMetric    = "curr_cpu_cycles" // for uncategorized energy; pkg - core - uncore
+	EstimatorModel        = getConfig("ESTIMATOR_MODEL", defaultMetricValue)         // auto-select
+	EstimatorSelectFilter = getConfig("ESTIMATOR_SELECT_FILTER", defaultMetricValue) // no filter
+	CoreUsageMetric       = getConfig("CORE_USAGE_METRIC", CPUInstruction)
+	DRAMUsageMetric       = getConfig("DRAM_USAGE_METRIC", CacheMiss)
+	UncoreUsageMetric     = getConfig("UNCORE_USAGE_METRIC", defaultMetricValue) // no metric (evenly divided)
+	GeneralUsageMetric    = getConfig("GENERAL_USAGE_METRIC", CPUInstruction)    // for uncategorized energy; pkg - core - uncore
 
 	versionRegex = regexp.MustCompile(`^(\d+)\.(\d+).`)
+
+	configPath = "/etc/config"
 )
+
+func getConfig(configKey, defaultValue string) (result string) {
+	result = string([]byte(defaultValue))
+	key := string([]byte(configKey))
+	configFile := filepath.Join(configPath, key)
+	value, err := os.ReadFile(configFile)
+	if err == nil {
+		result = bytes.NewBuffer(value).String()
+	} else {
+		strValue, present := os.LookupEnv(key)
+		if present {
+			result = strValue
+		}
+	}
+	return
+}
 
 // EnableEBPFCgroupID enables the eBPF code to collect cgroup id if the system has kernel version > 4.18
 func EnableEBPFCgroupID(enabled bool) {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+const (
+	// counter - attacher package
+	CPUCycle       = "cpu_cycles"
+	CPUInstruction = "cpu_instr"
+	CacheMiss      = "cache_miss"
+	// bpf - attacher package
+	CPUTime = "cpu_time"
+	// cgroup - cgroup package
+	CgroupfsMemory       = "cgroupfs_memory_usage_bytes"
+	CgroupfsKernelMemory = "cgroupfs_kernel_memory_usage_bytes"
+	CgroupfsTCPMemory    = "cgroupfs_tcp_memory_usage_bytes"
+	CgroupfsCPU          = "cgroupfs_cpu_usage_us"
+	CgroupfsSystemCPU    = "cgroupfs_system_cpu_usage_us"
+	CgroupfsUserCPU      = "cgroupfs_user_cpu_usage_us"
+	CgroupfsReadIO       = "cgroupfs_ioread_bytes"
+	CgroupfsWriteIO      = "cgroupfs_iowrite_bytes"
+	BytesReadIO          = "bytes_read"
+	BytesWriteIO         = "bytes_writes"
+	BlockDevicesIO       = "block_devices_used"
+	// kubelet - podlister package
+	KubeletContainerCPU    = "container_cpu_usage_seconds_total"
+	KubeletContainerMemory = "container_memory_working_set_bytes"
+	KubeletNodeCPU         = "node_cpu_usage_seconds_total"
+	KubeletNodeMemory      = "node_memory_working_set_bytes"
+
+	// system
+	CPUFrequency = "avg_cpu_frequency"
+)

--- a/pkg/podlister/kubelet_pod_lister.go
+++ b/pkg/podlister/kubelet_pod_lister.go
@@ -27,6 +27,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
+	"github.com/sustainable-computing-io/kepler/pkg/config"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -41,10 +42,10 @@ const (
 var (
 	podURL, metricsURL string
 
-	nodeCPUUsageMetricName      = "node_cpu_usage_seconds_total"
-	nodeMemUsageMetricName      = "node_memory_working_set_bytes"
-	containerCPUUsageMetricName = "container_cpu_usage_seconds_total"
-	containerMemUsageMetricName = "container_memory_working_set_bytes"
+	nodeCPUUsageMetricName      = config.KubeletNodeCPU
+	nodeMemUsageMetricName      = config.KubeletNodeMemory
+	containerCPUUsageMetricName = config.KubeletContainerCPU
+	containerMemUsageMetricName = config.KubeletContainerMemory
 
 	podNameTag   = "pod"
 	namespaceTag = "namespace"


### PR DESCRIPTION
This PR add a function `getConfig` to set configuration values from ConfigMap file or environment variable.

Working in a similar way to this python code in kepler-model-server.

```py
def getConfig(key, default):
    # check configmap path
    file = os.path.join(CONFIG_PATH, key)
    if os.path.exists(file):
        with open(file, "r") as f:
            return f.read()
    # check env
    return os.getenv(key, default)
```
Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>