### PR TITLE
Add support of Idle and Dynamic energy calculation

### DIFF
--- a/pkg/collector/container_accelerator_collector.go
+++ b/pkg/collector/container_accelerator_collector.go
@@ -50,10 +50,10 @@ func (c *Collector) updateAcceleratorMetrics() {
 
 			c.createContainersMetricsIfNotExist(containerID, 0, uint64(pid), false)
 
-			if err = c.ContainersMetrics[containerID].CounterStats[config.GPUSMUtilization].AddNewCurr(uint64(processUtilization.SmUtil)); err != nil {
+			if err = c.ContainersMetrics[containerID].CounterStats[config.GPUSMUtilization].AddNewDelta(uint64(processUtilization.SmUtil)); err != nil {
 				klog.V(5).Infoln(err)
 			}
-			if err = c.ContainersMetrics[containerID].CounterStats[config.GPUMemUtilization].AddNewCurr(uint64(processUtilization.MemUtil)); err != nil {
+			if err = c.ContainersMetrics[containerID].CounterStats[config.GPUMemUtilization].AddNewDelta(uint64(processUtilization.MemUtil)); err != nil {
 				klog.V(5).Infoln(err)
 			}
 		}

--- a/pkg/collector/container_cgroup_collector.go
+++ b/pkg/collector/container_cgroup_collector.go
@@ -33,7 +33,7 @@ func (c *Collector) updateCgroupMetrics() {
 		for cgroupFSKey, cgroupFSValue := range cgroupFSStandardStats {
 			readVal := cgroupFSValue.(uint64)
 			if _, ok := c.ContainersMetrics[containerID].CgroupFSStats[cgroupFSKey]; ok {
-				c.ContainersMetrics[containerID].CgroupFSStats[cgroupFSKey].AddAggrStat(containerID, readVal)
+				c.ContainersMetrics[containerID].CgroupFSStats[cgroupFSKey].SetAggrStat(containerID, readVal)
 			}
 		}
 	}

--- a/pkg/collector/container_energy_collector.go
+++ b/pkg/collector/container_energy_collector.go
@@ -22,5 +22,5 @@ import (
 
 // updateContainerEnergy matches the container resource usage with the node energy consumption
 func (c *Collector) updateContainerEnergy() {
-	model.UpdateContainerEnergy(c.ContainersMetrics, c.NodeMetrics)
+	model.UpdateContainerEnergy(c.ContainersMetrics, &c.NodeMetrics)
 }

--- a/pkg/collector/container_hc_collector.go
+++ b/pkg/collector/container_hc_collector.go
@@ -80,7 +80,7 @@ func (c *Collector) updateBPFMetrics() {
 			c.ContainersMetrics[containerID].SetLatestProcess(ct.CGroupID, ct.PID, C.GoString(comm))
 		}
 
-		if err = c.ContainersMetrics[containerID].CPUTime.AddNewCurr(ct.ProcessRunTime); err != nil {
+		if err = c.ContainersMetrics[containerID].CPUTime.AddNewDelta(ct.ProcessRunTime); err != nil {
 			klog.V(5).Infoln(err)
 		}
 
@@ -96,7 +96,7 @@ func (c *Collector) updateBPFMetrics() {
 			default:
 				val = 0
 			}
-			if err = c.ContainersMetrics[containerID].CounterStats[counterKey].AddNewCurr(val); err != nil {
+			if err = c.ContainersMetrics[containerID].CounterStats[counterKey].AddNewDelta(val); err != nil {
 				klog.V(5).Infoln(err)
 			}
 		}
@@ -110,8 +110,8 @@ func (c *Collector) updateBPFMetrics() {
 				if disks > c.ContainersMetrics[containerID].Disks {
 					c.ContainersMetrics[containerID].Disks = disks
 				}
-				c.ContainersMetrics[containerID].BytesRead.AddAggrStat(containerID, rBytes)
-				c.ContainersMetrics[containerID].BytesWrite.AddAggrStat(containerID, wBytes)
+				c.ContainersMetrics[containerID].BytesRead.SetAggrStat(containerID, rBytes)
+				c.ContainersMetrics[containerID].BytesWrite.SetAggrStat(containerID, wBytes)
 			}
 		}
 	}

--- a/pkg/collector/metric/container_metric_test.go
+++ b/pkg/collector/metric/container_metric_test.go
@@ -24,79 +24,70 @@ import (
 var _ = Describe("Test Container Metric", func() {
 
 	c := ContainerMetrics{
-		EnergyInCore:   &UInt64Stat{Curr: uint64(1), Aggr: uint64(2)},
-		EnergyInDRAM:   &UInt64Stat{Curr: uint64(3), Aggr: uint64(4)},
-		EnergyInUncore: &UInt64Stat{Curr: uint64(5), Aggr: uint64(6)},
-		EnergyInPkg:    &UInt64Stat{Curr: uint64(7), Aggr: uint64(8)},
-		EnergyInGPU:    &UInt64Stat{Curr: uint64(9), Aggr: uint64(10)},
-		EnergyInOther:  &UInt64Stat{Curr: uint64(11), Aggr: uint64(12)},
+		DynEnergyInCore:   &UInt64Stat{Delta: uint64(1), Aggr: uint64(2)},
+		DynEnergyInDRAM:   &UInt64Stat{Delta: uint64(3), Aggr: uint64(4)},
+		DynEnergyInUncore: &UInt64Stat{Delta: uint64(5), Aggr: uint64(6)},
+		DynEnergyInPkg:    &UInt64Stat{Delta: uint64(7), Aggr: uint64(8)},
+		DynEnergyInGPU:    &UInt64Stat{Delta: uint64(9), Aggr: uint64(10)},
+		DynEnergyInOther:  &UInt64Stat{Delta: uint64(11), Aggr: uint64(12)},
 		CgroupFSStats: map[string]*UInt64StatCollection{
 			CORE: {
 				Stat: map[string]*UInt64Stat{
-					"usage": {Curr: uint64(13), Aggr: uint64(14)},
+					"usage": {Delta: uint64(13), Aggr: uint64(14)},
 				},
 			},
 			DRAM: {
 				Stat: map[string]*UInt64Stat{
-					"usage": {Curr: uint64(15), Aggr: uint64(16)},
+					"usage": {Delta: uint64(15), Aggr: uint64(16)},
 				},
 			},
 			UNCORE: {
 				Stat: map[string]*UInt64Stat{
-					"usage": {Curr: uint64(17), Aggr: uint64(18)},
+					"usage": {Delta: uint64(17), Aggr: uint64(18)},
 				},
 			},
 			PKG: {
 				Stat: map[string]*UInt64Stat{
-					"usage": {Curr: uint64(19), Aggr: uint64(20)},
+					"usage": {Delta: uint64(19), Aggr: uint64(20)},
 				},
 			},
 			GPU: {
 				Stat: map[string]*UInt64Stat{
-					"usage": {Curr: uint64(21), Aggr: uint64(22)},
+					"usage": {Delta: uint64(21), Aggr: uint64(22)},
 				},
 			},
 			OTHER: {
 				Stat: map[string]*UInt64Stat{
-					"usage": {Curr: uint64(23), Aggr: uint64(24)},
+					"usage": {Delta: uint64(23), Aggr: uint64(24)},
 				},
 			},
 		},
 	}
 
-	It("Test GetPrometheusEnergyValue", func() {
-		Expect(c.GetPrometheusEnergyValue(CORE, true)).To(Equal(float64(1)))
-		Expect(c.GetPrometheusEnergyValue(DRAM, true)).To(Equal(float64(3)))
-		Expect(c.GetPrometheusEnergyValue(UNCORE, true)).To(Equal(float64(5)))
-		Expect(c.GetPrometheusEnergyValue(PKG, true)).To(Equal(float64(7)))
-		Expect(c.GetPrometheusEnergyValue(GPU, true)).To(Equal(float64(9)))
-		Expect(c.GetPrometheusEnergyValue(OTHER, true)).To(Equal(float64(11)))
-	})
-
-	It("Test getIntCurrAndAggrValue", func() {
-		curr, aggr, err := c.getIntCurrAndAggrValue(CORE)
+	It("Test getIntDeltaAndAggrValue", func() {
+		delta, aggr, err := c.getIntDeltaAndAggrValue(CORE)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(curr).To(Equal(uint64(13)))
+		Expect(delta).To(Equal(uint64(13)))
 		Expect(aggr).To(Equal(uint64(14)))
-		curr, aggr, err = c.getIntCurrAndAggrValue(DRAM)
+		delta, aggr, err = c.getIntDeltaAndAggrValue(DRAM)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(curr).To(Equal(uint64(15)))
+		Expect(delta).To(Equal(uint64(15)))
 		Expect(aggr).To(Equal(uint64(16)))
-		curr, aggr, err = c.getIntCurrAndAggrValue(UNCORE)
+		delta, aggr, err = c.getIntDeltaAndAggrValue(UNCORE)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(curr).To(Equal(uint64(17)))
+		Expect(delta).To(Equal(uint64(17)))
 		Expect(aggr).To(Equal(uint64(18)))
-		curr, aggr, err = c.getIntCurrAndAggrValue(PKG)
+		delta, aggr, err = c.getIntDeltaAndAggrValue(PKG)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(curr).To(Equal(uint64(19)))
+		Expect(delta).To(Equal(uint64(19)))
 		Expect(aggr).To(Equal(uint64(20)))
-		curr, aggr, err = c.getIntCurrAndAggrValue(GPU)
+		delta, aggr, err = c.getIntDeltaAndAggrValue(GPU)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(curr).To(Equal(uint64(21)))
+		Expect(delta).To(Equal(uint64(21)))
 		Expect(aggr).To(Equal(uint64(22)))
-		curr, aggr, err = c.getIntCurrAndAggrValue(OTHER)
+		delta, aggr, err = c.getIntDeltaAndAggrValue(OTHER)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(curr).To(Equal(uint64(23)))
+		Expect(delta).To(Equal(uint64(23)))
 		Expect(aggr).To(Equal(uint64(24)))
 	})
 })

--- a/pkg/collector/metric/node_metric_test.go
+++ b/pkg/collector/metric/node_metric_test.go
@@ -46,12 +46,12 @@ func createMockContainerMetrics(containerName, podName, namespace string) *Conta
 	containerMetrics := NewContainerMetrics(containerName, podName, namespace)
 	// cgroup - cgroup package
 	// we need to add two aggregated values to the stats so that it can calculate a current value (i.e. agg diff)
-	containerMetrics.CgroupFSStats[config.CgroupfsMemory].AddAggrStat(containerName, 100)
-	containerMetrics.CgroupFSStats[config.CgroupfsMemory].AddAggrStat(containerName, 110)
-	containerMetrics.CgroupFSStats[config.CgroupfsKernelMemory].AddAggrStat(containerName, 200)
-	containerMetrics.CgroupFSStats[config.CgroupfsKernelMemory].AddAggrStat(containerName, 220)
-	containerMetrics.CgroupFSStats[config.CgroupfsTCPMemory].AddAggrStat(containerName, 300)
-	containerMetrics.CgroupFSStats[config.CgroupfsTCPMemory].AddAggrStat(containerName, 330)
+	containerMetrics.CgroupFSStats[config.CgroupfsMemory].SetAggrStat(containerName, 100)
+	containerMetrics.CgroupFSStats[config.CgroupfsMemory].SetAggrStat(containerName, 110)
+	containerMetrics.CgroupFSStats[config.CgroupfsKernelMemory].SetAggrStat(containerName, 200)
+	containerMetrics.CgroupFSStats[config.CgroupfsKernelMemory].SetAggrStat(containerName, 220)
+	containerMetrics.CgroupFSStats[config.CgroupfsTCPMemory].SetAggrStat(containerName, 300)
+	containerMetrics.CgroupFSStats[config.CgroupfsTCPMemory].SetAggrStat(containerName, 330)
 	return containerMetrics
 }
 
@@ -63,20 +63,20 @@ func createMockNodeMetrics(containersMetrics map[string]*ContainerMetrics) *Node
 
 	// the NodeComponentsEnergy is the aggregated energy consumption of the node components
 	// then, the components energy consumption is added to the in the nodeMetrics as Agg data
-	// this means that, to have a Curr value, we must have at least two Agg data (to have Agg diff)
+	// this means that, to have a Delta value, we must have at least two Agg data (to have Agg diff)
 	// therefore, we need to add two values for NodeComponentsEnergy to have energy values to test
 	componentsEnergies[machineSocketID] = source.NodeComponentsEnergy{
 		Pkg:  10,
 		Core: 10,
 		DRAM: 10,
 	}
-	nodeMetrics.AddNodeComponentsEnergy(componentsEnergies)
+	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
 	componentsEnergies[machineSocketID] = source.NodeComponentsEnergy{
 		Pkg:  18,
 		Core: 15,
 		DRAM: 11,
 	}
-	nodeMetrics.AddNodeComponentsEnergy(componentsEnergies)
+	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
 
 	return nodeMetrics
 }
@@ -99,50 +99,8 @@ var _ = Describe("Test Node Metric", func() {
 		Expect(v).To(Equal(float64(10)))
 	})
 
-	It("Test GetPrometheusEnergyValue", func() {
-		out := nodeMetrics.GetEnergyValue(CORE)
-		Expect(out).To(Equal(uint64(5)))
-	})
-
-	It("Test getEnergyValue dram", func() {
-		cur := nodeMetrics.GetEnergyValue(DRAM)
-		Expect(nodeMetrics.EnergyInDRAM.Curr()).To(Equal(cur))
-	})
-
-	It("Test getEnergyValue uncore", func() {
-		cur := nodeMetrics.GetEnergyValue(UNCORE)
-		Expect(nodeMetrics.EnergyInUncore.Curr()).To(Equal(cur))
-	})
-
-	It("Test getEnergyValue pkg", func() {
-		cur := nodeMetrics.GetEnergyValue(PKG)
-		Expect(nodeMetrics.EnergyInPkg.Curr()).To(Equal(cur))
-	})
-
-	It("Test getEnergyValue gpu", func() {
-		cur := nodeMetrics.GetEnergyValue(GPU)
-		Expect(nodeMetrics.EnergyInGPU.Curr()).To(Equal(cur))
-	})
-
-	It("Test getEnergyValue other", func() {
-		cur := nodeMetrics.GetEnergyValue(OTHER)
-		Expect(nodeMetrics.EnergyInOther.Curr()).To(Equal(cur))
-	})
-
 	It("test AddNodeGPUEnergy", func() {
 		gpuEnergy := make([]uint32, 1)
 		nodeMetrics.AddNodeGPUEnergy(gpuEnergy)
-	})
-
-	It("test GetNodeTotalEnergyPerComponent", func() {
-		cur := nodeMetrics.GetNodeTotalEnergyPerComponent()
-		Expect(uint64(5)).To(Equal(cur.Core))
-		Expect(uint64(0)).To(Equal(cur.Uncore))
-		Expect(uint64(8)).To(Equal(cur.Pkg))
-	})
-
-	It("test GetNodeTotalEnergy", func() {
-		cur := nodeMetrics.GetNodeTotalEnergy()
-		Expect(uint64(9)).To(Equal(cur))
 	})
 })

--- a/pkg/collector/metric/utils.go
+++ b/pkg/collector/metric/utils.go
@@ -63,7 +63,7 @@ func setEnabledMetrics() []string {
 func getPrometheusMetrics() []string {
 	var labels []string
 	for _, feature := range ContainerFeaturesNames {
-		labels = append(labels, CurrPrefix+feature, AggrPrefix+feature)
+		labels = append(labels, DeltaPrefix+feature, AggrPrefix+feature)
 	}
 	// TO-DO: remove this hard code metric
 	labels = append(labels, blockDeviceLabel)

--- a/pkg/collector/metric_collector.go
+++ b/pkg/collector/metric_collector.go
@@ -98,7 +98,7 @@ func (c *Collector) Update() {
 
 	// reset the previous collected value because not all containers will have new data
 	// that is, a container that was inactive will not have any update but we need to set its metrics to 0
-	c.resetCurrValue()
+	c.resetDeltaValue()
 
 	// update container metrics regarding the resource utilization to be used to calculate the energy consumption
 	// we first updates the bpf which is resposible to include new containers in the ContainersMetrics collection
@@ -132,12 +132,12 @@ func (c *Collector) Update() {
 	klog.V(2).Infof("Collector Update elapsed time: %s", time.Since(start))
 }
 
-// resetCurrValue reset existing podEnergy previous curr value
-func (c *Collector) resetCurrValue() {
+// resetDeltaValue reset existing podEnergy previous curr value
+func (c *Collector) resetDeltaValue() {
 	for _, v := range c.ContainersMetrics {
-		v.ResetCurr()
+		v.ResetDeltaValues()
 	}
-	c.NodeMetrics.ResetCurr()
+	c.NodeMetrics.ResetDeltaValues()
 }
 
 // init adds the information of containers that were already running before kepler has been created

--- a/pkg/collector/metric_collector_test.go
+++ b/pkg/collector/metric_collector_test.go
@@ -41,40 +41,40 @@ func createMockContainersMetrics() map[string]*collector_metric.ContainerMetrics
 func createMockContainerMetrics(containerName, podName, namespace string) *collector_metric.ContainerMetrics {
 	containerMetrics := collector_metric.NewContainerMetrics(containerName, podName, namespace)
 	// counter - attacher package
-	err := containerMetrics.CounterStats[config.CPUCycle].AddNewCurr(10)
+	err := containerMetrics.CounterStats[config.CPUCycle].AddNewDelta(10)
 	Expect(err).NotTo(HaveOccurred())
-	err = containerMetrics.CounterStats[config.CPUInstruction].AddNewCurr(10)
+	err = containerMetrics.CounterStats[config.CPUInstruction].AddNewDelta(10)
 	Expect(err).NotTo(HaveOccurred())
-	err = containerMetrics.CounterStats[config.CacheMiss].AddNewCurr(10)
+	err = containerMetrics.CounterStats[config.CacheMiss].AddNewDelta(10)
 	Expect(err).NotTo(HaveOccurred())
 	// bpf - cpu time
-	err = containerMetrics.CPUTime.AddNewCurr(10) // config.CPUTime
+	err = containerMetrics.CPUTime.AddNewDelta(10) // config.CPUTime
 	Expect(err).NotTo(HaveOccurred())
 	// cgroup - cgroup package
 	// we need to add two aggregated values to the stats so that it can calculate a current value (i.e. agg diff)
-	containerMetrics.CgroupFSStats[config.CgroupfsMemory].AddAggrStat(containerName, 10)
-	containerMetrics.CgroupFSStats[config.CgroupfsMemory].AddAggrStat(containerName, 20)
-	containerMetrics.CgroupFSStats[config.CgroupfsKernelMemory].AddAggrStat(containerName, 10) // not used
-	containerMetrics.CgroupFSStats[config.CgroupfsKernelMemory].AddAggrStat(containerName, 20) // not used
-	containerMetrics.CgroupFSStats[config.CgroupfsTCPMemory].AddAggrStat(containerName, 10)    // not used
-	containerMetrics.CgroupFSStats[config.CgroupfsTCPMemory].AddAggrStat(containerName, 20)    // not used
-	containerMetrics.CgroupFSStats[config.CgroupfsCPU].AddAggrStat(containerName, 10)
-	containerMetrics.CgroupFSStats[config.CgroupfsCPU].AddAggrStat(containerName, 20)
-	containerMetrics.CgroupFSStats[config.CgroupfsSystemCPU].AddAggrStat(containerName, 10)
-	containerMetrics.CgroupFSStats[config.CgroupfsSystemCPU].AddAggrStat(containerName, 20)
-	containerMetrics.CgroupFSStats[config.CgroupfsUserCPU].AddAggrStat(containerName, 10)
-	containerMetrics.CgroupFSStats[config.CgroupfsUserCPU].AddAggrStat(containerName, 20)
-	containerMetrics.CgroupFSStats[config.CgroupfsReadIO].AddAggrStat(containerName, 10)  // not used
-	containerMetrics.CgroupFSStats[config.CgroupfsReadIO].AddAggrStat(containerName, 20)  // not used
-	containerMetrics.CgroupFSStats[config.CgroupfsWriteIO].AddAggrStat(containerName, 10) // not used
-	containerMetrics.CgroupFSStats[config.CgroupfsWriteIO].AddAggrStat(containerName, 20) // not used
-	containerMetrics.CgroupFSStats[config.BlockDevicesIO].AddAggrStat(containerName, 10)  // not used
-	containerMetrics.CgroupFSStats[config.BlockDevicesIO].AddAggrStat(containerName, 20)  // not used
+	containerMetrics.CgroupFSStats[config.CgroupfsMemory].SetAggrStat(containerName, 10)
+	containerMetrics.CgroupFSStats[config.CgroupfsMemory].SetAggrStat(containerName, 20)
+	containerMetrics.CgroupFSStats[config.CgroupfsKernelMemory].SetAggrStat(containerName, 10) // not used
+	containerMetrics.CgroupFSStats[config.CgroupfsKernelMemory].SetAggrStat(containerName, 20) // not used
+	containerMetrics.CgroupFSStats[config.CgroupfsTCPMemory].SetAggrStat(containerName, 10)    // not used
+	containerMetrics.CgroupFSStats[config.CgroupfsTCPMemory].SetAggrStat(containerName, 20)    // not used
+	containerMetrics.CgroupFSStats[config.CgroupfsCPU].SetAggrStat(containerName, 10)
+	containerMetrics.CgroupFSStats[config.CgroupfsCPU].SetAggrStat(containerName, 20)
+	containerMetrics.CgroupFSStats[config.CgroupfsSystemCPU].SetAggrStat(containerName, 10)
+	containerMetrics.CgroupFSStats[config.CgroupfsSystemCPU].SetAggrStat(containerName, 20)
+	containerMetrics.CgroupFSStats[config.CgroupfsUserCPU].SetAggrStat(containerName, 10)
+	containerMetrics.CgroupFSStats[config.CgroupfsUserCPU].SetAggrStat(containerName, 20)
+	containerMetrics.CgroupFSStats[config.CgroupfsReadIO].SetAggrStat(containerName, 10)  // not used
+	containerMetrics.CgroupFSStats[config.CgroupfsReadIO].SetAggrStat(containerName, 20)  // not used
+	containerMetrics.CgroupFSStats[config.CgroupfsWriteIO].SetAggrStat(containerName, 10) // not used
+	containerMetrics.CgroupFSStats[config.CgroupfsWriteIO].SetAggrStat(containerName, 20) // not used
+	containerMetrics.CgroupFSStats[config.BlockDevicesIO].SetAggrStat(containerName, 10)  // not used
+	containerMetrics.CgroupFSStats[config.BlockDevicesIO].SetAggrStat(containerName, 20)  // not used
 	// cgroup - I/O stat metrics
-	containerMetrics.BytesRead.AddAggrStat(containerName, 10)  // config.BytesReadIO
-	containerMetrics.BytesRead.AddAggrStat(containerName, 20)  // config.BytesReadIO
-	containerMetrics.BytesWrite.AddAggrStat(containerName, 10) // config.BytesWriteIO
-	containerMetrics.BytesWrite.AddAggrStat(containerName, 20) // config.BytesWriteIO
+	containerMetrics.BytesRead.SetAggrStat(containerName, 10)  // config.BytesReadIO
+	containerMetrics.BytesRead.SetAggrStat(containerName, 20)  // config.BytesReadIO
+	containerMetrics.BytesWrite.SetAggrStat(containerName, 10) // config.BytesWriteIO
+	containerMetrics.BytesWrite.SetAggrStat(containerName, 20) // config.BytesWriteIO
 	// kubelet - cgroup package
 	err = containerMetrics.KubeletStats[config.KubeletContainerCPU].SetNewAggr(10) // not used
 	Expect(err).NotTo(HaveOccurred())
@@ -110,13 +110,13 @@ func createMockNodeMetrics(containersMetrics map[string]*collector_metric.Contai
 		Core: 10,
 		DRAM: 10,
 	}
-	nodeMetrics.AddNodeComponentsEnergy(componentsEnergies)
+	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
 	componentsEnergies[machineSocketID] = source.NodeComponentsEnergy{
 		Pkg:  18,
 		Core: 15,
 		DRAM: 11,
 	}
-	nodeMetrics.AddNodeComponentsEnergy(componentsEnergies)
+	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
 
 	return nodeMetrics
 }
@@ -153,7 +153,7 @@ var _ = Describe("Test Collector Unit", func() {
 		metricCollector.updateNodeEnergyMetrics()
 		// TODO CONTINUE -- it is missing the node energy
 		metricCollector.updateContainerEnergy()
-		Expect(metricCollector.ContainersMetrics["containerA"].EnergyInPkg.Curr).ShouldNot(BeNil())
+		Expect(metricCollector.ContainersMetrics["containerA"].DynEnergyInPkg.Delta).ShouldNot(BeNil())
 	})
 
 	It("HandleInactiveContainers without error", func() {

--- a/pkg/model/container_power.go
+++ b/pkg/model/container_power.go
@@ -73,7 +73,7 @@ func getContainerMetricsList(containersMetrics map[string]*collector_metric.Cont
 }
 
 // UpdateContainerEnergy returns container energy consumption for each node component
-func UpdateContainerEnergy(containersMetrics map[string]*collector_metric.ContainerMetrics, nodeMetrics collector_metric.NodeMetrics) {
+func UpdateContainerEnergy(containersMetrics map[string]*collector_metric.ContainerMetrics, nodeMetrics *collector_metric.NodeMetrics) {
 	// If the node can expose power measurement per component, we can use the RATIO power model
 	// Otherwise, we estimate it from trained power model
 	if components.IsSystemCollectionSupported() {
@@ -107,19 +107,19 @@ func updateContainerEnergyByTrainedPowerModel(containersMetrics map[string]*coll
 	// update the container's components energy consumption
 	// TODO: the model server does not predict GPU
 	for i, containerID := range containerIDList {
-		if err := containersMetrics[containerID].EnergyInCore.AddNewCurr(containerComponentPowers[i].Core); err != nil {
+		if err := containersMetrics[containerID].DynEnergyInCore.AddNewDelta(containerComponentPowers[i].Core); err != nil {
 			klog.V(5).Infoln(err)
 		}
-		if err := containersMetrics[containerID].EnergyInDRAM.AddNewCurr(containerComponentPowers[i].DRAM); err != nil {
+		if err := containersMetrics[containerID].DynEnergyInDRAM.AddNewDelta(containerComponentPowers[i].DRAM); err != nil {
 			klog.V(5).Infoln(err)
 		}
-		if err := containersMetrics[containerID].EnergyInUncore.AddNewCurr(containerComponentPowers[i].Uncore); err != nil {
+		if err := containersMetrics[containerID].DynEnergyInUncore.AddNewDelta(containerComponentPowers[i].Uncore); err != nil {
 			klog.V(5).Infoln(err)
 		}
-		if err := containersMetrics[containerID].EnergyInPkg.AddNewCurr(containerComponentPowers[i].Pkg); err != nil {
+		if err := containersMetrics[containerID].DynEnergyInPkg.AddNewDelta(containerComponentPowers[i].Pkg); err != nil {
 			klog.V(5).Infoln(err)
 		}
-		if err := containersMetrics[containerID].EnergyInOther.AddNewCurr(containerOtherPowers[i]); err != nil {
+		if err := containersMetrics[containerID].DynEnergyInOther.AddNewDelta(containerOtherPowers[i]); err != nil {
 			klog.V(5).Infoln(err)
 		}
 	}

--- a/pkg/model/container_power_test.go
+++ b/pkg/model/container_power_test.go
@@ -59,40 +59,40 @@ func createMockContainersMetrics() map[string]*collector_metric.ContainerMetrics
 func createMockContainerMetrics(containerName, podName, namespace string) *collector_metric.ContainerMetrics {
 	containerMetrics := collector_metric.NewContainerMetrics(containerName, podName, namespace)
 	// counter - attacher package
-	err := containerMetrics.CounterStats[config.CPUCycle].AddNewCurr(10)
+	err := containerMetrics.CounterStats[config.CPUCycle].AddNewDelta(10)
 	Expect(err).NotTo(HaveOccurred())
-	err = containerMetrics.CounterStats[config.CPUInstruction].AddNewCurr(10)
+	err = containerMetrics.CounterStats[config.CPUInstruction].AddNewDelta(10)
 	Expect(err).NotTo(HaveOccurred())
-	err = containerMetrics.CounterStats[config.CacheMiss].AddNewCurr(10)
+	err = containerMetrics.CounterStats[config.CacheMiss].AddNewDelta(10)
 	Expect(err).NotTo(HaveOccurred())
 	// bpf - cpu time
-	err = containerMetrics.CPUTime.AddNewCurr(10) // config.CPUTime
+	err = containerMetrics.CPUTime.AddNewDelta(10) // config.CPUTime
 	Expect(err).NotTo(HaveOccurred())
 	// cgroup - cgroup package
 	// we need to add two aggregated values to the stats so that it can calculate a current value (i.e. agg diff)
-	containerMetrics.CgroupFSStats[config.CgroupfsMemory].AddAggrStat(containerName, 10)
-	containerMetrics.CgroupFSStats[config.CgroupfsMemory].AddAggrStat(containerName, 20)
-	containerMetrics.CgroupFSStats[config.CgroupfsKernelMemory].AddAggrStat(containerName, 10) // not used
-	containerMetrics.CgroupFSStats[config.CgroupfsKernelMemory].AddAggrStat(containerName, 20) // not used
-	containerMetrics.CgroupFSStats[config.CgroupfsTCPMemory].AddAggrStat(containerName, 10)    // not used
-	containerMetrics.CgroupFSStats[config.CgroupfsTCPMemory].AddAggrStat(containerName, 20)    // not used
-	containerMetrics.CgroupFSStats[config.CgroupfsCPU].AddAggrStat(containerName, 10)
-	containerMetrics.CgroupFSStats[config.CgroupfsCPU].AddAggrStat(containerName, 20)
-	containerMetrics.CgroupFSStats[config.CgroupfsSystemCPU].AddAggrStat(containerName, 10)
-	containerMetrics.CgroupFSStats[config.CgroupfsSystemCPU].AddAggrStat(containerName, 20)
-	containerMetrics.CgroupFSStats[config.CgroupfsUserCPU].AddAggrStat(containerName, 10)
-	containerMetrics.CgroupFSStats[config.CgroupfsUserCPU].AddAggrStat(containerName, 20)
-	containerMetrics.CgroupFSStats[config.CgroupfsReadIO].AddAggrStat(containerName, 10)  // not used
-	containerMetrics.CgroupFSStats[config.CgroupfsReadIO].AddAggrStat(containerName, 20)  // not used
-	containerMetrics.CgroupFSStats[config.CgroupfsWriteIO].AddAggrStat(containerName, 10) // not used
-	containerMetrics.CgroupFSStats[config.CgroupfsWriteIO].AddAggrStat(containerName, 20) // not used
-	containerMetrics.CgroupFSStats[config.BlockDevicesIO].AddAggrStat(containerName, 10)  // not used
-	containerMetrics.CgroupFSStats[config.BlockDevicesIO].AddAggrStat(containerName, 20)  // not used
+	containerMetrics.CgroupFSStats[config.CgroupfsMemory].SetAggrStat(containerName, 10)
+	containerMetrics.CgroupFSStats[config.CgroupfsMemory].SetAggrStat(containerName, 20)
+	containerMetrics.CgroupFSStats[config.CgroupfsKernelMemory].SetAggrStat(containerName, 10) // not used
+	containerMetrics.CgroupFSStats[config.CgroupfsKernelMemory].SetAggrStat(containerName, 20) // not used
+	containerMetrics.CgroupFSStats[config.CgroupfsTCPMemory].SetAggrStat(containerName, 10)    // not used
+	containerMetrics.CgroupFSStats[config.CgroupfsTCPMemory].SetAggrStat(containerName, 20)    // not used
+	containerMetrics.CgroupFSStats[config.CgroupfsCPU].SetAggrStat(containerName, 10)
+	containerMetrics.CgroupFSStats[config.CgroupfsCPU].SetAggrStat(containerName, 20)
+	containerMetrics.CgroupFSStats[config.CgroupfsSystemCPU].SetAggrStat(containerName, 10)
+	containerMetrics.CgroupFSStats[config.CgroupfsSystemCPU].SetAggrStat(containerName, 20)
+	containerMetrics.CgroupFSStats[config.CgroupfsUserCPU].SetAggrStat(containerName, 10)
+	containerMetrics.CgroupFSStats[config.CgroupfsUserCPU].SetAggrStat(containerName, 20)
+	containerMetrics.CgroupFSStats[config.CgroupfsReadIO].SetAggrStat(containerName, 10)  // not used
+	containerMetrics.CgroupFSStats[config.CgroupfsReadIO].SetAggrStat(containerName, 20)  // not used
+	containerMetrics.CgroupFSStats[config.CgroupfsWriteIO].SetAggrStat(containerName, 10) // not used
+	containerMetrics.CgroupFSStats[config.CgroupfsWriteIO].SetAggrStat(containerName, 20) // not used
+	containerMetrics.CgroupFSStats[config.BlockDevicesIO].SetAggrStat(containerName, 10)  // not used
+	containerMetrics.CgroupFSStats[config.BlockDevicesIO].SetAggrStat(containerName, 20)  // not used
 	// cgroup - I/O stat metrics
-	containerMetrics.BytesRead.AddAggrStat(containerName, 10)  // config.BytesReadIO
-	containerMetrics.BytesRead.AddAggrStat(containerName, 20)  // config.BytesReadIO
-	containerMetrics.BytesWrite.AddAggrStat(containerName, 10) // config.BytesWriteIO
-	containerMetrics.BytesWrite.AddAggrStat(containerName, 20) // config.BytesWriteIO
+	containerMetrics.BytesRead.SetAggrStat(containerName, 10)  // config.BytesReadIO
+	containerMetrics.BytesRead.SetAggrStat(containerName, 20)  // config.BytesReadIO
+	containerMetrics.BytesWrite.SetAggrStat(containerName, 10) // config.BytesWriteIO
+	containerMetrics.BytesWrite.SetAggrStat(containerName, 20) // config.BytesWriteIO
 	// kubelet - cgroup package
 	err = containerMetrics.KubeletStats[config.KubeletContainerCPU].SetNewAggr(10) // not used
 	Expect(err).NotTo(HaveOccurred())
@@ -159,24 +159,24 @@ var _ = Describe("ContainerPower", func() {
 				Core: 10,
 				DRAM: 10,
 			}
-			nodeMetrics.AddNodeComponentsEnergy(componentsEnergies)
+			nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
 			componentsEnergies[machineSocketID] = source.NodeComponentsEnergy{
 				Pkg:  18,
 				Core: 15,
 				DRAM: 11,
 			}
-			nodeMetrics.AddNodeComponentsEnergy(componentsEnergies)
+			nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
 
 			nodePlatformEnergy := map[string]float64{}
 			nodePlatformEnergy[machineSensorID] = 0 // empty
-			nodeMetrics.AddLastestPlatformEnergy(nodePlatformEnergy)
+			nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy)
 
 			// calculate container energy consumption
-			UpdateContainerEnergy(containersMetrics, nodeMetrics)
+			UpdateContainerEnergy(containersMetrics, &nodeMetrics)
 
 			// Unit test use is reported by default settings through LR model
-			// and following will be reported so EnergyInPkg.Curr will be 9512
-			Expect(containersMetrics["containerA"].EnergyInPkg.Curr).To(Equal(uint64(9512)))
+			// and following will be reported so EnergyInPkg.Delta will be 9512
+			Expect(containersMetrics["containerA"].DynEnergyInPkg.Delta).To(Equal(uint64(9512)))
 		})
 	})
 })

--- a/pkg/model/estimator/local/ratio.go
+++ b/pkg/model/estimator/local/ratio.go
@@ -56,67 +56,90 @@ func getEnergyRatio(containerResUsage, nodeTotalResUsage, nodeResEnergyUtilizati
 }
 
 // UpdateContainerEnergyByRatioPowerModel calculates the container energy consumption based on the resource utilization ratio
-func UpdateContainerEnergyByRatioPowerModel(containersMetrics map[string]*collector_metric.ContainerMetrics, nodeMetrics collector_metric.NodeMetrics) {
-	nodeTotalEnergyPerComponent := nodeMetrics.GetNodeTotalEnergyPerComponent()
+func UpdateContainerEnergyByRatioPowerModel(containersMetrics map[string]*collector_metric.ContainerMetrics, nodeMetrics *collector_metric.NodeMetrics) {
+	pkgDynPower := float64(nodeMetrics.GetSumDeltaDynEnergyFromAllSources(collector_metric.PKG))
+	coreDynPower := float64(nodeMetrics.GetSumDeltaDynEnergyFromAllSources(collector_metric.CORE))
+	uncoreDynPower := float64(nodeMetrics.GetSumDeltaDynEnergyFromAllSources(collector_metric.UNCORE))
+	dramDynPower := float64(nodeMetrics.GetSumDeltaDynEnergyFromAllSources(collector_metric.DRAM))
+	otherDynPower := float64(nodeMetrics.GetSumDeltaDynEnergyFromAllSources(collector_metric.OTHER))
+	gpuDynPower := float64(nodeMetrics.GetSumDeltaDynEnergyFromAllSources(collector_metric.GPU))
+
 	containerNumber := float64(len(containersMetrics))
+	// evenly divide the idle power to all containers. TODO: use the container resource request
+	pkgIdlePowerPerContainer := nodeMetrics.GetSumDeltaIdleEnergyromAllSources(collector_metric.PKG) / uint64(containerNumber)
+	coreIdlePowerPerContainer := nodeMetrics.GetSumDeltaIdleEnergyromAllSources(collector_metric.CORE) / uint64(containerNumber)
+	uncoreIdlePowerPerContainer := nodeMetrics.GetSumDeltaIdleEnergyromAllSources(collector_metric.UNCORE) / uint64(containerNumber)
+	dramIdlePowerPerContainer := nodeMetrics.GetSumDeltaIdleEnergyromAllSources(collector_metric.DRAM) / uint64(containerNumber)
+	otherIdlePowerPerContainer := nodeMetrics.GetSumDeltaIdleEnergyromAllSources(collector_metric.OTHER) / uint64(containerNumber)
 
 	for containerID, container := range containersMetrics {
-		var containerResUsage, nodeTotalResUsage, nodeResEnergyUtilization float64
+		var containerResUsage, nodeTotalResUsage float64
 
 		// calculate the container package/socket energy consumption
 		if _, ok := container.CounterStats[config.CoreUsageMetric]; ok {
-			containerResUsage = float64(container.CounterStats[config.CoreUsageMetric].Curr)
+			containerResUsage = float64(container.CounterStats[config.CoreUsageMetric].Delta)
 			nodeTotalResUsage = nodeMetrics.GetNodeResUsagePerResType(config.CoreUsageMetric)
-			nodeResEnergyUtilization = float64(nodeTotalEnergyPerComponent.Pkg)
-			containerPkgEnergy := getEnergyRatio(containerResUsage, nodeTotalResUsage, nodeResEnergyUtilization, containerNumber)
-			if err := containersMetrics[containerID].EnergyInPkg.AddNewCurr(containerPkgEnergy); err != nil {
+			containerPkgEnergy := getEnergyRatio(containerResUsage, nodeTotalResUsage, pkgDynPower, containerNumber)
+			if err := containersMetrics[containerID].DynEnergyInPkg.AddNewDelta(containerPkgEnergy); err != nil {
 				klog.Infoln(err)
 			}
 
 			// calculate the container core energy consumption
-			nodeResEnergyUtilization = float64(nodeTotalEnergyPerComponent.Core)
-			containerCoreEnergy := getEnergyRatio(containerResUsage, nodeTotalResUsage, nodeResEnergyUtilization, containerNumber)
-			if err := containersMetrics[containerID].EnergyInCore.AddNewCurr(containerCoreEnergy); err != nil {
+			containerCoreEnergy := getEnergyRatio(containerResUsage, nodeTotalResUsage, coreDynPower, containerNumber)
+			if err := containersMetrics[containerID].DynEnergyInCore.AddNewDelta(containerCoreEnergy); err != nil {
 				klog.Infoln(err)
 			}
 		}
 
 		// calculate the container uncore energy consumption
-		nodeResEnergyUtilization = float64(nodeTotalEnergyPerComponent.Uncore)
-		containerUncoreEnergy := uint64(math.Ceil(nodeResEnergyUtilization / containerNumber))
-		if err := containersMetrics[containerID].EnergyInUncore.AddNewCurr(containerUncoreEnergy); err != nil {
+		containerUncoreEnergy := uint64(math.Ceil(uncoreDynPower / containerNumber))
+		if err := containersMetrics[containerID].DynEnergyInUncore.AddNewDelta(containerUncoreEnergy); err != nil {
 			klog.Infoln(err)
 		}
 
 		// calculate the container dram energy consumption
 		if _, ok := container.CounterStats[config.DRAMUsageMetric]; ok {
-			containerResUsage = float64(container.CounterStats[config.DRAMUsageMetric].Curr)
+			containerResUsage = float64(container.CounterStats[config.DRAMUsageMetric].Delta)
 			nodeTotalResUsage = nodeMetrics.GetNodeResUsagePerResType(config.DRAMUsageMetric)
-			nodeResEnergyUtilization = float64(nodeTotalEnergyPerComponent.DRAM)
-			containerDramEnergy := getEnergyRatio(containerResUsage, nodeTotalResUsage, nodeResEnergyUtilization, containerNumber)
-			if err := containersMetrics[containerID].EnergyInDRAM.AddNewCurr(containerDramEnergy); err != nil {
+			containerDramEnergy := getEnergyRatio(containerResUsage, nodeTotalResUsage, dramDynPower, containerNumber)
+			if err := containersMetrics[containerID].DynEnergyInDRAM.AddNewDelta(containerDramEnergy); err != nil {
 				klog.Infoln(err)
 			}
 		}
 
 		// calculate the container gpu energy consumption
 		if accelerator.IsGPUCollectionSupported() {
-			containerResUsage = float64(container.CounterStats[config.GpuUsageMetric].Curr)
+			containerResUsage = float64(container.CounterStats[config.GpuUsageMetric].Delta)
 			nodeTotalResUsage = nodeMetrics.GetNodeResUsagePerResType(config.GpuUsageMetric)
-			nodeResEnergyUtilization = float64(nodeMetrics.GetEnergyValue(collector_metric.GPU))
-			containerGPUEnergy := getEnergyRatio(containerResUsage, nodeTotalResUsage, nodeResEnergyUtilization, containerNumber)
-			if err := containersMetrics[containerID].EnergyInGPU.AddNewCurr(containerGPUEnergy); err != nil {
+			containerGPUEnergy := getEnergyRatio(containerResUsage, nodeTotalResUsage, gpuDynPower, containerNumber)
+			if err := containersMetrics[containerID].DynEnergyInGPU.AddNewDelta(containerGPUEnergy); err != nil {
 				klog.Infoln(err)
 			} else {
 				klog.V(5).Infof("gpu power ratio: containerID %v containerResUsage: %f, nodeTotalResUsage: %f, nodeResEnergyUtilization: %f, containerNumber: %f containerGPUEnergy: %v",
-					containerID, containerResUsage, nodeTotalResUsage, nodeResEnergyUtilization, containerNumber, containersMetrics[containerID].EnergyInGPU.Curr)
+					containerID, containerResUsage, nodeTotalResUsage, gpuDynPower, containerNumber, containersMetrics[containerID].DynEnergyInGPU.Delta)
 			}
 		}
 
 		// calculate the container host other components energy consumption
-		nodeResEnergyUtilization = float64(nodeMetrics.GetEnergyValue(collector_metric.OTHER))
-		containerOtherHostComponentsEnergy := uint64(math.Ceil(nodeResEnergyUtilization / containerNumber))
-		if err := containersMetrics[containerID].EnergyInOther.AddNewCurr(containerOtherHostComponentsEnergy); err != nil {
+		containerOtherHostComponentsEnergy := uint64(math.Ceil(otherDynPower / containerNumber))
+		if err := containersMetrics[containerID].DynEnergyInOther.AddNewDelta(containerOtherHostComponentsEnergy); err != nil {
+			klog.Infoln(err)
+		}
+
+		// Idle energy
+		if err := containersMetrics[containerID].IdleEnergyInPkg.AddNewDelta(pkgIdlePowerPerContainer); err != nil {
+			klog.Infoln(err)
+		}
+		if err := containersMetrics[containerID].IdleEnergyInCore.AddNewDelta(coreIdlePowerPerContainer); err != nil {
+			klog.Infoln(err)
+		}
+		if err := containersMetrics[containerID].IdleEnergyInUncore.AddNewDelta(uncoreIdlePowerPerContainer); err != nil {
+			klog.Infoln(err)
+		}
+		if err := containersMetrics[containerID].IdleEnergyInDRAM.AddNewDelta(dramIdlePowerPerContainer); err != nil {
+			klog.Infoln(err)
+		}
+		if err := containersMetrics[containerID].IdleEnergyInOther.AddNewDelta(otherIdlePowerPerContainer); err != nil {
 			klog.Infoln(err)
 		}
 	}

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -57,16 +57,16 @@ var _ = Describe("Test Model Unit", func() {
 			Core: 0,
 			DRAM: 0,
 		}
-		nodeMetrics.AddNodeComponentsEnergy(componentsEnergies)
+		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
 		nodePlatformEnergy := map[string]float64{}
 		nodePlatformEnergy[machineSensorID] = 0 // empty
-		nodeMetrics.AddLastestPlatformEnergy(nodePlatformEnergy)
+		nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy)
 
 		// calculate container energy consumption
-		UpdateContainerEnergy(containersMetrics, nodeMetrics)
+		UpdateContainerEnergy(containersMetrics, &nodeMetrics)
 		// Unit test use is reported by default settings through LR model
-		// and following will be reported so EnergyInPkg.Curr will be 9512
-		Expect(containersMetrics["containerA"].EnergyInPkg.Curr).To(Equal(uint64(9512)))
+		// and following will be reported so EnergyInPkg.Delta will be 9512
+		Expect(containersMetrics["containerA"].DynEnergyInPkg.Delta).To(Equal(uint64(9512)))
 	})
 
 	It("Get container power with no dependency but with total node power ", func() {
@@ -81,16 +81,16 @@ var _ = Describe("Test Model Unit", func() {
 			Core: 0,
 			DRAM: 0,
 		}
-		nodeMetrics.AddNodeComponentsEnergy(componentsEnergies)
+		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
 		nodePlatformEnergy := map[string]float64{}
 		nodePlatformEnergy[machineSensorID] = 10
-		nodeMetrics.AddLastestPlatformEnergy(nodePlatformEnergy)
+		nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy)
 
 		// calculate container energy consumption
-		UpdateContainerEnergy(containersMetrics, nodeMetrics)
+		UpdateContainerEnergy(containersMetrics, &nodeMetrics)
 		// Unit test use is reported by default settings through LR model
-		// and following will be reported so EnergyInPkg.Curr will be 9512
-		Expect(containersMetrics["containerA"].EnergyInPkg.Curr).To(Equal(uint64(9512)))
+		// and following will be reported so EnergyInPkg.Delta will be 9512
+		Expect(containersMetrics["containerA"].DynEnergyInPkg.Delta).To(Equal(uint64(9512)))
 	})
 
 	It("Get container power with no dependency but with all node power ", func() {
@@ -109,24 +109,24 @@ var _ = Describe("Test Model Unit", func() {
 			Core: 10,
 			DRAM: 10,
 		}
-		nodeMetrics.AddNodeComponentsEnergy(componentsEnergies)
+		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
 		componentsEnergies[machineSocketID] = source.NodeComponentsEnergy{
 			Pkg:  18,
 			Core: 15,
 			DRAM: 11,
 		}
-		nodeMetrics.AddNodeComponentsEnergy(componentsEnergies)
+		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
 		nodePlatformEnergy := map[string]float64{}
 		nodePlatformEnergy[machineSensorID] = 10
-		nodeMetrics.AddLastestPlatformEnergy(nodePlatformEnergy)
+		nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy)
 		nodePlatformEnergy[machineSensorID] = 15
-		nodeMetrics.AddLastestPlatformEnergy(nodePlatformEnergy)
+		nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy)
 
 		// calculate container energy consumption
 
-		UpdateContainerEnergy(containersMetrics, nodeMetrics)
+		UpdateContainerEnergy(containersMetrics, &nodeMetrics)
 		// Unit test use is reported by default settings through LR model
-		// and following will be reported so EnergyInPkg.Curr will be 9512
-		Expect(containersMetrics["containerA"].EnergyInPkg.Curr).To(Equal(uint64(9512)))
+		// and following will be reported so EnergyInPkg.Delta will be 9512
+		Expect(containersMetrics["containerA"].DynEnergyInPkg.Delta).To(Equal(uint64(9512)))
 	})
 })

--- a/pkg/model/node_component_power.go
+++ b/pkg/model/node_component_power.go
@@ -55,7 +55,7 @@ func IsNodeComponentPowerModelEnabled() bool {
 }
 
 // GetNodeComponentPowers returns estimated RAPL power for the node
-func GetNodeComponentPowers(nodeMetrics collector_metric.NodeMetrics) (nodeComponentsEnergy map[int]source.NodeComponentsEnergy) {
+func GetNodeComponentPowers(nodeMetrics *collector_metric.NodeMetrics) (nodeComponentsEnergy map[int]source.NodeComponentsEnergy) {
 	nodeComponentsEnergy = map[int]source.NodeComponentsEnergy{}
 	// TODO: make the estimator also retrieve the socket ID, we are estimating that the node will have only socket
 	socketID := 0

--- a/pkg/model/node_total_power.go
+++ b/pkg/model/node_total_power.go
@@ -48,7 +48,7 @@ func IsNodePlatformPowerModelEnabled() bool {
 }
 
 // GetNodeTotalEnergy returns a single estimated value of node total power
-func GetEstimatedNodePlatformPower(nodeMetrics collector_metric.NodeMetrics) (platformEnergy map[string]float64) {
+func GetEstimatedNodePlatformPower(nodeMetrics *collector_metric.NodeMetrics) (platformEnergy map[string]float64) {
 	platformEnergy = map[string]float64{}
 	platformEnergy[estimatorACPISensorID] = 0
 	if NodePlatformPowerModelEnabled {

--- a/pkg/model/utils.go
+++ b/pkg/model/utils.go
@@ -65,7 +65,7 @@ func containerMetricsToArray(containersMetrics map[string]*collector_metric.Cont
 }
 
 // TODO: as in containerMetricsToArray, consider exchange a protobuf stricture istead of simple arrays to make it more predictable and consistent
-func nodeMetricsToArray(nodeMetrics collector_metric.NodeMetrics) [][]float64 {
+func nodeMetricsToArray(nodeMetrics *collector_metric.NodeMetrics) [][]float64 {
 	nodeMetricResourceUsageValuesOnly := []float64{}
 	for _, metricName := range collector_metric.ContainerMetricNames {
 		nodeMetricResourceUsageValuesOnly = append(nodeMetricResourceUsageValuesOnly, nodeMetrics.ResourceUsage[metricName])


### PR DESCRIPTION
Measuring idle power consumption is important for getting an accurate picture of overall energy usage. 

It's important to measure the idle and dynamic energy separately so that the energy consumption of resource-intensive processes can be evaluated fairly. For example, It's not fair to assign all idle energy to a process just considering the resource utilization since the idle power does not vary with the utilization.

Therefore, this PR adds the support of Idle and Dynamic energy calculation for a container.
The Idle energy is calculated by using the minimal observed energy. In my experiments, few seconds are enough to get the idle state.

Currently the model server only calculates the dynamic energy, so that the overall metrics will more transparent.

For the prometheus metrics, this PR introduces a new label called `mode` which shows if the energy is idle or dynamic:
```
# HELP kepler_node_package_joules_total Aggregated RAPL value in package (socket) in joules
# TYPE kepler_node_package_joules_total counter
kepler_node_package_joules_total{instance="node1",mode="dynamic",package="0",source="rapl"} 0.005
kepler_node_package_joules_total{instance="node1",mode="idle",package="0",source="rapl"} 0.005
```