### PR TITLE
Fix null pointer issue in gpu metrics

### DIFF
--- a/pkg/collector/container_accelerator_collector.go
+++ b/pkg/collector/container_accelerator_collector.go
@@ -38,7 +38,7 @@ func (c *Collector) updateAcceleratorMetrics() {
 	// calculate the gpu's processes energy consumption for each gpu
 	for _, device := range accelerator.GetGpus() {
 		if processesUtilization, err = accelerator.GetProcessResourceUtilizationPerDevice(device, time.Since(lastUtilizationTimestamp)); err != nil {
-			klog.V(2).Infoln(err)
+			continue
 		}
 
 		var containerID string

--- a/pkg/power/accelerator/gpu.go
+++ b/pkg/power/accelerator/gpu.go
@@ -20,8 +20,6 @@ limitations under the License.
 package accelerator
 
 import (
-	"fmt"
-
 	accelerator_source "github.com/sustainable-computing-io/kepler/pkg/power/accelerator/source"
 	"k8s.io/klog/v2"
 )
@@ -37,12 +35,12 @@ Then, we use gpu.go file to initialize the acceleratorImpl from power.go when gp
 // init initialize the acceleratorImpl and start it
 func init() {
 	acceleratorImpl = &accelerator_source.GPUNvml{}
-	if err = acceleratorImpl.Init(); err == nil {
-		klog.V(1).Infoln("Using nvml to obtain gpu power")
-		fmt.Println("Using nvml to obtain gpu power")
+	err := acceleratorImpl.Init()
+	if err == nil {
+		klog.Infoln("Using nvml to obtain gpu power")
 		return
 	}
-	fmt.Printf("Failed to init nvml: %v, using dummy source to obtain gpu power\n", err)
+	klog.Infof("Failed to init nvml, err: %v\n", err)
 	acceleratorImpl = &accelerator_source.GPUDummy{}
-	err = acceleratorImpl.Init()
+	errLib = acceleratorImpl.Init()
 }

--- a/pkg/power/accelerator/source/gpu_nvml.go
+++ b/pkg/power/accelerator/source/gpu_nvml.go
@@ -41,8 +41,7 @@ type GPUNvml struct {
 func (n *GPUNvml) Init() (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("could not init nvml: %v", err)
-			klog.Infoln(err)
+			err = fmt.Errorf("could not init nvml: %v", r)
 		}
 	}()
 	if ret := nvml.Init(); ret != nvml.SUCCESS {
@@ -58,7 +57,7 @@ func (n *GPUNvml) Init() (err error) {
 		err = fmt.Errorf("failed to get nvml device count: %v", nvml.ErrorString(ret))
 		return err
 	}
-	fmt.Printf("found %d gpu devices\n", count)
+	klog.Infof("found %d gpu devices\n", count)
 	devices = make([]interface{}, count)
 	for i := 0; i < count; i++ {
 		device, ret := nvml.DeviceGetHandleByIndex(i)


### PR DESCRIPTION
According to issue #610, null pointer access can occur while collecting GPU metrics.

This PR fixes the null pointer error and also includes an attempt to re-initialize the GPU driver in case it is no longer available.

This PR also fix the problem that the GPU error message was nil.