### PR TITLE
fix: avoid warnings about marco redefine

### DIFF
--- a/bpfassets/perf_event/perf_event.c
+++ b/bpfassets/perf_event/perf_event.c
@@ -26,7 +26,9 @@ limitations under the License.
 #define CPU_REF_FREQ 2500
 #endif
 
+#ifndef HZ
 #define HZ 1000
+#endif
 
 typedef struct process_metrics_t
 {

--- a/pkg/bpfassets/perf_event_bindata.go
+++ b/pkg/bpfassets/perf_event_bindata.go
@@ -84,7 +84,9 @@ limitations under the License.
 #define CPU_REF_FREQ 2500
 #endif
 
+#ifndef HZ
 #define HZ 1000
+#endif
 
 typedef struct process_metrics_t
 {


### PR DESCRIPTION
Fixes: #518 