### PR TITLE
pod cache: cache system process

### DIFF
--- a/pkg/cgroup/resolve_container.go
+++ b/pkg/cgroup/resolve_container.go
@@ -122,15 +122,11 @@ func getContainerInfo(cGroupID, pid uint64) (*ContainerInfo, error) {
 		return cinfo, nil
 	}
 
-	// in the case the containerID is not a kubernetes container, the updateListPodCache will not add it to the cache
 	if _, ok := containerIDToContainerInfo[containerID]; !ok {
 		// some system process might have container ID, but we need to replace it if the container is not a kubernetes container
-		if info.ContainerName == utils.SystemProcessName {
-			containerID = utils.SystemProcessName
-		}
+		containerIDToContainerInfo[containerID] = info
 	}
 
-	containerIDToContainerInfo[containerID] = info
 	return containerIDToContainerInfo[containerID], nil
 }
 


### PR DESCRIPTION
per profiling stack in #381, the pod cache update causes the latency. As previously in [release 0.3](https://github.com/sustainable-computing-io/kepler/blob/release-0.3/pkg/podlister/resolve_container.go#L125), when the pod is not found, the system process name is used in the cache.