### PR TITLE
power: switch to model based estimator when the RAPL interface is not available

### DIFF
--- a/pkg/power/components/source/dummy.go
+++ b/pkg/power/components/source/dummy.go
@@ -18,7 +18,7 @@ package source
 
 var (
 	// this variable is used for unit and functional test purpose
-	SystemCollectionSupported = true
+	SystemCollectionSupported = false
 )
 
 type PowerDummy struct{}


### PR DESCRIPTION
this should activate ML based estimator and fix the 0 counter issue on VM

cc @jichenjc @sallyom 