### PR TITLE
Add kernel headers to run bcc unit test

### DIFF
--- a/.github/workflows/unit_test_bcc.yml
+++ b/.github/workflows/unit_test_bcc.yml
@@ -8,5 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: install linux headers
+      run: sudo apt-get install linux-headers-$(uname -r)
     - name: test bcc in docker container
       run: sudo podman run --privileged -v $(pwd):/home -v /sys:/sys -v /lib/modules:/lib/modules -v /usr/src:/usr/src quay.io/sustainable_computing_io/kepler_builder:go1.18 bash -c "cd /home; export PATH=/usr/local/go/bin:$PATH; make test-verbose"


### PR DESCRIPTION
The unit test failed with a bcc error due to the inability to locate the kernel headers. Despite the kernel libs folder being mounted in the docker container, it appears that the headers were not installed during VM setup.

To address this issue, I included a new step in the github workflow that installs the kernel headers prior to running the test.

This might fix the unit test error in the PR #626