### PR TITLE
Fix issue 687 by filling empty path

### DIFF
--- a/pkg/cgroup/cgroup_stats_linux.go
+++ b/pkg/cgroup/cgroup_stats_linux.go
@@ -43,11 +43,14 @@ type CCgroupV12StatManager struct {
 // See comments here: https://github.com/sustainable-computing-io/kepler/pull/609#discussion_r1155043868
 func NewCGroupStatManager(pid int) (CCgroupStatHandler, error) {
 	p := fmt.Sprintf(procPath, pid)
-	_, path, err := cgroups.ParseCgroupFileUnified(p)
+	cgroupMap, path, err := cgroups.ParseCgroupFileUnified(p)
 	if err != nil {
 		return nil, err
 	}
-
+	if path == "" {
+		// if there is no subsystem (<controller>::<cgrouppath>), use common path from pids subsystem
+		path = cgroupMap["pids"]
+	}
 	if config.GetCGroupVersion() == 1 {
 		manager, err := cgroups.Load(cgroups.V1, cgroups.StaticPath(path))
 		if err != nil {


### PR DESCRIPTION
This PR fixes the issue https://github.com/sustainable-computing-io/kepler/issues/687.
The idea is when there is no empty subsystem to get a unified path, we just use the most common subsystem that is pids to get the path. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>