### PR TITLE
CI: enable commit msg check

### DIFF
--- a/.github/workflows/commitMsg.yml
+++ b/.github/workflows/commitMsg.yml
@@ -1,0 +1,37 @@
+name: 'Commit Message Check'
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  check-commit-message:
+    name: Check Commit Message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Try to keep the subject line to 50 characters or less; do not exceed 72 characters
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '^[^#].{72}'
+          error: 'The maximum line length of 72 characters is exceeded.'
+          excludeDescription: 'true' # optional: this excludes the description body of a pull request
+          excludeTitle: 'true' # optional: this excludes the title of a pull request
+      - name: Providing additional context if I am right means formatting in topic":" something
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '^.*:\s.*'
+          error: 'topic: someting for example commit msg as [CI: enhancement xxx]'
+      - name: The first word in the commit message subject should be capitalized unless it starts with a lowercase symbol or other identifier
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '^[^].*'
+          error: 'topic: someting for example commit msg as [CI: enhancement xxx]'

--- a/Developer.md
+++ b/Developer.md
@@ -29,3 +29,10 @@ Please see keywords below for more details, as the code talks.
 or
 if runtime.GOOS == "linux" {
 ```
+
+## Commit message
+ref to https://www.kubernetes.dev/docs/guide/pull-requests/#commit-message-guidelines
+we have 3 rules as commit messages check to ensure commit message is meaningful.
+- Try to keep the subject line to 50 characters or less; do not exceed 72 characters
+- Providing additional context if I am right means formatting in topic":" something
+- The first word in the commit message subject should be capitalized unless it starts with a lowercase symbol or other identifier


### PR DESCRIPTION
this pr use https://github.com/GsActions/commit-message-checker with regex as implementation.

Signed-off-by: Sam Yuan <yy19902439@126.com>