### PR TITLE
config: parse config yaml

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,6 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
@@ -121,6 +120,7 @@ func parseYaml(dataBuf []byte, key string) string {
 	if err := yaml.Unmarshal(dataBuf, &data); err == nil {
 		for k, v := range data.(map[interface{}]interface{}) {
 			if k == key {
+				//nolint:all // ignore
 				switch v.(type) {
 				case string:
 					result = v.(string)
@@ -141,7 +141,7 @@ func parseYaml(dataBuf []byte, key string) string {
 func getConfig(configKey, defaultValue string) (result string) {
 	result = string([]byte(defaultValue))
 	key := string([]byte(configKey))
-	dataBuf, err := ioutil.ReadFile(configPath)
+	dataBuf, err := os.ReadFile(configPath)
 	if err == nil {
 		res := parseYaml(dataBuf, key)
 		if res != "" {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -126,4 +126,15 @@ var _ = Describe("Test Configuration", func() {
 		Expect(initModelURL).NotTo(Equal(""))
 
 	})
+	It("Test parseYaml with sample", func() {
+		buf := []byte(`NUMBER: 1`)
+		res := parseYaml(buf, "NUMBER")
+		Expect(res).To(Equal("1"))
+		buf = []byte(`BOOL: false`)
+		res = parseYaml(buf, "BOOL")
+		Expect(res).To(Equal("false"))
+		buf = []byte(`STRING: foo`)
+		res = parseYaml(buf, "STRING")
+		Expect(res).To(Equal("foo"))
+	})
 })


### PR DESCRIPTION
currently every config key has its own config file. This PR is to use yaml for all config keys.

This is tested with this config file `/etc/kepler/kepler.config`:
```
ENABLE_PROCESS_METRICS: true
MODEL_CONFIG: |
  PROCESS_COMPONENTS_INIT_URL=https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models/DynComponentModelWeight/BPFOnly/ScikitMixed
/ScikitMixed.json
```