### PR TITLE
Do not configure the model server if it is not enabled

### DIFF
--- a/pkg/collector/metrics.go
+++ b/pkg/collector/metrics.go
@@ -83,6 +83,7 @@ func SetEnabledMetrics() {
 	uintFeatures = getUIntFeatures()
 	features = append(features, FloatFeatures...)
 	features = append(features, uintFeatures...)
+
 	metricNames = getEstimatorMetrics()
 }
 
@@ -105,7 +106,12 @@ func getEstimatorMetrics() []string {
 	// TO-DO: remove this hard code metric
 	names = append(names, blockDeviceLabel)
 	ratio.InitMetricIndexes(names)
-	model.InitEstimateFunctions(names, systemFeatures, systemValues)
+
+	// do not try to inilialize estimator if it was not configured
+	if config.ModelServerEndpoint != "" {
+		model.InitEstimateFunctions(names, systemFeatures, systemValues)
+	}
+
 	return names
 }
 


### PR DESCRIPTION
The model server is not enabled by default as it should be used mainly when we cannot collect RAPL metrics.

So even though the model server is disabled we are trying to connect to it during boot time

This PR updates to not configure the model server if not enabled and fix issue #308

Signed by: Marcelo Amaral <marcelo.amaral1@ibm.com>