### PR TITLE
fix: no more logs if value are same

### DIFF
--- a/pkg/collector/metric/stats.go
+++ b/pkg/collector/metric/stats.go
@@ -99,7 +99,7 @@ func (s *UInt64Stat) SetNewAggr(newAggr uint64) error {
 	}
 	if newAggr == s.Aggr {
 		// if a counter has not changed, we skip it
-		return fmt.Errorf("the input value has not changed")
+		return nil
 	}
 	// verify aggregated value overflow
 	if newAggr == math.MaxUint64 {


### PR DESCRIPTION
no need compare this value and report error because it's not an edge case

lead to so many logs like this which is annoying
```
I0203 01:35:46.115453       1 stats.go:130] the input value has not changed
I0203 01:35:46.115473       1 stats.go:130] the input value has not changed
I0203 01:35:46.115477       1 stats.go:130] the input value has not changed
I0203 01:35:46.115480       1 stats.go:130] the input value has not changed
I0203 01:35:46.116324       1 stats.go:130] the input value has not changed
I0203 01:35:46.116341       1 stats.go:130] the input value has not changed
I0203 01:35:46.116345       1 stats.go:130] the input value has not changed
I0203 01:35:46.116348       1 stats.go:130] the input value has not changed
I0203 01:35:46.116493       1 stats.go:130] the input value has not changed
I0203 01:35:46.116506       1 stats.go:130] the input value has not changed
I0203 01:35:46.116510       1 stats.go:130] the input value has not changed
I0203 01:35:46.116513       1 stats.go:130] the input value has not changed
I0203 01:35:46.116632       1 stats.go:130] the input value has not changed
I0203 01:35:46.116645       1 stats.go:130] the input value has not changed
I0203 01:35:46.116649       1 stats.go:130] the input value has not changed
I0203 01:35:46.116652       1 stats.go:130] the input value has not changed
I0203 01:35:46.116773       1 stats.go:130] the input value has not changed
I0203 01:35:46.116787       1 stats.go:130] the input value has not changed
I0203 01:35:46.116791       1 stats.go:130] the input value has not changed
I0203 01:35:46.116794       1 stats.go:130] the input value has not changed
I0203 01:35:46.117046       1 stats.go:130] the input value has not changed
I0203 01:35:46.117058       1 stats.go:130] the input value has not changed
I0203 01:35:46.117062       1 stats.go:130] the input value has not changed
I0203 01:35:46.117065       1 stats.go:130] the input value has not changed
I0203 01:35:46.117617       1 stats.go:130] the input value has not changed
I0203 01:35:46.117829       1 stats.go:130] the input value has not changed
I0203 01:35:46.117847       1 stats.go:130] the input value has not changed
I0203 01:35:46.117851       1 stats.go:130] the input value has not changed
I0203 01:35:46.117854       1 stats.go:130] the input value has not changed
I0203 01:35:46.118385       1 stats.go:130] the input value has not changed
I0203 01:35:46.118402       1 stats.go:130] the input value has not changed
I0203 01:35:46.118406       1 stats.go:130] the input value has not changed
I0203 01:35:46.118420       1 stats.go:130] the input value has not changed
I0203 01:35:46.118537       1 stats.go:130] the input value has not changed

```