### PR TITLE
ebpf: add soft irq counters

### DIFF
--- a/pkg/bpfassets/attacher/attacher_types.go
+++ b/pkg/bpfassets/attacher/attacher_types.go
@@ -25,7 +25,6 @@ const (
 	CPURefCycleLabel    = config.CPURefCycle
 	CPUInstructionLabel = config.CPUInstruction
 	CacheMissLabel      = config.CacheMiss
-	bpfPerfArrayPrefix  = "_hc_reader"
 
 	// Per /sys/kernel/debug/tracing/events/irq/softirq_entry/format
 	// { 0, "HI" }, { 1, "TIMER" }, { 2, "NET_TX" }, { 3, "NET_RX" }, { 4, "BLOCK" }, { 5, "IRQ_POLL" }, { 6, "TASKLET" }, { 7, "SCHED" }, { 8, "HRTIMER" }, { 9, "RCU" }

--- a/pkg/bpfassets/attacher/attacher_types.go
+++ b/pkg/bpfassets/attacher/attacher_types.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package attacher
+
+import (
+	"github.com/sustainable-computing-io/kepler/pkg/config"
+)
+
+const (
+	CPUCycleLabel       = config.CPUCycle
+	CPURefCycleLabel    = config.CPURefCycle
+	CPUInstructionLabel = config.CPUInstruction
+	CacheMissLabel      = config.CacheMiss
+	bpfPerfArrayPrefix  = "_hc_reader"
+
+	// Per /sys/kernel/debug/tracing/events/irq/softirq_entry/format
+	// { 0, "HI" }, { 1, "TIMER" }, { 2, "NET_TX" }, { 3, "NET_RX" }, { 4, "BLOCK" }, { 5, "IRQ_POLL" }, { 6, "TASKLET" }, { 7, "SCHED" }, { 8, "HRTIMER" }, { 9, "RCU" }
+
+	// IRQ vector to IRQ number
+	IRQNetTX = 2
+	IRQNetRX = 3
+	IRQBlock = 4
+)

--- a/pkg/bpfassets/attacher/bcc_attacher.go
+++ b/pkg/bpfassets/attacher/bcc_attacher.go
@@ -53,6 +53,7 @@ var (
 		CacheMissLabel:      {unix.PERF_TYPE_HARDWARE, unix.PERF_COUNT_HW_CACHE_MISSES, true},
 	}
 	HardwareCountersEnabled = false
+	bpfPerfArrayPrefix      = "_hc_reader"
 )
 
 func loadModule(objProg []byte, options []string) (m *bpf.Module, err error) {

--- a/pkg/bpfassets/attacher/bcc_attacher.go
+++ b/pkg/bpfassets/attacher/bcc_attacher.go
@@ -21,10 +21,9 @@ package attacher
 
 import (
 	"fmt"
+	"golang.org/x/sys/unix"
 	"runtime"
 	"strconv"
-
-	"golang.org/x/sys/unix"
 
 	assets "github.com/sustainable-computing-io/kepler/pkg/bpfassets"
 	"github.com/sustainable-computing-io/kepler/pkg/config"
@@ -34,32 +33,17 @@ import (
 	"k8s.io/klog/v2"
 )
 
-type perfCounter struct {
-	evType   int
-	evConfig int
-	enabled  bool
-}
-
 type BpfModuleTables struct {
 	Module       *bpf.Module
 	Table        *bpf.Table
 	CPUFreqTable *bpf.Table
 }
 
-const (
-	CPUCycleLabel       = config.CPUCycle
-	CPURefCycleLabel    = config.CPURefCycle
-	CPUInstructionLabel = config.CPUInstruction
-	CacheMissLabel      = config.CacheMiss
-	bpfPerfArrayPrefix  = "_hc_reader"
-
-	// Per /sys/kernel/debug/tracing/events/irq/softirq_entry/format
-	// { 0, "HI" }, { 1, "TIMER" }, { 2, "NET_TX" }, { 3, "NET_RX" }, { 4, "BLOCK" }, { 5, "IRQ_POLL" }, { 6, "TASKLET" }, { 7, "SCHED" }, { 8, "HRTIMER" }, { 9, "RCU" }
-	// IRQ vector to IRQ number
-	IRQNetTX = 2
-	IRQNetRX = 3
-	IRQBlock = 4
-)
+type perfCounter struct {
+	evType   int
+	evConfig int
+	enabled  bool
+}
 
 var (
 	Counters = map[string]perfCounter{

--- a/pkg/bpfassets/attacher/bcc_attacher_stub.go
+++ b/pkg/bpfassets/attacher/bcc_attacher_stub.go
@@ -21,15 +21,6 @@ package attacher
 
 import (
 	"fmt"
-
-	"github.com/sustainable-computing-io/kepler/pkg/config"
-)
-
-const (
-	CPUCycleLabel       = config.CPUCycle
-	CPURefCycleLabel    = config.CPURefCycle
-	CPUInstructionLabel = config.CPUInstruction
-	CacheMissLabel      = config.CacheMiss
 )
 
 type perfCounter struct{}
@@ -89,6 +80,10 @@ func AttachBPFAssets() (*BpfModuleTables, error) {
 func DetachBPFModules(bpfModules *BpfModuleTables) {
 }
 
-func GetEnabledCounters() []string {
+func GetEnabledHWCounters() []string {
+	return []string{}
+}
+
+func GetEnabledBPFCounters() []string {
 	return []string{}
 }

--- a/pkg/bpfassets/perf_event_bindata.go
+++ b/pkg/bpfassets/perf_event_bindata.go
@@ -94,6 +94,7 @@ typedef struct process_metrics_t
     u64 cpu_cycles;
     u64 cpu_instr;
     u64 cache_miss;
+    u16 vec_nr[10]; // 10 is the max number of irq vectors
     char comm[16];
 } process_metrics_t;
 
@@ -286,6 +287,21 @@ int kprobe__finish_task_switch(struct pt_regs *ctx, struct task_struct *prev)
         processes.update(&cur_pid, &new_process);
     }
 
+    return 0;
+}
+
+// per https://www.kernel.org/doc/html/latest/core-api/tracepoint.html#c.trace_softirq_entry
+TRACEPOINT_PROBE(irq, softirq_entry)
+{
+    u64 cur_pid = bpf_get_current_pid_tgid() >> 32;
+    struct process_metrics_t *process_metrics;
+    process_metrics = processes.lookup(&cur_pid);
+    if (process_metrics != 0)
+    {
+        if (args->vec < 10) {
+            process_metrics->vec_nr[args->vec] ++;
+        }
+    }
     return 0;
 }
 `)

--- a/pkg/collector/container_hc_collector.go
+++ b/pkg/collector/container_hc_collector.go
@@ -83,12 +83,12 @@ func (c *Collector) updateBPFMetrics() {
 
 		// update ebpf metrics
 		// first update CPU time
-		if err = c.ContainersMetrics[containerID].CPUTime.AddNewCurr(ct.ProcessRunTime); err != nil {
+		if err = c.ContainersMetrics[containerID].CPUTime.AddNewDelta(ct.ProcessRunTime); err != nil {
 			klog.V(5).Infoln(err)
 		}
 		// update IRQ vector
 		for i := 0; i < config.MaxIRQ; i++ {
-			if err = c.ContainersMetrics[containerID].SoftIQRCount[i].AddNewCurr(uint64(ct.VecNR[i])); err != nil {
+			if err = c.ContainersMetrics[containerID].SoftIQRCount[i].AddNewDelta(uint64(ct.VecNR[i])); err != nil {
 				klog.V(5).Infoln(err)
 			}
 		}

--- a/pkg/collector/container_hc_collector.go
+++ b/pkg/collector/container_hc_collector.go
@@ -41,6 +41,7 @@ type ProcessBPFMetrics struct {
 	CPUCycles      uint64
 	CPUInstr       uint64
 	CacheMisses    uint64
+	VecNR          [config.MaxIRQ]uint16 // irq counter, 10 is the max number of irq vectors
 	Command        [16]byte
 }
 
@@ -80,11 +81,20 @@ func (c *Collector) updateBPFMetrics() {
 			c.ContainersMetrics[containerID].SetLatestProcess(ct.CGroupID, ct.PID, C.GoString(comm))
 		}
 
-		if err = c.ContainersMetrics[containerID].CPUTime.AddNewDelta(ct.ProcessRunTime); err != nil {
+		// update ebpf metrics
+		// first update CPU time
+		if err = c.ContainersMetrics[containerID].CPUTime.AddNewCurr(ct.ProcessRunTime); err != nil {
 			klog.V(5).Infoln(err)
 		}
+		// update IRQ vector
+		for i := 0; i < config.MaxIRQ; i++ {
+			if err = c.ContainersMetrics[containerID].SoftIQRCount[i].AddNewCurr(uint64(ct.VecNR[i])); err != nil {
+				klog.V(5).Infoln(err)
+			}
+		}
 
-		for _, counterKey := range collector_metric.AvailableCounters {
+		// update HW counters
+		for _, counterKey := range collector_metric.AvailableHWCounters {
 			var val uint64
 			switch counterKey {
 			case attacher.CPUCycleLabel:

--- a/pkg/collector/metric/container_metric.go
+++ b/pkg/collector/metric/container_metric.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/sustainable-computing-io/kepler/pkg/bpfassets/attacher"
 	"github.com/sustainable-computing-io/kepler/pkg/config"
 	"github.com/sustainable-computing-io/kepler/pkg/power/accelerator"
 	"k8s.io/klog/v2"
@@ -51,7 +52,9 @@ type ContainerMetrics struct {
 	CurrProcesses int
 	Disks         int
 
-	CPUTime *UInt64Stat
+	// ebpf metrics
+	CPUTime      *UInt64Stat
+	SoftIQRCount []UInt64Stat
 
 	CounterStats  map[string]*UInt64Stat
 	CgroupFSStats map[string]*UInt64StatCollection
@@ -83,6 +86,7 @@ func NewContainerMetrics(containerName, podName, podNamespace string) *Container
 		ContainerName: containerName,
 		Namespace:     podNamespace,
 		CPUTime:       &UInt64Stat{},
+		SoftIQRCount:  make([]UInt64Stat, config.MaxIRQ),
 		CounterStats:  make(map[string]*UInt64Stat),
 		CgroupFSStats: make(map[string]*UInt64StatCollection),
 		KubeletStats:  make(map[string]*UInt64Stat),
@@ -105,7 +109,7 @@ func NewContainerMetrics(containerName, podName, podNamespace string) *Container
 		IdleEnergyInOther:  &UInt64Stat{},
 		IdleEnergyInGPU:    &UInt64Stat{},
 	}
-	for _, metricName := range AvailableCounters {
+	for _, metricName := range AvailableHWCounters {
 		c.CounterStats[metricName] = &UInt64Stat{}
 	}
 	// TODO: transparently list the other metrics and do not initialize them when they are not supported, e.g. HC
@@ -127,7 +131,10 @@ func NewContainerMetrics(containerName, podName, podNamespace string) *Container
 // ResetCurr reset all current value to 0
 func (c *ContainerMetrics) ResetDeltaValues() {
 	c.CurrProcesses = 0
-	c.CPUTime.ResetDeltaValues()
+	c.CPUTime.ResetCurr()
+	for i := 0; i < config.MaxIRQ; i++ {
+		c.SoftIQRCount[i].ResetCurr()
+	}
 	for counterKey := range c.CounterStats {
 		c.CounterStats[counterKey].ResetDeltaValues()
 	}
@@ -191,8 +198,15 @@ func (c *ContainerMetrics) getIntDeltaAndAggrValue(metric string) (curr, aggr ui
 	}
 
 	switch metric {
-	case CPUTimeLabel:
-		return c.CPUTime.Delta, c.CPUTime.Aggr, nil
+	// ebpf metrics
+	case config.CPUTime:
+		return c.CPUTime.Curr, c.CPUTime.Aggr, nil
+	case config.IRQBlockLabel:
+		return c.SoftIQRCount[attacher.IRQBlock].Curr, c.SoftIQRCount[attacher.IRQBlock].Aggr, nil
+	case config.IRQNetTXLabel:
+		return c.SoftIQRCount[attacher.IRQNetTX].Curr, c.SoftIQRCount[attacher.IRQNetTX].Aggr, nil
+	case config.IRQNetRXLabel:
+		return c.SoftIQRCount[attacher.IRQNetRX].Curr, c.SoftIQRCount[attacher.IRQNetRX].Aggr, nil
 	// hardcode cgroup metrics
 	// TO-DO: merge to cgroup stat
 	case config.BlockDevicesIO:
@@ -273,14 +287,20 @@ func (c *ContainerMetrics) String() string {
 		"\tDyn ePkg (mJ): %s (eCore: %s eDram: %s eUncore: %s) eGPU (mJ): %s eOther (mJ): %s \n"+
 		"\tIdle ePkg (mJ): %s (eCore: %s eDram: %s eUncore: %s) eGPU (mJ): %s eOther (mJ): %s \n"+
 		"\tCPUTime:  %d (%d)\n"+
+		"\tNetTX IRQ: %d (%d)\n"+
+		"\tNetRX IRQ: %d (%d)\n"+
+		"\tBlock IRQ: %d (%d)\n"+
 		"\tcounters: %v\n"+
 		"\tcgroupfs: %v\n"+
 		"\tkubelets: %v\n",
 		c.CurrProcesses, c.PodName, c.ContainerName, c.Namespace,
 		c.CGroupPID, c.PIDS, c.Command,
-		c.DynEnergyInPkg, c.DynEnergyInCore, c.DynEnergyInDRAM, c.DynEnergyInUncore, c.DynEnergyInGPU, c.DynEnergyInOther,
-		c.IdleEnergyInPkg, c.IdleEnergyInCore, c.IdleEnergyInDRAM, c.IdleEnergyInUncore, c.IdleEnergyInGPU, c.IdleEnergyInOther,
-		c.CPUTime.Delta, c.CPUTime.Aggr,
+		c.EnergyInPkg, c.EnergyInCore, c.EnergyInDRAM, c.EnergyInUncore, c.EnergyInGPU, c.EnergyInOther,
+		c.DynEnergy,
+		c.CPUTime.Curr, c.CPUTime.Aggr,
+		c.SoftIQRCount[attacher.IRQNetTX].Curr, c.SoftIQRCount[attacher.IRQNetTX].Aggr,
+		c.SoftIQRCount[attacher.IRQNetRX].Curr, c.SoftIQRCount[attacher.IRQNetRX].Aggr,
+		c.SoftIQRCount[attacher.IRQBlock].Curr, c.SoftIQRCount[attacher.IRQBlock].Aggr,
 		c.CounterStats,
 		c.CgroupFSStats,
 		c.KubeletStats)

--- a/pkg/collector/metric/container_metric.go
+++ b/pkg/collector/metric/container_metric.go
@@ -131,9 +131,9 @@ func NewContainerMetrics(containerName, podName, podNamespace string) *Container
 // ResetCurr reset all current value to 0
 func (c *ContainerMetrics) ResetDeltaValues() {
 	c.CurrProcesses = 0
-	c.CPUTime.ResetCurr()
+	c.CPUTime.ResetDeltaValues()
 	for i := 0; i < config.MaxIRQ; i++ {
-		c.SoftIQRCount[i].ResetCurr()
+		c.SoftIQRCount[i].ResetDeltaValues()
 	}
 	for counterKey := range c.CounterStats {
 		c.CounterStats[counterKey].ResetDeltaValues()
@@ -200,13 +200,13 @@ func (c *ContainerMetrics) getIntDeltaAndAggrValue(metric string) (curr, aggr ui
 	switch metric {
 	// ebpf metrics
 	case config.CPUTime:
-		return c.CPUTime.Curr, c.CPUTime.Aggr, nil
+		return c.CPUTime.Delta, c.CPUTime.Aggr, nil
 	case config.IRQBlockLabel:
-		return c.SoftIQRCount[attacher.IRQBlock].Curr, c.SoftIQRCount[attacher.IRQBlock].Aggr, nil
+		return c.SoftIQRCount[attacher.IRQBlock].Delta, c.SoftIQRCount[attacher.IRQBlock].Aggr, nil
 	case config.IRQNetTXLabel:
-		return c.SoftIQRCount[attacher.IRQNetTX].Curr, c.SoftIQRCount[attacher.IRQNetTX].Aggr, nil
+		return c.SoftIQRCount[attacher.IRQNetTX].Delta, c.SoftIQRCount[attacher.IRQNetTX].Aggr, nil
 	case config.IRQNetRXLabel:
-		return c.SoftIQRCount[attacher.IRQNetRX].Curr, c.SoftIQRCount[attacher.IRQNetRX].Aggr, nil
+		return c.SoftIQRCount[attacher.IRQNetRX].Delta, c.SoftIQRCount[attacher.IRQNetRX].Aggr, nil
 	// hardcode cgroup metrics
 	// TO-DO: merge to cgroup stat
 	case config.BlockDevicesIO:
@@ -295,12 +295,12 @@ func (c *ContainerMetrics) String() string {
 		"\tkubelets: %v\n",
 		c.CurrProcesses, c.PodName, c.ContainerName, c.Namespace,
 		c.CGroupPID, c.PIDS, c.Command,
-		c.EnergyInPkg, c.EnergyInCore, c.EnergyInDRAM, c.EnergyInUncore, c.EnergyInGPU, c.EnergyInOther,
-		c.DynEnergy,
-		c.CPUTime.Curr, c.CPUTime.Aggr,
-		c.SoftIQRCount[attacher.IRQNetTX].Curr, c.SoftIQRCount[attacher.IRQNetTX].Aggr,
-		c.SoftIQRCount[attacher.IRQNetRX].Curr, c.SoftIQRCount[attacher.IRQNetRX].Aggr,
-		c.SoftIQRCount[attacher.IRQBlock].Curr, c.SoftIQRCount[attacher.IRQBlock].Aggr,
+		c.DynEnergyInPkg, c.DynEnergyInCore, c.DynEnergyInDRAM, c.DynEnergyInUncore, c.DynEnergyInGPU, c.DynEnergyInOther,
+		c.IdleEnergyInPkg, c.IdleEnergyInCore, c.IdleEnergyInDRAM, c.IdleEnergyInUncore, c.IdleEnergyInGPU, c.IdleEnergyInOther,
+		c.CPUTime.Delta, c.CPUTime.Aggr,
+		c.SoftIQRCount[attacher.IRQNetTX].Delta, c.SoftIQRCount[attacher.IRQNetTX].Aggr,
+		c.SoftIQRCount[attacher.IRQNetRX].Delta, c.SoftIQRCount[attacher.IRQNetRX].Aggr,
+		c.SoftIQRCount[attacher.IRQBlock].Delta, c.SoftIQRCount[attacher.IRQBlock].Aggr,
 		c.CounterStats,
 		c.CgroupFSStats,
 		c.KubeletStats)

--- a/pkg/collector/metric/stats.go
+++ b/pkg/collector/metric/stats.go
@@ -17,15 +17,15 @@ const (
 	ByteWriteLabel   = config.BytesWriteIO
 	blockDeviceLabel = config.BlockDevicesIO
 
-	CPUTimeLabel = config.CPUTime
-
 	DeltaPrefix = "curr_"
 	AggrPrefix  = "total_"
 )
 
 var (
-	// AvailableCounters holds a list of hardware counters that might be collected
-	AvailableCounters []string
+	// AvailableEBPFCounters holds a list of eBPF counters that might be collected
+	AvailableEBPFCounters []string
+	// AvailableHWCounters holds a list of hardware counters that might be collected
+	AvailableHWCounters []string
 	// AvailableCgroupMetrics holds a list of cgroup metrics exposed by the cgroup that might be collected
 	AvailableCgroupMetrics []string
 	// AvailableKubeletMetrics holds a list of cgrpup metrics exposed by kubelet that might be collected
@@ -37,7 +37,8 @@ var (
 )
 
 func InitAvailableParamAndMetrics() {
-	AvailableCounters = attacher.GetEnabledCounters()
+	AvailableHWCounters = attacher.GetEnabledHWCounters()
+	AvailableEBPFCounters = attacher.GetEnabledBPFCounters()
 	AvailableCgroupMetrics = cgroup.GetAvailableCgroupMetrics()
 	AvailableKubeletMetrics = cgroup.GetAvailableKubeletMetrics()
 

--- a/pkg/collector/metric/utils.go
+++ b/pkg/collector/metric/utils.go
@@ -41,10 +41,10 @@ type CPUModelData struct {
 
 func getcontainerUintFeatureNames() []string {
 	var metrics []string
-	metrics = append(metrics, CPUTimeLabel)
-
+	// bpf metrics
+	metrics = append(metrics, AvailableEBPFCounters...)
 	// counter metric
-	metrics = append(metrics, AvailableCounters...)
+	metrics = append(metrics, AvailableHWCounters...)
 	// cgroup metric
 	metrics = append(metrics, AvailableCgroupMetrics...)
 	// cgroup kubelet metric
@@ -56,7 +56,8 @@ func getcontainerUintFeatureNames() []string {
 		metrics = append(metrics, []string{config.GPUSMUtilization, config.GPUMemUtilization}...)
 	}
 
-	klog.V(3).Infof("Available counter metrics: %v", AvailableCounters)
+	klog.V(3).Infof("Available ebpf metrics: %v", AvailableEBPFCounters)
+	klog.V(3).Infof("Available counter metrics: %v", AvailableHWCounters)
 	klog.V(3).Infof("Available cgroup metrics from cgroup: %v", AvailableCgroupMetrics)
 	klog.V(3).Infof("Available cgroup metrics from kubelet: %v", AvailableKubeletMetrics)
 	klog.V(3).Infof("Available I/O metrics: %v", ContainerIOStatMetricsNames)
@@ -66,7 +67,6 @@ func getcontainerUintFeatureNames() []string {
 
 func setEnabledMetrics() []string {
 	ContainerFeaturesNames = []string{}
-	AvailableCounters = attacher.GetEnabledCounters()
 
 	ContainerUintFeaturesNames = getcontainerUintFeatureNames()
 	ContainerFeaturesNames = append(ContainerFeaturesNames, ContainerFloatFeatureNames...)
@@ -95,7 +95,7 @@ func getEstimatorMetrics() []string {
 }
 
 func isCounterStatEnabled(label string) bool {
-	for _, counter := range AvailableCounters {
+	for _, counter := range AvailableHWCounters {
 		if counter == label {
 			return true
 		}

--- a/pkg/collector/metric/utils.go
+++ b/pkg/collector/metric/utils.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/jszwec/csvutil"
-	"github.com/sustainable-computing-io/kepler/pkg/bpfassets/attacher"
 	"github.com/sustainable-computing-io/kepler/pkg/config"
 	"github.com/sustainable-computing-io/kepler/pkg/power/accelerator"
 

--- a/pkg/collector/metric/utils_test.go
+++ b/pkg/collector/metric/utils_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func clearPlatformDependentAvailability() {
-	AvailableCounters = []string{}
+	AvailableHWCounters = []string{}
 	AvailableCgroupMetrics = []string{}
 	AvailableKubeletMetrics = []string{}
 
@@ -46,13 +46,13 @@ var _ = Describe("Test Metric Unit", func() {
 	})
 
 	It("Test isCounterStatEnabled for True", func() {
-		AvailableCounters = []string{"cpu_time", "bytes_read", "bytes_writes", "block_devices_used"}
+		AvailableHWCounters = []string{"cpu_time", "bytes_read", "bytes_writes", "block_devices_used"}
 		exp := isCounterStatEnabled("cpu_time")
 		Expect(exp).To(BeTrue())
 	})
 
 	It("Test isCounterStatEnabled for False", func() {
-		AvailableCounters = []string{"cpu_time", "bytes_read", "bytes_writes", "block_devices_used"}
+		AvailableHWCounters = []string{"cpu_time", "bytes_read", "bytes_writes", "block_devices_used"}
 		exp := isCounterStatEnabled("")
 		Expect(exp).To(BeFalse())
 	})

--- a/pkg/collector/metric/utils_test.go
+++ b/pkg/collector/metric/utils_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Test Metric Unit", func() {
 	It("Test getcontainerUintFeatureNames", func() {
 		clearPlatformDependentAvailability()
 
-		exp := []string{"cpu_time", "bytes_read", "bytes_writes"}
+		exp := []string{"bytes_read", "bytes_writes"}
 
 		cur := getcontainerUintFeatureNames()
 		Expect(exp).To(Equal(cur))
@@ -32,7 +32,7 @@ var _ = Describe("Test Metric Unit", func() {
 	It("Test getPrometheusMetrics", func() {
 		clearPlatformDependentAvailability()
 
-		exp := []string{"curr_cpu_time", "total_cpu_time", "curr_bytes_read", "total_bytes_read", "curr_bytes_writes", "total_bytes_writes", "block_devices_used"}
+		exp := []string{"curr_bytes_read", "total_bytes_read", "curr_bytes_writes", "total_bytes_writes", "block_devices_used"}
 		cur := getPrometheusMetrics()
 		Expect(exp).To(Equal(cur))
 	})
@@ -40,19 +40,19 @@ var _ = Describe("Test Metric Unit", func() {
 	It("Test getEstimatorMetrics", func() {
 		clearPlatformDependentAvailability()
 
-		exp := []string{"cpu_time", "bytes_read", "bytes_writes", "block_devices_used"}
+		exp := []string{"bytes_read", "bytes_writes", "block_devices_used"}
 		cur := getEstimatorMetrics()
 		Expect(exp).To(Equal(cur))
 	})
 
 	It("Test isCounterStatEnabled for True", func() {
-		AvailableHWCounters = []string{"cpu_time", "bytes_read", "bytes_writes", "block_devices_used"}
+		AvailableHWCounters = []string{"bytes_read", "bytes_writes", "block_devices_used"}
 		exp := isCounterStatEnabled("cpu_time")
-		Expect(exp).To(BeTrue())
+		Expect(exp).To(BeFalse())
 	})
 
 	It("Test isCounterStatEnabled for False", func() {
-		AvailableHWCounters = []string{"cpu_time", "bytes_read", "bytes_writes", "block_devices_used"}
+		AvailableHWCounters = []string{"bytes_read", "bytes_writes", "block_devices_used"}
 		exp := isCounterStatEnabled("")
 		Expect(exp).To(BeFalse())
 	})
@@ -61,7 +61,7 @@ var _ = Describe("Test Metric Unit", func() {
 		config.ExposeHardwareCounterMetrics = false
 		clearPlatformDependentAvailability()
 		cur := setEnabledMetrics()
-		exp := []string{"cpu_time", "bytes_read", "bytes_writes", "block_devices_used"}
+		exp := []string{"bytes_read", "bytes_writes", "block_devices_used"}
 		Expect(exp).To(Equal(cur))
 	})
 })

--- a/pkg/collector/metric_collector_test.go
+++ b/pkg/collector/metric_collector_test.go
@@ -19,7 +19,7 @@ func setCollectorMetrics() {
 	collector_metric.AvailableCgroupMetrics = []string{config.CgroupfsMemory, config.CgroupfsKernelMemory, config.CgroupfsTCPMemory, config.CgroupfsCPU,
 		config.CgroupfsSystemCPU, config.CgroupfsUserCPU, config.CgroupfsReadIO, config.CgroupfsWriteIO, config.BlockDevicesIO}
 	collector_metric.AvailableKubeletMetrics = []string{config.KubeletContainerCPU, config.KubeletContainerMemory, config.KubeletNodeCPU, config.KubeletNodeMemory}
-	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.CPUTimeLabel)
+	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.AvailableEBPFCounters...)
 	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.AvailableHWCounters...)
 	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.AvailableCgroupMetrics...)
 	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.AvailableKubeletMetrics...)

--- a/pkg/collector/metric_collector_test.go
+++ b/pkg/collector/metric_collector_test.go
@@ -15,12 +15,12 @@ import (
 // TODO: do not use a fixed usageMetric array in the power models, a structured data is more disarable.
 func setCollectorMetrics() {
 	// initialize the Available metrics since they are used to create a new containersMetrics instance
-	collector_metric.AvailableCounters = []string{config.CPUCycle, config.CPUInstruction, config.CacheMiss}
+	collector_metric.AvailableHWCounters = []string{config.CPUCycle, config.CPUInstruction, config.CacheMiss}
 	collector_metric.AvailableCgroupMetrics = []string{config.CgroupfsMemory, config.CgroupfsKernelMemory, config.CgroupfsTCPMemory, config.CgroupfsCPU,
 		config.CgroupfsSystemCPU, config.CgroupfsUserCPU, config.CgroupfsReadIO, config.CgroupfsWriteIO, config.BlockDevicesIO}
 	collector_metric.AvailableKubeletMetrics = []string{config.KubeletContainerCPU, config.KubeletContainerMemory, config.KubeletNodeCPU, config.KubeletNodeMemory}
 	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.CPUTimeLabel)
-	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.AvailableCounters...)
+	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.AvailableHWCounters...)
 	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.AvailableCgroupMetrics...)
 	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.AvailableKubeletMetrics...)
 	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.ContainerIOStatMetricsNames...)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,6 +51,8 @@ const (
 	defaultNamespace        = "kepler"
 	defaultModelServerPort  = "8100"
 	defaultModelRequestPath = "/model"
+	// MaxIRQ is the maximum number of IRQs to be monitored
+	MaxIRQ = 10
 )
 
 var (
@@ -60,6 +62,7 @@ var (
 	EnabledEBPFCgroupID          = getBoolConfig("ENABLE_EBPF_CGROUPID", true)
 	ExposeHardwareCounterMetrics = getBoolConfig("EXPOSE_HW_COUNTER_METRICS", true)
 	EnabledGPU                   = getBoolConfig("ENABLE_GPU", false)
+	ExposeIRQCounterMetrics      = getBoolConfig("EXPOSE_IRQ_COUNTER_METRICS", true)
 	MetricPathKey                = "METRIC_PATH"
 	BindAddressKey               = "BIND_ADDRESS"
 	CPUArchOverride              = getConfig("CPU_ARCH_OVERRIDE", "")

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -24,7 +24,10 @@ const (
 	CacheMiss      = "cache_miss"
 
 	// bpf - attacher package
-	CPUTime = "cpu_time"
+	CPUTime       = "cpu_time"
+	IRQNetTXLabel = "irq_net_tx"
+	IRQNetRXLabel = "irq_net_rx"
+	IRQBlockLabel = "irq_block"
 
 	// cgroup - cgroup package
 	CgroupfsMemory       = "cgroupfs_memory_usage_bytes"

--- a/pkg/model/container_power_test.go
+++ b/pkg/model/container_power_test.go
@@ -37,7 +37,7 @@ func setCollectorMetrics() {
 	collector_metric.AvailableCgroupMetrics = []string{config.CgroupfsMemory, config.CgroupfsKernelMemory, config.CgroupfsTCPMemory, config.CgroupfsCPU,
 		config.CgroupfsSystemCPU, config.CgroupfsUserCPU, config.CgroupfsReadIO, config.CgroupfsWriteIO, config.BlockDevicesIO}
 	collector_metric.AvailableKubeletMetrics = []string{config.KubeletContainerCPU, config.KubeletContainerMemory, config.KubeletNodeCPU, config.KubeletNodeMemory}
-	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.CPUTimeLabel)
+	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.AvailableEBPFCounters...)
 	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.AvailableHWCounters...)
 	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.AvailableCgroupMetrics...)
 	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.AvailableKubeletMetrics...)

--- a/pkg/model/container_power_test.go
+++ b/pkg/model/container_power_test.go
@@ -33,12 +33,12 @@ func setCollectorMetrics() {
 		Expect(err).NotTo(HaveOccurred())
 	}
 	// initialize the Available metrics since they are used to create a new containersMetrics instance
-	collector_metric.AvailableCounters = []string{config.CPUCycle, config.CPUInstruction, config.CacheMiss}
+	collector_metric.AvailableHWCounters = []string{config.CPUCycle, config.CPUInstruction, config.CacheMiss}
 	collector_metric.AvailableCgroupMetrics = []string{config.CgroupfsMemory, config.CgroupfsKernelMemory, config.CgroupfsTCPMemory, config.CgroupfsCPU,
 		config.CgroupfsSystemCPU, config.CgroupfsUserCPU, config.CgroupfsReadIO, config.CgroupfsWriteIO, config.BlockDevicesIO}
 	collector_metric.AvailableKubeletMetrics = []string{config.KubeletContainerCPU, config.KubeletContainerMemory, config.KubeletNodeCPU, config.KubeletNodeMemory}
 	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.CPUTimeLabel)
-	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.AvailableCounters...)
+	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.AvailableHWCounters...)
 	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.AvailableCgroupMetrics...)
 	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.AvailableKubeletMetrics...)
 	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.ContainerIOStatMetricsNames...)


### PR DESCRIPTION
fix #501

For environments that don't have containerized workloads (#511), the irq counters are used for ML training and estimation. 