### PR TITLE
Split OpenShift machineconfigs into separate kernel-devel and cgroupv2

### DIFF
--- a/manifests/openshift/cluster-prereqs/50-master-cgroupv2.yaml
+++ b/manifests/openshift/cluster-prereqs/50-master-cgroupv2.yaml
@@ -2,12 +2,10 @@
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
-  name: 50-master-kernel-devel-cgroupv2
+  name: 50-master-cgroupv2
   labels:
     machineconfiguration.openshift.io/role: master
 spec:
   kernelArguments:
     - systemd.unified_cgroup_hierarchy=1
     - cgroup_no_v1="all"
-  extensions:
-  - kernel-devel

--- a/manifests/openshift/cluster-prereqs/50-worker-cgroupv2.yaml
+++ b/manifests/openshift/cluster-prereqs/50-worker-cgroupv2.yaml
@@ -2,12 +2,10 @@
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
-  name: 50-worker-kernel-devel-cgroupv2
+  name: 50-worker-cgroupv2
   labels:
     machineconfiguration.openshift.io/role: worker
 spec:
   kernelArguments:
     - systemd.unified_cgroup_hierarchy=1
     - cgroup_no_v1="all"
-  extensions:
-  - kernel-devel

--- a/manifests/openshift/cluster-prereqs/51-master-kernel-devel.yaml
+++ b/manifests/openshift/cluster-prereqs/51-master-kernel-devel.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 51-master-kernel-devel
+  labels:
+    machineconfiguration.openshift.io/role: master
+spec:
+  extensions:
+  - kernel-devel

--- a/manifests/openshift/cluster-prereqs/51-worker-kernel-devel.yaml
+++ b/manifests/openshift/cluster-prereqs/51-worker-kernel-devel.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 51-worker-kernel-devel
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  extensions:
+  - kernel-devel

--- a/manifests/openshift/cluster-prereqs/kustomization.yaml
+++ b/manifests/openshift/cluster-prereqs/kustomization.yaml
@@ -2,5 +2,7 @@ commonLabels:
   sustainable-computing.io/app: kepler
 
 resources:
-- 50-master-kernel-devel-cgroupv2.yaml
-- 50-worker-kernel-devel-cgroupv2.yaml
+- 50-master-cgroupv2.yaml
+- 50-worker-cgroupv2.yaml
+- 51-master-kernel-devel.yaml
+- 51-worker-kernel-devel.yaml


### PR DESCRIPTION
From what I understand (@rootfs please correct me) the CGroupsv2 are no longer required to successfully run Kepler. On the other hand, kernel-devel packages seem to be necessary.

Since kernel-devel is necessary and cgroupsv2 aren't, my proposition is to split the manifests into kernel-devel and cgroupv2 added separately so it is possible to install kernel-devel via MachineConfigs separately. I don't have a cluster suitable to verify whether the kustomization.yaml works correctly right now, so it would be good to test it.

@williamcaban @sallyom WDYT? We could somehow make it optional in the OpenShift deploymen scripts to install CGroupsv2 or not, but I don't have time budget to work this out right now.

@sustainable-computing-io/kepler-deployment