### PR TITLE
fix: nodeInfo => info

### DIFF
--- a/pkg/collector/prometheus_collector.go
+++ b/pkg/collector/prometheus_collector.go
@@ -278,7 +278,7 @@ func (p *PrometheusCollector) Describe(ch chan<- *prometheus.Desc) {
 
 func (p *PrometheusCollector) newNodeMetrics() {
 	nodeInfo := prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "node", "nodeInfo"),
+		prometheus.BuildFQName(namespace, "node", "info"),
 		"Labeled node information",
 		[]string{"cpu_architecture"}, nil,
 	)


### PR DESCRIPTION
https://sustainable-computing.io/design/metrics/#kepler-metrics-overview

```


    kepler_node_nodeInfo (Counter) This metric shows the node metada like the node CPU architecture.

    Note that this metrics is deprecated and might be updated to kepler_node_info in the next release.

```