### PR TITLE
Update Grafana dashboards with the new container metrics

### DIFF
--- a/grafana-dashboards/Kepler-Exporter.json
+++ b/grafana-dashboards/Kepler-Exporter.json
@@ -22,7 +22,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 28,
+  "id": 26,
+  "iteration": 1667798877250,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -41,7 +42,10 @@
       "type": "row"
     },
     {
-      "datasource": "prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "Using CO2 emissions  by power generation type as reported by US Energy Information Administration https://www.eia.gov/tools/faqs/faq.php?id=74&t=11",
       "fieldConfig": {
         "defaults": {
@@ -53,7 +57,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "#EAB839",
@@ -69,8 +74,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 11,
-        "w": 21,
+        "h": 6,
+        "w": 19,
         "x": 2,
         "y": 1
       },
@@ -88,33 +93,46 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "9.0.4",
+      "pluginVersion": "8.5.5",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "editorMode": "code",
-          "expr": "sum(rate(pod_curr_energy_in_pkg_millijoule{pod_namespace='$namespace'}[24h])/3600000000*$coal)",
+          "expr": "(sum(\n    (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $coal\n)\n+\n(sum(\n    (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $coal\n)",
+          "hide": false,
           "legendFormat": "CO2 Coal",
           "range": true,
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "editorMode": "code",
-          "expr": "sum(rate(pod_curr_energy_in_pkg_millijoule{pod_namespace='$namespace'}[24h])/3600000000*$petroleum)",
+          "expr": "(sum(\n    (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $petroleum\n)\n+\n(sum(\n    (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $petroleum\n)",
           "hide": false,
           "legendFormat": "CO2 Petroleum",
           "range": true,
           "refId": "B"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "editorMode": "code",
-          "expr": "sum(rate(pod_curr_energy_in_pkg_millijoule{pod_namespace='$namespace'}[24h])/3600000000*$natural_gas)",
+          "expr": "(sum(\n    (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $natural_gas\n)\n+\n(sum(\n    (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $natural_gas\n)",
           "hide": false,
           "legendFormat": "CO2 Natural Gas",
           "range": true,
           "refId": "C"
         }
       ],
-      "title": "Namespace Carbon Footprint (pounds per kWh in 24hrs)",
+      "title": "Carbon Footprint (pounds per kWh per day) in Namespace: $namespace  (PKG+DRAM)",
       "transparent": true,
       "type": "gauge"
     },
@@ -125,28 +143,31 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 7
       },
       "id": 8,
       "panels": [],
-      "title": "Energy Consumption",
+      "title": "Power Consumption",
       "type": "row"
     },
     {
-      "datasource": "prometheus",
-      "description": "The mW per second",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
+            "axisLabel": "watt",
+            "axisPlacement": "left",
             "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
+            "drawStyle": "bars",
+            "fillOpacity": 44,
+            "gradientMode": "opacity",
             "hideFrom": {
               "graph": false,
               "legend": false,
@@ -154,16 +175,16 @@
               "viz": false
             },
             "lineInterpolation": "linear",
-            "lineWidth": 1,
+            "lineWidth": 0,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "always",
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -174,327 +195,12 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
                 "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 13
-      },
-      "id": 2,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": "prometheus",
-          "editorMode": "code",
-          "expr": "rate(pod_curr_energy_in_pkg_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1m])/3",
-          "legendFormat": "Total",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": "prometheus",
-          "editorMode": "code",
-          "expr": "rate(pod_curr_energy_in_core_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1m])/3",
-          "hide": false,
-          "legendFormat": "CPU",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "rate(pod_curr_energy_in_dram_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1m])/3",
-          "hide": false,
-          "legendFormat": "DRAM",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "rate(pod_curr_energy_in_gpu_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1m])/3",
-          "hide": false,
-          "legendFormat": "GPU",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "rate(pod_curr_energy_in_other_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1m])/3",
-          "hide": false,
-          "legendFormat": "Other",
-          "range": true,
-          "refId": "E"
-        }
-      ],
-      "title": "Pod Current Energy Consumption (mW*s)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": "prometheus",
-      "description": "Total W*s Consumed",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 13
-      },
-      "id": 3,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "7.5.15",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum_over_time(pod_curr_energy_in_pkg_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
-          "instant": false,
-          "legendFormat": "Total",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum_over_time(pod_curr_energy_in_core_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
-          "hide": false,
-          "legendFormat": "CPU",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum_over_time(pod_curr_energy_in_dram_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
-          "hide": false,
-          "legendFormat": "DRAM",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum_over_time(pod_curr_energy_in_gpu_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
-          "hide": false,
-          "legendFormat": "GPU",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum_over_time(pod_curr_energy_in_other_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
-          "hide": false,
-          "legendFormat": "Other",
-          "range": true,
-          "refId": "E"
-        }
-      ],
-      "title": "Total Pod Energy Consumption (kW*h)",
-      "transformations": [],
-      "type": "timeseries"
-    },
-    {
-      "datasource": "prometheus",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "#EAB839",
-                "value": 0.1
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 22
-      },
-      "id": 5,
-      "options": {
-        "displayMode": "gradient",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "orientation": "vertical",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "text": {}
-      },
-      "pluginVersion": "9.0.4",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum_over_time(pod_curr_energy_in_pkg_millijoule{pod_namespace=\"$namespace\"}[24h])*15/3/3600000000",
-          "legendFormat": "{{pod_name}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Total Pod Energy Consumption (kW*h) in $namespace in 24 hours",
-      "type": "bargauge"
-    },
-    {
-      "datasource": "prometheus",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "displayMode": "color-text",
-            "filterable": false,
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "#EAB839",
-                "value": 0.01
-              },
-              {
-                "color": "red",
-                "value": 0.1
               }
             ]
           }
@@ -502,38 +208,60 @@
         "overrides": [
           {
             "matcher": {
-              "id": "byName",
-              "options": "pod_namespace"
+              "id": "byRegexp",
+              "options": ".*DRAM.*"
             },
             "properties": [
               {
-                "id": "displayName",
-                "value": "Namespace"
-              },
-              {
-                "id": "custom.filterable",
-                "value": true
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
             "matcher": {
-              "id": "byName",
-              "options": "Value"
+              "id": "byRegexp",
+              "options": ".*OTHER.*"
             },
             "properties": [
               {
-                "id": "displayName",
-                "value": "kW*h"
-              },
-              {
-                "id": "custom.displayMode",
-                "value": "lcd-gauge"
-              },
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*GPU.*"
+            },
+            "properties": [
               {
                 "id": "color",
                 "value": {
-                  "mode": "continuous-GrYlRd"
+                  "fixedColor": "semi-dark-green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*PKG.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
                 }
               }
             ]
@@ -541,44 +269,532 @@
         ]
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 22
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 8
       },
-      "id": 6,
-      "maxPerRow": 8,
+      "id": 16,
       "options": {
-        "footer": {
-          "fields": "",
-          "reducer": [
-            "sum"
+        "legend": {
+          "calcs": [
+            "mean"
           ],
-          "show": false
+          "displayMode": "table",
+          "placement": "right",
+          "sortBy": "Mean",
+          "sortDesc": true
         },
-        "frameIndex": 0,
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": true,
-            "displayName": "kW*h"
-          }
-        ]
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
-      "pluginVersion": "9.0.4",
-      "repeatDirection": "h",
       "targets": [
         {
           "datasource": "prometheus",
           "editorMode": "code",
-          "expr": "sum by (pod_namespace) (sum_over_time(pod_curr_energy_in_pkg_millijoule[24h])*15/3/3600000000)",
-          "legendFormat": "__auto",
+          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{pod_name}} / {{container_namespace}} / PKG",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "prometheus",
+          "editorMode": "code",
+          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{pod_name}} / {{container_namespace}} / DRAM",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{pod_name}} / {{container_namespace}} / OTHER",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod_name, container_namespace) (irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
+          "hide": false,
+          "legendFormat": "{{pod_name}} / {{container_namespace}} / GPU",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Pod/Process Power Consumption (W) in Namespace: $namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "watt",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 44,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 0,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Package.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*DRAM.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*OtherComponents.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*GPU.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "PKG",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "DRAM",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\"}[1m]))",
+          "hide": false,
+          "legendFormat": "OTHER",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1m]))",
+          "hide": false,
+          "legendFormat": " GPU",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Total Power Consumption (W) in Namespace: $namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "kWh",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 44,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 0,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Package.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*DRAM.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*OtherComponents.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*GPU.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(\n  (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "PKG (CORE+UNCORE)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(\n  (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "DRAM",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(\n  (increase(\n    kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(\n    kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(\n      kepler_container_other_host_components_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n)",
+          "hide": false,
+          "legendFormat": "OTHER",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(\n  (increase(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n)",
+          "hide": false,
+          "legendFormat": " GPU",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Total Power Consumption (kWh per day) in Namespace: $namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 15,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "8.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (container_namespace) (\n  (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n)\n+\nsum by (container_namespace) (\n  (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n)",
+          "interval": "",
+          "legendFormat": "{{container_namespace}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Total Energy Consumption (kW*h) by Namespace in 24 hours",
-      "type": "table"
+      "title": "Total Power Consumption (PKG+DRAM) by Namespace (kWh per day)",
+      "type": "bargauge"
     }
   ],
   "refresh": "",
@@ -590,20 +806,72 @@
       {
         "current": {
           "selected": false,
-          "text": "kepler",
-          "value": "kepler"
+          "text": "prometheus",
+          "value": "prometheus"
         },
-        "datasource": "prometheus",
-        "definition": "label_values(pod_curr_energy_in_pkg_millijoule, pod_namespace)",
-        "description": "Namespace for pods to choose",
         "hide": 0,
         "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(kepler_container_package_joules_total, container_namespace)",
+        "description": "Namespace for pods to choose",
+        "hide": 0,
+        "includeAll": true,
         "label": "Namespace",
         "multi": false,
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(pod_curr_energy_in_pkg_millijoule, pod_namespace)",
+          "query": "label_values(kepler_container_package_joules_total, container_namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}, pod_name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pod",
+        "multi": false,
+        "name": "pod",
+        "options": [],
+        "query": {
+          "query": "label_values(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}, pod_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -618,55 +886,76 @@
       {
         "current": {
           "selected": false,
-          "text": "alertmanager-main-2",
-          "value": "alertmanager-main-2"
+          "text": "2.23",
+          "value": "2.23"
         },
-        "datasource": "prometheus",
-        "definition": "label_values(pod_curr_energy_in_pkg_millijoule{pod_namespace=\"$namespace\"}, pod_name)",
         "hide": 0,
-        "includeAll": false,
-        "label": "Pod",
-        "multi": false,
-        "name": "pod",
-        "options": [],
-        "query": {
-          "query": "label_values(pod_curr_energy_in_pkg_millijoule{pod_namespace=\"$namespace\"}, pod_name)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "hide": 2,
+        "label": "Coal Coeff",
         "name": "coal",
+        "options": [
+          {
+            "selected": true,
+            "text": "2.23",
+            "value": "2.23"
+          }
+        ],
         "query": "2.23",
         "skipUrlSync": false,
-        "type": "constant"
+        "type": "textbox"
       },
       {
-        "hide": 2,
+        "current": {
+          "selected": false,
+          "text": "0.91",
+          "value": "0.91"
+        },
+        "hide": 0,
+        "label": "Natural Gas Coeff",
         "name": "natural_gas",
+        "options": [
+          {
+            "selected": true,
+            "text": "0.91",
+            "value": "0.91"
+          }
+        ],
         "query": "0.91",
         "skipUrlSync": false,
-        "type": "constant"
+        "type": "textbox"
       },
       {
-        "hide": 2,
+        "current": {
+          "selected": false,
+          "text": "2.13",
+          "value": "2.13"
+        },
+        "hide": 0,
+        "label": "Petroleum Coeff",
         "name": "petroleum",
+        "options": [
+          {
+            "selected": true,
+            "text": "2.13",
+            "value": "2.13"
+          }
+        ],
         "query": "2.13",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "description": "1W*s = 1J and 1J = (1/3600000)kWh",
+        "hide": 2,
+        "label": "",
+        "name": "watt_per_second_to_kWh",
+        "query": "0.000000277777777777778",
         "skipUrlSync": false,
         "type": "constant"
       }
     ]
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},

--- a/grafana-dashboards/README.md
+++ b/grafana-dashboards/README.md
@@ -2,10 +2,10 @@
 This directory stores pre-generated Grafana dashboard. Due to data format changes, dashboards used prior to PR #112 are in [legacy](./legacy) directory.
 
 # Customerize Dashboard
-The metrics used by node and Pod are:
+The metrics used by Pod are:
 ```
-node_energy_stat
-node_curr_energy_in_[core|dram|uncore|gpu|pkg|other]_joule
-pod_curr_energy_in_[core|dram|uncore|gpu|pkg|other]_joule
-pod_total_energy_in_[core|dram|uncore|gpu|pkg|other]_joule
+kepler_container_package_joules_total{}
+kepler_container_dram_joules_total{}
+kepler_container_gpu_joules_total{}
+kepler_container_other_host_components_joules_total{}
 ```


### PR DESCRIPTION
**Why this PR is needed?**
PR #287 will update Prometheus metrics and affect the current Grafana dashboard. Where the new metrics will report energy per container and have more meaningful names. More details are written in issue #286.

Currently, it is difficult to understand all the queries in the existing Grafana dashboard. There are some constant values ​​that are not obvious and some queries that are wrong. For example:

The `sum_over_time(pod_curr_energy_in_core_millijoule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000` metric:
`sum_over_time` sum the metric within the timeframe (the value in the square brackets) by getting a cumulative number from the gauge. The problem here is the granularity, we know the gauge is reported every 3s. So the query will not sum the aggregation across the 3s. Instead of a gauge, a counter should be used, e.g., `pod_aggr_energy_in_core_millijoule`, but of course it won't make sense to use `sum_over_time`. If we use the counter, to get the `kw*h`, we will need to use the `increase` function:
```
1W*s = 1J and 1J = (1/3600000)kWh = 0.000000277777777777778
(sum(increase(pod_aggr_energy_in_core_millijoule{}[1h])))*0.000000277777777777778
```
So, in Prometheus, metrics are based on averages and approximations. In fact, the `increase` function takes the average of the time period and multiplies it by the interval.

Also, in case we are using a counter, division by 3 makes no sense, as the `rate` function already returns values ​​per second... and the `increase` just get the rate and multiply by the interval.

Additionally, I didn't understand the multiplication by `15` and the division by `3600000000`...

Another example:
The `rate(pod_curr_energy_in_gpu_millijoule{}[1m])/3` metric.
The previous metric `pod_curr_energy_in_gpu_millijoule` was a gauge, and `rate` over a gauge metric doesn't make sense... Again, it would make sense to use the counter `pod_aggr_energy_in_core_millijoule`, but not divide by 3....

**What this PR does?**
This PR updates the Grafana dashboard with the new metrics and the properly queries.

For the  query that will return watt, we will have:
```
sum without (command, container_name)(
    rate(kepler_container_package_joules_total{}[5s])
)
```

And another query will return `kWh per day`:
Note that, to calculate the `kwh` we need to multiply the kilowatts by the hours of daily use, therefore we will count the how many hours within a day the container is running.
```
sum by (pod_name, container_name) (
  (increase(kepler_container_package_joules_total{}[1h]) * $watt_per_second_to_kWh)
  *
  (count_over_time(kepler_container_package_joules_total{}[24h]) /
    count_over_time(kepler_container_package_joules_total{}[1h])
  )
)
```


I have also fixed other minor issues in the dashboard, such as 
- have the `All` value in the namespace and pod variables
- make the Coal, Natural Gas and Petroleum Coefficient transparent and editable

**Additional comments**
<img width="1536" alt="image" src="https://user-images.githubusercontent.com/5133121/195767522-187bb2ef-1a55-42b5-a5a6-b3feba745f63.png">






Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>