### PR TITLE
Exclude VM node when deploy kepler exporter

### DIFF
--- a/manifests/kubernetes/deployment.yaml
+++ b/manifests/kubernetes/deployment.yaml
@@ -57,6 +57,14 @@ spec:
     spec:
       hostNetwork: true
       serviceAccountName: kepler-sa
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/cpu-cpuid.HYPERVISOR
+                operator: DoesNotExist
+                values:
       containers:
       - name: kepler-exporter
         image: quay.io/sustainable_computing_io/kepler:latest


### PR DESCRIPTION
Currently kepler exporter cannot get data successfully on VM node. With this PR change, kepler exporter will not deploy on VM nodes. Only bare metal nodes will be scheduled for kepler deployment.

Signed-off-by: Hao, Ruomeng <ruomeng.hao@intel.com>