### PR TITLE
Update cgroup v1 stat error handling

### DIFF
--- a/pkg/cgroup/cgroup_stats_linux.go
+++ b/pkg/cgroup/cgroup_stats_linux.go
@@ -71,8 +71,12 @@ func NewCGroupStatManager(pid int) (CCgroupStatHandler, error) {
 	}
 }
 
+func errPassthrough(err error) error {
+	return err
+}
+
 func (c CCgroupV1StatManager) SetCGroupStat(containerID string, cgroupStatMap map[string]*types.UInt64StatCollection) error {
-	stat, err := c.manager.Stat(cgroups.IgnoreNotExist)
+	stat, err := c.manager.Stat(errPassthrough)
 	if err != nil {
 		return err
 	}
@@ -81,8 +85,7 @@ func (c CCgroupV1StatManager) SetCGroupStat(containerID string, cgroupStatMap ma
 	cgroupStatMap[config.CgroupfsKernelMemory].SetAggrStat(containerID, stat.Memory.Kernel.Usage)
 	cgroupStatMap[config.CgroupfsTCPMemory].SetAggrStat(containerID, stat.Memory.KernelTCP.Usage)
 	// cgroup v1 cpu
-	cgroupStatMap[config.CgroupfsCPU].SetAggrStat(containerID, stat.CPU.Usage.Total/1000) // Usec
-
+	cgroupStatMap[config.CgroupfsCPU].SetAggrStat(containerID, stat.CPU.Usage.Total/1000)        // Usec
 	cgroupStatMap[config.CgroupfsSystemCPU].SetAggrStat(containerID, stat.CPU.Usage.Kernel/1000) // Usec
 	cgroupStatMap[config.CgroupfsUserCPU].SetAggrStat(containerID, stat.CPU.Usage.User/1000)     // Usec
 	// cgroup v1 IO


### PR DESCRIPTION
Fix #636

The cgroup v1 stat had `IgnoreNotExist`, but if the cgroup does not exist if returns an empty structure, which leads to segmentation fault.