### PR TITLE
Update adding the estimated value to gauge logic

### DIFF
--- a/pkg/collector/metric/node_metric.go
+++ b/pkg/collector/metric/node_metric.go
@@ -197,20 +197,31 @@ func (ne *NodeMetrics) AddNodeResUsageFromContainerResUsage(containersMetrics ma
 }
 
 // SetLastestPlatformEnergy adds the lastest energy consumption from the node sensor
-func (ne *NodeMetrics) SetLastestPlatformEnergy(platformEnergy map[string]float64) {
+func (ne *NodeMetrics) SetLastestPlatformEnergy(platformEnergy map[string]float64, gauge bool) {
 	for sensorID, energy := range platformEnergy {
-		ne.TotalEnergyInPlatform.SetDeltaStat(sensorID, uint64(math.Ceil(energy)))
+		if gauge {
+			ne.TotalEnergyInPlatform.SetDeltaStat(sensorID, uint64(math.Ceil(energy)))
+		} else {
+			ne.TotalEnergyInPlatform.SetAggrStat(sensorID, uint64(math.Ceil(energy)))
+		}
 	}
 }
 
 // SetNodeComponentsEnergy adds the lastest energy consumption collected from the node's components (e.g., using RAPL)
-func (ne *NodeMetrics) SetNodeComponentsEnergy(componentsEnergy map[int]source.NodeComponentsEnergy) {
+func (ne *NodeMetrics) SetNodeComponentsEnergy(componentsEnergy map[int]source.NodeComponentsEnergy, gauge bool) {
 	for pkgID, energy := range componentsEnergy {
 		key := strconv.Itoa(pkgID)
-		ne.TotalEnergyInCore.SetAggrStat(key, energy.Core)
-		ne.TotalEnergyInDRAM.SetAggrStat(key, energy.DRAM)
-		ne.TotalEnergyInUncore.SetAggrStat(key, energy.Uncore)
-		ne.TotalEnergyInPkg.SetAggrStat(key, energy.Pkg)
+		if gauge {
+			ne.TotalEnergyInCore.SetDeltaStat(key, energy.Core)
+			ne.TotalEnergyInDRAM.SetDeltaStat(key, energy.DRAM)
+			ne.TotalEnergyInUncore.SetDeltaStat(key, energy.Uncore)
+			ne.TotalEnergyInPkg.SetDeltaStat(key, energy.Pkg)
+		} else {
+			ne.TotalEnergyInCore.SetAggrStat(key, energy.Core)
+			ne.TotalEnergyInDRAM.SetAggrStat(key, energy.DRAM)
+			ne.TotalEnergyInUncore.SetAggrStat(key, energy.Uncore)
+			ne.TotalEnergyInPkg.SetAggrStat(key, energy.Pkg)
+		}
 	}
 }
 

--- a/pkg/collector/metric/node_metric_test.go
+++ b/pkg/collector/metric/node_metric_test.go
@@ -70,13 +70,13 @@ func createMockNodeMetrics(containersMetrics map[string]*ContainerMetrics) *Node
 		Core: 10,
 		DRAM: 10,
 	}
-	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 	componentsEnergies[machineSocketID] = source.NodeComponentsEnergy{
 		Pkg:  18,
 		Core: 15,
 		DRAM: 11,
 	}
-	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 
 	return nodeMetrics
 }

--- a/pkg/collector/metric_collector_test.go
+++ b/pkg/collector/metric_collector_test.go
@@ -106,13 +106,13 @@ func createMockNodeMetrics(containersMetrics map[string]*collector_metric.Contai
 		Core: 10,
 		DRAM: 10,
 	}
-	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 	componentsEnergies[machineSocketID] = source.NodeComponentsEnergy{
 		Pkg:  18,
 		Core: 15,
 		DRAM: 11,
 	}
-	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 
 	return nodeMetrics
 }

--- a/pkg/collector/prometheus_collector_test.go
+++ b/pkg/collector/prometheus_collector_test.go
@@ -93,11 +93,11 @@ var _ = Describe("Test Prometheus Collector Unit", func() {
 		nodePlatformEnergy := map[string]float64{}
 		// initialize the node energy with aggregated energy, which will be used to calculate delta energy
 		nodePlatformEnergy["sensor0"] = 5
-		exporter.NodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy)
+		exporter.NodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy, true)
 		exporter.NodeMetrics.UpdateIdleEnergy()
 		// the second node energy will represent the idle and dynamic power
 		nodePlatformEnergy["sensor0"] = 10 // 5J idle, 5J dynamic power
-		exporter.NodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy)
+		exporter.NodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy, true)
 		exporter.NodeMetrics.UpdateIdleEnergy()
 		exporter.NodeMetrics.UpdateDynEnergy()
 
@@ -110,7 +110,7 @@ var _ = Describe("Test Prometheus Collector Unit", func() {
 			DRAM:   5,
 			Uncore: 5,
 		}
-		exporter.NodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+		exporter.NodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 		componentsEnergies[0] = source.NodeComponentsEnergy{
 			Pkg:    10,
 			Core:   10,
@@ -118,7 +118,7 @@ var _ = Describe("Test Prometheus Collector Unit", func() {
 			Uncore: 10,
 		}
 		// the second node energy will force to calculate a delta. The delta is calculates after added at least two aggregated metric
-		exporter.NodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+		exporter.NodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 		exporter.NodeMetrics.UpdateIdleEnergy()
 		// the third node energy will represent the idle and dynamic power. The idle power is only calculated after there at at least two delta values
 		componentsEnergies[0] = source.NodeComponentsEnergy{
@@ -127,7 +127,7 @@ var _ = Describe("Test Prometheus Collector Unit", func() {
 			DRAM:   20, // 10J delta, which is 5J idle, 5J dynamic power
 			Uncore: 20, // 10J delta, which is 5J idle, 5J dynamic power
 		}
-		exporter.NodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+		exporter.NodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 		exporter.NodeMetrics.UpdateIdleEnergy()
 		exporter.NodeMetrics.UpdateDynEnergy()
 		var wg sync.WaitGroup

--- a/pkg/model/container_power_test.go
+++ b/pkg/model/container_power_test.go
@@ -156,17 +156,17 @@ var _ = Describe("ContainerPower", func() {
 				Core: 10,
 				DRAM: 10,
 			}
-			nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+			nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 			componentsEnergies[machineSocketID] = source.NodeComponentsEnergy{
 				Pkg:  18,
 				Core: 15,
 				DRAM: 11,
 			}
-			nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+			nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 
 			nodePlatformEnergy := map[string]float64{}
 			nodePlatformEnergy[machineSensorID] = 0 // empty
-			nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy)
+			nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy, true)
 
 			// calculate container energy consumption
 			UpdateContainerEnergy(containersMetrics, &nodeMetrics)

--- a/pkg/model/estimator/local/benchmark_test.go
+++ b/pkg/model/estimator/local/benchmark_test.go
@@ -36,13 +36,14 @@ func benchmarkNtesting(b *testing.B, continerNumber int) {
 	nodePlatformEnergy := map[string]float64{}
 
 	nodePlatformEnergy["sensor0"] = 10
-	nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy)
+	nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy, true)
 	nodeMetrics.UpdateIdleEnergy()
 
 	nodePlatformEnergy["sensor0"] = 20
-	nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy)
+	nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy, true)
 	nodeMetrics.UpdateIdleEnergy()
 	nodeMetrics.UpdateDynEnergy()
+
 	componentsEnergies := make(map[int]source.NodeComponentsEnergy)
 	componentsEnergies[0] = source.NodeComponentsEnergy{
 		Pkg:    5,
@@ -50,14 +51,14 @@ func benchmarkNtesting(b *testing.B, continerNumber int) {
 		DRAM:   5,
 		Uncore: 5,
 	}
-	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 	componentsEnergies[0] = source.NodeComponentsEnergy{
 		Pkg:    10,
 		Core:   10,
 		DRAM:   10,
 		Uncore: 10,
 	}
-	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 	nodeMetrics.UpdateIdleEnergy()
 	componentsEnergies[0] = source.NodeComponentsEnergy{
 		Pkg:    uint64(continerNumber),
@@ -65,8 +66,8 @@ func benchmarkNtesting(b *testing.B, continerNumber int) {
 		DRAM:   uint64(continerNumber),
 		Uncore: uint64(continerNumber),
 	}
+	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 
-	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
 	nodeMetrics.UpdateIdleEnergy()
 	nodeMetrics.UpdateDynEnergy()
 	b.ReportAllocs()

--- a/pkg/model/estimator/local/ratio_test.go
+++ b/pkg/model/estimator/local/ratio_test.go
@@ -55,11 +55,11 @@ var _ = Describe("Test Ratio Unit", func() {
 		nodePlatformEnergy := map[string]float64{}
 		// initialize the node energy with aggregated energy, which will be used to calculate delta energy
 		nodePlatformEnergy["sensor0"] = 10
-		nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy)
+		nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy, true)
 		nodeMetrics.UpdateIdleEnergy()
 		// the second node energy will represent the idle and dynamic power
 		nodePlatformEnergy["sensor0"] = 20 // 5J idle, 5J dynamic power
-		nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy)
+		nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy, true)
 		nodeMetrics.UpdateIdleEnergy()
 		nodeMetrics.UpdateDynEnergy()
 
@@ -72,7 +72,7 @@ var _ = Describe("Test Ratio Unit", func() {
 			DRAM:   5,
 			Uncore: 5,
 		}
-		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 		componentsEnergies[0] = source.NodeComponentsEnergy{
 			Pkg:    10,
 			Core:   10,
@@ -80,7 +80,7 @@ var _ = Describe("Test Ratio Unit", func() {
 			Uncore: 10,
 		}
 		// the second node energy will force to calculate a delta. The delta is calculates after added at least two aggregated metric
-		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 		nodeMetrics.UpdateIdleEnergy()
 		// the third node energy will represent the idle and dynamic power. The idle power is only calculated after there at at least two delta values
 		componentsEnergies[0] = source.NodeComponentsEnergy{
@@ -89,7 +89,7 @@ var _ = Describe("Test Ratio Unit", func() {
 			DRAM:   40, // 10J delta, which is 5J idle, 5J dynamic power
 			Uncore: 40, // 10J delta, which is 5J idle, 5J dynamic power
 		}
-		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 		nodeMetrics.UpdateIdleEnergy()
 		nodeMetrics.UpdateDynEnergy()
 

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -63,10 +63,10 @@ var _ = Describe("Test Model Unit", func() {
 			Core: 0,
 			DRAM: 0,
 		}
-		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 		nodePlatformEnergy := map[string]float64{}
 		nodePlatformEnergy[machineSensorID] = 0 // empty
-		nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy)
+		nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy, false)
 
 		// calculate container energy consumption
 		UpdateContainerEnergy(containersMetrics, &nodeMetrics)
@@ -87,10 +87,10 @@ var _ = Describe("Test Model Unit", func() {
 			Core: 0,
 			DRAM: 0,
 		}
-		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 		nodePlatformEnergy := map[string]float64{}
 		nodePlatformEnergy[machineSensorID] = 10
-		nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy)
+		nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy, true)
 
 		// calculate container energy consumption
 		UpdateContainerEnergy(containersMetrics, &nodeMetrics)
@@ -115,18 +115,18 @@ var _ = Describe("Test Model Unit", func() {
 			Core: 10,
 			DRAM: 10,
 		}
-		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 		componentsEnergies[machineSocketID] = source.NodeComponentsEnergy{
 			Pkg:  18,
 			Core: 15,
 			DRAM: 11,
 		}
-		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies)
+		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false)
 		nodePlatformEnergy := map[string]float64{}
 		nodePlatformEnergy[machineSensorID] = 10
-		nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy)
+		nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy, true)
 		nodePlatformEnergy[machineSensorID] = 15
-		nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy)
+		nodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy, true)
 
 		// calculate container energy consumption
 


### PR DESCRIPTION
The pre-trained Power Model provides node component power estimates, which return gauge metrics in contrast to the counter metrics used by RAPL.

Consequently, updating the estimated node component as counters would be considered a bug, as it would not appropriately aggregate the gauge values.

To address this issue, this PR includes logic to determine whether a metric should be treated as a gauge or a counter, ensuring proper handling of gauge values.