### PR TITLE
image: use cuda image to support gpu

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -27,7 +27,7 @@ RUN make clean $MAKE_TARGET SOURCE_GIT_TAG=$SOURCE_GIT_TAG BIN_TIMESTAMP=$BIN_TI
 # RUN make test
 
 # build image
-FROM quay.io/sustainable_computing_io/kepler_base:ubi-8.6-bcc-0.24
+FROM quay.io/sustainable_computing_io/kepler_base:cuda-11.8.0-base-ubi8-bcc-0.24
 
 ARG ARCH=amd64
 

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.6
+FROM docker.io/nvidia/cuda:11.8.0-base-ubi8
 
 ARG ARCH=amd64
 
@@ -18,6 +18,6 @@ RUN yum install -y http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
     yum install -y http://mirror.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/bcc-devel-0.24.0-2.el8.x86_64.rpm
 
 # nvidia driver is updated on a (bi)monthly basis
-RUN yum install -y https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/nvidia-driver-NVML-520.61.05-1.el8.x86_64.rpm
+# RUN yum install -y nvidia-driver-NVML nvidia-driver-cuda
 
     


### PR DESCRIPTION
Per [compatibility matrix](https://docs.nvidia.com/deploy/cuda-compatibility/index.html), 11.8 supports most of the up to date GPU driver.

The latest cuda is 12.0, but the base image is not [there](https://hub.docker.com/r/nvidia/cuda/tags?page=1) yet
