### PR TITLE
Fix cgroup stat collector and build tags

### DIFF
--- a/pkg/cgroup/cgroup_interface.go
+++ b/pkg/cgroup/cgroup_interface.go
@@ -19,5 +19,5 @@ package cgroup
 import "github.com/sustainable-computing-io/kepler/pkg/collector/metric/types"
 
 type CCgroupStatHandler interface {
-	SetCGroupStat(containerID string, CgroupStatMap map[string]*types.UInt64StatCollection)
+	SetCGroupStat(containerID string, CgroupStatMap map[string]*types.UInt64StatCollection) error
 }

--- a/pkg/cgroup/cgroup_stats_darwin.go
+++ b/pkg/cgroup/cgroup_stats_darwin.go
@@ -1,5 +1,5 @@
-//go:build darwin
-// +build darwin
+//go:build darwin && !linux
+// +build darwin,!linux
 
 /*
 Copyright 2023.
@@ -20,6 +20,6 @@ limitations under the License.
 package cgroup
 
 // If Kepler in not running in Linux OS the cgroup stat handler is nil
-func NewCGroupStatHandler(pid int) (CCgroupStatHandler, error) {
+func NewCGroupStatManager(pid int) (CCgroupStatHandler, error) {
 	return nil, nil
 }

--- a/pkg/collector/container_cgroup_collector.go
+++ b/pkg/collector/container_cgroup_collector.go
@@ -31,9 +31,13 @@ func (c *Collector) updateCgroupMetrics() {
 			continue
 		}
 		if c.ContainersMetrics[key].CgroupStatHandler == nil {
-			handler, err := cgroup.NewCGroupStatHandler(int(c.ContainersMetrics[key].PID))
+			handler, err := cgroup.NewCGroupStatManager(int(c.ContainersMetrics[key].PID))
 			if err != nil {
 				klog.V(3).Infoln("Error: could not start cgroup stat handler for PID:", c.ContainersMetrics[key].PID)
+				if key != c.systemProcessName {
+					// if cgroup handler does not exist, it means that the container was deleted
+					delete(c.ContainersMetrics, key)
+				}
 				continue
 			}
 			c.ContainersMetrics[key].CgroupStatHandler = handler

--- a/pkg/collector/metric/container_metric.go
+++ b/pkg/collector/metric/container_metric.go
@@ -271,5 +271,9 @@ func (c *ContainerMetrics) UpdateCgroupMetrics() {
 	if c.CgroupStatHandler == nil {
 		return
 	}
-	c.CgroupStatHandler.SetCGroupStat(c.ContainerID, c.CgroupStatMap)
+	klog.Infoln(c.PodName, c.ContainerID)
+	err := c.CgroupStatHandler.SetCGroupStat(c.ContainerID, c.CgroupStatMap)
+	if err != nil {
+		klog.V(3).Infof("Error reading cgroup stats for container %s (%s): %v", c.ContainerName, c.ContainerID, err)
+	}
 }

--- a/pkg/utils/util_darwin.go
+++ b/pkg/utils/util_darwin.go
@@ -1,5 +1,5 @@
-//go:build darwin
-// +build darwin
+//go:build darwin && !linux
+// +build darwin,!linux
 
 /*
 Copyright 2021.


### PR DESCRIPTION
There is a bug in the current code that collects cgroup metrics.
We are calling the stat function only once, so that we do not update the cgroup metrics and are only using old values.

This PR fix this.