### PR TITLE
add process_count metric for mapping container to CPU/Package

### DIFF
--- a/pkg/collector/metric/node_metric.go
+++ b/pkg/collector/metric/node_metric.go
@@ -42,6 +42,7 @@ const (
 var (
 	NodeName            = getNodeName()
 	NodeCPUArchitecture = getCPUArch()
+	NodeCPUPackageMap   = getCPUPackageMap()
 
 	// NodeMetricNames holds the name of the system metadata information.
 	NodeMetadataNames []string = []string{"cpu_architecture"}

--- a/pkg/collector/metric/utils.go
+++ b/pkg/collector/metric/utils.go
@@ -231,3 +231,20 @@ func getCPUArchitecture() (string, error) {
 
 	return "", fmt.Errorf("no CPU power model found for architecture %s", myCPUModel)
 }
+
+func getCPUPackageMap() (cpuPackageMap map[int32]string) {
+	cpuPackageMap = make(map[int32]string)
+	// check if mapping available
+	numCPU := int32(runtime.NumCPU())
+	for cpu := int32(0); cpu < numCPU; cpu++ {
+		targetFileName := fmt.Sprintf("/sys/devices/system/cpu/cpu%d/topology/physical_package_id", cpu)
+		value, err := os.ReadFile(targetFileName)
+		if err != nil {
+			klog.Errorf("cannot get CPU-Package map: %v", err)
+			return
+		}
+		cpuPackageMap[cpu] = strings.TrimSpace(string(value))
+	}
+	klog.V(3).Infof("CPU-Package Map: %v\n", cpuPackageMap)
+	return
+}


### PR DESCRIPTION
Regarding https://github.com/sustainable-computing-io/kepler/issues/570 (specifically the idea in https://github.com/sustainable-computing-io/kepler/issues/570#issuecomment-1484535723),

**work included in this PR:**
- add function to getCPUPackageMap mapping from CPU ID to Package ID 
- refactor updateBPFMetrics function to prevent potential complexity test failed

**undo work (postponed to other PR):**
- expose pid_time BPFHash to ProcessCPUTimestamp Table in BpfModuleTables 
- reset the table together with main table (c.bpfHCMeter.Table) 
- readProcessCPUTimestamp and assign to c.ContainersMetrics/c.ProcessMetrics CPUIDs as a count of processes (pids) that use that CPU of considering container (for process case will be always 1)
- export CPUIDs to container metric `kepler_container_process_count_current` with label of CPU ID and Package ID

```bash
# HELP kepler_container_process_count_current Latest number of processes that have executed on a specific CPU
# TYPE kepler_container_process_count_current gauge
kepler_container_process_count_current{container_name="containerA",container_namespace="test",cpu="1",package="1",pod_name="podA"} 1
```
- add simple test case for exported metric (undo, postponed to other PR)

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>