### PR TITLE
Do not remove system-process from the cache

### DIFF
--- a/pkg/collector/reader.go
+++ b/pkg/collector/reader.go
@@ -387,6 +387,9 @@ func handleInactivePods(foundPod map[string]bool) {
 			return
 		}
 		for podName := range podEnergy {
+			if podName == systemProcessName {
+				continue
+			}
 			if _, found := alivePods[podName]; !found {
 				delete(podEnergy, podName)
 			}


### PR DESCRIPTION
The PR #268 introduced the logic to remove from the cache the pods that were deleted.

However, it is removing the system process since it does not find a "pod alive".

So, this PR verifies if the pod is the system-process and does not delete it...


Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>