### PR TITLE
feat: add sbom to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,3 +133,16 @@ jobs:
           tags: quay.io/sustainable_computing_io/kepler
           labels: latest, ${{ github.event.inputs.release }}
           file: build/Dockerfile
+
+    - name: Generate SBOM
+      uses: anchore/sbom-action@v0.14.2
+      with:
+        image: quay.io/sustainable_computing_io/kepler:${{ github.event.inputs.release }}
+        artifact-name: sbom-kepler-${{ github.event.inputs.release }}.json
+        output-file: ./sbom-kepler-${{ github.event.inputs.release }}.spdx.json
+
+    - name: Attach SBOM to release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ github.event.inputs.tag }}
+        files: ./sbom-kepler-${{ github.event.inputs.release }}.spdx.json


### PR DESCRIPTION
This PR is to attach a Software bill of materials (SBOM) to the release.yml workflow.

This PR closes: https://github.com/sustainable-computing-io/kepler/issues/685 

I have tested this by forking the repo and creating a test quay.io account to ensure it works and it works fine. The produced SBOM is 19.3MB and will be attached after the container is pushed.