### PR TITLE
gpu: 1) reset err to nil upon successful init, 2) calculate dyn energy so the container gpu metric is calculated

### DIFF
--- a/pkg/collector/metric/node_metric.go
+++ b/pkg/collector/metric/node_metric.go
@@ -267,6 +267,12 @@ func (ne *NodeMetrics) UpdateDynEnergy() {
 	for sensorID := range ne.TotalEnergyInPlatform.Stat {
 		ne.CalcDynEnergy(PLATFORM, sensorID)
 	}
+	// gpu metric
+	if config.EnabledGPU && accelerator.IsGPUCollectionSupported() {
+		for gpuID := range ne.TotalEnergyInGPU.Stat {
+			ne.CalcDynEnergy(GPU, gpuID)
+		}
+	}
 }
 
 func (ne *NodeMetrics) CalcDynEnergy(component, id string) {

--- a/pkg/collector/metric/node_metric.go
+++ b/pkg/collector/metric/node_metric.go
@@ -219,7 +219,7 @@ func (ne *NodeMetrics) SetNodeComponentsEnergy(componentsEnergy map[int]source.N
 func (ne *NodeMetrics) AddNodeGPUEnergy(gpuEnergy []uint32) {
 	for gpuID, energy := range gpuEnergy {
 		key := strconv.Itoa(gpuID)
-		ne.TotalEnergyInGPU.AddDeltaStat(key, uint64(energy))
+		ne.TotalEnergyInGPU.SetDeltaStat(key, uint64(energy))
 	}
 }
 

--- a/pkg/power/accelerator/gpu.go
+++ b/pkg/power/accelerator/gpu.go
@@ -38,8 +38,11 @@ func init() {
 	err := acceleratorImpl.Init()
 	if err == nil {
 		klog.Infoln("Using nvml to obtain gpu power")
+		// If the library was successfully initialized, we don't need to return an error in the Init() function
+		errLib = nil
 		return
 	}
+	// If the library was not successfully initialized, we use the dummy implementation
 	klog.Infof("Failed to init nvml, err: %v\n", err)
 	acceleratorImpl = &accelerator_source.GPUDummy{}
 	errLib = acceleratorImpl.Init()


### PR DESCRIPTION
This PR fixes two issue: 
-  currently with gpu successfully init'ed, the errLib var is not reset, so the output message is confusing.

```console
# kubectl logs -n kepler daemonset/kepler-exporter
I0424 17:44:39.940320       1 gpu_nvml.go:60] found 2 gpu devices
I0424 17:44:39.950882       1 gpu.go:40] Using nvml to obtain gpu power
I0424 17:44:39.954359       1 exporter.go:150] Kepler running on version: 396134a
I0424 17:44:39.954376       1 config.go:172] using gCgroup ID in the BPF program: true
I0424 17:44:39.954403       1 config.go:174] kernel version:
I0424 17:44:39.954520       1 power.go:66] use sysfs to obtain power
I0424 17:44:40.224739       1 exporter.go:175] Initializing the GPU collector
I0424 17:44:40.224758       1 exporter.go:180] Failed to initialize the GPU collector: could not start accelerator collector
I0424 17:44:41.676402       1 bcc_attacher.go:143] Successfully load eBPF module with option: [-DNUM_CPUS=64 -DSET_GROUP_ID]
I0424 17:44:41.697512       1 exporter.go:217] Started Kepler in 1.743171906s
```

With the change, the log message is correct:

```console
# kubectl logs -n kepler daemonset/kepler-exporter
I0424 21:10:35.125710       1 gpu_nvml.go:60] found 2 gpu devices
I0424 21:10:35.136256       1 gpu.go:40] Using nvml to obtain gpu power
I0424 21:10:35.151766       1 exporter.go:149] Kepler running on version: v0.4.11-97-gb7ad7fb-dirty
I0424 21:10:35.151791       1 config.go:169] using gCgroup ID in the BPF program: true
I0424 21:10:35.151817       1 config.go:170] kernel version: 4.18
I0424 21:10:35.151942       1 power.go:66] use sysfs to obtain power
I0424 21:10:35.387882       1 exporter.go:167] Initializing the GPU collector
I0424 21:10:36.803420       1 bcc_attacher.go:135] Successfully load eBPF module with option: [-DNUM_CPUS=64 -DSET_GROUP_ID]
I0424 21:10:36.821350       1 exporter.go:209] Started Kepler in 1.669608096s
```
- the GPU dyn energy is not calculated, as a result, the container gpu metric is always 0

With the change, container gpu metrics is reported
![image](https://user-images.githubusercontent.com/7062400/234118405-024246d7-357a-4d82-8a0d-add16c0afdf1.png)
