### PR TITLE
set HavecGroupsMetric value of collector

### DIFF
--- a/pkg/collector/prometheus_collector.go
+++ b/pkg/collector/prometheus_collector.go
@@ -241,10 +241,15 @@ func (p *PrometheusCollector) Describe(ch chan<- *prometheus.Desc) {
 
 	// container cGroups Counters (counter)
 	if config.ExposeCgroupMetrics {
-		ch <- p.containerDesc.containerCgroupCPUUsageUsTotal
-		ch <- p.containerDesc.containerCgroupMemoryUsageBytesTotal
-		ch <- p.containerDesc.containerCgroupSystemCPUUsageUsTotal
-		ch <- p.containerDesc.containerCgroupUserCPUUsageUsTotal
+		if len(collector_metric.AvailableCGroupMetrics) != 0 {
+			ch <- p.containerDesc.containerCgroupCPUUsageUsTotal
+			ch <- p.containerDesc.containerCgroupMemoryUsageBytesTotal
+			ch <- p.containerDesc.containerCgroupSystemCPUUsageUsTotal
+			ch <- p.containerDesc.containerCgroupUserCPUUsageUsTotal
+			p.HavecGroupsMetric = true
+		} else {
+			p.HavecGroupsMetric = false
+		}
 	}
 
 	// container Kubelet Counters (counter)


### PR DESCRIPTION
Regarding the bug in https://github.com/sustainable-computing-io/kepler/issues/620, this PR set the variable `HavecGroupsMetric` in the same way as `AvailableKubeletMetrics`.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>