### PR TITLE
fix: avoid put duplicate PID into array

### DIFF
--- a/pkg/collector/metric/container_metric.go
+++ b/pkg/collector/metric/container_metric.go
@@ -140,7 +140,18 @@ func (c *ContainerMetrics) ResetCurr() {
 // NOTICE: can lose main container info for multi-container pod
 func (c *ContainerMetrics) SetLatestProcess(cgroupPID, pid uint64, comm string) {
 	c.CGroupPID = cgroupPID
-	c.PIDS = append(c.PIDS, pid)
+
+	// TODO: review if we can remove the PIDS list as it's for GPU consumption and likely will remove this dependency
+	notexist := true
+	for _, v := range c.PIDS {
+		if v == pid {
+			notexist = false
+		}
+	}
+	if notexist {
+		c.PIDS = append(c.PIDS, pid)
+	}
+
 	c.Command = comm
 }
 


### PR DESCRIPTION
fix #362 
output looks like :(20180 below only occur once)

```
I1107 02:48:35.842949       1 metric_collector.go:127] energy from pod (1 processes): name: prometheus-k8s-0 namespace: monitoring
        cgrouppid: 0 pid: [20180] comm: prometheus
        ePkg (mJ): 0 (0) (eCore: 0 (0) eDram: 0 (0) eUncore: 0 (0)) eGPU (mJ): 0 (0) eOther (mJ): 0 (0)
        eDyn (mJ): 0 (0)
        avgFreq: 0.00
        CPUTime:  4008 (1358979)
        counters: map[cache_miss:0 (0) cpu_cycles:0 (0) cpu_instr:0 (0)]
        cgroupfs: map[]
        kubelets: map[container_cpu_usage_seconds_total:0 (14226) container_memory_working_set_bytes:65536 (1450950656)]

I1107 02:48:35.842969       1 metric_collector.go:127] energy from pod (1 processes): name: counter namespace: n1
        cgrouppid: 0 pid: [24414 2356896 2356900 2356966 2357079 2357155 2357223 2357295 2357374 2357439 2357504 2357581 2357595 2357653 2357844 2357914 2357918 2357980 2358049 2358062 2358133 2358199 2358211 2358334 2358418 2358479 2358539 2358612 2358667 2358711 2358721 2358848 2358852 2358982 2359091 2359132 2359156 2359281 2359293 2359359 2359416 2359439 2359508 2359566 2359580 2359634 2359700 2359756 2359770 2359835 2359891 2359903 2360009 2360078 2360090 2360177 2360245 2360309 2360363 2360455 2360510 2360525 2360579 2360644 2360700 2360780 2360836 2360913 2360970 2360984 2360997 2361078 2361130 2361145 2361215 2361271 2361295 2361363 2361458 2361472 2361596 2361648 2361660 2361726 2361784 2361796 2361865 2361936 2361948 2362087 2362099 2362166 2362312 2362373 2362387 2362441 2362509 2362563 2362577 2362698 2362710 2362773 2362830 2362883 2362895 2363030 2363042 2363110 2363190 2363314 2363386 2363456 2363510 2363522 2363587 2363646 2363726 2363784 2363811 2363881 2363947 2363962 2364086 2364111 2364178 2364234 2364248 2364410 2364463 2364544 2364600 2364679 2364736 2364750 2364834 2364900 2364912 2365035 2365059 2365128 2365253 2365320 2365374 2365455 2365591 2365661 2365834 2365858 2365982 2366006 2366126 2366141 2366195 2366334 2366454 2366467 2366535 2366593 2366608 2366620 2366741 2366833 2366982 2367035 2367049 2367104 2367220 2367234 2367238 2367341 2367418 2367531 2367558 2367621 2367629 2367772 2367834 2367858 2367867 2367927 2367985 2368049 2368173 2368187 2368191 2368260 2368316 2368328 2368473 2368477 2368599 2368781 2368785 2368809 2368932 2368946 2368994 2369000 2369133 2369205 2369258 2369354 2369399 2369422 2369490 2369546 2369560 2369564 2369702 2369721 2369726 2369799 2369857 2369861 2369974 2370030 2370043 2370112 2370116 2370299 2370434 2370490] comm: sh

```

Signed-off-by: jichenjc <jichenjc@cn.ibm.com>