### PR TITLE
allow expose metrics with options

### DIFF
--- a/pkg/attacher/bcc_attacher.go
+++ b/pkg/attacher/bcc_attacher.go
@@ -136,6 +136,12 @@ func DetachBPFModules(bpfModules *BpfModuleTables) {
 
 func GetEnabledCounters() []string {
 	var metrics []string
+	klog.V(5).Infof("hardeware counter metr %t", config.ExposeHardwareCounterMetrics)
+	if !config.ExposeHardwareCounterMetrics {
+		klog.V(5).Info("hardeware counter metrics not enabled")
+		return metrics
+	}
+
 	for metric, counter := range Counters {
 		if counter.enabled {
 			metrics = append(metrics, metric)

--- a/pkg/collector/metrics.go
+++ b/pkg/collector/metrics.go
@@ -44,9 +44,9 @@ var (
 	availableKubeletMetrics []string = podlister.GetAvailableKubeletMetrics()
 	// TO-DO: merge to cgroup stat and remove hard-code metric list
 	iostatMetrics []string = []string{ByteReadLabel, ByteWriteLabel}
-	uintFeatures  []string = getUIntFeatures()
-	features      []string = append(FloatFeatures, uintFeatures...)
-	metricNames   []string = getEstimatorMetrics()
+	uintFeatures  []string
+	features      []string
+	metricNames   []string
 
 	cpuInstrCounterEnabled = isCounterStatEnabled(attacher.CPUInstructionLabel)
 )
@@ -54,17 +54,30 @@ var (
 func getUIntFeatures() []string {
 	var metrics []string
 	metrics = append(metrics, CPUTimeLabel)
+
 	// counter metric
 	metrics = append(metrics, availableCounters...)
 	// cgroup metric
 	metrics = append(metrics, availableCgroupMetrics...)
 	// kubelet metric
 	metrics = append(metrics, availableKubeletMetrics...)
+
 	metrics = append(metrics, iostatMetrics...)
+
 	klog.V(3).Infof("Available counter metrics: %v", availableCounters)
 	klog.V(3).Infof("Available cgroup metrics: %v", availableCgroupMetrics)
 	klog.V(3).Infof("Available kubelet metrics: %v", availableKubeletMetrics)
+
 	return metrics
+}
+
+func SetEnabledMetrics() {
+	availableCounters = attacher.GetEnabledCounters()
+
+	uintFeatures = getUIntFeatures()
+	features = append(features, FloatFeatures...)
+	features = append(features, uintFeatures...)
+	metricNames = getEstimatorMetrics()
 }
 
 func getPrometheusMetrics() []string {

--- a/pkg/collector/metrics_test.go
+++ b/pkg/collector/metrics_test.go
@@ -21,6 +21,7 @@ func clearPlatformDependentAvailability() {
 var _ = Describe("Test Metric Unit", func() {
 	It("Check feature values", func() {
 		setPodStatProm()
+		SetEnabledMetrics()
 		Expect(len(uintFeatures)).Should(BeNumerically(">", 0))
 		Expect(len(podEnergyLabels)).Should(BeNumerically(">", 0))
 		Expect(len(podEnergyLabels)).Should(BeNumerically(">", 0))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,7 +45,8 @@ type config struct {
 var c config
 
 var (
-	EnabledEBPFCgroupID = false
+	EnabledEBPFCgroupID          = false
+	ExposeHardwareCounterMetrics = true
 
 	EstimatorModel        = "" // auto-select
 	EstimatorSelectFilter = "" // no filter
@@ -65,6 +66,11 @@ func EnableEBPFCgroupID(enabled bool) {
 		EnabledEBPFCgroupID = true
 	}
 	klog.V(1).Infoln("config set EnabledEBPFCgroupID to ", EnabledEBPFCgroupID)
+}
+
+// EnableHardwareCounterMetrics enables the exposure of hardware counter metrics
+func EnableHardwareCounterMetrics(enabled bool) {
+	ExposeHardwareCounterMetrics = enabled
 }
 
 func (c config) getUnixName() (unix.Utsname, error) {


### PR DESCRIPTION
related to #258

fix 2 things
1) the exposure of hardware counter is able to be configured
2) klog initialized in main, so all global var init info including settings are not printed correctly, this PR also fixed that

Signed-off-by: jichenjc <jichenjc@cn.ibm.com>