### PR TITLE
Delete metrics of deleted container

### DIFF
--- a/pkg/cgroup/cgroup_stats_linux.go
+++ b/pkg/cgroup/cgroup_stats_linux.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/sustainable-computing-io/kepler/pkg/collector/metric/types"
 	"github.com/sustainable-computing-io/kepler/pkg/config"
-	"k8s.io/klog/v2"
 )
 
 type CCgroupV1StatManager struct {
@@ -84,7 +83,6 @@ func (c CCgroupV1StatManager) SetCGroupStat(containerID string, cgroupStatMap ma
 	// cgroup v1 cpu
 	cgroupStatMap[config.CgroupfsCPU].SetAggrStat(containerID, stat.CPU.Usage.Total/1000) // Usec
 
-	klog.Infoln(containerID, stat.CPU.Usage.Total/1000)
 	cgroupStatMap[config.CgroupfsSystemCPU].SetAggrStat(containerID, stat.CPU.Usage.Kernel/1000) // Usec
 	cgroupStatMap[config.CgroupfsUserCPU].SetAggrStat(containerID, stat.CPU.Usage.User/1000)     // Usec
 	// cgroup v1 IO

--- a/pkg/collector/container_cgroup_collector.go
+++ b/pkg/collector/container_cgroup_collector.go
@@ -35,14 +35,18 @@ func (c *Collector) updateCgroupMetrics() {
 			if err != nil {
 				klog.V(3).Infoln("Error: could not start cgroup stat handler for PID:", c.ContainersMetrics[key].PID)
 				if key != c.systemProcessName {
-					// if cgroup handler does not exist, it means that the container was deleted
+					// if cgroup manager does not exist, it means that the container was deleted
 					delete(c.ContainersMetrics, key)
 				}
 				continue
 			}
 			c.ContainersMetrics[key].CgroupStatHandler = handler
 		}
-		c.ContainersMetrics[key].UpdateCgroupMetrics()
+		err := c.ContainersMetrics[key].UpdateCgroupMetrics()
+		// if the cgroup metrics of a container does not exist, it means that the container was deleted
+		if key != c.systemProcessName && err != nil {
+			delete(c.ContainersMetrics, key)
+		}
 	}
 }
 

--- a/pkg/collector/metric/container_metric.go
+++ b/pkg/collector/metric/container_metric.go
@@ -267,13 +267,13 @@ func (c *ContainerMetrics) String() string {
 		c.KubeletStats)
 }
 
-func (c *ContainerMetrics) UpdateCgroupMetrics() {
+func (c *ContainerMetrics) UpdateCgroupMetrics() error {
 	if c.CgroupStatHandler == nil {
-		return
+		return nil
 	}
-	klog.Infoln(c.PodName, c.ContainerID)
 	err := c.CgroupStatHandler.SetCGroupStat(c.ContainerID, c.CgroupStatMap)
 	if err != nil {
 		klog.V(3).Infof("Error reading cgroup stats for container %s (%s): %v", c.ContainerName, c.ContainerID, err)
 	}
+	return err
 }


### PR DESCRIPTION
If the cgroup metrics of a container does not exist, it means that the container was deleted so that we can remove it from the metrics map.

This PR also removes some leftover debug messages.