### PR TITLE
Replace the containerID of system process with a common name for aggregation

### DIFF
--- a/pkg/cgroup/resolve_container.go
+++ b/pkg/cgroup/resolve_container.go
@@ -123,10 +123,16 @@ func getContainerInfo(cGroupID, pid uint64, withCGroupID bool) (*ContainerInfo, 
 	}
 
 	if _, ok := containerIDToContainerInfo[containerID]; !ok {
-		// some system process might have container ID, but we need to replace it if the container is not a kubernetes container
 		containerIDToContainerInfo[containerID] = info
+		// some system process might have container ID, but we need to replace it if the container is not a kubernetes container
+		if info.ContainerName == utils.SystemProcessName {
+			containerID = utils.SystemProcessName
+			// in addition to the system container ID, add also the system process name to the cache
+			if _, ok := containerIDToContainerInfo[containerID]; !ok {
+				containerIDToContainerInfo[containerID] = info
+			}
+		}
 	}
-
 	return containerIDToContainerInfo[containerID], nil
 }
 


### PR DESCRIPTION
The PR #383 fixed the problem of not adding the system containerID to the cache.

However, it removed the logic  of using common name `system_process` to aggregate all the system process resource utilization. Without this logic, we will have the system processes resource utilization divided in different "container" instances because of using different containerIDs.

Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>