### PR TITLE
add DEBUG_DEPLOY OPT in manifest-build

### DIFF
--- a/hack/build-manifest.sh
+++ b/hack/build-manifest.sh
@@ -117,6 +117,11 @@ if [ ! -z ${CI_DEPLOY} ]; then
     uncomment_patch ci ${MANIFESTS_OUT_DIR}/exporter/kustomization.yaml
 fi
 
+if [ ! -z ${DEBUG_DEPLOY} ]; then
+    echo "enable debug"
+    uncomment_patch debug ${MANIFESTS_OUT_DIR}/base/kustomization.yaml
+fi
+
 if [ ! -z ${MODEL_SERVER_DEPLOY} ]; then
     echo "enable model-server"
     uncomment_path model-server ${MANIFESTS_OUT_DIR}/base/kustomization.yaml

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -18,20 +18,23 @@ Consult the documentation of your Linux distribution on details for enabling the
   # > make build-manifest OPTS="ESTIMATOR_SIDECAR_DEPLOY OPENSHIFT_DEPLOY"
   ```
 
-Deployment Option|Description
----|---
-BM_DEPLOY|baremetal deployment patched with node selector feature.node.kubernetes.io/cpu-cpuid.HYPERVISOR to not exist
-OPENSHIFT_DEPLOY|patch openshift-specific attribute to kepler daemonset and deploy SecurityContextConstraints
-PROMETHEUS_DEPLOY|patch prometheus-related resource (ServiceMonitor, RBAC role, rolebinding) - require [prometheus deployment](https://github.com/sustainable-computing-io/kepler#deploy-the-prometheus-operator-and-the-whole-monitoring-stack)
-CLUSTER_PREREQ_DEPLOY|deploy prerequisites for kepler on openshift cluster (only available when OPENSHIFT_DEPLOY set)
-CI_DEPLOY|deploy volumn mount for CI
-ESTIMATOR_SIDECAR_DEPLOY|patch estimator sidecar and corresponding configmap to kepler daemonset
-MODEL_SERVER_DEPLOY|deploy model server and corresponding configmap to kepler daemonset
-TRAINER_DEPLOY|patch online-trainer sidecar to model server (only available when MODEL_SERVER_DEPLOY set)
+Deployment Option|Description|Dependency
+---|---|---
+BM_DEPLOY|baremetal deployment patched with node selector feature.node.kubernetes.io/cpu-cpuid.HYPERVISOR to not exist|-
+OPENSHIFT_DEPLOY|patch openshift-specific attribute to kepler daemonset and deploy SecurityContextConstraints|-
+PROMETHEUS_DEPLOY|patch prometheus-related resource (ServiceMonitor, RBAC role, rolebinding) |require prometheus deployment which can be OpenShift integrated or [custom deploy](https://github.com/sustainable-computing-io/kepler#deploy-the-prometheus-operator-and-the-whole-monitoring-stack)
+CLUSTER_PREREQ_DEPLOY|deploy prerequisites for kepler on openshift cluster| OPENSHIFT_DEPLOY option set
+CI_DEPLOY|update proc path for kind cluster using in CI|-
+ESTIMATOR_SIDECAR_DEPLOY|patch estimator sidecar and corresponding configmap to kepler daemonset|-
+MODEL_SERVER_DEPLOY|deploy model server and corresponding configmap to kepler daemonset|-
+TRAIN_DEPLOY|patch online-trainer sidecar to model server| MODEL_SERVER_DEPLOY option set
+DEBUG_DEPLOY|patch KEPLER_LOG_LEVEL for debugging|
 
- -  kubectl v1.21.0 is minimum version that support build manifest
- -  manifest sources and outputs will be in  _output/generated-manifests by default
-
+ -  build-manifest requirements:
+    -  kubectl v1.21+
+    -  make
+    -  go
+ -  manifest sources and outputs will be in  `_output/generated-manifests` by default
 ## Installing Kepler on Kubernetes
 
 Deploy kustomized manifest

--- a/manifests/config/base/kustomization.yaml
+++ b/manifests/config/base/kustomization.yaml
@@ -12,3 +12,5 @@ bases:
 patchesStrategicMerge: []
 # add this line to set model-server endpoint to kepler
 # - ./patch/patch-model-server-kepler-config.yaml
+# add this line to change log level for debugging
+# - ./patch/patch-debug.yaml

--- a/manifests/config/base/patch/patch-debug.yaml
+++ b/manifests/config/base/patch/patch-debug.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kepler-cfm
+  namespace: system
+data:
+  KEPLER_LOG_LEVEL: "5"

--- a/manifests/config/exporter/exporter.yaml
+++ b/manifests/config/exporter/exporter.yaml
@@ -10,6 +10,7 @@ metadata:
   namespace: system
 data:
   KEPLER_NAMESPACE: $(KEPLER_NAMESPACE)
+  KEPLER_LOG_LEVEL: "1"
   METRIC_PATH: "/metrics"
   BIND_ADDRESS: "0.0.0.0:9102"
   ENABLE_GPU: "true"
@@ -53,8 +54,10 @@ spec:
         securityContext:
           privileged: true
         command:
-        - /usr/bin/kepler
-        - -v=1
+        - /bin/sh
+        - -c
+        args:
+        - /usr/bin/kepler -v=$(KEPLER_LOG_LEVEL)
         ports:
         - containerPort: 9102
           hostPort: 9102

--- a/manifests/config/exporter/kustomization.yaml
+++ b/manifests/config/exporter/kustomization.yaml
@@ -34,6 +34,14 @@ vars:
     name: system
   fieldref:
     fieldpath: metadata.name
+- name: KEPLER_LOG_LEVEL
+  objref:
+    kind: ConfigMap
+    group: ""
+    version: v1
+    name: kepler-cfm
+  fieldref:
+    fieldpath: data.KEPLER_LOG_LEVEL
 
 configurations:
 - ./kustomizeconfig.yaml

--- a/manifests/config/exporter/kustomizeconfig.yaml
+++ b/manifests/config/exporter/kustomizeconfig.yaml
@@ -9,3 +9,8 @@ varReference:
   version: v1
   name: kepler-cfm
   path: data/KEPLER_NAMESPACE
+- kind: DaemonSet
+  group: apps
+  version: v1
+  name: kepler-exporter
+  path: spec/template/spec/containers[0]/args[0]

--- a/manifests/config/exporter/patch/patch-estimator-sidecar.yaml
+++ b/manifests/config/exporter/patch/patch-estimator-sidecar.yaml
@@ -18,6 +18,15 @@ spec:
   template:
     spec:
       containers:
+      - command:
+        - /bin/sh
+        - -c
+        args:
+        - until [ -e /tmp/estimator.sock ]; do sleep 1; done && /usr/bin/kepler -v=$(KEPLER_LOG_LEVEL)
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+        name: kepler-exporter
       - image: kepler-estimator:latest
         imagePullPolicy: Always
         name: estimator
@@ -27,15 +36,6 @@ spec:
           readOnly: true
         - mountPath: /tmp
           name: tmp
-      - command:
-        - /bin/sh
-        - -c
-        args:
-        - until [ -e /tmp/estimator.sock ]; do sleep 1; done && /usr/bin/kepler -v=1
-        volumeMounts:
-        - mountPath: /tmp
-          name: tmp
-        name: kepler-exporter
       volumes:
       - emptyDir: {}
         name: tmp


### PR DESCRIPTION
According to https://github.com/sustainable-computing-io/kepler/issues/466, this PR introduces a new option for simple modification of kepler log in manifest building.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>