### PR TITLE
exporter: only profile exporter, skip ebpf compilation

### DIFF
--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -145,8 +145,6 @@ func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
 
-	startProfiling(*cpuProfile, *memProfile)
-
 	klog.Infof("Kepler running on version: %s", kversion.Version)
 
 	config.SetEnabledEBPFCgroupID(*enabledEBPFCgroupID)
@@ -209,6 +207,8 @@ func main() {
 			klog.Fatalf("%s", fmt.Sprintf("failed to write response: %v", err))
 		}
 	})
+
+	startProfiling(*cpuProfile, *memProfile)
 
 	ch := make(chan error)
 	go func() {


### PR DESCRIPTION
The ebpf compilation skews the overall picture of cpu usage by Kepler. This PR starts profiling after kepler is fully initialized so we can focus on the runtime cpu usage.