### PR TITLE
Export container's usage metrics separately (kepler_container_<metric source>_<metric name>_total)

### DIFF
--- a/pkg/cgroup/slice_handler.go
+++ b/pkg/cgroup/slice_handler.go
@@ -197,3 +197,17 @@ func GetAvailableCgroupMetrics() []string {
 	}
 	return availableMetrics
 }
+
+func HasCgroupExportMetric(availableMetrics []string) bool {
+	expectedFound := len(ExportMetrics)
+	foundCount := 0
+	for _, metric := range availableMetrics {
+		if _, ok := ExportMetrics[metric]; ok {
+			foundCount += 1
+		}
+		if foundCount >= expectedFound {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cgroup/stat_reader.go
+++ b/pkg/cgroup/stat_reader.go
@@ -71,6 +71,13 @@ var standardMetricName = map[string][]CgroupFSReadMetric{
 	},
 }
 
+var ExportMetrics = map[string]any{
+	config.CgroupfsCPU:       nil,
+	config.CgroupfsMemory:    nil,
+	config.CgroupfsSystemCPU: nil,
+	config.CgroupfsUserCPU:   nil,
+}
+
 type StatReader interface {
 	Read() map[string]interface{}
 }

--- a/pkg/collector/metric/stats.go
+++ b/pkg/collector/metric/stats.go
@@ -32,8 +32,7 @@ var (
 	AvailableKubeletMetrics []string
 
 	// CPUHardwareCounterEnabled defined if hardware counters should be accounted and exported
-	CPUHardwareCounterEnabled bool = false
-	// CPUHardwareCounterEnabled = isCounterStatEnabled(attacher.CPUInstructionLabel)
+	CPUHardwareCounterEnabled = false
 )
 
 func InitAvailableParamAndMetrics() {
@@ -41,6 +40,7 @@ func InitAvailableParamAndMetrics() {
 	AvailableEBPFCounters = attacher.GetEnabledBPFCounters()
 	AvailableCgroupMetrics = cgroup.GetAvailableCgroupMetrics()
 	AvailableKubeletMetrics = cgroup.GetAvailableKubeletMetrics()
+	CPUHardwareCounterEnabled = isCounterStatEnabled(attacher.CPUInstructionLabel)
 
 	// defined in utils to init metrics
 	setEnabledMetrics()

--- a/pkg/collector/metric_collector_test.go
+++ b/pkg/collector/metric_collector_test.go
@@ -26,6 +26,7 @@ func setCollectorMetrics() {
 	collector_metric.ContainerUintFeaturesNames = append(collector_metric.ContainerUintFeaturesNames, collector_metric.ContainerIOStatMetricsNames...)
 	// ContainerMetricNames is used by the nodeMetrics to extract the resource usage. Only the metrics in ContainerMetricNames will be used.
 	collector_metric.ContainerMetricNames = collector_metric.ContainerUintFeaturesNames
+	collector_metric.CPUHardwareCounterEnabled = true
 }
 
 // add two containers with all metrics initialized

--- a/pkg/collector/prometheus_collector_test.go
+++ b/pkg/collector/prometheus_collector_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sustainable-computing-io/kepler/pkg/cgroup"
 	collector_metric "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
 	"github.com/sustainable-computing-io/kepler/pkg/config"
 	model "github.com/sustainable-computing-io/kepler/pkg/model/estimator/local"
@@ -157,6 +158,13 @@ var _ = Describe("Test Prometheus Collector Unit", func() {
 		body, _ := io.ReadAll(res.Body)
 		Expect(len(body)).Should(BeNumerically(">", 0))
 		fmt.Printf("Result:\n %s\n", body)
+
+		// check container cgroup export metric validity
+		Expect(len(cgroup.ExportMetrics)).To(Equal(4))
+		validAvailableCgroupMetrics := []string{config.CgroupfsCPU, config.CgroupfsMemory, config.CgroupfsSystemCPU, config.CgroupfsUserCPU}
+		Expect(cgroup.HasCgroupExportMetric(validAvailableCgroupMetrics)).To(Equal(true))
+		invalidAvailableCgroupMetrics := []string{config.CgroupfsCPU, config.CgroupfsMemory}
+		Expect(cgroup.HasCgroupExportMetric(invalidAvailableCgroupMetrics)).To(Equal(false))
 
 		// check pkg energy
 		val, err := convertPromToValue(body, nodePackageEnergyMetric)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,10 +62,12 @@ var (
 
 	KeplerNamespace              = getConfig("KELPER_NAMESPACE", defaultNamespace)
 	EnabledEBPFCgroupID          = getBoolConfig("ENABLE_EBPF_CGROUPID", true)
-	ExposeHardwareCounterMetrics = getBoolConfig("EXPOSE_HW_COUNTER_METRICS", true)
 	EnabledGPU                   = getBoolConfig("ENABLE_GPU", false)
-	ExposeIRQCounterMetrics      = getBoolConfig("EXPOSE_IRQ_COUNTER_METRICS", true)
 	EnableProcessMetrics         = getBoolConfig("ENABLE_PROCESS_METRICS", false)
+	ExposeHardwareCounterMetrics = getBoolConfig("EXPOSE_HW_COUNTER_METRICS", true)
+	ExposeCgroupMetrics          = getBoolConfig("EXPOSE_CGROUP_METRICS", true)
+	ExposeKubeletMetrics         = getBoolConfig("EXPOSE_KUBELET_METRICS", true)
+	ExposeIRQCounterMetrics      = getBoolConfig("EXPOSE_IRQ_COUNTER_METRICS", true)
 	MetricPathKey                = "METRIC_PATH"
 	BindAddressKey               = "BIND_ADDRESS"
 	CPUArchOverride              = getConfig("CPU_ARCH_OVERRIDE", "")


### PR DESCRIPTION
Regarding the issue https://github.com/sustainable-computing-io/kepler/issues/495, this PR added cgroups metrics to prometheus collector. 

Also, this PR updates exported naming of some existing metrics to the same format and add config to enable/disable the exporting. 

```
# HELP kepler_container_bpf_block_irq_total Aggregated block irq value
# TYPE kepler_container_bpf_block_irq_total counter
kepler_container_bpf_block_irq_total{container_name="containerA",container_namespace="test",pod_name="podA"} 0
kepler_container_bpf_block_irq_total{container_name="containerB",container_namespace="test",pod_name="podB"} 0
# HELP kepler_container_bpf_cpu_time_us_total Aggregated CPU time
# TYPE kepler_container_bpf_cpu_time_us_total counter
kepler_container_bpf_cpu_time_us_total{container_name="containerA",container_namespace="test",pod_name="podA"} 0
kepler_container_bpf_cpu_time_us_total{container_name="containerB",container_namespace="test",pod_name="podB"} 0
# HELP kepler_container_bpf_net_rx_irq_total Aggregated network rx irq value
# TYPE kepler_container_bpf_net_rx_irq_total counter
kepler_container_bpf_net_rx_irq_total{container_name="containerA",container_namespace="test",pod_name="podA"} 0
kepler_container_bpf_net_rx_irq_total{container_name="containerB",container_namespace="test",pod_name="podB"} 0
# HELP kepler_container_bpf_net_tx_irq_total Aggregated network tx irq value
# TYPE kepler_container_bpf_net_tx_irq_total counter
kepler_container_bpf_net_tx_irq_total{container_name="containerA",container_namespace="test",pod_name="podA"} 0
kepler_container_bpf_net_tx_irq_total{container_name="containerB",container_namespace="test",pod_name="podB"} 0
# HELP kepler_container_cache_miss_total Aggregated cache miss value
# TYPE kepler_container_cache_miss_total counter
kepler_container_cache_miss_total{command="",container_name="containerA",container_namespace="test",pod_name="podA"} 0
kepler_container_cache_miss_total{command="",container_name="containerB",container_namespace="test",pod_name="podB"} 0
# HELP kepler_container_cgroupfs_cpu_usage_us_total Aggregated cpu usage obtain from cGroups
# TYPE kepler_container_cgroupfs_cpu_usage_us_total counter
kepler_container_cgroupfs_cpu_usage_us_total{command="",container_name="containerA",container_namespace="test",pod_name="podA"} 0
kepler_container_cgroupfs_cpu_usage_us_total{command="",container_name="containerB",container_namespace="test",pod_name="podB"} 0
# HELP kepler_container_cgroupfs_memory_usage_bytes_total Aggregated memory bytes obtain from cGroups
# TYPE kepler_container_cgroupfs_memory_usage_bytes_total counter
kepler_container_cgroupfs_memory_usage_bytes_total{command="",container_name="containerA",container_namespace="test",pod_name="podA"} 0
kepler_container_cgroupfs_memory_usage_bytes_total{command="",container_name="containerB",container_namespace="test",pod_name="podB"} 0
# HELP kepler_container_cgroupfs_system_cpu_usage_us_total Aggregated system cpu usage obtain from cGroups
# TYPE kepler_container_cgroupfs_system_cpu_usage_us_total counter
kepler_container_cgroupfs_system_cpu_usage_us_total{command="",container_name="containerA",container_namespace="test",pod_name="podA"} 0
kepler_container_cgroupfs_system_cpu_usage_us_total{command="",container_name="containerB",container_namespace="test",pod_name="podB"} 0
# HELP kepler_container_cgroupfs_user_cpu_usage_us_total Aggregated user cpu usage obtain from cGroups
# TYPE kepler_container_cgroupfs_user_cpu_usage_us_total counter
kepler_container_cgroupfs_user_cpu_usage_us_total{command="",container_name="containerA",container_namespace="test",pod_name="podA"} 0
kepler_container_cgroupfs_user_cpu_usage_us_total{command="",container_name="containerB",container_namespace="test",pod_name="podB"} 0
...
# HELP kepler_container_cpu_cycles_total Aggregated CPU cycle value
# TYPE kepler_container_cpu_cycles_total counter
kepler_container_cpu_cycles_total{command="",container_name="containerA",container_namespace="test",pod_name="podA"} 0
kepler_container_cpu_cycles_total{command="",container_name="containerB",container_namespace="test",pod_name="podB"} 0
# HELP kepler_container_cpu_instructions_total Aggregated CPU instruction value
# TYPE kepler_container_cpu_instructions_total counter
kepler_container_cpu_instructions_total{command="",container_name="containerA",container_namespace="test",pod_name="podA"} 100
kepler_container_cpu_instructions_total{command="",container_name="containerB",container_namespace="test",pod_name="podB"} 100
...
# HELP kepler_container_kubelet_cpu_usage_total Aggregated cpu usage obtain from kubelet
# TYPE kepler_container_kubelet_cpu_usage_total counter
kepler_container_kubelet_cpu_usage_total{command="",container_name="containerA",container_namespace="test",pod_name="podA"} 0
kepler_container_kubelet_cpu_usage_total{command="",container_name="containerB",container_namespace="test",pod_name="podB"} 0
# HELP kepler_container_kubelet_memory_bytes_total Aggregated memory bytes obtain from kubelet
# TYPE kepler_container_kubelet_memory_bytes_total counter
kepler_container_kubelet_memory_bytes_total{command="",container_name="containerA",container_namespace="test",pod_name="podA"} 0
kepler_container_kubelet_memory_bytes_total{command="",container_name="containerB",container_namespace="test",pod_name="podB"} 0
```

I also found that `CPUHardwareCounterEnabled` will never be set to `true` and hardware counter will never be exported.
Any reason behind this comment out?

https://github.com/sustainable-computing-io/kepler/blob/91e732f90612b5c906dfd770568ce620dfcd3afd/pkg/collector/metric/stats.go#L35-L36

I just moved it to `InitAvailableParamAndMetrics` function and add `config.ExposeHardwareCounterMetrics` condition instead.


Updated to 
**Hardware counters**
- kepler_container_cache_miss_total
- kepler_container_cpu_cycles_total
- kepler_container_cpu_instructions_total

**cGroups**
- kepler_container_cgroupfs_cpu_usage_us_total
- kepler_container_cgroupfs_memory_usage_bytes_total
- kepler_container_cgroupfs_system_cpu_usage_us_total
- kepler_container_cgroupfs_user_cpu_usage_us_total

**kubelet**
- kepler_container_kubelet_cpu_usage_total
- kepler_container_kubelet_memory_bytes_total

**BPF**
- kepler_container_bpf_block_irq_total
- kepler_container_bpf_cpu_time_us_total
- kepler_container_bpf_net_rx_irq_total
- kepler_container_bpf_net_tx_irq_total


Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>