### PR TITLE
change model output from joule to millijoule

### DIFF
--- a/pkg/model/container_power_test.go
+++ b/pkg/model/container_power_test.go
@@ -175,9 +175,8 @@ var _ = Describe("ContainerPower", func() {
 			UpdateContainerEnergy(containersMetrics, nodeMetrics)
 
 			// Unit test use is reported by default settings through LR model
-			// and following will be reported so EnergyInPkg.Curr will be 1323
-			// map[dram:[1330.24062191839 1330.24062191839] pkg:[1323.5139455775347 1323.5139455775347]]
-			Expect(containersMetrics["containerA"].EnergyInPkg.Curr).To(Equal(uint64(1323)))
+			// and following will be reported so EnergyInPkg.Curr will be 9512
+			Expect(containersMetrics["containerA"].EnergyInPkg.Curr).To(Equal(uint64(9512)))
 		})
 	})
 })

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -65,9 +65,8 @@ var _ = Describe("Test Model Unit", func() {
 		// calculate container energy consumption
 		UpdateContainerEnergy(containersMetrics, nodeMetrics)
 		// Unit test use is reported by default settings through LR model
-		// and following will be reported so EnergyInPkg.Curr will be 1323
-		// map[dram:[1330.24062191839 1330.24062191839] pkg:[1323.5139455775347 1323.5139455775347]]
-		Expect(containersMetrics["containerA"].EnergyInPkg.Curr).To(Equal(uint64(1323)))
+		// and following will be reported so EnergyInPkg.Curr will be 9512
+		Expect(containersMetrics["containerA"].EnergyInPkg.Curr).To(Equal(uint64(9512)))
 	})
 
 	It("Get container power with no dependency but with total node power ", func() {
@@ -90,9 +89,8 @@ var _ = Describe("Test Model Unit", func() {
 		// calculate container energy consumption
 		UpdateContainerEnergy(containersMetrics, nodeMetrics)
 		// Unit test use is reported by default settings through LR model
-		// and following will be reported so EnergyInPkg.Curr will be 1323
-		// map[dram:[1330.24062191839 1330.24062191839] pkg:[1323.5139455775347 1323.5139455775347]]
-		Expect(containersMetrics["containerA"].EnergyInPkg.Curr).To(Equal(uint64(1323)))
+		// and following will be reported so EnergyInPkg.Curr will be 9512
+		Expect(containersMetrics["containerA"].EnergyInPkg.Curr).To(Equal(uint64(9512)))
 	})
 
 	It("Get container power with no dependency but with all node power ", func() {
@@ -128,8 +126,7 @@ var _ = Describe("Test Model Unit", func() {
 
 		UpdateContainerEnergy(containersMetrics, nodeMetrics)
 		// Unit test use is reported by default settings through LR model
-		// and following will be reported so EnergyInPkg.Curr will be 1323
-		// map[dram:[1330.24062191839 1330.24062191839] pkg:[1323.5139455775347 1323.5139455775347]]
-		Expect(containersMetrics["containerA"].EnergyInPkg.Curr).To(Equal(uint64(1323)))
+		// and following will be reported so EnergyInPkg.Curr will be 9512
+		Expect(containersMetrics["containerA"].EnergyInPkg.Curr).To(Equal(uint64(9512)))
 	})
 })

--- a/pkg/model/utils.go
+++ b/pkg/model/utils.go
@@ -21,13 +21,17 @@ import (
 	"github.com/sustainable-computing-io/kepler/pkg/power/components/source"
 )
 
+const (
+	jouleToMiliJoule = 1000
+)
+
 // getComponentPower called by getPodComponentPowers to check if component key is present in powers response and fills with single 0
 func getComponentPower(powers map[string][]float64, componentKey string, index int) uint64 {
 	values := powers[componentKey]
 	if index >= len(values) {
 		return 0
 	} else {
-		return uint64(values[index])
+		return uint64(values[index] * jouleToMiliJoule)
 	}
 }
 


### PR DESCRIPTION
This PR relates to model update corresponding to Kepler 0.4's new collection and exported power unit.

The updated modes were trained offline and uploaded in [kepler-model-server PR#64]( https://github.com/sustainable-computing-io/kepler-model-server/pull/64). 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>