### PR TITLE
Turn off hostNetwork and hostPort to prevent port conflicts

### DIFF
--- a/manifests/config/exporter/exporter.yaml
+++ b/manifests/config/exporter/exporter.yaml
@@ -40,7 +40,6 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
-      hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: kepler-sa
       containers:
@@ -60,7 +59,6 @@ spec:
         - /usr/bin/kepler -v=$(KEPLER_LOG_LEVEL)
         ports:
         - containerPort: 9102
-          hostPort: 9102
           name: http
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
fixes #527
related:  #71 

On Openshift port 9102 is already used on teh control plane by the OVN Kubernetes CNI. Attempting to reuse it caused the kepelr-exporter pod to get stuck in 'pending'. This commit stops kepler-export requiring the port and so allows it to start

