### PR TITLE
log: reduce container cgroup collector verbosity

### DIFF
--- a/pkg/collector/container_cgroup_collector.go
+++ b/pkg/collector/container_cgroup_collector.go
@@ -47,7 +47,7 @@ func (c *Collector) updateCgroupMetrics() {
 		if key != c.systemProcessName && err != nil {
 			delete(c.ContainersMetrics, key)
 		}
-		klog.Infoln(c.ContainersMetrics[key])
+		klog.V(5).Infoln(c.ContainersMetrics[key])
 	}
 }
 


### PR DESCRIPTION
printing excess logs add quite some overhead