### PR TITLE
cmd: don't silently exit, when there is a panic,print the panic stack

### DIFF
--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"runtime/debug"
 	"runtime/pprof"
 	"syscall"
 	"time"
@@ -70,6 +71,8 @@ func healthProbe(w http.ResponseWriter, req *http.Request) {
 }
 
 func finalizing() {
+	stack := "exit stack: \n" + string(debug.Stack())
+	klog.Infof(stack)
 	exitCode := 10
 	klog.Infoln(finishingMsg)
 	klog.FlushAndExit(klog.ExitFlushTimeout, exitCode)


### PR DESCRIPTION
to debug test failures or other runtime issues, we need to have the panic stack
I used this to debug #397 

```console
% go test ./e2e/... --race --bench=. -cover --count=1 --vet=all -v
=== RUN   TestE2eTest
Running Suite: E2eTest Suite - /Users/hchen/go/src/github.com/sustainable-computing-io/kepler/e2e
=================================================================================================
Random Seed: 1668628355

Will run 3 of 3 specs
keplerSession sdtErr
keplerSession sdtErr I1116 14:52:39.443328    5553 exporter.go:150] Kepler running on version:
I1116 14:52:39.443436    5553 config.go:89] using gCgroup ID in the BPF program: true
I1116 14:52:39.443497    5553 config.go:90] kernel version: 22.1
I1116 14:52:39.443544    5553 exporter.go:159] Initializing the Model Server
I1116 14:52:39.564276    5553 slice_handler.go:179] Not able to find any valid .scope file in /sys/fs/cgroup/cpu, this likely cause all cgroup metrics to be 0
I1116 14:52:39.564521    5553 exporter.go:75] exit stack:
goroutine 1 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:24 +0x65
main.finalizing()
	/Users/hchen/go/src/github.com/sustainable-computing-io/kepler/cmd/exporter.go:74 +0x1d
panic({0x1008171c0, 0x100f4f5f0})
	/usr/local/go/src/runtime/panic.go:838 +0x207
github.com/sustainable-computing-io/kepler/pkg/cgroup.SearchByContainerID.func1({0xc00003c198, 0x12}, {0x0?, 0x0?}, {0x100f59d68?, 0x6a?})
	/Users/hchen/go/src/github.com/sustainable-computing-io/kepler/pkg/cgroup/path_handler.go:31 +0x3e
path/filepath.WalkDir({0xc00003c198, 0x12}, 0xc00014dc20)
	/usr/local/go/src/path/filepath/path.go:479 +0x50
github.com/sustainable-computing-io/kepler/pkg/cgroup.SearchByContainerID({0xc00003c198?, 0x1?}, {0x0?, 0x0?})
	/Users/hchen/go/src/github.com/sustainable-computing-io/kepler/pkg/cgroup/path_handler.go:29 +0x4d
github.com/sustainable-computing-io/kepler/pkg/cgroup.TryInitStatReaders({0x0, 0x0})
	/Users/hchen/go/src/github.com/sustainable-computing-io/kepler/pkg/cgroup/slice_handler.go:155 +0xbc
github.com/sustainable-computing-io/kepler/pkg/cgroup.GetAvailableCgroupMetrics()
	/Users/hchen/go/src/github.com/sustainable-computing-io/kepler/pkg/cgroup/slice_handler.go:193 +0x45
github.com/sustainable-computing-io/kepler/pkg/collector/metric.InitAvailableParamAndMetrics()
	/Users/hchen/go/src/github.com/sustainable-computing-io/kepler/pkg/collector/metric/stats.go:43 +0x4f
main.main()
	/Users/hchen/go/src/github.com/sustainable-computing-io/kepler/cmd/exporter.go:164 +0x2ae
I1116 14:52:39.564538    5553 exporter.go:77] Exiting...
```