### PR TITLE
gpu power: add GPU features

### DIFF
--- a/pkg/collector/metric/utils.go
+++ b/pkg/collector/metric/utils.go
@@ -18,6 +18,8 @@ package metric
 
 import (
 	"github.com/sustainable-computing-io/kepler/pkg/bpfassets/attacher"
+	"github.com/sustainable-computing-io/kepler/pkg/config"
+	"github.com/sustainable-computing-io/kepler/pkg/power/accelerator"
 
 	"k8s.io/klog/v2"
 )
@@ -34,6 +36,10 @@ func getcontainerUintFeatureNames() []string {
 	metrics = append(metrics, AvailableKubeletMetrics...)
 	// cgroup I/O metric
 	metrics = append(metrics, ContainerIOStatMetricsNames...)
+	// gpu metric
+	if config.EnabledGPU && accelerator.IsGPUCollectionSupported() {
+		metrics = append(metrics, []string{config.GPUSMUtilization, config.GPUMemUtilization}...)
+	}
 
 	klog.V(3).Infof("Available counter metrics: %v", AvailableCounters)
 	klog.V(3).Infof("Available cgroup metrics from cgroup: %v", AvailableCgroupMetrics)

--- a/pkg/model/estimator/local/ratio.go
+++ b/pkg/model/estimator/local/ratio.go
@@ -104,10 +104,12 @@ func UpdateContainerEnergyByRatioPowerModel(containersMetrics map[string]*collec
 			containerResUsage = float64(container.CounterStats[config.GpuUsageMetric].Curr)
 			nodeTotalResUsage = nodeMetrics.GetNodeResUsagePerResType(config.GpuUsageMetric)
 			nodeResEnergyUtilization = float64(nodeMetrics.GetEnergyValue(collector_metric.GPU))
-			klog.V(5).Infof("gpu power: containerID %v containerResUsage: %f, nodeTotalResUsage: %f, nodeResEnergyUtilization: %f, containerNumber: %f\n", containerID, containerResUsage, nodeTotalResUsage, nodeResEnergyUtilization, containerNumber)
 			containerGPUEnergy := getEnergyRatio(containerResUsage, nodeTotalResUsage, nodeResEnergyUtilization, containerNumber)
 			if err := containersMetrics[containerID].EnergyInGPU.AddNewCurr(containerGPUEnergy); err != nil {
 				klog.Infoln(err)
+			} else {
+				klog.V(5).Infof("gpu power ratio: containerID %v containerResUsage: %f, nodeTotalResUsage: %f, nodeResEnergyUtilization: %f, containerNumber: %f containerGPUEnergy: %v",
+					containerID, containerResUsage, nodeTotalResUsage, nodeResEnergyUtilization, containerNumber, containersMetrics[containerID].EnergyInGPU.Curr)
 			}
 		}
 


### PR DESCRIPTION
The node total GPU usage is always 0, and thus forcing GPU energy evenly attributed on all Pods. Since GPU process utilization already accounts GPU resource usage, this PR uses GPU utilization, that is already set in the container metrics, to account GPU energy ratio.