### PR TITLE
Add GinkgoWriter in the e2e test to see the kepler execution command output

### DIFF
--- a/e2e/healthcheck_test.go
+++ b/e2e/healthcheck_test.go
@@ -18,7 +18,7 @@ var _ = Describe("healthz check should pass", func() {
 			if !ok {
 				address = "localhost:8888"
 				cmd := exec.Command(keplerBin)
-				keplerSession, err = gexec.Start(cmd, nil, nil)
+				keplerSession, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 				time.Sleep(5 * time.Second) // wait for server start up
 			}


### PR DESCRIPTION
The PR #225 is failing the integration test for mac environment

However, currently the test is not reporting the command execution output when it fails....

When using Ginkgo it can be convenient to direct output to the [GinkgoWriter](https://pkg.go.dev/github.com/onsi/gomega/gexec#Start), then the command will log output when running tests in verbose mode, or when a test fails.
 
Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>