### PR TITLE
Return zeros for model disabled case

### DIFF
--- a/pkg/model/pod_power.go
+++ b/pkg/model/pod_power.go
@@ -105,12 +105,12 @@ func getPodTotalPower(usageValues [][]float64, systemValues []string) (valid boo
 
 // getPodTotalPower returns estimated pods' RAPL power
 func getPodComponentPowers(usageValues [][]float64, systemValues []string) (bool, []source.RAPLPower) {
+	podNumber := len(usageValues)
 	if PodComponentPowerModelValid {
 		powers, err := PodComponentPowerModelFunc(usageValues, systemValues)
 		if err != nil {
-			return false, []source.RAPLPower{}
+			return false, make([]source.RAPLPower, podNumber)
 		}
-		podNumber := len(usageValues)
 		raplPowers := make([]source.RAPLPower, podNumber)
 		for index := 0; index < podNumber; index++ {
 			pkgPower := getComponentPower(powers, "pkg", index)
@@ -121,5 +121,5 @@ func getPodComponentPowers(usageValues [][]float64, systemValues []string) (bool
 		}
 		return true, raplPowers
 	}
-	return false, []source.RAPLPower{}
+	return false, make([]source.RAPLPower, podNumber)
 }


### PR DESCRIPTION
This PR handles an issue https://github.com/sustainable-computing-io/kepler/issues/308#issuecomment-1285159101 when the pod ratio is not applicable and also the model is not enabled (which is undesirable case in https://github.com/sustainable-computing-io/kepler/discussions/266#discussioncomment-3794406). 

The GetPodPowers  function will return zero values for all pods.
https://github.com/sustainable-computing-io/kepler/blob/ba30dc29bbb622e6e6aa38433f69400cf52e7236/pkg/model/pod_power.go#L53

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>