### PR TITLE
Fix: to make pod_power.go logic robust

### DIFF
--- a/pkg/model/pod_power.go
+++ b/pkg/model/pod_power.go
@@ -51,6 +51,14 @@ func InitPodPowerEstimator(usageMetrics, systemFeatures, systemValues []string) 
 
 // GetContainerPower returns pods' RAPL power and other power
 func GetContainerPower(usageValues [][]float64, systemValues []string, nodeTotalPower, nodeTotalGPUPower uint64, nodeTotalPowerPerComponents source.RAPLPower) (componentPodPowers []source.RAPLPower, otherPodPowers []uint64) {
+	componentPodPowers = make([]source.RAPLPower, len(usageValues))
+	otherPodPowers = make([]uint64, len(usageValues))
+	if len(usageValues) == 0 {
+		// in some edges case otherPodPowers will happens an out of bounds error
+		// directly return to avoid panic
+		return
+	}
+
 	if nodeTotalPowerPerComponents.Pkg > 0 {
 		if nodeTotalPower < nodeTotalPowerPerComponents.Pkg+nodeTotalPowerPerComponents.DRAM+nodeTotalGPUPower {
 			// case: NodeTotalPower is invalid but NodeComponentPower model is available, set = pkg+DRAM+GPU
@@ -64,6 +72,7 @@ func GetContainerPower(usageValues [][]float64, systemValues []string, nodeTotal
 			Core: socketPower,
 		}
 	}
+
 	if nodeTotalPower > 0 {
 		// total power all set, use ratio
 		nodeOtherPower := nodeTotalPower - nodeTotalPowerPerComponents.Pkg - nodeTotalPowerPerComponents.DRAM - nodeTotalGPUPower

--- a/pkg/model/pod_power_test.go
+++ b/pkg/model/pod_power_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sustainable-computing-io/kepler/pkg/power/rapl/source"
+)
+
+var _ = Describe("PodPower", func() {
+	Context("with edge case", func() {
+		It("should return array with length", func() {
+			containerMetricValuesOnly := make([][]float64, 0)
+			NodeMetadataValues := make([]string, 0)
+			nodeTotalPowerPerComponents := source.RAPLPower{}
+			componentPodPowers, otherPodPowers := GetContainerPower(
+				containerMetricValuesOnly,
+				NodeMetadataValues,
+				0,
+				0,
+				nodeTotalPowerPerComponents)
+			lenComponentPodPowers := len(componentPodPowers)
+			lenOtherPodPowers := len(otherPodPowers)
+			Expect(lenComponentPodPowers).Should(BeNumerically(">", -1))
+			Expect(lenOtherPodPowers).Should(BeNumerically(">", -1))
+			Expect(lenComponentPodPowers).Should(BeNumerically("==", lenOtherPodPowers))
+		})
+	})
+})


### PR DESCRIPTION
In some edge case, for example BCC lib not found there will be some array out of bounds happens.
With this pr, makes the array inited with make function to avoid panic.

Signed-off-by: Sam Yuan <yy19902439@126.com>