### PR TITLE
fix can't make cluster-up/sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ port 9102.
 ```
 # build manifests file for VM+Baremetal and Baremetal only
 # manifests are created in  _output/manifests/kubernetes/generated/ by default
+# kubectl v1.21.0 is minimum version that support build manifest
 # make build-manifest
 ```
 

--- a/cluster-up/cluster-up.sh
+++ b/cluster-up/cluster-up.sh
@@ -22,5 +22,12 @@ if [ -z "$CLUSTER_PROVIDER" ]; then
     exit 1
 fi
 
+version=$(kubectl version --short | grep 'Client Version' | sed 's/.*v//g' | cut -b -4)
+if [ 1 -eq "$(echo "${version} < 1.21" | bc)" ]
+then
+    echo "You need to update your kubectl version to 1.21+ to support kustomize"
+    exit 1
+fi
+
 source cluster-up/cluster/$CLUSTER_PROVIDER/common.sh
 up

--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -166,10 +166,12 @@ function _prepare_config() {
     sed -i -e "s/$_registry_name/${REGISTRY_NAME}/g" ${CONFIG_OUT_DIR}/local-registry.yml
     sed -i -e "s/$_registry_port/${REGISTRY_PORT}/g" ${CONFIG_OUT_DIR}/local-registry.yml
 
+    kubectl kustomize manifests/kubernetes/vm > manifests/kubernetes/vm/deployment.yaml
+
     # make cluster-sync overwrite the CONFIG_OUT_DIR, so that we update the manifest dir directly.
     # TODO: configure the kepler yaml in the CONFIG_OUT_DIR, not in the MANIFEST DIR.
-    echo "WARN: we are changing the file manifests/kubernetes/deployment.yaml"
-    sed -i -e "s/path: \/proc/path: \/proc-host/g" manifests/kubernetes/deployment.yaml
+    echo "WARN: we are changing the file manifests/kubernetes/vm/deployment.yaml"
+    sed -i -e "s/path: \/proc/path: \/proc-host/g" manifests/kubernetes/vm/deployment.yaml
 }
 
 function _get_nodes() {

--- a/hack/build-manifest.sh
+++ b/hack/build-manifest.sh
@@ -19,6 +19,13 @@
 
 set -ex
 
+version=$(kubectl version --short | grep 'Client Version' | sed 's/.*v//g' | cut -b -4)
+if [ 1 -eq "$(echo "${version} < 1.21" | bc)" ]
+then
+    echo "You need to update your kubectl version to 1.21+ to support kustomize"
+    exit 1
+fi
+
 CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
 IMAGE_TAG=${IMAGE_TAG:-devel}
 IMAGE_REPO=${IMAGE_REPO:-quay.io/sustainable_computing_io/kepler}
@@ -40,7 +47,8 @@ kubectl kustomize ${MANIFESTS_OUT_DIR}/vm > ${MANIFESTS_OUT_DIR}/vm/deployment.y
 if [[ $CLUSTER_PROVIDER == "openshift" ]]; then
     cat manifests/${CLUSTER_PROVIDER}/kepler/01-kepler-install.yaml | sed "s|image:.*|image: $IMAGE_REPO:$IMAGE_TAG|" > ${MANIFESTS_OUT_DIR}/kepler/01-kepler-install.yaml
 else
-    cat manifests/${CLUSTER_PROVIDER}/deployment.yaml | sed "s|image:.*|image: $IMAGE_REPO:$IMAGE_TAG|" > ${MANIFESTS_OUT_DIR}/deployment.yaml
+    sed -i "s|image:.*|image: $IMAGE_REPO:$IMAGE_TAG|" ${MANIFESTS_OUT_DIR}/bm/deployment.yaml
+    sed -i "s|image:.*|image: $IMAGE_REPO:$IMAGE_TAG|" ${MANIFESTS_OUT_DIR}/vm/deployment.yaml
 fi
 
 echo "Done $0"

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -15,6 +15,7 @@ port 9102.
 ```
 # build manifests file for VM+Baremetal and Baremetal only
 # manifests are created in  _output/manifests/kubernetes/generated/ by default
+# kubectl v1.21.0 is minimum version that support build manifest
 # make build-manifest
 ```
 

--- a/manifests/kubernetes/deployment.yaml
+++ b/manifests/kubernetes/deployment.yaml
@@ -1,1 +1,0 @@
-base/deployment.yaml


### PR DESCRIPTION
I used following to fix #318 

```
CLUSTER_PROVIDER="kind" make cluster-up
CLUSTER_PROVIDER="kind" make cluster-sync

I can see this 

# kubectl get pods -A
NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE
kepler               kepler-exporter-g7qd8                        1/1     Running   0          2m55s
kube-system          coredns-565d847f94-fjg2t                     1/1     Running   0          5m12s
kube-system          coredns-565d847f94-llwwh                     1/1     Running   0          5m12s
kube-system          etcd-kind-control-plane                      1/1     Running   0          5m31s
kube-system          kindnet-jj5gf                                1/1     Running   0          5m12s
kube-system          kube-apiserver-kind-control-plane            1/1     Running   0          5m29s
kube-system          kube-controller-manager-kind-control-plane   1/1     Running   0          5m28s
kube-system          kube-proxy-8sdvq                             1/1     Running   0          5m12s
kube-system          kube-scheduler-kind-control-plane            1/1     Running   0          5m29s
local-path-storage   local-path-provisioner-684f458cdd-vvcgq      1/1     Running   0          5m12s

```


Signed-off-by: jichenjc <jichenjc@cn.ibm.com>