### PR TITLE
fix no config case at model init

### DIFF
--- a/pkg/model/estimator/local/lr.go
+++ b/pkg/model/estimator/local/lr.go
@@ -157,11 +157,16 @@ func (r *LinearRegressor) Init() bool {
 		// next try loading from URL by config
 		weight, err = r.loadWeightFromURL()
 	}
-	if err == nil {
+	if weight != nil {
 		r.valid = true
 		r.modelWeight = weight
 		klog.V(3).Infof("LR Model (%s) Weight: %v", r.OutputType.String(), r.modelWeight)
 	} else {
+		if err == nil {
+			klog.V(3).Infof("LR Model (%s): no config", r.OutputType.String())
+		} else {
+			klog.V(3).Infof("LR Model (%s): %v", r.OutputType.String(), err)
+		}
 		r.valid = false
 	}
 	return r.valid


### PR DESCRIPTION
This PR is to fix this issue https://github.com/sustainable-computing-io/kepler/issues/389 by checking weight value instead of error and report no config when no error but no weight available.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>