### PR TITLE
arm64: support Ampere xgene hwmon based power source

### DIFF
--- a/build/Dockerfile.base.arm64
+++ b/build/Dockerfile.base.arm64
@@ -1,7 +1,23 @@
-FROM --platform=linux/arm64 registry.access.redhat.com/ubi8/ubi:8.4
+FROM docker.io/nvidia/cuda:11.8.0-base-ubi8
 
-ARG ARCH=arm64
+ARG ARCH=aarch64
 
-RUN yum update -y && \
-    yum install -y kmod xz python3 && yum clean all -y && \
+# enable centos appstream
+RUN yum install -y http://mirror.centos.org/centos/8-stream/BaseOS/aarch64/os/Packages/centos-gpg-keys-8-6.el8.noarch.rpm && \
+    yum install -y http://mirror.centos.org/centos/8-stream/BaseOS/aarch64/os/Packages/centos-stream-repos-8-6.el8.noarch.rpm
+
+RUN yum install -y dnf-plugins-core && \
+    yum config-manager --set-enabled powertools
+
+
+# don't update yet, this will conflict with protected pkg i.e. redhat-release
+#RUN yum update -y
+
+# install less frequently updated pkg first
+RUN yum install -y kmod xz python3 && yum clean all -y && \
     pip3 install  --no-cache-dir archspec 
+
+# bcc pkg is updated more frequently
+RUN yum install -y bcc-0.24.0 && yum install -y bcc-devel-0.24.0
+
+    

--- a/data/normalized_cpu_arch.csv
+++ b/data/normalized_cpu_arch.csv
@@ -8,4 +8,4 @@ cascadelake,Cascade Lake
 coffeelake,Coffee Lake
 alderlake,Alder Lake
 cascadelake,Cascade Lake
-neoverse_n1, neoverse_n1
+neoverse_n1,neoverse_n1

--- a/data/normalized_cpu_arch.csv
+++ b/data/normalized_cpu_arch.csv
@@ -8,3 +8,4 @@ cascadelake,Cascade Lake
 coffeelake,Coffee Lake
 alderlake,Alder Lake
 cascadelake,Cascade Lake
+neoverse_n1, neoverse_n1

--- a/pkg/power/components/source/apm_xgene_sysfs.go
+++ b/pkg/power/components/source/apm_xgene_sysfs.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	// sysfs path templates for Ampere Xgene hwmon
+	powerLabelPathTemplate = "/sys/class/hwmon/hwmon*/power*_label"
+	cpuPowerLabel          = "CPU power"
+)
+
+var (
+	powerInputPath = ""
+	currTime       = time.Now()
+)
+
+type ApmXgeneSysfs struct{}
+
+func (r *ApmXgeneSysfs) IsSystemCollectionSupported() bool {
+	labelFiles, err := filepath.Glob(powerLabelPathTemplate)
+	for _, labelFile := range labelFiles {
+		var data []byte
+		if data, err = os.ReadFile(labelFile); err != nil {
+			continue
+		}
+		if strings.TrimSuffix(strings.TrimSpace(string(data)), "\n") == cpuPowerLabel {
+			// replace the label file with the input file
+			powerInputPath = strings.Replace(labelFile, "label", "input", 1)
+			klog.V(1).Infof("Found power input file: %s", powerInputPath)
+			return true
+		}
+	}
+	return false
+}
+
+func (r *ApmXgeneSysfs) GetEnergyFromDram() (uint64, error) {
+	return 0, nil
+}
+
+func (r *ApmXgeneSysfs) GetEnergyFromCore() (uint64, error) {
+	now := time.Now()
+	diff := now.Sub(startTime)
+	seconds := diff.Seconds()
+	// read from the power input file and convert file content to numbers
+	var data []byte
+	var err error
+	if data, err = os.ReadFile(powerInputPath); err != nil {
+		return 0, err
+	}
+	power, err := strconv.ParseFloat(strings.TrimSpace(string(data)), 64)
+	if err != nil {
+		return 0, err
+	}
+	// convert to milliwatts
+	power = power * 1000
+	return uint64(power * seconds), nil
+}
+
+func (r *ApmXgeneSysfs) GetEnergyFromUncore() (uint64, error) {
+	return 0, nil
+}
+
+func (r *ApmXgeneSysfs) GetEnergyFromPackage() (uint64, error) {
+	return 0, nil
+}
+
+func (r *ApmXgeneSysfs) GetNodeComponentsEnergy() map[int]NodeComponentsEnergy {
+	coreEnergy, _ := r.GetEnergyFromCore()
+	dramEnergy, _ := r.GetEnergyFromDram()
+	componentsEnergies := make(map[int]NodeComponentsEnergy)
+	componentsEnergies[0] = NodeComponentsEnergy{
+		Core:   coreEnergy,
+		DRAM:   dramEnergy,
+		Uncore: 0,
+		Pkg:    coreEnergy,
+	}
+	return componentsEnergies
+}
+
+func (r *ApmXgeneSysfs) StopPower() {
+}

--- a/pkg/power/components/source/apm_xgene_sysfs.go
+++ b/pkg/power/components/source/apm_xgene_sysfs.go
@@ -41,6 +41,9 @@ type ApmXgeneSysfs struct{}
 
 func (r *ApmXgeneSysfs) IsSystemCollectionSupported() bool {
 	labelFiles, err := filepath.Glob(powerLabelPathTemplate)
+	if err != nil {
+		return false
+	}
 	for _, labelFile := range labelFiles {
 		var data []byte
 		if data, err = os.ReadFile(labelFile); err != nil {

--- a/pkg/power/components/source/apm_xgene_sysfs.go
+++ b/pkg/power/components/source/apm_xgene_sysfs.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021.
+Copyright 2023.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -35,10 +35,11 @@ const (
 
 var (
 	powerInputPath = ""
-	currTime       = time.Now()
 )
 
-type ApmXgeneSysfs struct{}
+type ApmXgeneSysfs struct {
+	currTime time.Time
+}
 
 func (r *ApmXgeneSysfs) IsSystemCollectionSupported() bool {
 	labelFiles, err := filepath.Glob(powerLabelPathTemplate)
@@ -65,9 +66,14 @@ func (r *ApmXgeneSysfs) GetEnergyFromDram() (uint64, error) {
 }
 
 func (r *ApmXgeneSysfs) GetEnergyFromCore() (uint64, error) {
+	if r.currTime.IsZero() {
+		r.currTime = time.Now()
+		return 0, nil
+	}
 	now := time.Now()
-	diff := now.Sub(currTime)
+	diff := now.Sub(r.currTime)
 	seconds := diff.Seconds()
+	r.currTime = now
 	// read from the power input file and convert file content to numbers
 	var data []byte
 	var err error

--- a/pkg/power/components/source/apm_xgene_sysfs.go
+++ b/pkg/power/components/source/apm_xgene_sysfs.go
@@ -62,7 +62,7 @@ func (r *ApmXgeneSysfs) GetEnergyFromDram() (uint64, error) {
 
 func (r *ApmXgeneSysfs) GetEnergyFromCore() (uint64, error) {
 	now := time.Now()
-	diff := now.Sub(startTime)
+	diff := now.Sub(currTime)
 	seconds := diff.Seconds()
 	// read from the power input file and convert file content to numbers
 	var data []byte
@@ -74,8 +74,6 @@ func (r *ApmXgeneSysfs) GetEnergyFromCore() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	// convert to milliwatts
-	power = power * 1000
 	return uint64(power * seconds), nil
 }
 

--- a/pkg/power/components/source/apm_xgene_sysfs.go
+++ b/pkg/power/components/source/apm_xgene_sysfs.go
@@ -30,6 +30,7 @@ const (
 	// sysfs path templates for Ampere Xgene hwmon
 	powerLabelPathTemplate = "/sys/class/hwmon/hwmon*/power*_label"
 	cpuPowerLabel          = "CPU power"
+	uJTomJ                 = 1000
 )
 
 var (
@@ -77,7 +78,8 @@ func (r *ApmXgeneSysfs) GetEnergyFromCore() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return uint64(power * seconds), nil
+	// per https://dri.freedesktop.org/docs/drm/hwmon/xgene-hwmon.html, the power is in uJ/s
+	return uint64(power*seconds) / uJTomJ, nil
 }
 
 func (r *ApmXgeneSysfs) GetEnergyFromUncore() (uint64, error) {


### PR DESCRIPTION
This is based on the [Ampere wiki](https://github.com/AmpereComputing/ampere-lts-kernel/wiki/hwmon-drivers). Currently the xgene hwmon driver is used. There is no DIMM power reading in this module. 

The [altra hwmon](https://github.com/torvalds/linux/commits/master/drivers/hwmon/smpro-hwmon.c) is only recently merged to kernel source. It exposes DIMM and CPU power readings