### PR TITLE
process: init process estimator so as to use other models

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -35,6 +35,7 @@ func InitEstimateFunctions(usageMetrics, systemFeatures, systemValues []string) 
 	InitNodeComponentPowerEstimator(usageMetrics, systemFeatures, systemValues)
 	InitContainerPowerEstimator(usageMetrics, systemFeatures, systemValues)
 	InitProcessPowerEstimator(usageMetrics, systemFeatures, systemValues)
+	InitProcessPowerEstimator(usageMetrics, systemFeatures, systemValues)
 }
 
 // initEstimateFunction called by InitEstimateFunctions to initiate estimate function for each power model


### PR DESCRIPTION
To use non-ratio models such as BPFCounterOnly for Kepler process metrics, the process estimator needs to be initiated.