### PR TITLE
Add version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ OUTPUT_DIR :=_output
 CROSS_BUILD_BINDIR :=$(OUTPUT_DIR)/bin
 FROM_SOURCE :=false
 ARCH :=$(shell uname -m |sed -e "s/x86_64/amd64/" |sed -e "s/aarch64/arm64/")
+GIT_VERSION     := $(shell git describe --dirty --tags --match='v*')
+VERSION         ?= $(GIT_VERSION)
+LDFLAGS         := "-w -s -X 'github.com/sustainable-computing-io/kepler/pkg/version.Version=$(VERSION)'"
 
 ifdef IMAGE_REPO
 	IMAGE_REPO := $(IMAGE_REPO)
@@ -64,7 +67,7 @@ tidy-vendor:
 _build_local: format
 	@mkdir -p "$(CROSS_BUILD_BINDIR)/$(GOOS)_$(GOARCH)"
 	+@GOOS=$(GOOS) GOARCH=$(GOARCH) go build -tags ${GO_BUILD_TAGS} \
-		-o $(CROSS_BUILD_BINDIR)/$(GOOS)_$(GOARCH)/kepler ./cmd/exporter.go
+		-o $(CROSS_BUILD_BINDIR)/$(GOOS)_$(GOARCH)/kepler -ldflags $(LDFLAGS) ./cmd/exporter.go
 
 cross-build-linux-amd64:
 	+$(MAKE) _build_local GOOS=linux GOARCH=amd64

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sustainable-computing-io/kepler/pkg/manager"
 	"github.com/sustainable-computing-io/kepler/pkg/power/gpu"
 	"github.com/sustainable-computing-io/kepler/pkg/power/rapl"
+	kversion "github.com/sustainable-computing-io/kepler/pkg/version"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -69,6 +70,8 @@ func main() {
 	defer finalizing()
 	klog.InitFlags(nil)
 	flag.Parse()
+
+	klog.Infof("Kepler running on version: %s", kversion.Version)
 
 	config.SetEnabledEBPFCgroupID(*enabledEBPFCgroupID)
 	config.SetEnabledHardwareCounterMetrics(*exposeHardwareCounterMetrics)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+// Version is set by the linker flags in the Makefile.
+var Version string


### PR DESCRIPTION
output

```
# kubectl logs kepler-exporter-zmjtw -n kepler
I1028 02:15:11.663915       1 exporter.go:74] Kepler running on version: v0.3-71-gbce84ee-dirty
```

Signed-off-by: jichenjc <jichenjc@cn.ibm.com>