### PR TITLE
CI: use bcc tar files

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -28,24 +28,9 @@ jobs:
           GOBIN: /home/runner/go/bin
     - name: Build bcc
       run: |
-          set -x
-          sudo apt-get update
-          # Use release 9 of llvm etc. - later versions have an unfixed
-          # bug on Ubuntu:
-          # https://github.com/iovisor/bcc/issues/2915
-          sudo apt-get -y install bison build-essential cmake flex git libelf-dev libfl-dev libedit-dev libllvm11 llvm-11-dev libclang-cpp11-dev libclang-common-11-dev libclang1-11 libclang-11-dev python zlib1g-dev
-          pushd /tmp
-          git clone --depth 1 --branch v0.25.0 https://github.com/iovisor/bcc.git
-          mkdir -p bcc/build; cd bcc/build
-          # Symlink /usr/lib/llvm to avoid "Unable to find clang libraries"
-          # The directory appears only to be created when installing the
-          # virtual llvm-dev package.
-          # https://github.com/iovisor/bcc/issues/492
-          sudo ln -s /usr/lib/llvm-11 /usr/local/llvm
-          cmake ..
-          make
-          sudo make install
-          popd
+          wget https://github.com/sustainable-computing-io/kepler-ci-artifacts/releases/download/v0.25.0/bcc_v0.25.0.tar.gz
+          tar -zxvf bcc_v0.25.0.tar.gz
+          sudo dpkg -i libbcc_0.25.0-1_amd64.deb
     - name: Run 
       run: |
           make test-verbose


### PR DESCRIPTION
use tar files at https://github.com/sustainable-computing-io/kepler-ci-artifacts/releases/tag/v0.25.0 in CI process to accelerate CI processing instead of build from source.