### PR TITLE
[WIP] metrics: turn off cgroup metrics

### DIFF
--- a/pkg/bpfassets/perf_event_bindata.go
+++ b/pkg/bpfassets/perf_event_bindata.go
@@ -382,13 +382,11 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//
-//	data/
-//	  foo.txt
-//	  img/
-//	    a.png
-//	    b.png
-//
+//     data/
+//       foo.txt
+//       img/
+//         a.png
+//         b.png
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("nonexistent") would return an error

--- a/pkg/collector/metric_collector.go
+++ b/pkg/collector/metric_collector.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sustainable-computing-io/kepler/pkg/config"
 	"github.com/sustainable-computing-io/kepler/pkg/power/accelerator"
 	"github.com/sustainable-computing-io/kepler/pkg/power/acpi"
+	"github.com/sustainable-computing-io/kepler/pkg/power/components"
 	"github.com/sustainable-computing-io/kepler/pkg/utils"
 
 	collector_metric "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
@@ -112,7 +113,10 @@ func (c *Collector) Update() {
 	c.updateBPFMetrics() // collect new hardware counter metrics if possible
 
 	// TODO: collect cgroup metrics only from cgroup to avoid unnecessary overhead to kubelet
-	c.updateCgroupMetrics()  // collect new cgroup metrics from cgroup
+	// collect cgroup metrics only if no power meter is available or if cgroup metrics are exported
+	if !components.IsSystemCollectionSupported() || config.ExposeCgroupMetrics {
+		c.updateCgroupMetrics() // collect new cgroup metrics from cgroup
+	}
 	c.updateKubeletMetrics() // collect new cgroup metrics from kubelet
 
 	if config.EnabledGPU && accelerator.IsGPUCollectionSupported() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,7 +68,7 @@ var (
 	EnabledGPU                   = getBoolConfig("ENABLE_GPU", false)
 	EnableProcessMetrics         = getBoolConfig("ENABLE_PROCESS_METRICS", false)
 	ExposeHardwareCounterMetrics = getBoolConfig("EXPOSE_HW_COUNTER_METRICS", true)
-	ExposeCgroupMetrics          = getBoolConfig("EXPOSE_CGROUP_METRICS", true)
+	ExposeCgroupMetrics          = getBoolConfig("EXPOSE_CGROUP_METRICS", false)
 	ExposeKubeletMetrics         = getBoolConfig("EXPOSE_KUBELET_METRICS", true)
 	ExposeIRQCounterMetrics      = getBoolConfig("EXPOSE_IRQ_COUNTER_METRICS", true)
 	MetricPathKey                = "METRIC_PATH"


### PR DESCRIPTION
containerd cgroup library adds quite some overhead

When cgroup metric collector is turned on, the library uses 14% of the CPU usage
```
(pprof) top20 -cum (all)
Active filters:
   focus=(all)
Showing nodes accounting for 1120ms, 72.73% of 1540ms total
Showing top 20 nodes out of 180
      flat  flat%   sum%        cum   cum%
     850ms 55.19% 55.19%      850ms 55.19%  runtime.cgocall
         0     0% 55.19%      820ms 53.25%  github.com/iovisor/gobpf/bcc._Cfunc_bpf_module_create_c_from_string
         0     0% 55.19%      820ms 53.25%  github.com/iovisor/gobpf/bcc.compile
         0     0% 55.19%      820ms 53.25%  github.com/iovisor/gobpf/bcc.newModule
         0     0% 55.19%      820ms 53.25%  github.com/iovisor/gobpf/bcc.newModule.func3
         0     0% 55.19%      290ms 18.83%  github.com/sustainable-computing-io/kepler/pkg/collector.(*Collector).Update
         0     0% 55.19%      290ms 18.83%  github.com/sustainable-computing-io/kepler/pkg/manager.(*CollectorManager).Start.func1
         0     0% 55.19%      220ms 14.29%  github.com/containerd/cgroups/v3/cgroup2.(*Manager).Stat
         0     0% 55.19%      220ms 14.29%  github.com/sustainable-computing-io/kepler/pkg/cgroup.CCgroupV12StatManager.SetCGroupStat
         0     0% 55.19%      220ms 14.29%  github.com/sustainable-computing-io/kepler/pkg/collector.(*Collector).updateCgroupMetrics
         0     0% 55.19%      220ms 14.29%  github.com/sustainable-computing-io/kepler/pkg/collector/metric.(*ContainerMetrics).UpdateCgroupMetrics
         0     0% 55.19%      120ms  7.79%  github.com/containerd/cgroups/v3/cgroup2.readHugeTlbStats
         0     0% 55.19%      120ms  7.79%  os.ReadFile
     120ms  7.79% 62.99%      120ms  7.79%  syscall.Syscall
     120ms  7.79% 70.78%      120ms  7.79%  syscall.Syscall6
         0     0% 70.78%      100ms  6.49%  os.Open (inline)
         0     0% 70.78%      100ms  6.49%  os.OpenFile
         0     0% 70.78%      100ms  6.49%  os.openFileNolog
      30ms  1.95% 72.73%       80ms  5.19%  runtime.mallocgc
         0     0% 72.73%       70ms  4.55%  internal/poll.ignoringEINTRIO (inline)
```

With this fix, the cgroup metric is only turned on when it is really being used. So at least the overhead doesn't happen to bare metal env:
```
(pprof) top20 -cum (all)
Active filters:
   focus=(all)
Showing nodes accounting for 0.87s, 75.65% of 1.15s total
Showing top 20 nodes out of 58
      flat  flat%   sum%        cum   cum%
     0.85s 73.91% 73.91%      0.85s 73.91%  runtime.cgocall
         0     0% 73.91%      0.84s 73.04%  github.com/iovisor/gobpf/bcc._Cfunc_bpf_module_create_c_from_string
         0     0% 73.91%      0.84s 73.04%  github.com/iovisor/gobpf/bcc.compile
         0     0% 73.91%      0.84s 73.04%  github.com/iovisor/gobpf/bcc.newModule
         0     0% 73.91%      0.84s 73.04%  github.com/iovisor/gobpf/bcc.newModule.func3
         0     0% 73.91%      0.05s  4.35%  github.com/sustainable-computing-io/kepler/pkg/collector.(*Collector).Update
         0     0% 73.91%      0.05s  4.35%  github.com/sustainable-computing-io/kepler/pkg/manager.(*CollectorManager).Start.func1
         0     0% 73.91%      0.04s  3.48%  github.com/sustainable-computing-io/kepler/pkg/collector.(*Collector).updateBPFMetrics
     0.02s  1.74% 75.65%      0.03s  2.61%  runtime.mallocgc
         0     0% 75.65%      0.02s  1.74%  github.com/sustainable-computing-io/kepler/pkg/bpfassets/attacher.TableDeleteBatch
         0     0% 75.65%      0.02s  1.74%  github.com/sustainable-computing-io/kepler/pkg/cgroup.GetContainerID (inline)
         0     0% 75.65%      0.02s  1.74%  github.com/sustainable-computing-io/kepler/pkg/cgroup.getContainerIDFromPath
         0     0% 75.65%      0.02s  1.74%  github.com/sustainable-computing-io/kepler/pkg/cgroup.getContainerIDFromcGroupID
         0     0% 75.65%      0.02s  1.74%  github.com/sustainable-computing-io/kepler/pkg/cgroup.getContainerInfo
         0     0% 75.65%      0.02s  1.74%  runtime.newobject
         0     0% 75.65%      0.01s  0.87%  github.com/iovisor/gobpf/bcc.(*TableIterator).Next
         0     0% 75.65%      0.01s  0.87%  github.com/iovisor/gobpf/bcc.(*TableIterator).Next.func2
         0     0% 75.65%      0.01s  0.87%  github.com/iovisor/gobpf/bcc._C2func_bpf_get_first_key
         0     0% 75.65%      0.01s  0.87%  github.com/prometheus/common/expfmt.(*TextParser).TextToMetricFamilies
         0     0% 75.65%      0.01s  0.87%  github.com/prometheus/common/expfmt.(*TextParser).startLabelName
```