### PR TITLE
Fix container GPU power

### DIFF
--- a/pkg/collector/metric/container_metric_test.go
+++ b/pkg/collector/metric/container_metric_test.go
@@ -100,14 +100,6 @@ var _ = Describe("Test Container Metric", func() {
 		Expect(0).To(Equal(instance.CurrProcesses))
 	})
 
-	It("Test GetBasicValues", func() {
-		instance := NewContainerMetrics("container", "PodName", "Namespace", "container")
-		instance.Command = "12345678901234567890"
-		exp := []string{"PodName", "Namespace", "1234567890"}
-		cur := instance.GetBasicValues()
-		Expect(exp).To(Equal(cur))
-	})
-
 	It("Test SumAllDynDeltaValues", func() {
 		instance := NewContainerMetrics("container", "PodName", "Namespace", "container")
 		exp := instance.DynEnergyInPkg.Delta + instance.DynEnergyInGPU.Delta + instance.DynEnergyInOther.Delta

--- a/pkg/collector/metric/process_metric.go
+++ b/pkg/collector/metric/process_metric.go
@@ -183,44 +183,44 @@ func (p *ProcessMetrics) String() string {
 		p.CounterStats)
 }
 
-func (c *ProcessMetrics) GetDynEnergyStat(component string) (energyStat *types.UInt64Stat) {
+func (p *ProcessMetrics) GetDynEnergyStat(component string) (energyStat *types.UInt64Stat) {
 	switch component {
 	case PKG:
-		return c.DynEnergyInPkg
+		return p.DynEnergyInPkg
 	case CORE:
-		return c.DynEnergyInCore
+		return p.DynEnergyInCore
 	case DRAM:
-		return c.DynEnergyInDRAM
+		return p.DynEnergyInDRAM
 	case UNCORE:
-		return c.DynEnergyInUncore
+		return p.DynEnergyInUncore
 	case GPU:
-		return c.DynEnergyInGPU
+		return p.DynEnergyInGPU
 	case OTHER:
-		return c.DynEnergyInOther
+		return p.DynEnergyInOther
 	case PLATFORM:
-		return c.DynEnergyInPlatform
+		return p.DynEnergyInPlatform
 	default:
 		klog.Fatalf("DynEnergy component type %s is unknown\n", component)
 	}
 	return
 }
 
-func (c *ProcessMetrics) GetIdleEnergyStat(component string) (energyStat *types.UInt64Stat) {
+func (p *ProcessMetrics) GetIdleEnergyStat(component string) (energyStat *types.UInt64Stat) {
 	switch component {
 	case PKG:
-		return c.IdleEnergyInPkg
+		return p.IdleEnergyInPkg
 	case CORE:
-		return c.IdleEnergyInCore
+		return p.IdleEnergyInCore
 	case DRAM:
-		return c.IdleEnergyInDRAM
+		return p.IdleEnergyInDRAM
 	case UNCORE:
-		return c.IdleEnergyInUncore
+		return p.IdleEnergyInUncore
 	case GPU:
-		return c.IdleEnergyInGPU
+		return p.IdleEnergyInGPU
 	case OTHER:
-		return c.IdleEnergyInOther
+		return p.IdleEnergyInOther
 	case PLATFORM:
-		return c.IdleEnergyInPlatform
+		return p.IdleEnergyInPlatform
 	default:
 		klog.Fatalf("IdleEnergy component type %s is unknown\n", component)
 	}

--- a/pkg/collector/metric/process_metric_test.go
+++ b/pkg/collector/metric/process_metric_test.go
@@ -7,13 +7,6 @@ import (
 
 var _ = Describe("ProcessMetric", func() {
 
-	It("Test GetBasicValues", func() {
-		p := NewProcessMetrics(0, "12345678901234567890")
-		exp := []string{"1234567890"}
-		cur := p.GetBasicValues()
-		Expect(exp).To(Equal(cur))
-	})
-
 	It("Test ResetDeltaValues", func() {
 		p := NewProcessMetrics(0, "command")
 		p.ResetDeltaValues()

--- a/pkg/collector/prometheus_collector.go
+++ b/pkg/collector/prometheus_collector.go
@@ -763,28 +763,26 @@ func (p *PrometheusCollector) updatePodMetrics(wg *sync.WaitGroup, ch chan<- pro
 			ch <- prometheus.MustNewConstMetric(
 				p.containerDesc.containerOtherComponentsJoulesTotal,
 				prometheus.CounterValue,
-				float64(container.DynEnergyInOther.Aggr)/miliJouleToJoule,
-				container.ContainerID, container.PodName, container.ContainerName, container.Namespace, containerCommand, "dynamic",
-			)
-			ch <- prometheus.MustNewConstMetric(
-				p.containerDesc.containerOtherComponentsJoulesTotal,
-				prometheus.CounterValue,
 				float64(container.IdleEnergyInOther.Aggr)/miliJouleToJoule,
 				container.ContainerID, container.PodName, container.ContainerName, container.Namespace, containerCommand, "idle",
 			)
 			if config.EnabledGPU {
-				ch <- prometheus.MustNewConstMetric(
-					p.containerDesc.containerGPUJoulesTotal,
-					prometheus.CounterValue,
-					float64(container.DynEnergyInGPU.Aggr)/miliJouleToJoule,
-					container.ContainerID, container.PodName, container.ContainerName, container.Namespace, containerCommand, "dynamic",
-				)
-				ch <- prometheus.MustNewConstMetric(
-					p.containerDesc.containerGPUJoulesTotal,
-					prometheus.CounterValue,
-					float64(container.IdleEnergyInGPU.Aggr)/miliJouleToJoule,
-					container.ContainerID, container.PodName, container.ContainerName, container.Namespace, containerCommand, "idle",
-				)
+				if container.DynEnergyInGPU.Aggr > 0 {
+					ch <- prometheus.MustNewConstMetric(
+						p.containerDesc.containerGPUJoulesTotal,
+						prometheus.CounterValue,
+						float64(container.DynEnergyInGPU.Aggr)/miliJouleToJoule,
+						container.ContainerID, container.PodName, container.ContainerName, container.Namespace, containerCommand, "dynamic",
+					)
+				}
+				if container.IdleEnergyInGPU.Aggr > 0 {
+					ch <- prometheus.MustNewConstMetric(
+						p.containerDesc.containerGPUJoulesTotal,
+						prometheus.CounterValue,
+						float64(container.IdleEnergyInGPU.Aggr)/miliJouleToJoule,
+						container.ContainerID, container.PodName, container.ContainerName, container.Namespace, containerCommand, "idle",
+					)
+				}
 			}
 			ch <- prometheus.MustNewConstMetric(
 				p.containerDesc.containerJoulesTotal,

--- a/pkg/collector/utils.go
+++ b/pkg/collector/utils.go
@@ -34,6 +34,10 @@ func (c *Collector) createContainersMetricsIfNotExist(containerID string, cGroup
 		namespace := c.systemProcessNamespace
 
 		if containerName == c.systemProcessName {
+			// if the systemProcess already exist in ContainersMetrics do not overwrite the data
+			if _, exist := c.ContainersMetrics[containerID]; exist {
+				return
+			}
 			containerID = c.systemProcessName
 		} else {
 			namespace, err = cgroup.GetPodNameSpace(cGroupID, pid, withCGroupID)

--- a/pkg/model/container_power.go
+++ b/pkg/model/container_power.go
@@ -18,10 +18,13 @@ limitations under the License.
 package model
 
 import (
+	"sync"
+
 	collector_metric "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
 	"github.com/sustainable-computing-io/kepler/pkg/config"
 	"github.com/sustainable-computing-io/kepler/pkg/model/estimator/local"
 	"github.com/sustainable-computing-io/kepler/pkg/model/types"
+	"github.com/sustainable-computing-io/kepler/pkg/power/accelerator"
 	"github.com/sustainable-computing-io/kepler/pkg/power/components"
 	"github.com/sustainable-computing-io/kepler/pkg/power/components/source"
 	"k8s.io/klog/v2"
@@ -63,13 +66,30 @@ func InitContainerPowerEstimator(usageMetrics, systemFeatures, systemValues []st
 
 // UpdateContainerEnergy returns container energy consumption for each node component
 func UpdateContainerEnergy(containersMetrics map[string]*collector_metric.ContainerMetrics, nodeMetrics *collector_metric.NodeMetrics) {
+	var wg sync.WaitGroup
 	// If the node can expose power measurement per component, we can use the RATIO power model
 	// Otherwise, we estimate it from trained power model
 	if components.IsSystemCollectionSupported() {
-		local.UpdateContainerEnergyByRatioPowerModel(containersMetrics, nodeMetrics)
+		wg.Add(6)
+		go local.UpdateContainerComponentEnergyByRatioPowerModel(containersMetrics, nodeMetrics, collector_metric.PKG, config.CoreUsageMetric, &wg)
+		go local.UpdateContainerComponentEnergyByRatioPowerModel(containersMetrics, nodeMetrics, collector_metric.CORE, config.CoreUsageMetric, &wg)
+		go local.UpdateContainerComponentEnergyByRatioPowerModel(containersMetrics, nodeMetrics, collector_metric.DRAM, config.DRAMUsageMetric, &wg)
+		go local.UpdateContainerComponentEnergyByRatioPowerModel(containersMetrics, nodeMetrics, collector_metric.PLATFORM, config.CoreUsageMetric, &wg)
+		// If the resource usage metrics is empty, we evenly divide the power consumption of the resource across all containers
+		go local.UpdateContainerComponentEnergyByRatioPowerModel(containersMetrics, nodeMetrics, collector_metric.UNCORE, "", &wg)
+		go local.UpdateContainerComponentEnergyByRatioPowerModel(containersMetrics, nodeMetrics, collector_metric.OTHER, "", &wg)
 	} else {
+		// The estimator power model updates the power consumption of Pkg, Core, Dram, Uncore and Other
 		UpdateContainerEnergyByTrainedPowerModel(containersMetrics)
 	}
+
+	// Currently, we do not have a power model that can forecast GPU power in the absence of real-time power metrics.
+	// Generally, if we can obtain GPU metrics, we can also acquire GPU power metrics.
+	if accelerator.IsGPUCollectionSupported() {
+		wg.Add(1)
+		go local.UpdateContainerComponentEnergyByRatioPowerModel(containersMetrics, nodeMetrics, collector_metric.GPU, config.GpuUsageMetric, &wg)
+	}
+	wg.Wait()
 }
 
 func UpdateContainerEnergyByTrainedPowerModel(containersMetrics map[string]*collector_metric.ContainerMetrics) {

--- a/pkg/model/estimator/local/benchmark_test.go
+++ b/pkg/model/estimator/local/benchmark_test.go
@@ -18,6 +18,7 @@ package local_test
 
 import (
 	"strconv"
+	"sync"
 	"testing"
 
 	collector_metric "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
@@ -76,22 +77,25 @@ func benchmarkNtesting(b *testing.B, continerNumber int) {
 	}
 	nodeMetrics.AddNodeResUsageFromContainerResUsage(containersMetrics)
 	b.ResetTimer()
-	local.UpdateContainerEnergyByRatioPowerModel(containersMetrics, nodeMetrics)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go local.UpdateContainerComponentEnergyByRatioPowerModel(containersMetrics, nodeMetrics, collector_metric.PKG, config.CoreUsageMetric, &wg)
+	wg.Wait()
 	b.StopTimer()
 }
 
-func BenchmarkUpdateContainerEnergyByRatioPowerModelWith1000Contianer(b *testing.B) {
+func BenchmarkUpdateContainerEnergyByTrainedPowerModelWith1000Contianer(b *testing.B) {
 	benchmarkNtesting(b, 1000)
 }
 
-func BenchmarkUpdateContainerEnergyByRatioPowerModelWith2000Contianer(b *testing.B) {
+func BenchmarkUpdateContainerEnergyByTrainedPowerModelWith2000Contianer(b *testing.B) {
 	benchmarkNtesting(b, 2000)
 }
 
-func BenchmarkUpdateContainerEnergyByRatioPowerModelWith5000Contianer(b *testing.B) {
+func BenchmarkUpdateContainerEnergyByTrainedPowerModelWith5000Contianer(b *testing.B) {
 	benchmarkNtesting(b, 5000)
 }
 
-func BenchmarkUpdateContainerEnergyByRatioPowerModelWith10000Contianer(b *testing.B) {
+func BenchmarkUpdateContainerEnergyByTrainedPowerModelWith10000Contianer(b *testing.B) {
 	benchmarkNtesting(b, 10000)
 }

--- a/pkg/model/estimator/local/ratio.go
+++ b/pkg/model/estimator/local/ratio.go
@@ -23,9 +23,8 @@ package local
 
 import (
 	"math"
+	"sync"
 
-	"github.com/sustainable-computing-io/kepler/pkg/config"
-	"github.com/sustainable-computing-io/kepler/pkg/power/accelerator"
 	"k8s.io/klog/v2"
 
 	collector_metric "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
@@ -42,93 +41,32 @@ func getEnergyRatio(unitResUsage, totalResUsage, resEnergyUtilization, totalNumb
 	return uint64(math.Ceil(power))
 }
 
-// UpdateContainerEnergyByRatioPowerModel calculates the container energy consumption based on the resource utilization ratio
-func UpdateContainerEnergyByRatioPowerModel(containersMetrics map[string]*collector_metric.ContainerMetrics, nodeMetrics *collector_metric.NodeMetrics) {
-	pkgDynPower := float64(nodeMetrics.GetSumDeltaDynEnergyFromAllSources(collector_metric.PKG))
-	coreDynPower := float64(nodeMetrics.GetSumDeltaDynEnergyFromAllSources(collector_metric.CORE))
-	uncoreDynPower := float64(nodeMetrics.GetSumDeltaDynEnergyFromAllSources(collector_metric.UNCORE))
-	dramDynPower := float64(nodeMetrics.GetSumDeltaDynEnergyFromAllSources(collector_metric.DRAM))
-	otherDynPower := float64(nodeMetrics.GetSumDeltaDynEnergyFromAllSources(collector_metric.OTHER))
-	gpuDynPower := float64(nodeMetrics.GetSumDeltaDynEnergyFromAllSources(collector_metric.GPU))
-
+// UpdateContainerComponentEnergyByRatioPowerModel calculates the container energy consumption based on the resource utilization ratio
+func UpdateContainerComponentEnergyByRatioPowerModel(containersMetrics map[string]*collector_metric.ContainerMetrics, nodeMetrics *collector_metric.NodeMetrics, component, usageMetric string, wg *sync.WaitGroup) {
+	defer wg.Done()
+	nodeTotalResourceUsage := float64(0)
 	containerNumber := float64(len(containersMetrics))
-	// evenly divide the idle power to all containers. TODO: use the container resource request
-	pkgIdlePowerPerContainer := nodeMetrics.GetSumDeltaIdleEnergyromAllSources(collector_metric.PKG) / uint64(containerNumber)
-	coreIdlePowerPerContainer := nodeMetrics.GetSumDeltaIdleEnergyromAllSources(collector_metric.CORE) / uint64(containerNumber)
-	uncoreIdlePowerPerContainer := nodeMetrics.GetSumDeltaIdleEnergyromAllSources(collector_metric.UNCORE) / uint64(containerNumber)
-	dramIdlePowerPerContainer := nodeMetrics.GetSumDeltaIdleEnergyromAllSources(collector_metric.DRAM) / uint64(containerNumber)
-	otherIdlePowerPerContainer := nodeMetrics.GetSumDeltaIdleEnergyromAllSources(collector_metric.OTHER) / uint64(containerNumber)
+	totalDynPower := float64(nodeMetrics.GetSumDeltaDynEnergyFromAllSources(component))
 
-	containerUncoreEnergy := uint64(math.Ceil(uncoreDynPower / containerNumber))
-	containerOtherHostComponentsEnergy := uint64(math.Ceil(otherDynPower / containerNumber))
-	NodeCoreUsageMetric := nodeMetrics.GetNodeResUsagePerResType(config.CoreUsageMetric)
-	NodeDRAMUsageMetric := nodeMetrics.GetNodeResUsagePerResType(config.DRAMUsageMetric)
-	NodeGpuUsageMetric := nodeMetrics.GetNodeResUsagePerResType(config.GpuUsageMetric)
+	// evenly divide the idle power to all containers. TODO: use the container resource limit
+	idlePowerPerContainer := nodeMetrics.GetSumDeltaIdleEnergyromAllSources(component) / uint64(containerNumber)
+
+	// if usageMetric exist, divide the power using the ratio. Otherwise, evenly divide the power.
+	if usageMetric != "" {
+		nodeTotalResourceUsage = nodeMetrics.GetNodeResUsagePerResType(usageMetric)
+	}
+
 	for containerID, container := range containersMetrics {
-		var containerResUsage, nodeTotalResUsage float64
-
-		// calculate the container package/socket energy consumption
-		if _, ok := container.CounterStats[config.CoreUsageMetric]; ok {
-			containerResUsage = float64(container.CounterStats[config.CoreUsageMetric].Delta)
-			nodeTotalResUsage = NodeCoreUsageMetric
-			containerPkgEnergy := getEnergyRatio(containerResUsage, nodeTotalResUsage, pkgDynPower, containerNumber)
-			if err := containersMetrics[containerID].DynEnergyInPkg.AddNewDelta(containerPkgEnergy); err != nil {
-				klog.Infoln(err)
-			}
-
-			// calculate the container core energy consumption
-			containerCoreEnergy := getEnergyRatio(containerResUsage, nodeTotalResUsage, coreDynPower, containerNumber)
-			if err := containersMetrics[containerID].DynEnergyInCore.AddNewDelta(containerCoreEnergy); err != nil {
-				klog.Infoln(err)
+		if _, ok := container.CounterStats[usageMetric]; ok {
+			containerResUsage := float64(container.CounterStats[usageMetric].Delta)
+			if containerResUsage > 0 {
+				containerEnergy := getEnergyRatio(containerResUsage, nodeTotalResourceUsage, totalDynPower, containerNumber)
+				if err := containersMetrics[containerID].GetDynEnergyStat(component).AddNewDelta(containerEnergy); err != nil {
+					klog.Infoln(err)
+				}
 			}
 		}
-
-		// calculate the container uncore energy consumption
-		if err := containersMetrics[containerID].DynEnergyInUncore.AddNewDelta(containerUncoreEnergy); err != nil {
-			klog.Infoln(err)
-		}
-
-		// calculate the container dram energy consumption
-		if _, ok := container.CounterStats[config.DRAMUsageMetric]; ok {
-			containerResUsage = float64(container.CounterStats[config.DRAMUsageMetric].Delta)
-			nodeTotalResUsage = NodeDRAMUsageMetric
-			containerDramEnergy := getEnergyRatio(containerResUsage, nodeTotalResUsage, dramDynPower, containerNumber)
-			if err := containersMetrics[containerID].DynEnergyInDRAM.AddNewDelta(containerDramEnergy); err != nil {
-				klog.Infoln(err)
-			}
-		}
-
-		// calculate the container gpu energy consumption
-		if accelerator.IsGPUCollectionSupported() {
-			containerResUsage = float64(container.CounterStats[config.GpuUsageMetric].Delta)
-			nodeTotalResUsage = NodeGpuUsageMetric
-			containerGPUEnergy := getEnergyRatio(containerResUsage, nodeTotalResUsage, gpuDynPower, containerNumber)
-			if err := containersMetrics[containerID].DynEnergyInGPU.AddNewDelta(containerGPUEnergy); err != nil {
-				klog.Infoln(err)
-			} else {
-				klog.V(5).Infof("gpu power ratio: containerID %v containerResUsage: %f, nodeTotalResUsage: %f, nodeResEnergyUtilization: %f, containerNumber: %f containerGPUEnergy: %v",
-					containerID, containerResUsage, nodeTotalResUsage, gpuDynPower, containerNumber, containersMetrics[containerID].DynEnergyInGPU.Delta)
-			}
-		}
-
-		// calculate the container host other components energy consumption
-		if err := containersMetrics[containerID].DynEnergyInOther.AddNewDelta(containerOtherHostComponentsEnergy); err != nil {
-			klog.Infoln(err)
-		}
-		// Idle energy
-		if err := containersMetrics[containerID].IdleEnergyInPkg.AddNewDelta(pkgIdlePowerPerContainer); err != nil {
-			klog.Infoln(err)
-		}
-		if err := containersMetrics[containerID].IdleEnergyInCore.AddNewDelta(coreIdlePowerPerContainer); err != nil {
-			klog.Infoln(err)
-		}
-		if err := containersMetrics[containerID].IdleEnergyInUncore.AddNewDelta(uncoreIdlePowerPerContainer); err != nil {
-			klog.Infoln(err)
-		}
-		if err := containersMetrics[containerID].IdleEnergyInDRAM.AddNewDelta(dramIdlePowerPerContainer); err != nil {
-			klog.Infoln(err)
-		}
-		if err := containersMetrics[containerID].IdleEnergyInOther.AddNewDelta(otherIdlePowerPerContainer); err != nil {
+		if err := containersMetrics[containerID].GetIdleEnergyStat(component).AddNewDelta(idlePowerPerContainer); err != nil {
 			klog.Infoln(err)
 		}
 	}

--- a/pkg/model/estimator/local/ratio_test.go
+++ b/pkg/model/estimator/local/ratio_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package local
 
 import (
+	"sync"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -99,7 +101,10 @@ var _ = Describe("Test Ratio Unit", func() {
 
 		Expect(nodeMetrics.GetSumAggrDynEnergyFromAllSources(collector_metric.PLATFORM)).Should(BeEquivalentTo(20))
 
-		UpdateContainerEnergyByRatioPowerModel(containersMetrics, nodeMetrics)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go UpdateContainerComponentEnergyByRatioPowerModel(containersMetrics, nodeMetrics, collector_metric.PKG, config.CoreUsageMetric, &wg)
+		wg.Wait()
 		// The pkg dynamic energy is 5mJ, the container cpu usage is 50%, so the dynamic energy is 2.5mJ = ~3mJ
 		Expect(containersMetrics["containerA"].DynEnergyInPkg.Delta).Should(BeEquivalentTo(uint64(9)))
 		Expect(containersMetrics["containerB"].DynEnergyInPkg.Delta).Should(BeEquivalentTo(uint64(9)))

--- a/pkg/model/process_power.go
+++ b/pkg/model/process_power.go
@@ -18,10 +18,13 @@ limitations under the License.
 package model
 
 import (
+	"sync"
+
 	collector_metric "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
 	"github.com/sustainable-computing-io/kepler/pkg/config"
 	"github.com/sustainable-computing-io/kepler/pkg/model/estimator/local"
 	"github.com/sustainable-computing-io/kepler/pkg/model/types"
+	"github.com/sustainable-computing-io/kepler/pkg/power/accelerator"
 	"github.com/sustainable-computing-io/kepler/pkg/power/components"
 	"github.com/sustainable-computing-io/kepler/pkg/power/components/source"
 	"k8s.io/klog/v2"
@@ -65,13 +68,29 @@ func InitProcessPowerEstimator(usageMetrics, systemFeatures, systemValues []stri
 
 // updateProcessEnergy returns Process energy consumption for each node component
 func UpdateProcessEnergy(processMetrics map[uint64]*collector_metric.ProcessMetrics, systemContainerMetrics *collector_metric.ContainerMetrics) {
+	var wg sync.WaitGroup
 	// If the node can expose power measurement per component, we can use the RATIO power model
 	// Otherwise, we estimate it from trained power model
 	if components.IsSystemCollectionSupported() {
-		local.UpdateProcessEnergyByRatioPowerModel(processMetrics, systemContainerMetrics)
+		wg.Add(6)
+		go local.UpdateProcessComponentEnergyByRatioPowerModel(processMetrics, systemContainerMetrics, collector_metric.PKG, config.CoreUsageMetric, &wg)
+		go local.UpdateProcessComponentEnergyByRatioPowerModel(processMetrics, systemContainerMetrics, collector_metric.CORE, config.CoreUsageMetric, &wg)
+		go local.UpdateProcessComponentEnergyByRatioPowerModel(processMetrics, systemContainerMetrics, collector_metric.PLATFORM, config.CoreUsageMetric, &wg)
+		go local.UpdateProcessComponentEnergyByRatioPowerModel(processMetrics, systemContainerMetrics, collector_metric.DRAM, config.DRAMUsageMetric, &wg)
+		// If the resource usage metrics is empty, we evenly divide the power consumption of the resource across all processes
+		go local.UpdateProcessComponentEnergyByRatioPowerModel(processMetrics, systemContainerMetrics, collector_metric.UNCORE, "", &wg)
+		go local.UpdateProcessComponentEnergyByRatioPowerModel(processMetrics, systemContainerMetrics, collector_metric.OTHER, "", &wg)
 	} else {
 		updateProcessEnergyByTrainedPowerModel(processMetrics)
 	}
+
+	// Currently, we do not have a power model that can forecast GPU power in the absence of real-time power metrics.
+	// Generally, if we can obtain GPU metrics, we can also acquire GPU power metrics.
+	if accelerator.IsGPUCollectionSupported() {
+		wg.Add(1)
+		go local.UpdateProcessComponentEnergyByRatioPowerModel(processMetrics, systemContainerMetrics, collector_metric.GPU, config.GpuUsageMetric, &wg)
+	}
+	wg.Wait()
 }
 
 func updateProcessEnergyByTrainedPowerModel(processsMetrics map[uint64]*collector_metric.ProcessMetrics) {

--- a/pkg/power/accelerator/source/gpu_nvml.go
+++ b/pkg/power/accelerator/source/gpu_nvml.go
@@ -67,6 +67,8 @@ func (n *GPUNvml) Init() (err error) {
 			err = fmt.Errorf("failed to get nvml device %d: %v ", i, nvml.ErrorString(ret))
 			return err
 		}
+		name, _ := device.GetName()
+		klog.Infoln("GPU", i, name)
 		devices[i] = device
 	}
 	n.collectionSupported = true
@@ -111,13 +113,16 @@ func (n *GPUNvml) GetProcessResourceUtilizationPerDevice(device interface{}, sin
 	}
 
 	for _, pinfo := range processUtilizationSample {
-		processAcceleratorMetrics[pinfo.Pid] = ProcessUtilizationSample{
-			Pid:       pinfo.Pid,
-			TimeStamp: pinfo.TimeStamp,
-			SmUtil:    pinfo.SmUtil,
-			MemUtil:   pinfo.MemUtil,
-			EncUtil:   pinfo.EncUtil,
-			DecUtil:   pinfo.DecUtil,
+		// pid 0 means no data.
+		if pinfo.Pid != 0 {
+			processAcceleratorMetrics[pinfo.Pid] = ProcessUtilizationSample{
+				Pid:       pinfo.Pid,
+				TimeStamp: pinfo.TimeStamp,
+				SmUtil:    pinfo.SmUtil,
+				MemUtil:   pinfo.MemUtil,
+				EncUtil:   pinfo.EncUtil,
+				DecUtil:   pinfo.DecUtil,
+			}
 		}
 	}
 


### PR DESCRIPTION
There exist clusters that lacks CPU power metrics, but exposes GPU power information instead (we are doing experiments in a cluster like that). When CPU power metrics are not available, the Kepler power typically relies on the estimator approach. However, in cases where GPU power metrics are present, it is preferable to use the estimator approach for CPU metrics and the ratio approach for GPU metrics.

This PR allows for the use of two different power models, addressing the aforementioned issue. Additionally, the pull request fixes a bug related to updating GPU metrics for deleted containers where a null pointer error was encountered.