### PR TITLE
Update the approach of checking the CPUArchitecture

### DIFF
--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -9,9 +9,12 @@ RUN yum install -y http://mirror.centos.org/centos/8-stream/BaseOS/aarch64/os/Pa
 # don't update yet, this will conflict with protected pkg i.e. redhat-release
 #RUN yum update -y
 
+# enable EPEL and install cpuid
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+    yum install -y cpuid
+
 # install less frequently updated pkg first
-RUN yum install -y kmod xz python3 && yum clean all -y && \
-    pip3 install  --no-cache-dir archspec 
+RUN yum install -y kmod xz python3 && yum clean all -y
 
 # bcc pkg is updated more frequently
 RUN yum install -y http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/bcc-0.24.0-2.el8.x86_64.rpm && \
@@ -20,4 +23,3 @@ RUN yum install -y http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
 # nvidia driver is updated on a (bi)monthly basis
 # RUN yum install -y nvidia-driver-NVML nvidia-driver-cuda
 
-    

--- a/data/normalized_cpu_arch.csv
+++ b/data/normalized_cpu_arch.csv
@@ -1,11 +1,12 @@
-Name,Architecture
-sandybridge,Sandy Bridge
-ivybridge,Ivy Bridge
-haswell,Haswell
-broadwell,Broadwell
-skylake,Sky Lake
-cascadelake,Cascade Lake
-coffeelake,Coffee Lake
-alderlake,Alder Lake
-cascadelake,Cascade Lake
-neoverse_n1,neoverse_n1
+Architecture
+Sandy Bridge
+Ivy Bridge
+Haswell
+Broadwell
+Sky Lake
+Cascade Lake
+Coffee Lake
+Alder Lake
+Cascade Lake
+Sapphire Rapids
+neoverse_n1

--- a/pkg/collector/metric/utils.go
+++ b/pkg/collector/metric/utils.go
@@ -17,12 +17,27 @@ limitations under the License.
 package metric
 
 import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/jszwec/csvutil"
 	"github.com/sustainable-computing-io/kepler/pkg/bpfassets/attacher"
 	"github.com/sustainable-computing-io/kepler/pkg/config"
 	"github.com/sustainable-computing-io/kepler/pkg/power/accelerator"
 
 	"k8s.io/klog/v2"
 )
+
+var CPUModelDataPath = "/var/lib/kepler/data/normalized_cpu_arch.csv"
+
+type CPUModelData struct {
+	Architecture string `csv:"Architecture"`
+}
 
 func getcontainerUintFeatureNames() []string {
 	var metrics []string
@@ -86,4 +101,104 @@ func isCounterStatEnabled(label string) bool {
 		}
 	}
 	return false
+}
+
+func getNodeName() string {
+	nodeName, err := os.Hostname()
+	if err != nil {
+		klog.Fatalf("could not get the node name: %s", err)
+	}
+	return nodeName
+}
+
+func getCPUArch() string {
+	arch, err := getCPUArchitecture()
+	if err == nil {
+		return arch
+	}
+	return "unknown"
+}
+
+func getX86Architecture() (string, error) {
+	// use cpuid to get CPUArchitecture
+	grep := exec.Command("grep", "uarch")
+	output := exec.Command("cpuid", "-1")
+	pipe, err := output.StdoutPipe()
+	if err != nil {
+		return "", err
+	}
+	defer pipe.Close()
+
+	grep.Stdin = pipe
+	err = output.Start()
+	if err != nil {
+		return "", err
+	}
+	res, err := grep.Output()
+	if err != nil {
+		return "", err
+	}
+
+	// format the CPUArchitecture result
+	uarch := strings.Split(string(res), "=")
+	if len(uarch) != 2 {
+		return "", fmt.Errorf("could not get the CPU Architecture")
+	}
+
+	return strings.Split(uarch[1], "{")[0], nil
+}
+
+func getArm64Architecture() (string, error) {
+	output, err := exec.Command("archspec", "cpu").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(string(output), "\n"), nil
+}
+
+func getCPUArchitecture() (string, error) {
+	// check if there is a CPU architecture override
+	cpuArchOverride := config.CPUArchOverride
+	if len(cpuArchOverride) > 0 {
+		klog.V(2).Infof("cpu arch override: %v\n", cpuArchOverride)
+		return cpuArchOverride, nil
+	}
+
+	var (
+		myCPUModel string
+		err        error
+	)
+	if runtime.GOARCH == "amd64" {
+		myCPUModel, err = getX86Architecture()
+		if err != nil {
+			return "", err
+		}
+	} else {
+		myCPUModel, err = getArm64Architecture()
+		if err != nil {
+			return "", err
+		}
+	}
+	file, err := os.Open(CPUModelDataPath)
+	if err != nil {
+		return "", err
+	}
+	reader := csv.NewReader(file)
+
+	dec, err := csvutil.NewDecoder(reader)
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		var p CPUModelData
+		if err := dec.Decode(&p); err == io.EOF {
+			break
+		}
+		if strings.Contains(myCPUModel, p.Architecture) {
+			return p.Architecture, nil
+		}
+	}
+
+	return "", fmt.Errorf("no CPU power model found for architecture %s", myCPUModel)
 }


### PR DESCRIPTION
fix #522 

1. Use cpuid instead of archspec to retrieve correct CPUArchitecture information. 
2. Add Sapphire Rapids cpu model.


Signed-off-by: Zhou,Lei <lei.zhou@intel.com>