### PR TITLE
Ignore cgroup error related to minikube cluster

### DIFF
--- a/pkg/cgroup/cgroup_stats_linux.go
+++ b/pkg/cgroup/cgroup_stats_linux.go
@@ -71,12 +71,8 @@ func NewCGroupStatManager(pid int) (CCgroupStatHandler, error) {
 	}
 }
 
-func errPassthrough(err error) error {
-	return err
-}
-
 func (c CCgroupV1StatManager) SetCGroupStat(containerID string, cgroupStatMap map[string]*types.UInt64StatCollection) error {
-	stat, err := c.manager.Stat(errPassthrough)
+	stat, err := c.manager.Stat(cgroups.IgnoreNotExist)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/container_cgroup_collector.go
+++ b/pkg/collector/container_cgroup_collector.go
@@ -17,6 +17,8 @@ limitations under the License.
 package collector
 
 import (
+	"strings"
+
 	"github.com/sustainable-computing-io/kepler/pkg/cgroup"
 	collector_metric "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
 
@@ -42,10 +44,13 @@ func (c *Collector) updateCgroupMetrics() {
 			}
 			c.ContainersMetrics[key].CgroupStatHandler = handler
 		}
-		err := c.ContainersMetrics[key].UpdateCgroupMetrics()
-		// if the cgroup metrics of a container does not exist, it means that the container was deleted
-		if key != c.systemProcessName && err != nil {
-			delete(c.ContainersMetrics, key)
+		if err := c.ContainersMetrics[key].UpdateCgroupMetrics(); err != nil {
+			// if the cgroup metrics of a container does not exist, it means that the container was deleted
+			if key != c.systemProcessName && strings.Contains(err.Error(), "cgroup deleted") {
+				delete(c.ContainersMetrics, key)
+				klog.V(1).Infof("Container/Pod %s/%s was removed from the map because the cgroup was deleted",
+					c.ContainersMetrics[key].ContainerName, c.ContainersMetrics[key].PodName)
+			}
 		}
 	}
 }


### PR DESCRIPTION
As described in this GitHub pull PR comment (https://github.com/sustainable-computing-io/kepler/pull/635#pullrequestreview-1425906295), Minikube clusters may have varying cgroup paths, leading to errors when attempting to read cgroup stats.

Rather than assuming that the cgroup error signifies the container's deletion and deleting containerID from the map, we should handle such errors by ignoring them.