### PR TITLE
bug: Fix build manifest

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -29,6 +29,8 @@ jobs:
         run: make cluster-sync
         env:
             CLUSTER_PROVIDER: ${{matrix.kube_provider}}
+            IMAGE_REPO: "localhost:5001/kepler"
+            IMAGE_TAG: "devel"
             CTR_CMD: docker
 
       - name: test if kepler is still alive

--- a/cluster-up/README.md
+++ b/cluster-up/README.md
@@ -30,6 +30,6 @@ This destroys the whole cluster.
 
 ```bash
 export CLUSTER_PROVIDER=`kind`
-make cluster-sync
+IMAGE_REPO="localhost:5001/kepler" IMAGE_TAG="devel" make cluster-sync
 ```
 This removes a running kepler deployment, creates a new docker image, pushes it to the local cluster registry, deploys kepler with the newly created image, and waits for the kepler container to be in the running state.

--- a/dev/README.md
+++ b/dev/README.md
@@ -20,6 +20,12 @@ export IMAGE_REPO=index.docker.io/myrepo
 export IMAGE_TAG=mybuild
 ```
 
+By default, please use:
+```bash
+export IMAGE_REPO="localhost:5001/kepler"
+export IMAGE_TAG="devel"
+```
+
 We assume that you have logged in your container registry
 
 Then point the `Makefile` to cluster provider to build the right manifests:

--- a/hack/build-manifest.sh
+++ b/hack/build-manifest.sh
@@ -27,7 +27,7 @@ then
 fi
 
 CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
-IMAGE_TAG=${IMAGE_TAG:-devel}
+IMAGE_TAG=${IMAGE_TAG:-latest}
 IMAGE_REPO=${IMAGE_REPO:-quay.io/sustainable_computing_io/kepler}
 
 MANIFESTS_OUT_DIR=${MANIFESTS_OUT_DIR:-"_output/manifests/${CLUSTER_PROVIDER}/generated"}

--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -40,6 +40,9 @@ function main() {
     echo "Deploying manifests..."
 
     # Ignore errors because some clusters might not have prometheus operator
+    echo "Deploying with image:"
+    cat ${MANIFESTS_OUT_DIR}/deployment.yaml | grep "image:"
+
     kubectl apply -f ${MANIFESTS_OUT_DIR} || true
     
     # round for 3 times and each for 60s


### PR DESCRIPTION
in order to make cluster-sync happy, modified some make build-manifest  in previous PR

but this makes the image used for general deployment (not CI) using CI image (we sed it to devel )
and it lead to image not found issue

with this PR, check whether it's CI, if it's , sed the iamge
if it's not ,keep using latest image