### PR TITLE
Revert "user podID instead of podName to avoid duplicate"

### DIFF
--- a/pkg/collector/reader.go
+++ b/pkg/collector/reader.go
@@ -84,8 +84,7 @@ func init() {
 	for i := 0; i < len(*pods); i++ {
 		podName := (*pods)[i].Name
 		podNamespace := (*pods)[i].Namespace
-		podID := string((*pods)[i].ObjectMeta.UID)
-		podEnergy[podID] = NewPodEnergy(podName, podNamespace)
+		podEnergy[podName] = NewPodEnergy(podName, podNamespace)
 	}
 }
 
@@ -112,9 +111,9 @@ func (c *Collector) resetBPFTables() {
 // readBPFEvent reads BPF event and maps between pid/cgroupid and container/pod
 // initializes podEnergy component if not exists
 // adds stats from BPF events (CPU time, available HW counters)
-func (c *Collector) readBPFEvent() (pidPodID map[uint32]string, containerIDPodID map[string]string) {
-	pidPodID = make(map[uint32]string)
-	containerIDPodID = make(map[string]string)
+func (c *Collector) readBPFEvent() (pidPodName map[uint32]string, containerIDPodName map[string]string) {
+	pidPodName = make(map[uint32]string)
+	containerIDPodName = make(map[string]string)
 	if c.modules == nil {
 		return nil, nil
 	}
@@ -128,19 +127,13 @@ func (c *Collector) readBPFEvent() (pidPodID map[uint32]string, containerIDPodID
 			continue
 		}
 		comm := (*C.char)(unsafe.Pointer(&ct.Command))
-
-		podID, err := podlister.GetPodID(ct.CGroupPID, ct.PID)
-		if err != nil || podID == "" {
-			klog.V(5).Infof("failed to resolve pod ID for cGroup ID %v: %v, set podName=%s", ct.CGroupPID, err, systemProcessName)
-			podID = "system"
-		}
 		podName, err := podlister.GetPodName(ct.CGroupPID, ct.PID)
 
 		if err != nil {
-			klog.V(5).Infof("failed to resolve pod name for cGroup ID %v: %v, set podName=%s", ct.CGroupPID, err, systemProcessName)
+			klog.V(5).Infof("failed to resolve pod for cGroup ID %v: %v, set podName=%s", ct.CGroupPID, err, systemProcessName)
 			podName = systemProcessName
 		}
-		if _, ok := podEnergy[podID]; !ok {
+		if _, ok := podEnergy[podName]; !ok {
 			// new pod
 			var podNamespace string
 			if podName == systemProcessName {
@@ -152,28 +145,28 @@ func (c *Collector) readBPFEvent() (pidPodID map[uint32]string, containerIDPodID
 					podNamespace = "unknown"
 				}
 			}
-			podEnergy[podID] = NewPodEnergy(podName, podNamespace)
+			podEnergy[podName] = NewPodEnergy(podName, podNamespace)
 		}
-		foundPod[podID] = true
+		foundPod[podName] = true
 
-		podEnergy[podID].SetLatestProcess(ct.CGroupPID, ct.PID, C.GoString(comm))
+		podEnergy[podName].SetLatestProcess(ct.CGroupPID, ct.PID, C.GoString(comm))
 
 		var activeCPUs []int32
 		var avgFreq float64
 		var totalCPUTime uint64
 		if attacher.EnableCPUFreq {
 			avgFreq, totalCPUTime, activeCPUs = getAVGCPUFreqAndTotalCPUTime(cpuFrequency, &ct.CPUTime)
-			podEnergy[podID].AvgCPUFreq = avgFreq
+			podEnergy[podName].AvgCPUFreq = avgFreq
 		} else {
 			totalCPUTime = ct.ProcessRunTime
 			activeCPUs = getActiveCPUs(&ct.CPUTime)
 		}
 
 		for _, cpu := range activeCPUs {
-			podEnergy[podID].CurrCPUTimePerCPU[uint32(cpu)] += uint64(ct.CPUTime[cpu])
+			podEnergy[podName].CurrCPUTimePerCPU[uint32(cpu)] += uint64(ct.CPUTime[cpu])
 		}
 
-		if err = podEnergy[podID].CPUTime.AddNewCurr(totalCPUTime); err != nil {
+		if err = podEnergy[podName].CPUTime.AddNewCurr(totalCPUTime); err != nil {
 			klog.V(5).Infoln(err)
 		}
 
@@ -189,49 +182,49 @@ func (c *Collector) readBPFEvent() (pidPodID map[uint32]string, containerIDPodID
 			default:
 				val = 0
 			}
-			if err = podEnergy[podID].CounterStats[counterKey].AddNewCurr(val); err != nil {
+			if err = podEnergy[podName].CounterStats[counterKey].AddNewCurr(val); err != nil {
 				klog.V(5).Infoln(err)
 			}
 		}
 
-		podEnergy[podID].CurrProcesses++
+		podEnergy[podName].CurrProcesses++
 		containerID, err := podlister.GetContainerID(ct.CGroupPID, ct.PID)
 		if err != nil {
 			klog.V(5).Infoln(err)
 		}
 		// first-time found container (should not include non-container event)
-		if _, found := containerIDPodID[containerID]; !found && podName != systemProcessName {
-			containerIDPodID[containerID] = podID
+		if _, found := containerIDPodName[containerID]; !found && podName != systemProcessName {
+			containerIDPodName[containerID] = podName
 			// TO-DO: move to container-level section
 			rBytes, wBytes, disks, err := podlister.ReadCgroupIOStat(ct.CGroupPID, ct.PID)
 
 			if err == nil {
-				if disks > podEnergy[podID].Disks {
-					podEnergy[podID].Disks = disks
+				if disks > podEnergy[podName].Disks {
+					podEnergy[podName].Disks = disks
 				}
-				podEnergy[podID].BytesRead.AddStat(containerID, rBytes)
-				podEnergy[podID].BytesWrite.AddStat(containerID, wBytes)
+				podEnergy[podName].BytesRead.AddStat(containerID, rBytes)
+				podEnergy[podName].BytesWrite.AddStat(containerID, wBytes)
 			}
 		}
 		pid := uint32(ct.PID)
-		if _, found := pidPodID[pid]; !found {
-			pidPodID[pid] = podID
+		if _, found := pidPodName[pid]; !found {
+			pidPodName[pid] = podName
 		}
 	}
 	c.resetBPFTables()
 	handleInactivePods(foundPod)
-	return pidPodID, containerIDPodID
+	return pidPodName, containerIDPodName
 }
 
 // readCgroup adds container-level cgroup data
-func (c *Collector) readCgroup(containerIDPodID map[string]string) {
-	for containerID, podID := range containerIDPodID {
+func (c *Collector) readCgroup(containerIDPodName map[string]string) {
+	for containerID, podName := range containerIDPodName {
 		cgroup.TryInitStatReaders(containerID)
 		cgroupFSStandardStats := cgroup.GetStandardStat(containerID)
 		for cgroupFSKey, cgroupFSValue := range cgroupFSStandardStats {
 			readVal := cgroupFSValue.(uint64)
-			if _, ok := podEnergy[podID].CgroupFSStats[cgroupFSKey]; ok {
-				podEnergy[podID].CgroupFSStats[cgroupFSKey].AddStat(containerID, readVal)
+			if _, ok := podEnergy[podName].CgroupFSStats[cgroupFSKey]; ok {
+				podEnergy[podName].CgroupFSStats[cgroupFSKey].AddStat(containerID, readVal)
 			}
 		}
 	}
@@ -242,8 +235,8 @@ func (c *Collector) readKubelet() {
 	if len(availableKubeletMetrics) == 2 {
 		podCPU, podMem, _, _, _ := podlister.GetPodMetrics()
 		klog.V(5).Infof("Kubelet Read: %v, %v\n", podCPU, podMem)
-		for _, v := range podEnergy {
-			k := v.Namespace + "/" + v.PodName
+		for podName, v := range podEnergy {
+			k := v.Namespace + "/" + podName
 			readCPU := uint64(podCPU[k])
 			readMem := uint64(podMem[k])
 			cpuMetricName := availableKubeletMetrics[0]
@@ -276,31 +269,31 @@ func (c *Collector) reader() {
 			// read node-level settings (frequency)
 			cpuFrequency = acpiPowerMeter.GetCPUCoreFrequency()
 			// read pod metrics
-			pidPodID, containerIDPodID := c.readBPFEvent()
-			c.readCgroup(containerIDPodID)
+			pidPodName, containerIDPodName := c.readBPFEvent()
+			c.readCgroup(containerIDPodName)
 			c.readKubelet()
 			// convert to pod metrics to array
 			var podMetricValues [][]float64
-			var podIDList []string
-			for podID, v := range podEnergy {
+			var podNameList []string
+			for podName, v := range podEnergy {
 				values := v.ToEstimatorValues()
 				podMetricValues = append(podMetricValues, values)
-				podIDList = append(podIDList, podID)
+				podNameList = append(podNameList, podName)
 			}
 			// TO-DO: handle metrics read by GPU device in the same way as the other usage metrics
 			// read gpu power
 			gpuPerPid, _ := gpu.GetCurrGpuEnergyPerPid() // power not energy
 			podGPUDelta := make(map[string]float64)
-			for pid, podID := range pidPodID {
+			for pid, podName := range pidPodName {
 				gpuPower := gpuPerPid[pid]
-				if _, found := podGPUDelta[podID]; !found {
-					podGPUDelta[podID] = 0
+				if _, found := podGPUDelta[podName]; !found {
+					podGPUDelta[podName] = 0
 				} else {
-					podGPUDelta[podID] += gpuPower
+					podGPUDelta[podName] += gpuPower
 				}
 			}
-			for _, podID := range podIDList {
-				gpuNDelta = append(gpuNDelta, podGPUDelta[podID])
+			for _, podName := range podNameList {
+				gpuNDelta = append(gpuNDelta, podGPUDelta[podName])
 			}
 			// read and compute power (energy delta)
 			var totalCorePower, totalDRAMPower, totalUncorePower, totalPkgPower, totalGPUPower uint64
@@ -329,37 +322,37 @@ func (c *Collector) reader() {
 			podDynamicPower := model.GetDynamicPower(metricNames, podMetricValues, coreNDelta, dramNDelta, uncoreNDelta, pkgNDelta, gpuNDelta)
 			// get other energy - divide equally
 			podOther := uint64(0)
-			podCount := len(podIDList)
+			podCount := len(podNameList)
 			if podCount > 0 {
 				podOther = nodeEnergy.EnergyInOther / uint64(podCount)
 			}
 
 			// set pod energy
-			for i, podID := range podIDList {
-				if err := podEnergy[podID].EnergyInCore.AddNewCurr(podCore[i]); err != nil {
+			for i, podName := range podNameList {
+				if err := podEnergy[podName].EnergyInCore.AddNewCurr(podCore[i]); err != nil {
 					klog.V(5).Infoln(err)
 				}
-				if err := podEnergy[podID].EnergyInDRAM.AddNewCurr(podDRAM[i]); err != nil {
+				if err := podEnergy[podName].EnergyInDRAM.AddNewCurr(podDRAM[i]); err != nil {
 					klog.V(5).Infoln(err)
 				}
-				if err := podEnergy[podID].EnergyInUncore.AddNewCurr(podUncore[i]); err != nil {
+				if err := podEnergy[podName].EnergyInUncore.AddNewCurr(podUncore[i]); err != nil {
 					klog.V(5).Infoln(err)
 				}
-				if err := podEnergy[podID].EnergyInPkg.AddNewCurr(podPkg[i]); err != nil {
+				if err := podEnergy[podName].EnergyInPkg.AddNewCurr(podPkg[i]); err != nil {
 					klog.V(5).Infoln(err)
 				}
-				podGPU := uint64(math.Ceil(podGPUDelta[podID]))
-				if err := podEnergy[podID].EnergyInGPU.AddNewCurr(podGPU); err != nil {
+				podGPU := uint64(math.Ceil(podGPUDelta[podName]))
+				if err := podEnergy[podName].EnergyInGPU.AddNewCurr(podGPU); err != nil {
 					klog.V(5).Infoln(err)
 				}
-				if err := podEnergy[podID].EnergyInOther.AddNewCurr(podOther); err != nil {
+				if err := podEnergy[podName].EnergyInOther.AddNewCurr(podOther); err != nil {
 					klog.V(5).Infoln(err)
 				}
 			}
 			if len(podDynamicPower) != 0 {
-				for i, podID := range podIDList {
+				for i, podName := range podNameList {
 					power := uint64(podDynamicPower[i])
-					if err := podEnergy[podID].DynEnergy.AddNewCurr(power); err != nil {
+					if err := podEnergy[podName].DynEnergy.AddNewCurr(power); err != nil {
 						klog.V(5).Infoln(err)
 					}
 				}
@@ -424,9 +417,9 @@ func handleInactivePods(foundPod map[string]bool) {
 			klog.V(5).Infoln(err)
 			return
 		}
-		for podID := range podEnergy {
-			if _, found := alivePods[podID]; !found {
-				delete(podEnergy, podID)
+		for podName := range podEnergy {
+			if _, found := alivePods[podName]; !found {
+				delete(podEnergy, podName)
 			}
 		}
 	}

--- a/pkg/podlister/resolve_container.go
+++ b/pkg/podlister/resolve_container.go
@@ -35,7 +35,6 @@ type ContainerInfo struct {
 	PodName       string
 	ContainerName string
 	Namespace     string
-	PodID         string
 }
 
 const (
@@ -81,11 +80,6 @@ func GetSystemProcessNamespace() string {
 func GetPodName(cGroupID, pid uint64) (string, error) {
 	info, err := getContainerInfo(cGroupID, pid)
 	return info.PodName, err
-}
-
-func GetPodID(cGroupID, pid uint64) (string, error) {
-	info, err := getContainerInfo(cGroupID, pid)
-	return info.PodID, err
 }
 
 func GetPodNameSpace(cGroupID, pid uint64) (string, error) {
@@ -147,7 +141,6 @@ func updateListPodCache(targetContainerID string, stopWhenFound bool) (*[]corev1
 				PodName:       (*pods)[i].Name,
 				Namespace:     (*pods)[i].Namespace,
 				ContainerName: statuses[j].Name,
-				PodID:         string((*pods)[i].ObjectMeta.UID),
 			}
 			containerID := regexReplaceContainerIDPrefix.ReplaceAllString(statuses[j].ContainerID, "")
 			containerIDToContainerInfo[containerID] = info
@@ -161,7 +154,6 @@ func updateListPodCache(targetContainerID string, stopWhenFound bool) (*[]corev1
 				PodName:       (*pods)[i].Name,
 				Namespace:     (*pods)[i].Namespace,
 				ContainerName: statuses[j].Name,
-				PodID:         string((*pods)[i].ObjectMeta.UID),
 			}
 			containerID := regexReplaceContainerIDPrefix.ReplaceAllString(statuses[j].ContainerID, "")
 			containerIDToContainerInfo[containerID] = info
@@ -301,8 +293,8 @@ func GetAlivePods() (map[string]bool, error) {
 		return alivePods, err
 	}
 	for i := 0; i < len(*pods); i++ {
-		podID := string((*pods)[i].ObjectMeta.UID)
-		alivePods[podID] = true
+		podName := (*pods)[i].Name
+		alivePods[podName] = true
 	}
 	return alivePods, nil
 }


### PR DESCRIPTION
Reverts sustainable-computing-io/kepler#288

The PR #287 introduces the concept of use containerID, so that collecting the podID will not be necessary

Signed-off-by: Marcelo Amaral [marcelo.amaral1@ibm.com](mailto:marcelo.amaral1@ibm.com)