### PR TITLE
nit fix to reduce unused memory allocate...

### DIFF
--- a/pkg/cgroup/resolve_container.go
+++ b/pkg/cgroup/resolve_container.go
@@ -70,23 +70,8 @@ func Init() (*[]corev1.Pod, error) {
 	return updateListPodCache("", false)
 }
 
-func GetPodName(cGroupID, pid uint64, withCGroupID bool) (string, error) {
-	info, err := getContainerInfo(cGroupID, pid, withCGroupID)
-	return info.PodName, err
-}
-
-func GetPodNameSpace(cGroupID, pid uint64, withCGroupID bool) (string, error) {
-	info, err := getContainerInfo(cGroupID, pid, withCGroupID)
-	return info.Namespace, err
-}
-
-func GetContainerName(cGroupID, pid uint64, withCGroupID bool) (string, error) {
-	info, err := getContainerInfo(cGroupID, pid, withCGroupID)
-	return info.ContainerName, err
-}
-
 func GetContainerID(cGroupID, pid uint64, withCGroupID bool) (string, error) {
-	info, err := getContainerInfo(cGroupID, pid, withCGroupID)
+	info, err := GetContainerInfo(cGroupID, pid, withCGroupID)
 	return info.ContainerID, err
 }
 
@@ -98,7 +83,7 @@ func GetAvailableKubeletMetrics() []string {
 	return podLister.GetAvailableMetrics()
 }
 
-func getContainerInfo(cGroupID, pid uint64, withCGroupID bool) (*ContainerInfo, error) {
+func GetContainerInfo(cGroupID, pid uint64, withCGroupID bool) (*ContainerInfo, error) {
 	var err error
 	var containerID string
 	info := &ContainerInfo{

--- a/pkg/cgroup/resolve_container_test.go
+++ b/pkg/cgroup/resolve_container_test.go
@@ -116,8 +116,7 @@ func TestGetAliveContainers(t *testing.T) {
 	}
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
-			res, err := getAliveContainers(&testcase.pods)
-			g.Expect(err).NotTo(HaveOccurred())
+			res := getAliveContainers(&testcase.pods)
 			g.Expect(res).To(Equal(testcase.expectResults))
 		})
 	}

--- a/pkg/collector/container_cgroup_collector.go
+++ b/pkg/collector/container_cgroup_collector.go
@@ -58,7 +58,7 @@ func (c *Collector) updateCgroupMetrics() {
 // updateKubeletMetrics adds kubelet data (resident mem)
 func (c *Collector) updateKubeletMetrics() {
 	if len(collector_metric.AvailableKubeletMetrics) == 2 {
-		containerCPU, containerMem, _, _, _ := cgroup.GetContainerMetrics()
+		containerCPU, containerMem, _ := cgroup.GetContainerMetrics()
 		klog.V(5).Infof("Kubelet Read: %v, %v\n", containerCPU, containerMem)
 		for _, c := range c.ContainersMetrics {
 			k := c.Namespace + "/" + c.PodName + "/" + c.ContainerName

--- a/pkg/collector/utils.go
+++ b/pkg/collector/utils.go
@@ -19,35 +19,10 @@ package collector
 import (
 	"github.com/sustainable-computing-io/kepler/pkg/cgroup"
 	collector_metric "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
-	"k8s.io/klog/v2"
 )
 
 func (c *Collector) createContainersMetricsIfNotExist(containerID string, cGroupID, pid uint64, withCGroupID bool) {
 	if _, ok := c.ContainersMetrics[containerID]; !ok {
-		var err error
-		var podName, containerName string
-
-		// the acceletator package does not get the cgroup ID, then we need to verify if we can call the cgroup with cGroupID or not
-		podName, _ = cgroup.GetPodName(cGroupID, pid, withCGroupID)
-		containerName, _ = cgroup.GetContainerName(cGroupID, pid, withCGroupID)
-
-		namespace := c.systemProcessNamespace
-
-		if containerName == c.systemProcessName {
-			// if the systemProcess already exist in ContainersMetrics do not overwrite the data
-			if _, exist := c.ContainersMetrics[containerID]; exist {
-				return
-			}
-			containerID = c.systemProcessName
-		} else {
-			namespace, err = cgroup.GetPodNameSpace(cGroupID, pid, withCGroupID)
-			if err != nil {
-				klog.V(5).Infof("failed to find namespace for cGroup ID %v: %v", cGroupID, err)
-				namespace = "unknown"
-			}
-		}
-
-		c.ContainersMetrics[containerID] = collector_metric.NewContainerMetrics(containerName, podName, namespace, containerID)
 		info, _ := cgroup.GetContainerInfo(cGroupID, pid, withCGroupID)
 		c.ContainersMetrics[containerID] = collector_metric.NewContainerMetrics(info.ContainerName, info.PodName, info.Namespace, containerID)
 	}

--- a/pkg/collector/utils.go
+++ b/pkg/collector/utils.go
@@ -48,6 +48,8 @@ func (c *Collector) createContainersMetricsIfNotExist(containerID string, cGroup
 		}
 
 		c.ContainersMetrics[containerID] = collector_metric.NewContainerMetrics(containerName, podName, namespace, containerID)
+		info, _ := cgroup.GetContainerInfo(cGroupID, pid, withCGroupID)
+		c.ContainersMetrics[containerID] = collector_metric.NewContainerMetrics(info.ContainerName, info.PodName, info.Namespace, containerID)
 	}
 }
 

--- a/pkg/kubelet/pod_lister_test.go
+++ b/pkg/kubelet/pod_lister_test.go
@@ -122,12 +122,8 @@ func TestListMetrics(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 			defer f.Close()
 
-			cCPU, cMem, nodeCPU, nodeMem, err := parseMetrics(f)
+			cCPU, cMem, err := parseMetrics(f)
 			g.Expect(err).NotTo(HaveOccurred())
-
-			// See above simulated output
-			g.Expect(531271.893651).To(Equal(nodeCPU))
-			g.Expect(5.871231414e+09).To(Equal(nodeMem))
 
 			// 3 includes system container
 			g.Expect(3).To(Equal(len(cCPU)))


### PR DESCRIPTION
for each time we created ContainerInfo 3 times as duplication.
this PR is a nit fix to reduce creation works as memory allocation.

we don't need to get kubelet IO for each time, hence which makes cache miss or cache ineffective.

remove two useless return value.