### PR TITLE
collector: add kepler_process metrics

### DIFF
--- a/pkg/collector/container_accelerator_collector.go
+++ b/pkg/collector/container_accelerator_collector.go
@@ -49,12 +49,26 @@ func (c *Collector) updateAcceleratorMetrics() {
 			}
 
 			c.createContainersMetricsIfNotExist(containerID, 0, uint64(pid), false)
+			if config.EnableProcessMetrics {
+				c.createProcessMetricsIfNotExist(uint64(pid), "")
+			}
 
+			// update container metrics
 			if err = c.ContainersMetrics[containerID].CounterStats[config.GPUSMUtilization].AddNewDelta(uint64(processUtilization.SmUtil)); err != nil {
 				klog.V(5).Infoln(err)
 			}
 			if err = c.ContainersMetrics[containerID].CounterStats[config.GPUMemUtilization].AddNewDelta(uint64(processUtilization.MemUtil)); err != nil {
 				klog.V(5).Infoln(err)
+			}
+
+			if containerID == c.systemProcessName && config.EnableProcessMetrics {
+				// update process metrics
+				if err = c.ProcessMetrics[uint64(pid)].CounterStats[config.GPUSMUtilization].AddNewDelta(uint64(processUtilization.SmUtil)); err != nil {
+					klog.V(5).Infoln(err)
+				}
+				if err = c.ProcessMetrics[uint64(pid)].CounterStats[config.GPUMemUtilization].AddNewDelta(uint64(processUtilization.MemUtil)); err != nil {
+					klog.V(5).Infoln(err)
+				}
 			}
 		}
 	}

--- a/pkg/collector/container_hc_collector.go
+++ b/pkg/collector/container_hc_collector.go
@@ -93,7 +93,7 @@ func (c *Collector) updateBPFMetrics() {
 		}
 		// update IRQ vector
 		for i := 0; i < config.MaxIRQ; i++ {
-			if err = c.ContainersMetrics[containerID].SoftIQRCount[i].AddNewDelta(uint64(ct.VecNR[i])); err != nil {
+			if err = c.ContainersMetrics[containerID].SoftIRQCount[i].AddNewDelta(uint64(ct.VecNR[i])); err != nil {
 				klog.V(5).Infoln(err)
 			}
 		}

--- a/pkg/collector/container_hc_collector.go
+++ b/pkg/collector/container_hc_collector.go
@@ -64,7 +64,7 @@ func (c *Collector) updateBPFMetrics() {
 			klog.V(5).Infof("failed to decode received data: %v", err)
 			continue
 		}
-		comm := (*C.char)(unsafe.Pointer(&ct.Command))
+		comm := C.GoString((*C.char)(unsafe.Pointer(&ct.Command)))
 
 		containerID, _ := cgroup.GetContainerID(ct.CGroupID, ct.PID, config.EnabledEBPFCgroupID)
 		if err != nil {
@@ -78,7 +78,12 @@ func (c *Collector) updateBPFMetrics() {
 		// System process is the aggregation of all background process running outside kubernetes
 		// this means that the list of process might be very large, so we will not add this information to the cache
 		if containerID != c.systemProcessName {
-			c.ContainersMetrics[containerID].SetLatestProcess(ct.CGroupID, ct.PID, C.GoString(comm))
+			c.ContainersMetrics[containerID].SetLatestProcess(ct.CGroupID, ct.PID, comm)
+		} else if config.EnableProcessMetrics {
+			c.createProcessMetricsIfNotExist(ct.PID, comm)
+			if err = c.ProcessMetrics[ct.PID].CPUTime.AddNewDelta(ct.ProcessRunTime); err != nil {
+				klog.V(5).Infoln(err)
+			}
 		}
 
 		// update ebpf metrics
@@ -106,8 +111,15 @@ func (c *Collector) updateBPFMetrics() {
 			default:
 				val = 0
 			}
+
 			if err = c.ContainersMetrics[containerID].CounterStats[counterKey].AddNewDelta(val); err != nil {
 				klog.V(5).Infoln(err)
+			}
+			// track system process metrics
+			if containerID == c.systemProcessName && config.EnableProcessMetrics {
+				if err = c.ProcessMetrics[ct.PID].CounterStats[counterKey].AddNewDelta(val); err != nil {
+					klog.V(5).Infoln(err)
+				}
 			}
 		}
 
@@ -148,3 +160,5 @@ func (c *Collector) handleInactiveContainers(foundContainer map[string]bool) {
 		}
 	}
 }
+
+// TODO: remove inactive processes

--- a/pkg/collector/metric/container_metric.go
+++ b/pkg/collector/metric/container_metric.go
@@ -41,42 +41,21 @@ var (
 )
 
 type ContainerMetrics struct {
+	ProcessMetrics
+
 	CGroupPID     uint64
 	PIDS          []uint64
 	ContainerName string
 	PodName       string
 	Namespace     string
-	// TODO: we should consider deprecate the command information
-	Command string
 
 	CurrProcesses int
 	Disks         int
 
-	// ebpf metrics
-	CPUTime      *UInt64Stat
-	SoftIQRCount []UInt64Stat
-
-	CounterStats  map[string]*UInt64Stat
 	CgroupFSStats map[string]*UInt64StatCollection
 	KubeletStats  map[string]*UInt64Stat
-	GPUStats      map[string]*UInt64Stat
-
-	BytesRead  *UInt64StatCollection
-	BytesWrite *UInt64StatCollection
-
-	DynEnergyInCore   *UInt64Stat
-	DynEnergyInDRAM   *UInt64Stat
-	DynEnergyInUncore *UInt64Stat
-	DynEnergyInPkg    *UInt64Stat
-	DynEnergyInGPU    *UInt64Stat
-	DynEnergyInOther  *UInt64Stat
-
-	IdleEnergyInCore   *UInt64Stat
-	IdleEnergyInDRAM   *UInt64Stat
-	IdleEnergyInUncore *UInt64Stat
-	IdleEnergyInPkg    *UInt64Stat
-	IdleEnergyInGPU    *UInt64Stat
-	IdleEnergyInOther  *UInt64Stat
+	BytesRead     *UInt64StatCollection
+	BytesWrite    *UInt64StatCollection
 }
 
 // NewContainerMetrics creates a new ContainerMetrics instance
@@ -85,9 +64,23 @@ func NewContainerMetrics(containerName, podName, podNamespace string) *Container
 		PodName:       podName,
 		ContainerName: containerName,
 		Namespace:     podNamespace,
-		CPUTime:       &UInt64Stat{},
-		SoftIQRCount:  make([]UInt64Stat, config.MaxIRQ),
-		CounterStats:  make(map[string]*UInt64Stat),
+		ProcessMetrics: ProcessMetrics{
+			CPUTime:            &UInt64Stat{},
+			CounterStats:       make(map[string]*UInt64Stat),
+			SoftIQRCount:       make([]UInt64Stat, config.MaxIRQ),
+			DynEnergyInCore:    &UInt64Stat{},
+			DynEnergyInDRAM:    &UInt64Stat{},
+			DynEnergyInUncore:  &UInt64Stat{},
+			DynEnergyInPkg:     &UInt64Stat{},
+			DynEnergyInOther:   &UInt64Stat{},
+			DynEnergyInGPU:     &UInt64Stat{},
+			IdleEnergyInCore:   &UInt64Stat{},
+			IdleEnergyInDRAM:   &UInt64Stat{},
+			IdleEnergyInUncore: &UInt64Stat{},
+			IdleEnergyInPkg:    &UInt64Stat{},
+			IdleEnergyInOther:  &UInt64Stat{},
+			IdleEnergyInGPU:    &UInt64Stat{},
+		},
 		CgroupFSStats: make(map[string]*UInt64StatCollection),
 		KubeletStats:  make(map[string]*UInt64Stat),
 		BytesRead: &UInt64StatCollection{
@@ -96,18 +89,6 @@ func NewContainerMetrics(containerName, podName, podNamespace string) *Container
 		BytesWrite: &UInt64StatCollection{
 			Stat: make(map[string]*UInt64Stat),
 		},
-		DynEnergyInCore:    &UInt64Stat{},
-		DynEnergyInDRAM:    &UInt64Stat{},
-		DynEnergyInUncore:  &UInt64Stat{},
-		DynEnergyInPkg:     &UInt64Stat{},
-		DynEnergyInOther:   &UInt64Stat{},
-		DynEnergyInGPU:     &UInt64Stat{},
-		IdleEnergyInCore:   &UInt64Stat{},
-		IdleEnergyInDRAM:   &UInt64Stat{},
-		IdleEnergyInUncore: &UInt64Stat{},
-		IdleEnergyInPkg:    &UInt64Stat{},
-		IdleEnergyInOther:  &UInt64Stat{},
-		IdleEnergyInGPU:    &UInt64Stat{},
 	}
 	for _, metricName := range AvailableHWCounters {
 		c.CounterStats[metricName] = &UInt64Stat{}

--- a/pkg/collector/metric/container_metric.go
+++ b/pkg/collector/metric/container_metric.go
@@ -67,7 +67,7 @@ func NewContainerMetrics(containerName, podName, podNamespace string) *Container
 		ProcessMetrics: ProcessMetrics{
 			CPUTime:            &UInt64Stat{},
 			CounterStats:       make(map[string]*UInt64Stat),
-			SoftIQRCount:       make([]UInt64Stat, config.MaxIRQ),
+			SoftIRQCount:       make([]UInt64Stat, config.MaxIRQ),
 			DynEnergyInCore:    &UInt64Stat{},
 			DynEnergyInDRAM:    &UInt64Stat{},
 			DynEnergyInUncore:  &UInt64Stat{},
@@ -114,7 +114,7 @@ func (c *ContainerMetrics) ResetDeltaValues() {
 	c.CurrProcesses = 0
 	c.CPUTime.ResetDeltaValues()
 	for i := 0; i < config.MaxIRQ; i++ {
-		c.SoftIQRCount[i].ResetDeltaValues()
+		c.SoftIRQCount[i].ResetDeltaValues()
 	}
 	for counterKey := range c.CounterStats {
 		c.CounterStats[counterKey].ResetDeltaValues()
@@ -183,11 +183,11 @@ func (c *ContainerMetrics) getIntDeltaAndAggrValue(metric string) (curr, aggr ui
 	case config.CPUTime:
 		return c.CPUTime.Delta, c.CPUTime.Aggr, nil
 	case config.IRQBlockLabel:
-		return c.SoftIQRCount[attacher.IRQBlock].Delta, c.SoftIQRCount[attacher.IRQBlock].Aggr, nil
+		return c.SoftIRQCount[attacher.IRQBlock].Delta, c.SoftIRQCount[attacher.IRQBlock].Aggr, nil
 	case config.IRQNetTXLabel:
-		return c.SoftIQRCount[attacher.IRQNetTX].Delta, c.SoftIQRCount[attacher.IRQNetTX].Aggr, nil
+		return c.SoftIRQCount[attacher.IRQNetTX].Delta, c.SoftIRQCount[attacher.IRQNetTX].Aggr, nil
 	case config.IRQNetRXLabel:
-		return c.SoftIQRCount[attacher.IRQNetRX].Delta, c.SoftIQRCount[attacher.IRQNetRX].Aggr, nil
+		return c.SoftIRQCount[attacher.IRQNetRX].Delta, c.SoftIRQCount[attacher.IRQNetRX].Aggr, nil
 	// hardcode cgroup metrics
 	// TO-DO: merge to cgroup stat
 	case config.BlockDevicesIO:
@@ -279,9 +279,9 @@ func (c *ContainerMetrics) String() string {
 		c.DynEnergyInPkg, c.DynEnergyInCore, c.DynEnergyInDRAM, c.DynEnergyInUncore, c.DynEnergyInGPU, c.DynEnergyInOther,
 		c.IdleEnergyInPkg, c.IdleEnergyInCore, c.IdleEnergyInDRAM, c.IdleEnergyInUncore, c.IdleEnergyInGPU, c.IdleEnergyInOther,
 		c.CPUTime.Delta, c.CPUTime.Aggr,
-		c.SoftIQRCount[attacher.IRQNetTX].Delta, c.SoftIQRCount[attacher.IRQNetTX].Aggr,
-		c.SoftIQRCount[attacher.IRQNetRX].Delta, c.SoftIQRCount[attacher.IRQNetRX].Aggr,
-		c.SoftIQRCount[attacher.IRQBlock].Delta, c.SoftIQRCount[attacher.IRQBlock].Aggr,
+		c.SoftIRQCount[attacher.IRQNetTX].Delta, c.SoftIRQCount[attacher.IRQNetTX].Aggr,
+		c.SoftIRQCount[attacher.IRQNetRX].Delta, c.SoftIRQCount[attacher.IRQNetRX].Aggr,
+		c.SoftIRQCount[attacher.IRQBlock].Delta, c.SoftIRQCount[attacher.IRQBlock].Aggr,
 		c.CounterStats,
 		c.CgroupFSStats,
 		c.KubeletStats)

--- a/pkg/collector/metric/container_metric_test.go
+++ b/pkg/collector/metric/container_metric_test.go
@@ -24,12 +24,14 @@ import (
 var _ = Describe("Test Container Metric", func() {
 
 	c := ContainerMetrics{
-		DynEnergyInCore:   &UInt64Stat{Delta: uint64(1), Aggr: uint64(2)},
-		DynEnergyInDRAM:   &UInt64Stat{Delta: uint64(3), Aggr: uint64(4)},
-		DynEnergyInUncore: &UInt64Stat{Delta: uint64(5), Aggr: uint64(6)},
-		DynEnergyInPkg:    &UInt64Stat{Delta: uint64(7), Aggr: uint64(8)},
-		DynEnergyInGPU:    &UInt64Stat{Delta: uint64(9), Aggr: uint64(10)},
-		DynEnergyInOther:  &UInt64Stat{Delta: uint64(11), Aggr: uint64(12)},
+		ProcessMetrics: ProcessMetrics{
+			DynEnergyInCore:   &UInt64Stat{Delta: uint64(1), Aggr: uint64(2)},
+			DynEnergyInDRAM:   &UInt64Stat{Delta: uint64(3), Aggr: uint64(4)},
+			DynEnergyInUncore: &UInt64Stat{Delta: uint64(5), Aggr: uint64(6)},
+			DynEnergyInPkg:    &UInt64Stat{Delta: uint64(7), Aggr: uint64(8)},
+			DynEnergyInGPU:    &UInt64Stat{Delta: uint64(9), Aggr: uint64(10)},
+			DynEnergyInOther:  &UInt64Stat{Delta: uint64(11), Aggr: uint64(12)},
+		},
 		CgroupFSStats: map[string]*UInt64StatCollection{
 			CORE: {
 				Stat: map[string]*UInt64Stat{

--- a/pkg/collector/metric/process_metric.go
+++ b/pkg/collector/metric/process_metric.go
@@ -44,7 +44,7 @@ type ProcessMetrics struct {
 	CounterStats map[string]*UInt64Stat
 	// ebpf metrics
 	CPUTime           *UInt64Stat
-	SoftIQRCount      []UInt64Stat
+	SoftIRQCount      []UInt64Stat
 	GPUStats          map[string]*UInt64Stat
 	DynEnergyInCore   *UInt64Stat
 	DynEnergyInDRAM   *UInt64Stat
@@ -68,7 +68,7 @@ func NewProcessMetrics(pid uint64, command string) *ProcessMetrics {
 		Command:            command,
 		CPUTime:            &UInt64Stat{},
 		CounterStats:       make(map[string]*UInt64Stat),
-		SoftIQRCount:       make([]UInt64Stat, config.MaxIRQ),
+		SoftIRQCount:       make([]UInt64Stat, config.MaxIRQ),
 		DynEnergyInCore:    &UInt64Stat{},
 		DynEnergyInDRAM:    &UInt64Stat{},
 		DynEnergyInUncore:  &UInt64Stat{},
@@ -131,11 +131,11 @@ func (p *ProcessMetrics) getIntDeltaAndAggrValue(metric string) (curr, aggr uint
 	case config.CPUTime:
 		return p.CPUTime.Delta, p.CPUTime.Aggr, nil
 	case config.IRQBlockLabel:
-		return p.SoftIQRCount[attacher.IRQBlock].Delta, p.SoftIQRCount[attacher.IRQBlock].Aggr, nil
+		return p.SoftIRQCount[attacher.IRQBlock].Delta, p.SoftIRQCount[attacher.IRQBlock].Aggr, nil
 	case config.IRQNetTXLabel:
-		return p.SoftIQRCount[attacher.IRQNetTX].Delta, p.SoftIQRCount[attacher.IRQNetTX].Aggr, nil
+		return p.SoftIRQCount[attacher.IRQNetTX].Delta, p.SoftIRQCount[attacher.IRQNetTX].Aggr, nil
 	case config.IRQNetRXLabel:
-		return p.SoftIQRCount[attacher.IRQNetRX].Delta, p.SoftIQRCount[attacher.IRQNetRX].Aggr, nil
+		return p.SoftIRQCount[attacher.IRQNetRX].Delta, p.SoftIRQCount[attacher.IRQNetRX].Aggr, nil
 	}
 	klog.V(4).Infof("cannot extract: %s", metric)
 	return 0, 0, fmt.Errorf("cannot extract: %s", metric)

--- a/pkg/collector/metric/process_metric.go
+++ b/pkg/collector/metric/process_metric.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/sustainable-computing-io/kepler/pkg/bpfassets/attacher"
+	"github.com/sustainable-computing-io/kepler/pkg/config"
+	"github.com/sustainable-computing-io/kepler/pkg/power/accelerator"
+	"k8s.io/klog/v2"
+)
+
+var (
+	// ProcessMetricNames holds the list of names of the container metric
+	ProcessMetricNames []string
+	// ProcessFloatFeatureNames holds the feature name of the container float collector_metric. This is specific for the machine-learning based models.
+	ProcessFloatFeatureNames []string = []string{}
+	// ProcessUintFeaturesNames holds the feature name of the container utint collector_metric. This is specific for the machine-learning based models.
+	ProcessUintFeaturesNames []string
+	// ProcessFeaturesNames holds all the feature name of the container collector_metric. This is specific for the machine-learning based models.
+	ProcessFeaturesNames []string
+)
+
+type ProcessMetrics struct {
+	PID          uint64
+	Command      string
+	CounterStats map[string]*UInt64Stat
+	// ebpf metrics
+	CPUTime           *UInt64Stat
+	SoftIQRCount      []UInt64Stat
+	GPUStats          map[string]*UInt64Stat
+	DynEnergyInCore   *UInt64Stat
+	DynEnergyInDRAM   *UInt64Stat
+	DynEnergyInUncore *UInt64Stat
+	DynEnergyInPkg    *UInt64Stat
+	DynEnergyInGPU    *UInt64Stat
+	DynEnergyInOther  *UInt64Stat
+
+	IdleEnergyInCore   *UInt64Stat
+	IdleEnergyInDRAM   *UInt64Stat
+	IdleEnergyInUncore *UInt64Stat
+	IdleEnergyInPkg    *UInt64Stat
+	IdleEnergyInGPU    *UInt64Stat
+	IdleEnergyInOther  *UInt64Stat
+}
+
+// NewProcessMetrics creates a new ProcessMetrics instance
+func NewProcessMetrics(pid uint64, command string) *ProcessMetrics {
+	p := &ProcessMetrics{
+		PID:                pid,
+		Command:            command,
+		CPUTime:            &UInt64Stat{},
+		CounterStats:       make(map[string]*UInt64Stat),
+		SoftIQRCount:       make([]UInt64Stat, config.MaxIRQ),
+		DynEnergyInCore:    &UInt64Stat{},
+		DynEnergyInDRAM:    &UInt64Stat{},
+		DynEnergyInUncore:  &UInt64Stat{},
+		DynEnergyInPkg:     &UInt64Stat{},
+		DynEnergyInOther:   &UInt64Stat{},
+		DynEnergyInGPU:     &UInt64Stat{},
+		IdleEnergyInCore:   &UInt64Stat{},
+		IdleEnergyInDRAM:   &UInt64Stat{},
+		IdleEnergyInUncore: &UInt64Stat{},
+		IdleEnergyInPkg:    &UInt64Stat{},
+		IdleEnergyInOther:  &UInt64Stat{},
+		IdleEnergyInGPU:    &UInt64Stat{},
+	}
+
+	for _, metricName := range AvailableHWCounters {
+		p.CounterStats[metricName] = &UInt64Stat{}
+	}
+	// TODO: transparently list the other metrics and do not initialize them when they are not supported, e.g. HC
+	if accelerator.IsGPUCollectionSupported() {
+		p.CounterStats[config.GPUSMUtilization] = &UInt64Stat{}
+		p.CounterStats[config.GPUMemUtilization] = &UInt64Stat{}
+	}
+	return p
+}
+
+// ResetCurr reset all current value to 0
+func (p *ProcessMetrics) ResetDeltaValues() {
+	p.CPUTime.ResetDeltaValues()
+	for counterKey := range p.CounterStats {
+		p.CounterStats[counterKey].ResetDeltaValues()
+	}
+	p.DynEnergyInCore.ResetDeltaValues()
+	p.DynEnergyInDRAM.ResetDeltaValues()
+	p.DynEnergyInUncore.ResetDeltaValues()
+	p.DynEnergyInPkg.ResetDeltaValues()
+	p.DynEnergyInOther.ResetDeltaValues()
+	p.DynEnergyInGPU.ResetDeltaValues()
+	p.IdleEnergyInCore.ResetDeltaValues()
+	p.IdleEnergyInDRAM.ResetDeltaValues()
+	p.IdleEnergyInUncore.ResetDeltaValues()
+	p.IdleEnergyInPkg.ResetDeltaValues()
+	p.IdleEnergyInOther.ResetDeltaValues()
+	p.IdleEnergyInGPU.ResetDeltaValues()
+}
+
+// getFloatCurrAndAggrValue return curr, aggr float64 values of specific uint metric
+func (p *ProcessMetrics) getFloatCurrAndAggrValue(metric string) (curr, aggr float64, err error) {
+	// TO-ADD
+	return 0, 0, nil
+}
+
+// getIntDeltaAndAggrValue return curr, aggr uint64 values of specific uint metric
+func (p *ProcessMetrics) getIntDeltaAndAggrValue(metric string) (curr, aggr uint64, err error) {
+	if val, exists := p.CounterStats[metric]; exists {
+		return val.Delta, val.Aggr, nil
+	}
+
+	switch metric {
+	// ebpf metrics
+	case config.CPUTime:
+		return p.CPUTime.Delta, p.CPUTime.Aggr, nil
+	case config.IRQBlockLabel:
+		return p.SoftIQRCount[attacher.IRQBlock].Delta, p.SoftIQRCount[attacher.IRQBlock].Aggr, nil
+	case config.IRQNetTXLabel:
+		return p.SoftIQRCount[attacher.IRQNetTX].Delta, p.SoftIQRCount[attacher.IRQNetTX].Aggr, nil
+	case config.IRQNetRXLabel:
+		return p.SoftIQRCount[attacher.IRQNetRX].Delta, p.SoftIQRCount[attacher.IRQNetRX].Aggr, nil
+	}
+	klog.V(4).Infof("cannot extract: %s", metric)
+	return 0, 0, fmt.Errorf("cannot extract: %s", metric)
+}
+
+// ToEstimatorValues return values regarding metricNames
+func (p *ProcessMetrics) ToEstimatorValues() (values []float64) {
+	for _, metric := range ContainerFloatFeatureNames {
+		curr, _, _ := p.getFloatCurrAndAggrValue(metric)
+		values = append(values, curr)
+	}
+	for _, metric := range ContainerUintFeaturesNames {
+		curr, _, _ := p.getIntDeltaAndAggrValue(metric)
+		values = append(values, float64(curr))
+	}
+	return
+}
+
+// GetBasicValues return basic label balues
+func (p *ProcessMetrics) GetBasicValues() []string {
+	command := p.Command
+	if len(command) > 10 {
+		command = command[:10]
+	}
+	return []string{command}
+}
+
+// ToPrometheusValue return the value regarding metric label
+func (p *ProcessMetrics) ToPrometheusValue(metric string) string {
+	currentValue := false
+	if strings.Contains(metric, "curr_") {
+		currentValue = true
+		metric = strings.ReplaceAll(metric, "curr_", "")
+	}
+	metric = strings.ReplaceAll(metric, "total_", "")
+
+	if curr, aggr, err := p.getIntDeltaAndAggrValue(metric); err == nil {
+		if currentValue {
+			return strconv.FormatUint(curr, 10)
+		}
+		return strconv.FormatUint(aggr, 10)
+	}
+	if curr, aggr, err := p.getFloatCurrAndAggrValue(metric); err == nil {
+		if currentValue {
+			return fmt.Sprintf("%f", curr)
+		}
+		return fmt.Sprintf("%f", aggr)
+	}
+	klog.Errorf("cannot extract metric: %s", metric)
+	return ""
+}
+
+func (p *ProcessMetrics) SumAllDynDeltaValues() uint64 {
+	return p.DynEnergyInPkg.Delta + p.DynEnergyInGPU.Delta + p.DynEnergyInOther.Delta
+}
+
+func (p *ProcessMetrics) SumAllDynAggrValues() uint64 {
+	return p.DynEnergyInPkg.Aggr + p.DynEnergyInGPU.Aggr + p.DynEnergyInOther.Aggr
+}
+
+func (p *ProcessMetrics) String() string {
+	return fmt.Sprintf("energy from process pid: %d comm: %s\n"+
+		"\tDyn ePkg (mJ): %s (eCore: %s eDram: %s eUncore: %s) eGPU (mJ): %s eOther (mJ): %s \n"+
+		"\tIdle ePkg (mJ): %s (eCore: %s eDram: %s eUncore: %s) eGPU (mJ): %s eOther (mJ): %s \n"+
+		"\tCPUTime:  %d (%d)\n"+
+		"\tcounters: %v\n",
+		p.PID, p.Command,
+		p.DynEnergyInPkg, p.DynEnergyInCore, p.DynEnergyInDRAM, p.DynEnergyInUncore, p.DynEnergyInGPU, p.DynEnergyInOther,
+		p.IdleEnergyInPkg, p.IdleEnergyInCore, p.IdleEnergyInDRAM, p.IdleEnergyInUncore, p.IdleEnergyInGPU, p.IdleEnergyInOther,
+		p.CPUTime.Delta, p.CPUTime.Aggr,
+		p.CounterStats)
+}

--- a/pkg/collector/metric_collector.go
+++ b/pkg/collector/metric_collector.go
@@ -77,7 +77,7 @@ func (c *Collector) Initialize() error {
 	c.bpfHCMeter = m
 
 	pods, err := cgroup.Init()
-	if err != nil {
+	if err != nil && !config.EnableProcessMetrics {
 		klog.V(5).Infoln(err)
 		return err
 	}
@@ -156,6 +156,9 @@ func (c *Collector) resetDeltaValue() {
 // This is a necessary hacking to export metrics of idle containers, since we can only include in
 // the containers list the containers that present any updates from the bpf metrics
 func (c *Collector) prePopulateContainerMetrics(pods *[]corev1.Pod) {
+	if pods == nil {
+		return
+	}
 	for i := 0; i < len(*pods); i++ {
 		pod := (*pods)[i]
 		for j := 0; j < len(pod.Status.InitContainerStatuses); j++ {

--- a/pkg/collector/metric_collector.go
+++ b/pkg/collector/metric_collector.go
@@ -49,6 +49,9 @@ type Collector struct {
 	// ContainersMetrics holds all container energy and resource usage metrics
 	ContainersMetrics map[string]*collector_metric.ContainerMetrics
 
+	// ProcessMetrics hold all process energy and resource usage metrics
+	ProcessMetrics map[uint64]*collector_metric.ProcessMetrics
+
 	// generic names to be used for process that are not within a pod
 	systemProcessName      string
 	systemProcessNamespace string
@@ -59,6 +62,7 @@ func NewCollector() *Collector {
 		acpiPowerMeter:         acpi.NewACPIPowerMeter(),
 		NodeMetrics:            *collector_metric.NewNodeMetrics(),
 		ContainersMetrics:      map[string]*collector_metric.ContainerMetrics{},
+		ProcessMetrics:         map[uint64]*collector_metric.ProcessMetrics{},
 		systemProcessName:      utils.SystemProcessName,
 		systemProcessNamespace: utils.SystemProcessNamespace,
 	}
@@ -122,6 +126,11 @@ func (c *Collector) Update() {
 	// calculate the container energy consumption using its resource utilization and the node components energy consumption
 	c.updateContainerEnergy()
 
+	// calculate the process energy consumption using its resource utilization and the node components energy consumption
+	if config.EnableProcessMetrics {
+		c.updateProcessEnergy()
+	}
+
 	// check the log verbosity level before iterating in all container
 	if klog.V(3).Enabled() {
 		for _, v := range c.ContainersMetrics {
@@ -135,6 +144,9 @@ func (c *Collector) Update() {
 // resetDeltaValue reset existing podEnergy previous curr value
 func (c *Collector) resetDeltaValue() {
 	for _, v := range c.ContainersMetrics {
+		v.ResetDeltaValues()
+	}
+	for _, v := range c.ProcessMetrics {
 		v.ResetDeltaValues()
 	}
 	c.NodeMetrics.ResetDeltaValues()

--- a/pkg/collector/metric_collector_test.go
+++ b/pkg/collector/metric_collector_test.go
@@ -124,6 +124,7 @@ func createMockNodeMetrics(containersMetrics map[string]*collector_metric.Contai
 func newMockCollector() *Collector {
 	metricCollector := NewCollector()
 	metricCollector.ContainersMetrics = createMockContainersMetrics()
+	metricCollector.ProcessMetrics = map[uint64]*collector_metric.ProcessMetrics{}
 	metricCollector.NodeMetrics = createMockNodeMetrics(metricCollector.ContainersMetrics)
 
 	return metricCollector

--- a/pkg/collector/process_energy_collector.go
+++ b/pkg/collector/process_energy_collector.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"github.com/sustainable-computing-io/kepler/pkg/model"
+)
+
+// updateProcessEnergy matches the process resource usage with the node energy consumption
+func (c *Collector) updateProcessEnergy() {
+	model.UpdateProcessEnergy(c.ProcessMetrics, c.ContainersMetrics[c.systemProcessName])
+}

--- a/pkg/collector/prometheus_collector.go
+++ b/pkg/collector/prometheus_collector.go
@@ -802,19 +802,19 @@ func (p *PrometheusCollector) updatePodMetrics(wg *sync.WaitGroup, ch chan<- pro
 				ch <- prometheus.MustNewConstMetric(
 					p.containerDesc.containerNetTxIRQTotal,
 					prometheus.CounterValue,
-					float64(container.SoftIQRCount[attacher.IRQNetTX].Aggr),
+					float64(container.SoftIRQCount[attacher.IRQNetTX].Aggr),
 					container.PodName, container.ContainerName, container.Namespace,
 				)
 				ch <- prometheus.MustNewConstMetric(
 					p.containerDesc.containerNetRxIRQTotal,
 					prometheus.CounterValue,
-					float64(container.SoftIQRCount[attacher.IRQNetRX].Aggr),
+					float64(container.SoftIRQCount[attacher.IRQNetRX].Aggr),
 					container.PodName, container.ContainerName, container.Namespace,
 				)
 				ch <- prometheus.MustNewConstMetric(
 					p.containerDesc.containerBlockIRQTotal,
 					prometheus.CounterValue,
-					float64(container.SoftIQRCount[attacher.IRQBlock].Aggr),
+					float64(container.SoftIRQCount[attacher.IRQBlock].Aggr),
 					container.PodName, container.ContainerName, container.Namespace,
 				)
 			}

--- a/pkg/collector/prometheus_collector_test.go
+++ b/pkg/collector/prometheus_collector_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package collector
 
 import (
@@ -64,6 +80,7 @@ func newMockPrometheusExporter() *PrometheusCollector {
 	exporter.NodeCPUFrequency = &map[int32]uint64{}
 	exporter.NodeMetrics = collector_metric.NewNodeMetrics()
 	exporter.ContainersMetrics = &map[string]*collector_metric.ContainerMetrics{}
+	exporter.ProcessMetrics = &map[uint64]*collector_metric.ProcessMetrics{}
 	exporter.SamplePeriodSec = 3.0
 	collector_metric.ContainerMetricNames = []string{config.CoreUsageMetric}
 	return exporter

--- a/pkg/collector/prometheus_process_collector.go
+++ b/pkg/collector/prometheus_process_collector.go
@@ -1,0 +1,285 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"strconv"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sustainable-computing-io/kepler/pkg/bpfassets/attacher"
+	collector_metric "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
+	"github.com/sustainable-computing-io/kepler/pkg/config"
+)
+
+type processDesc struct {
+	// Energy (counter)
+	processCoreJoulesTotal            *prometheus.Desc
+	processUncoreJoulesTotal          *prometheus.Desc
+	processDramJoulesTotal            *prometheus.Desc
+	processPackageJoulesTotal         *prometheus.Desc
+	processOtherComponentsJoulesTotal *prometheus.Desc
+	processGPUJoulesTotal             *prometheus.Desc
+	processJoulesTotal                *prometheus.Desc
+
+	// Hardware Counters (counter)
+	processCPUCyclesTotal *prometheus.Desc
+	processCPUInstrTotal  *prometheus.Desc
+	processCacheMissTotal *prometheus.Desc
+
+	// Additional metrics (gauge)
+	processCPUTime *prometheus.Desc
+}
+
+// describeProcess is called by Describe to implement the prometheus.Collector interface
+func (p *PrometheusCollector) describeProcess(ch chan<- *prometheus.Desc) {
+	// process Energy (counter)
+	ch <- p.processDesc.processCoreJoulesTotal
+	ch <- p.processDesc.processUncoreJoulesTotal
+	ch <- p.processDesc.processDramJoulesTotal
+	ch <- p.processDesc.processPackageJoulesTotal
+	ch <- p.processDesc.processOtherComponentsJoulesTotal
+	if config.EnabledGPU {
+		ch <- p.processDesc.processGPUJoulesTotal
+	}
+	ch <- p.processDesc.processJoulesTotal
+
+	// process Hardware Counters (counter)
+	if collector_metric.CPUHardwareCounterEnabled {
+		ch <- p.processDesc.processCPUCyclesTotal
+		ch <- p.processDesc.processCPUInstrTotal
+		ch <- p.processDesc.processCacheMissTotal
+	}
+}
+
+func (p *PrometheusCollector) newprocessMetrics() {
+	// Energy (counter)
+	processCoreJoulesTotal := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "process", "core_joules_total"),
+		"Aggregated RAPL value in core in joules",
+		[]string{"pid", "command", "mode"}, nil,
+	)
+	processUncoreJoulesTotal := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "process", "uncore_joules_total"),
+		"Aggregated RAPL value in uncore in joules",
+		[]string{"pid", "command", "mode"}, nil,
+	)
+	processDramJoulesTotal := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "process", "dram_joules_total"),
+		"Aggregated RAPL value in dram in joules",
+		[]string{"pid", "command", "mode"}, nil,
+	)
+	processPackageJoulesTotal := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "process", "package_joules_total"),
+		"Aggregated RAPL value in package (socket) in joules",
+		[]string{"pid", "command", "mode"}, nil,
+	)
+	processOtherComponentsJoulesTotal := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "process", "other_host_components_joules_total"),
+		"Aggregated value in other host components (platform - package - dram) in joules",
+		[]string{"pid", "command", "mode"}, nil,
+	)
+	processGPUJoulesTotal := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "process", "gpu_joules_total"),
+		"Aggregated GPU value in joules",
+		[]string{"pid", "command", "mode"}, nil,
+	)
+	processJoulesTotal := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "process", "joules_total"),
+		"Aggregated RAPL Package + Uncore + DRAM + GPU + other host components (platform - package - dram) in joules",
+		[]string{"pid", "command", "mode"}, nil,
+	)
+
+	// Hardware Counters (counter)
+	processCPUCyclesTotal := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "process", "cpu_cycles_total"),
+		"Aggregated CPU cycle value",
+		[]string{"pid", "command"}, nil,
+	)
+	processCPUInstrTotal := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "process", "cpu_instructions_total"),
+		"Aggregated CPU instruction value",
+		[]string{"pid", "command"}, nil,
+	)
+	processCacheMissTotal := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "process", "cache_miss_total"),
+		"Aggregated cache miss value",
+		[]string{"pid", "command"}, nil,
+	)
+	// Additional metrics (gauge)
+	processCPUTime := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "process", "cpu_cpu_time_us"),
+		"Aggregated CPU time",
+		[]string{"pid", "command"}, nil)
+
+	p.processDesc = &processDesc{
+		processCoreJoulesTotal:            processCoreJoulesTotal,
+		processUncoreJoulesTotal:          processUncoreJoulesTotal,
+		processDramJoulesTotal:            processDramJoulesTotal,
+		processPackageJoulesTotal:         processPackageJoulesTotal,
+		processOtherComponentsJoulesTotal: processOtherComponentsJoulesTotal,
+		processGPUJoulesTotal:             processGPUJoulesTotal,
+		processJoulesTotal:                processJoulesTotal,
+		processCPUCyclesTotal:             processCPUCyclesTotal,
+		processCPUInstrTotal:              processCPUInstrTotal,
+		processCacheMissTotal:             processCacheMissTotal,
+		processCPUTime:                    processCPUTime,
+	}
+}
+
+// updateProcessMetrics send process metrics to prometheus
+func (p *PrometheusCollector) updateProcessMetrics(wg *sync.WaitGroup, ch chan<- prometheus.Metric) {
+	const commandLenLimit = 10
+	for pid, process := range *p.ProcessMetrics {
+		wg.Add(1)
+		go func(pid uint64, process *collector_metric.ProcessMetrics) {
+			defer wg.Done()
+			processCommand := process.Command
+			if len(processCommand) > commandLenLimit {
+				processCommand = process.Command[:commandLenLimit]
+			}
+			pidStr := strconv.FormatUint(pid, 10)
+			ch <- prometheus.MustNewConstMetric(
+				p.processDesc.processCPUTime,
+				prometheus.CounterValue,
+				float64(process.CPUTime.Aggr),
+				pidStr, processCommand,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				p.processDesc.processCoreJoulesTotal,
+				prometheus.CounterValue,
+				float64(process.DynEnergyInCore.Aggr)/miliJouleToJoule,
+				pidStr, processCommand, "dynamic",
+			)
+			ch <- prometheus.MustNewConstMetric(
+				p.processDesc.processCoreJoulesTotal,
+				prometheus.CounterValue,
+				float64(process.IdleEnergyInCore.Aggr)/miliJouleToJoule,
+				pidStr, processCommand, "idle",
+			)
+			ch <- prometheus.MustNewConstMetric(
+				p.processDesc.processUncoreJoulesTotal,
+				prometheus.CounterValue,
+				float64(process.DynEnergyInUncore.Aggr)/miliJouleToJoule,
+				pidStr, processCommand, "dynamic",
+			)
+			ch <- prometheus.MustNewConstMetric(
+				p.processDesc.processUncoreJoulesTotal,
+				prometheus.CounterValue,
+				float64(process.IdleEnergyInUncore.Aggr)/miliJouleToJoule,
+				pidStr, processCommand, "idle",
+			)
+			ch <- prometheus.MustNewConstMetric(
+				p.processDesc.processDramJoulesTotal,
+				prometheus.CounterValue,
+				float64(process.DynEnergyInDRAM.Aggr)/miliJouleToJoule,
+				pidStr, processCommand, "dynamic",
+			)
+			ch <- prometheus.MustNewConstMetric(
+				p.processDesc.processDramJoulesTotal,
+				prometheus.CounterValue,
+				float64(process.IdleEnergyInDRAM.Aggr)/miliJouleToJoule,
+				pidStr, processCommand, "idle",
+			)
+			ch <- prometheus.MustNewConstMetric(
+				p.processDesc.processPackageJoulesTotal,
+				prometheus.CounterValue,
+				float64(process.DynEnergyInPkg.Aggr)/miliJouleToJoule,
+				pidStr, processCommand, "dynamic",
+			)
+			ch <- prometheus.MustNewConstMetric(
+				p.processDesc.processPackageJoulesTotal,
+				prometheus.CounterValue,
+				float64(process.IdleEnergyInPkg.Aggr)/miliJouleToJoule,
+				pidStr, processCommand, "idle",
+			)
+			ch <- prometheus.MustNewConstMetric(
+				p.processDesc.processOtherComponentsJoulesTotal,
+				prometheus.CounterValue,
+				float64(process.DynEnergyInOther.Aggr)/miliJouleToJoule,
+				pidStr, processCommand, "dynamic",
+			)
+			ch <- prometheus.MustNewConstMetric(
+				p.processDesc.processOtherComponentsJoulesTotal,
+				prometheus.CounterValue,
+				float64(process.IdleEnergyInOther.Aggr)/miliJouleToJoule,
+				pidStr, processCommand, "idle",
+			)
+			if config.EnabledGPU {
+				ch <- prometheus.MustNewConstMetric(
+					p.processDesc.processGPUJoulesTotal,
+					prometheus.CounterValue,
+					float64(process.DynEnergyInGPU.Aggr)/miliJouleToJoule,
+					pidStr, processCommand, "dynamic",
+				)
+				ch <- prometheus.MustNewConstMetric(
+					p.processDesc.processGPUJoulesTotal,
+					prometheus.CounterValue,
+					float64(process.IdleEnergyInGPU.Aggr)/miliJouleToJoule,
+					pidStr, processCommand, "idle",
+				)
+			}
+			ch <- prometheus.MustNewConstMetric(
+				p.processDesc.processJoulesTotal,
+				prometheus.CounterValue,
+				(float64(process.DynEnergyInPkg.Aggr)/miliJouleToJoule +
+					float64(process.DynEnergyInUncore.Aggr)/miliJouleToJoule +
+					float64(process.DynEnergyInDRAM.Aggr)/miliJouleToJoule +
+					float64(process.DynEnergyInGPU.Aggr)/miliJouleToJoule +
+					float64(process.DynEnergyInOther.Aggr)/miliJouleToJoule),
+				pidStr, processCommand, "dynamic",
+			)
+			ch <- prometheus.MustNewConstMetric(
+				p.processDesc.processJoulesTotal,
+				prometheus.CounterValue,
+				(float64(process.IdleEnergyInPkg.Aggr)/miliJouleToJoule +
+					float64(process.IdleEnergyInUncore.Aggr)/miliJouleToJoule +
+					float64(process.IdleEnergyInDRAM.Aggr)/miliJouleToJoule +
+					float64(process.IdleEnergyInGPU.Aggr)/miliJouleToJoule +
+					float64(process.IdleEnergyInOther.Aggr)/miliJouleToJoule),
+				pidStr, processCommand, "idle",
+			)
+			if collector_metric.CPUHardwareCounterEnabled {
+				if process.CounterStats[attacher.CPUCycleLabel] != nil {
+					ch <- prometheus.MustNewConstMetric(
+						p.processDesc.processCPUCyclesTotal,
+						prometheus.CounterValue,
+						float64(process.CounterStats[attacher.CPUCycleLabel].Aggr),
+						pidStr, processCommand,
+					)
+				}
+				if process.CounterStats[attacher.CPUInstructionLabel] != nil {
+					ch <- prometheus.MustNewConstMetric(
+						p.processDesc.processCPUInstrTotal,
+						prometheus.CounterValue,
+						float64(process.CounterStats[attacher.CPUInstructionLabel].Aggr),
+						pidStr, processCommand,
+					)
+				}
+				if process.CounterStats[attacher.CacheMissLabel] != nil {
+					ch <- prometheus.MustNewConstMetric(
+						p.processDesc.processCacheMissTotal,
+						prometheus.CounterValue,
+						float64(process.CounterStats[attacher.CacheMissLabel].Aggr),
+						pidStr, processCommand,
+					)
+				}
+			}
+		}(pid, process)
+	}
+}

--- a/pkg/collector/utils.go
+++ b/pkg/collector/utils.go
@@ -46,3 +46,11 @@ func (c *Collector) createContainersMetricsIfNotExist(containerID string, cGroup
 		c.ContainersMetrics[containerID] = collector_metric.NewContainerMetrics(containerName, podName, namespace)
 	}
 }
+
+func (c *Collector) createProcessMetricsIfNotExist(pid uint64, command string) {
+	if p, ok := c.ProcessMetrics[pid]; !ok {
+		c.ProcessMetrics[pid] = collector_metric.NewProcessMetrics(pid, command)
+	} else if p.Command == "" {
+		p.Command = command
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,6 +63,7 @@ var (
 	ExposeHardwareCounterMetrics = getBoolConfig("EXPOSE_HW_COUNTER_METRICS", true)
 	EnabledGPU                   = getBoolConfig("ENABLE_GPU", false)
 	ExposeIRQCounterMetrics      = getBoolConfig("EXPOSE_IRQ_COUNTER_METRICS", true)
+	EnableProcessMetrics         = getBoolConfig("ENABLE_PROCESS_METRICS", false)
 	MetricPathKey                = "METRIC_PATH"
 	BindAddressKey               = "BIND_ADDRESS"
 	CPUArchOverride              = getConfig("CPU_ARCH_OVERRIDE", "")
@@ -89,6 +90,8 @@ var (
 	NodeComponentsKey      = "NODE_COMPONENTS"
 	ContainerTotalKey      = "CONTAINER_TOTAL"
 	ContainerComponentsKey = "CONTAINER_COMPONENTS"
+	ProcessTotalKey        = "PROCESS_TOTAL"
+	ProcessComponentsKey   = "PROCESS_COMPONENTS"
 
 	//  attribute
 	EstimatorEnabledKey = "ESTIMATOR"

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -44,6 +44,7 @@ func New() *CollectorManager {
 	manager.PrometheusCollector.NodeCPUFrequency = &manager.MetricCollector.NodeMetrics.CPUFrequency
 	manager.PrometheusCollector.NodeMetrics = &manager.MetricCollector.NodeMetrics
 	manager.PrometheusCollector.ContainersMetrics = &manager.MetricCollector.ContainersMetrics
+	manager.PrometheusCollector.ProcessMetrics = &manager.MetricCollector.ProcessMetrics
 	manager.PrometheusCollector.SamplePeriodSec = SamplePeriodSec
 	return manager
 }

--- a/pkg/model/container_power.go
+++ b/pkg/model/container_power.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:dupl // refactor this
 package model
 
 import (

--- a/pkg/model/estimator/local/ratio.go
+++ b/pkg/model/estimator/local/ratio.go
@@ -31,26 +31,26 @@ import (
 	collector_metric "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
 )
 
-func getSumMetricValues(containerMetricValues [][]float64) (sumMetricValues []float64) {
-	if len(containerMetricValues) == 0 {
+func getSumMetricValues(metricValues [][]float64) (sumMetricValues []float64) {
+	if len(metricValues) == 0 {
 		return
 	}
-	sumMetricValues = make([]float64, len(containerMetricValues[0]))
-	for _, values := range containerMetricValues {
-		for index, containerMetricValue := range values {
-			sumMetricValues[index] += containerMetricValue
+	sumMetricValues = make([]float64, len(metricValues[0]))
+	for _, values := range metricValues {
+		for index, metricValue := range values {
+			sumMetricValues[index] += metricValue
 		}
 	}
 	return
 }
 
-func getEnergyRatio(containerResUsage, nodeTotalResUsage, nodeResEnergyUtilization, containerNumber float64) uint64 {
+func getEnergyRatio(resUsage, nodeTotalResUsage, nodeResEnergyUtilization, totalNumber float64) uint64 {
 	var power float64
 	if nodeTotalResUsage > 0 {
-		power = (containerResUsage / nodeTotalResUsage) * nodeResEnergyUtilization
+		power = (resUsage / nodeTotalResUsage) * nodeResEnergyUtilization
 	} else {
-		// TODO: we should not equaly divide the energy consumptio across the containers. If a hardware counter metrics is not available we should use cgroup metrics.
-		power = nodeResEnergyUtilization / containerNumber
+		// TODO: we should not equaly divide the energy consumption across the all processes or containers. If a hardware counter metrics is not available we should use cgroup metrics.
+		power = nodeResEnergyUtilization / totalNumber
 	}
 	return uint64(math.Ceil(power))
 }

--- a/pkg/model/estimator/local/ratio_process.go
+++ b/pkg/model/estimator/local/ratio_process.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ratio_process.go
+calculate processess' component and other power by ratio approach when node power is available.
+*/
+
+package local
+
+import (
+	"math"
+
+	"github.com/sustainable-computing-io/kepler/pkg/config"
+	"github.com/sustainable-computing-io/kepler/pkg/power/accelerator"
+	"k8s.io/klog/v2"
+
+	collector_metric "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
+)
+
+// UpdateProcessEnergyByRatioPowerModel calculates the process energy consumption based on the energy consumption of the container that contains all the processes
+func UpdateProcessEnergyByRatioPowerModel(processMetrics map[uint64]*collector_metric.ProcessMetrics, containerMetrics *collector_metric.ContainerMetrics) {
+	pkgDynPower := float64(containerMetrics.DynEnergyInPkg.Delta)
+	coreDynPower := float64(containerMetrics.DynEnergyInCore.Delta)
+	uncoreDynPower := float64(containerMetrics.DynEnergyInUncore.Delta)
+	dramDynPower := float64(containerMetrics.DynEnergyInDRAM.Delta)
+	otherDynPower := float64(containerMetrics.DynEnergyInOther.Delta)
+	gpuDynPower := float64(containerMetrics.DynEnergyInGPU.Delta)
+
+	processNumber := float64(len(processMetrics))
+	// evenly divide the idle power to all processes. TODO: use the process resource request
+	pkgIdlePowerPerProcess := containerMetrics.IdleEnergyInPkg.Delta / uint64(processNumber)
+	coreIdlePowerPerProcess := containerMetrics.IdleEnergyInCore.Delta / uint64(processNumber)
+	uncoreIdlePowerPerProcess := containerMetrics.IdleEnergyInUncore.Delta / uint64(processNumber)
+	dramIdlePowerPerProcess := containerMetrics.IdleEnergyInDRAM.Delta / uint64(processNumber)
+	otherIdlePowerPerProcess := containerMetrics.IdleEnergyInOther.Delta / uint64(processNumber)
+
+	for pid, process := range processMetrics {
+		var processResUsage, containerTotalResUsage float64
+
+		// calculate the process package/socket energy consumption
+		if _, ok := process.CounterStats[config.CoreUsageMetric]; ok {
+			processResUsage = float64(process.CounterStats[config.CoreUsageMetric].Delta)
+			containerTotalResUsage = float64(containerMetrics.CounterStats[config.CoreUsageMetric].Delta)
+			processPkgEnergy := getEnergyRatio(processResUsage, containerTotalResUsage, pkgDynPower, processNumber)
+			if err := processMetrics[pid].DynEnergyInPkg.AddNewDelta(processPkgEnergy); err != nil {
+				klog.Infoln(err)
+			}
+			// calculate the process core energy consumption
+			processCoreEnergy := getEnergyRatio(processResUsage, containerTotalResUsage, coreDynPower, processNumber)
+			if err := processMetrics[pid].DynEnergyInCore.AddNewDelta(processCoreEnergy); err != nil {
+				klog.Infoln(err)
+			}
+		}
+
+		// calculate the process uncore energy consumption
+		processUncoreEnergy := uint64(math.Ceil(uncoreDynPower / processNumber))
+		if err := processMetrics[pid].DynEnergyInUncore.AddNewDelta(processUncoreEnergy); err != nil {
+			klog.Infoln(err)
+		}
+
+		// calculate the process dram energy consumption
+		if _, ok := process.CounterStats[config.DRAMUsageMetric]; ok {
+			processResUsage = float64(process.CounterStats[config.DRAMUsageMetric].Delta)
+			containerTotalResUsage = float64(containerMetrics.CounterStats[config.DRAMUsageMetric].Delta)
+			processDramEnergy := getEnergyRatio(processResUsage, containerTotalResUsage, dramDynPower, processNumber)
+			if err := processMetrics[pid].DynEnergyInDRAM.AddNewDelta(processDramEnergy); err != nil {
+				klog.Infoln(err)
+			}
+		}
+
+		// calculate the process gpu energy consumption
+		if accelerator.IsGPUCollectionSupported() {
+			processResUsage = float64(process.CounterStats[config.GpuUsageMetric].Delta)
+			containerTotalResUsage = float64(containerMetrics.CounterStats[config.GpuUsageMetric].Delta)
+			processGPUEnergy := getEnergyRatio(processResUsage, containerTotalResUsage, gpuDynPower, processNumber)
+			if err := processMetrics[pid].DynEnergyInGPU.AddNewDelta(processGPUEnergy); err != nil {
+				klog.Infoln(err)
+			} else {
+				klog.V(5).Infof("gpu power ratio: pid %v processResUsage: %f, nodeTotalResUsage: %f, nodeResEnergyUtilization: %f, processNumber: %f processGPUEnergy: %v",
+					pid, processResUsage, containerTotalResUsage, gpuDynPower, processNumber, processMetrics[pid].DynEnergyInGPU.Delta)
+			}
+		}
+
+		// calculate the process host other components energy consumption
+		processOtherHostComponentsEnergy := uint64(math.Ceil(otherDynPower / processNumber))
+		if err := processMetrics[pid].DynEnergyInOther.AddNewDelta(processOtherHostComponentsEnergy); err != nil {
+			klog.Infoln(err)
+		}
+
+		// Idle energy
+		if err := processMetrics[pid].IdleEnergyInPkg.AddNewDelta(pkgIdlePowerPerProcess); err != nil {
+			klog.Infoln(err)
+		}
+		if err := processMetrics[pid].IdleEnergyInCore.AddNewDelta(coreIdlePowerPerProcess); err != nil {
+			klog.Infoln(err)
+		}
+		if err := processMetrics[pid].IdleEnergyInUncore.AddNewDelta(uncoreIdlePowerPerProcess); err != nil {
+			klog.Infoln(err)
+		}
+		if err := processMetrics[pid].IdleEnergyInDRAM.AddNewDelta(dramIdlePowerPerProcess); err != nil {
+			klog.Infoln(err)
+		}
+		if err := processMetrics[pid].IdleEnergyInOther.AddNewDelta(otherIdlePowerPerProcess); err != nil {
+			klog.Infoln(err)
+		}
+	}
+}

--- a/pkg/model/process_power.go
+++ b/pkg/model/process_power.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:dupl // refactor this
+package model
+
+import (
+	collector_metric "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
+	"github.com/sustainable-computing-io/kepler/pkg/config"
+	"github.com/sustainable-computing-io/kepler/pkg/model/estimator/local"
+	"github.com/sustainable-computing-io/kepler/pkg/model/types"
+	"github.com/sustainable-computing-io/kepler/pkg/power/components"
+	"github.com/sustainable-computing-io/kepler/pkg/power/components/source"
+	"k8s.io/klog/v2"
+)
+
+var (
+	ProcessTotalPowerModelValid, ProcessComponentPowerModelValid bool
+	ProcessTotalPowerModelFunc                                   func([][]float64, []string) ([]float64, error)
+	ProcessComponentPowerModelFunc                               func([][]float64, []string) (map[string][]float64, error)
+
+	// counterOnly
+	defaultCounterDynCompURL = "https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models/DynComponentModelWeight/CounterOnly/ScikitMixed/ScikitMixed.json"
+)
+
+//nolint:all
+// initProcessComponentPowerModelConfig: the Process component power model must be set by default.
+func initProcessComponentPowerModelConfig() types.ModelConfig {
+	modelConfig := InitModelConfig(config.ProcessComponentsKey)
+	if modelConfig.InitModelURL == "" {
+		modelConfig.InitModelURL = defaultCounterDynCompURL
+	}
+	return modelConfig
+}
+
+func InitProcessPowerEstimator(usageMetrics, systemFeatures, systemValues []string) {
+	ProcessTotalPowerModelConfig := InitModelConfig(config.ProcessTotalKey)
+	var estimateFunc interface{}
+	// init func for ProcessTotalPower
+	ProcessTotalPowerModelValid, estimateFunc = initEstimateFunction(ProcessTotalPowerModelConfig, types.DynPower, types.DynModelWeight, usageMetrics, systemFeatures, systemValues, true)
+	if ProcessTotalPowerModelValid {
+		ProcessTotalPowerModelFunc = estimateFunc.(func([][]float64, []string) ([]float64, error))
+	}
+	ProcessComponentPowerModelConfig := initProcessComponentPowerModelConfig()
+	// init func for ProcessComponentPower
+	ProcessComponentPowerModelValid, estimateFunc = initEstimateFunction(ProcessComponentPowerModelConfig, types.DynComponentPower, types.DynComponentModelWeight, usageMetrics, systemFeatures, systemValues, false)
+	if ProcessComponentPowerModelValid {
+		ProcessComponentPowerModelFunc = estimateFunc.(func([][]float64, []string) (map[string][]float64, error))
+	}
+}
+
+// The current implementation from the model server returns a list of the Process energy.
+// The list follows the order of the Process ProcessMetricValuesOnly for the Process id...
+// TODO: make model server return a list of elemets that also contains the ProcessID to enforce consistency
+func getProcessMetricsList(processsMetrics map[string]*collector_metric.ProcessMetrics) (processMetricValuesOnly [][]float64) {
+	// convert to pod metrics to array
+	for _, c := range processsMetrics {
+		values := c.ToEstimatorValues()
+		processMetricValuesOnly = append(processMetricValuesOnly, values)
+	}
+	return
+}
+
+// updateProcessEnergy returns Process energy consumption for each node component
+func UpdateProcessEnergy(processMetrics map[uint64]*collector_metric.ProcessMetrics, systemContainerMetrics *collector_metric.ContainerMetrics) {
+	// If the node can expose power measurement per component, we can use the RATIO power model
+	// Otherwise, we estimate it from trained power model
+	if components.IsSystemCollectionSupported() {
+		local.UpdateProcessEnergyByRatioPowerModel(processMetrics, systemContainerMetrics)
+	} else {
+		updateProcessEnergyByTrainedPowerModel(processMetrics)
+	}
+}
+
+func updateProcessEnergyByTrainedPowerModel(processsMetrics map[uint64]*collector_metric.ProcessMetrics) {
+	var enabled bool
+	// convert the Process metrics map to an array since the model server does not receive structured data
+	// TODO: send data to model server via protobuf instead of no structured data
+	processMetricValuesOnly, processIDList := processMetricsToArray(processsMetrics)
+
+	totalPowerValid, totalProcessPowers := getProcessTotalPower(processMetricValuesOnly)
+
+	enabled, processComponentPowers := getProcessComponentPowers(processMetricValuesOnly)
+	if !enabled {
+		klog.V(5).Infoln("No ProcessComponentPower Model")
+		return
+	}
+	processOtherPowers := make([]uint64, len(processComponentPowers))
+	if totalPowerValid {
+		for index, componentPower := range processComponentPowers {
+			// TODO: include GPU into consideration
+			processOtherPowers[index] = uint64(totalProcessPowers[index]) - componentPower.Pkg - componentPower.DRAM
+		}
+	}
+
+	// update the Process's components energy consumption
+	// TODO: the model server does not predict GPU
+	for i, ProcessID := range processIDList {
+		if err := processsMetrics[ProcessID].DynEnergyInCore.AddNewDelta(processComponentPowers[i].Core); err != nil {
+			klog.V(5).Infoln(err)
+		}
+		if err := processsMetrics[ProcessID].DynEnergyInDRAM.AddNewDelta(processComponentPowers[i].DRAM); err != nil {
+			klog.V(5).Infoln(err)
+		}
+		if err := processsMetrics[ProcessID].DynEnergyInUncore.AddNewDelta(processComponentPowers[i].Uncore); err != nil {
+			klog.V(5).Infoln(err)
+		}
+		if err := processsMetrics[ProcessID].DynEnergyInPkg.AddNewDelta(processComponentPowers[i].Pkg); err != nil {
+			klog.V(5).Infoln(err)
+		}
+		if err := processsMetrics[ProcessID].DynEnergyInOther.AddNewDelta(processOtherPowers[i]); err != nil {
+			klog.V(5).Infoln(err)
+		}
+	}
+}
+
+// getProcessTotalPower returns estimated pods' total power
+func getProcessTotalPower(processMetricValuesOnly [][]float64) (valid bool, results []float64) {
+	valid = false
+	if ProcessTotalPowerModelValid {
+		powers, err := ProcessTotalPowerModelFunc(processMetricValuesOnly, collector_metric.NodeMetadataValues)
+		if err != nil || len(powers) == 0 {
+			return
+		}
+		results = powers
+		valid = true
+		return
+	}
+	return
+}
+
+// getProcessComponentPowers returns estimated pods' RAPL power
+func getProcessComponentPowers(processMetricValuesOnly [][]float64) (bool, []source.NodeComponentsEnergy) {
+	processNumber := len(processMetricValuesOnly)
+	if ProcessComponentPowerModelValid {
+		powers, err := ProcessComponentPowerModelFunc(processMetricValuesOnly, collector_metric.NodeMetadataValues)
+		if err != nil {
+			return false, make([]source.NodeComponentsEnergy, processNumber)
+		}
+		raplPowers := make([]source.NodeComponentsEnergy, processNumber)
+		for index := 0; index < processNumber; index++ {
+			pkgPower := getComponentPower(powers, "pkg", index)
+			corePower := getComponentPower(powers, "core", index)
+			uncorePower := getComponentPower(powers, "uncore", index)
+			dramPower := getComponentPower(powers, "dram", index)
+			raplPowers[index] = fillRAPLPower(pkgPower, corePower, uncorePower, dramPower)
+		}
+		return true, raplPowers
+	}
+	return false, make([]source.NodeComponentsEnergy, processNumber)
+}

--- a/pkg/model/utils.go
+++ b/pkg/model/utils.go
@@ -73,3 +73,13 @@ func nodeMetricsToArray(nodeMetrics *collector_metric.NodeMetrics) [][]float64 {
 	// the estimator expect a matrix
 	return [][]float64{nodeMetricResourceUsageValuesOnly}
 }
+
+// processMetricsToArray converts to process metrics map to array
+func processMetricsToArray(processMetrics map[uint64]*collector_metric.ProcessMetrics) (processMetricValuesOnly [][]float64, pidList []uint64) {
+	for pid, c := range processMetrics {
+		values := c.ToEstimatorValues()
+		processMetricValuesOnly = append(processMetricValuesOnly, values)
+		pidList = append(pidList, pid)
+	}
+	return
+}


### PR DESCRIPTION
fix #512 

In Kepler, all processes that don't have container IDs are classified as `system process` container. So we can use this special container to calculate process based energy.

In this PR, those processes that do not have container IDs are allocated into `kepler_process` metrics. These processes' aggregate energy consumption is based on `system process` container.