### PR TITLE
fix: switch from dummy to estimated method

### DIFF
--- a/pkg/bpfassets/perf_event_bindata.go
+++ b/pkg/bpfassets/perf_event_bindata.go
@@ -367,11 +367,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("nonexistent") would return an error

--- a/pkg/power/components/power.go
+++ b/pkg/power/components/power.go
@@ -40,11 +40,11 @@ type powerInterface interface {
 }
 
 var (
-	dummyImpl                = &source.PowerDummy{}
-	sysfsImpl                = &source.PowerSysfs{}
-	msrImpl                  = &source.PowerMSR{}
-	powerImpl powerInterface = sysfsImpl
-	useMSR                   = false // it looks MSR on kvm or hyper-v is not working
+	estimateImpl                = &source.PowerEstimate{}
+	sysfsImpl                   = &source.PowerSysfs{}
+	msrImpl                     = &source.PowerMSR{}
+	powerImpl    powerInterface = sysfsImpl
+	useMSR                      = false // it looks MSR on kvm or hyper-v is not working
 )
 
 func InitPowerImpl() {
@@ -56,8 +56,8 @@ func InitPowerImpl() {
 			klog.V(1).Infoln("use MSR to obtain power")
 			powerImpl = msrImpl
 		} else {
-			klog.V(1).Infoln("Not able to obtain power, use dummy method")
-			powerImpl = dummyImpl
+			klog.V(1).Infoln("Not able to obtain power, use estimate method")
+			powerImpl = estimateImpl
 		}
 	}
 }


### PR DESCRIPTION
estimate need files 

"/var/lib/kepler/data/normalized_cpu_arch.csv"   ==> from docker file 
"/var/lib/kepler/data/power_data.csv" ==> from docker file 
"/proc/meminfo" ==> host level, same to other /proc usage in kepler