### PR TITLE
Use function to init instead of global variable

### DIFF
--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/sustainable-computing-io/kepler/pkg/cgroup"
 	collector_metric "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
 	"github.com/sustainable-computing-io/kepler/pkg/config"
 	"github.com/sustainable-computing-io/kepler/pkg/manager"
@@ -76,11 +77,14 @@ func main() {
 	config.SetEnabledEBPFCgroupID(*enabledEBPFCgroupID)
 	config.SetEnabledHardwareCounterMetrics(*exposeHardwareCounterMetrics)
 	config.SetEnabledGPU(*enableGPU)
+
+	cgroup.SetSliceHandler()
+
 	if modelServerEndpoint != nil {
 		klog.Infof("Initializing the Model Server")
 		config.SetModelServerEndpoint(*modelServerEndpoint)
 	}
-	collector_metric.SetEnabledMetrics()
+	collector_metric.InitAvailableParamAndMetrics()
 
 	if *enableGPU {
 		klog.Infof("Initializing the GPU collector")

--- a/pkg/cgroup/slice_handler.go
+++ b/pkg/cgroup/slice_handler.go
@@ -51,7 +51,11 @@ type SliceHandler struct {
 	IOTopPath     string
 }
 
-var SliceHandlerInstance *SliceHandler = InitSliceHandler()
+var SliceHandlerInstance *SliceHandler
+
+func SetSliceHandler() {
+	SliceHandlerInstance = InitSliceHandler()
+}
 
 func (s *SliceHandler) Init() {
 	s.statReaders = make(map[string][]StatReader)

--- a/pkg/collector/metric/stats.go
+++ b/pkg/collector/metric/stats.go
@@ -27,16 +27,25 @@ const (
 
 var (
 	// AvailableCounters holds a list of hardware counters that might be collected
-	AvailableCounters []string = attacher.GetEnabledCounters()
+	AvailableCounters []string
 	// AvailableCgroupMetrics holds a list of cgroup metrics exposed by the cgroup that might be collected
-	AvailableCgroupMetrics []string = cgroup.GetAvailableCgroupMetrics()
+	AvailableCgroupMetrics []string
 	// AvailableKubeletMetrics holds a list of cgrpup metrics exposed by kubelet that might be collected
-	AvailableKubeletMetrics []string = cgroup.GetAvailableKubeletMetrics()
+	AvailableKubeletMetrics []string
 
 	// CPUHardwareCounterEnabled defined if hardware counters should be accounted and exported
 	CPUHardwareCounterEnabled bool = false
 	// CPUHardwareCounterEnabled = isCounterStatEnabled(attacher.CPUInstructionLabel)
 )
+
+func InitAvailableParamAndMetrics() {
+	AvailableCounters = attacher.GetEnabledCounters()
+	AvailableCgroupMetrics = cgroup.GetAvailableCgroupMetrics()
+	AvailableKubeletMetrics = cgroup.GetAvailableKubeletMetrics()
+
+	// defined in utils to init metrics
+	setEnabledMetrics()
+}
 
 type UInt64Stat struct {
 	Curr     uint64

--- a/pkg/collector/metric/utils.go
+++ b/pkg/collector/metric/utils.go
@@ -47,7 +47,7 @@ func getcontainerUintFeatureNames() []string {
 	return metrics
 }
 
-func SetEnabledMetrics() {
+func setEnabledMetrics() {
 	ContainerFeaturesNames = []string{}
 	AvailableCounters = attacher.GetEnabledCounters()
 


### PR DESCRIPTION
with this change, we can print those important info at beginning
```
I1104 11:32:22.132853       1 slice_handler.go:120] InitSliceHandler: &{map[] /sys/fs/cgroup/cpu /sys/fs/cgroup/memory /sys/fs/cgroup/blkio}
I1104 11:32:22.132925       1 bcc_attacher.go:143] hardeware counter metr true
I1104 11:32:22.192933       1 exporter.go:86] Initializing the Model Server
I1104 11:32:22.192968       1 bcc_attacher.go:143] hardeware counter metr true
I1104 11:32:22.192979       1 utils.go:42] Available counter metrics: [cpu_cycles cpu_instr cache_miss]
I1104 11:32:22.192989       1 utils.go:43] Available cgroup metrics from cgroup: []
I1104 11:32:22.192999       1 utils.go:44] Available cgroup metrics from kubelet: [container_cpu_usage_seconds_total container_memory_working_set_bytes]
I1104 11:32:22.193004       1 utils.go:45] Available I/O metrics: [bytes_read bytes_writes]
I1104 11:32:22.193011       1 exporter.go:92] Initializing the GPU collector

```

Signed-off-by: jichenjc <jichenjc@cn.ibm.com>