### PR TITLE
bpf: read cpu cores from /proc/cpuinfo to get all the cores

### DIFF
--- a/pkg/utils/util_linux.go
+++ b/pkg/utils/util_linux.go
@@ -20,9 +20,8 @@ limitations under the License.
 package utils
 
 import (
-	"fmt"
-
 	"encoding/binary"
+	"fmt"
 
 	"golang.org/x/sys/unix"
 )


### PR DESCRIPTION
Tested on setup with 64 cores, 32 are reserved by applications, kepler can only see 28 of them. This fix is to allow kepler to detect all the cores.