### PR TITLE
Fix model-server configmap and kepler dnsPolicy

### DIFF
--- a/hack/build-manifest.sh
+++ b/hack/build-manifest.sh
@@ -138,7 +138,7 @@ EXPORTER_IMG=${IMAGE_REPO}/${EXPORTER_IMAGE_NAME}:${IMAGE_TAG}
 ESTIMATOR_IMG=${ESTIMATOR_REPO}/${ESTIMATOR_IMAGE_NAME}:${IMAGE_TAG}
 MODEL_SERVER_IMG=${MODEL_SERVER_REPO}/${MODEL_SERVER_IMAGE_NAME}:${MODEL_SERVER_IMAGE_TAG}
 pushd ${MANIFESTS_OUT_DIR}/exporter;${KUSTOMIZE} edit set image kepler=${EXPORTER_IMG}; ${KUSTOMIZE} edit set image kepler-estimator=${ESTIMATOR_IMG}; popd
-pushd ${MANIFESTS_OUT_DIR}/model-server;${KUSTOMIZE} edit set image kepler=${MODEL_SERVER_IMG}; popd
+pushd ${MANIFESTS_OUT_DIR}/model-server;${KUSTOMIZE} edit set image kepler-model-server=${MODEL_SERVER_IMG}; popd
 
 echo "kustomize manifests..."
 ${KUSTOMIZE} build ${MANIFESTS_OUT_DIR}/base > ${MANIFESTS_OUT_DIR}/deployment.yaml

--- a/manifests/config/base/patch/patch-model-server-kepler-config.yaml
+++ b/manifests/config/base/patch/patch-model-server-kepler-config.yaml
@@ -5,4 +5,7 @@ metadata:
   namespace: system
 data:
   MODEL_SERVER_ENABLE: "true"
-  MODEL_SERVER_ENDPOINT: http://kepler-model-server.$(MODEL_SERVER_NAMESPACE).cluster.local:$(MODEL_SERVER_PORT)/model
+  MODEL_SERVER_URL: kepler-model-server.$(MODEL_SERVER_NAMESPACE).svc.cluster.local
+  MODEL_SERVER_PORT: |
+    $(MODEL_SERVER_PORT)
+  MODEL_SERVER_MODEL_REQ_PATH: /model

--- a/manifests/config/exporter/exporter.yaml
+++ b/manifests/config/exporter/exporter.yaml
@@ -40,6 +40,7 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: kepler-sa
       containers:
       - name: kepler-exporter

--- a/manifests/config/model-server/kustomizeconfig.yaml
+++ b/manifests/config/model-server/kustomizeconfig.yaml
@@ -3,4 +3,9 @@ varReference:
   group: ""
   version: v1
   name: kepler-cfm
-  path: data/MODEL_SERVER_ENDPOINT
+  path: data/MODEL_SERVER_URL
+- kind: ConfigMap
+  group: ""
+  version: v1
+  name: kepler-cfm
+  path: data/MODEL_SERVER_PORT

--- a/manifests/config/model-server/model-server.yaml
+++ b/manifests/config/model-server/model-server.yaml
@@ -48,6 +48,7 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 8100
+          name: http
         volumeMounts:
           - name: cfm
             mountPath: /etc/config

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,7 +54,7 @@ const (
 )
 
 var (
-	modelServerService = fmt.Sprintf("kepler-model-server.%s.cluster.local", KeplerNamespace)
+	modelServerService = fmt.Sprintf("kepler-model-server.%s.svc.cluster.local", KeplerNamespace)
 
 	KeplerNamespace              = getConfig("KELPER_NAMESPACE", defaultNamespace)
 	EnabledEBPFCgroupID          = getBoolConfig("ENABLE_EBPF_CGROUPID", true)
@@ -123,6 +123,7 @@ func SetModelServerReqEndpoint() (modelServerReqEndpoint string) {
 	modelServerURL := getConfig("MODEL_SERVER_URL", modelServerService)
 	if modelServerURL == modelServerService {
 		modelServerPort := getConfig("MODEL_SERVER_PORT", defaultModelServerPort)
+		modelServerPort = strings.TrimSuffix(modelServerPort, "\n") // trim \n for kustomized manifest
 		modelServerURL = fmt.Sprintf("http://%s:%s", modelServerURL, modelServerPort)
 	}
 	modelReqPath := getConfig("MODEL_SERVER_MODEL_REQ_PATH", defaultModelRequestPath)

--- a/pkg/model/estimator/local/lr.go
+++ b/pkg/model/estimator/local/lr.go
@@ -150,23 +150,25 @@ type LinearRegressor struct {
 func (r *LinearRegressor) Init() bool {
 	var err error
 	var weight interface{}
+	outputStr := r.OutputType.String()
 	// try getting weight from model server if it is enabled
 	if config.ModelServerEnable && config.ModelServerEndpoint != "" {
 		weight, err = r.getWeightFromServer()
-	} else if r.InitModelURL != "" {
+		klog.V(3).Infof("LR Model (%s): getWeightFromServer: %v", outputStr, weight)
+	}
+	if weight == nil && r.InitModelURL != "" {
 		// next try loading from URL by config
-		klog.V(5).Infof("getWeightFromServer failed, using InitModelURL:%v to load", r.InitModelURL)
 		weight, err = r.loadWeightFromURL()
+		klog.V(3).Infof("LR Model (%s): loadWeightFromURL(%v): %v", outputStr, r.InitModelURL, weight)
 	}
 	if weight != nil {
 		r.valid = true
 		r.modelWeight = weight
-		klog.V(3).Infof("LR Model (%s) Weight: %v", r.OutputType.String(), r.modelWeight)
 	} else {
 		if err == nil {
-			klog.V(3).Infof("LR Model (%s): no config", r.OutputType.String())
+			klog.V(3).Infof("LR Model (%s): no config", outputStr)
 		} else {
-			klog.V(3).Infof("LR Model (%s): %v", r.OutputType.String(), err)
+			klog.V(3).Infof("LR Model (%s): %v", outputStr, err)
 		}
 		r.valid = false
 	}


### PR DESCRIPTION
This PR fixed the model-server integration issue mentioned in https://github.com/sustainable-computing-io/kepler/issues/463.

significant fix points:
- kepler config map key-value items that are related to kepler-model-server endpoint
- dnsPolicy: ClusterFirstWithHostNet
- port name in model-server manifest
- change from else if to if to try getting weight from URL if from model server is failed

Note: the corresponding PR on kepler-model-server https://github.com/sustainable-computing-io/kepler-model-server/pull/62 is also needed to be reviewed and merged.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>