### PR TITLE
update grafana installation script and yaml files

### DIFF
--- a/manifests/config/dashboard/00-servicemonitoring-kepler.yaml
+++ b/manifests/config/dashboard/00-servicemonitoring-kepler.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   endpoints:
   - interval: 15s
-    port: kepler-exporter
+    port: http
     scheme: http
   selector:
     matchLabels:

--- a/manifests/config/dashboard/README.md
+++ b/manifests/config/dashboard/README.md
@@ -7,6 +7,7 @@ The following cmd will:
 - Define Prometheus datasource
 - Define Grafana dashboard
 
+It should be run from the top level of the repository
 ```bash
-$(pwd)/deploy-grafana.sh
+manifests/config/dashboard/deploy-grafana.sh
 ```

--- a/manifests/config/dashboard/deploy-grafana.sh
+++ b/manifests/config/dashboard/deploy-grafana.sh
@@ -6,15 +6,15 @@
 ## Installs Grafana community operator
 ## Creates Grafana instance
 
-oc apply --kustomize $(pwd)/manifests/openshift/dashboard
+oc apply --kustomize $(pwd)/manifests/config/dashboard
 while ! oc get grafana --all-namespaces
 do
     echo waiting for grafana custom resource definition to register
     sleep 5
 done
-oc apply -f $(pwd)/manifests/openshift/dashboard/02-grafana-instance.yaml
-oc apply -f $(pwd)/manifests/openshift/dashboard/02-grafana-sa.yaml
-oc apply -f $(pwd)/manifests/openshift/dashboard/03-grafana-sa-token-secret.yaml
+oc apply -f $(pwd)/manifests/config/dashboard/02-grafana-instance.yaml
+oc apply -f $(pwd)/manifests/config/dashboard/02-grafana-sa.yaml
+oc apply -f $(pwd)/manifests/config/dashboard/03-grafana-sa-token-secret.yaml
 
 SERVICE_ACCOUNT=grafana-serviceaccount
 SECRET=grafana-sa-token
@@ -44,7 +44,7 @@ do
 done
 
 # Deploy from updated manifest
-envsubst < $(pwd)/manifests/openshift/dashboard/03-grafana-datasource-UPDATETHIS.yaml | oc apply -f -
+envsubst < $(pwd)/manifests/config/dashboard/03-grafana-datasource-UPDATETHIS.yaml | oc apply -f -
 
 # Define Grafana dashboard
 while ! oc get grafanadashboard --all-namespaces;
@@ -53,4 +53,4 @@ do
     echo waiting for grafandashboard custom resource definition to register
 done
 
-oc apply -f $(pwd)/manifests/openshift/dashboard/04-grafana-dashboard.yaml
+oc apply -f $(pwd)/manifests/config/dashboard/04-grafana-dashboard.yaml


### PR DESCRIPTION
After testing the deploy-grafana.sh script on my openshift 4.12 single node cluster, it needs the following updates to run correctly:

This commit fixes three issues in the grafana installation

 1) it updates the paths to reflect the new project filesystem layout introduced with PR #449

2) fix the ServiceMonitor port to point to the kepler service port name rather than the service name

3) update the README to reflect the script should be run in the top level of the repo
   (due to its prepending of `pwd` to the paths)