### PR TITLE
Update the scape detect command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ test-mac-verbose: tidy-vendor
 	@go test ./... --race --bench=. -cover --count=1 --vet=all
 
 escapes_detect: tidy-vendor
-	@go build -tags $(GO_BUILD_TAGS) -gcflags="-m -l" ./... | grep "escapes to heap" || true
+	@go build -tags $(GO_BUILD_TAGS) -gcflags="-m -l" ./... 2>&1 | grep "escapes to heap" || true
 
 set_govulncheck:
 	@go install golang.org/x/vuln/cmd/govulncheck@latest


### PR DESCRIPTION
The `grep` in the scape detect command is not working and all analysis are being reported, including the `does not scape` cases (where it means there is no problem).

The results are on stderr and we need to merge stderr with stdout.

Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>