### PR TITLE
Push latest and current release tag on running Release GA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
           context: .
           platforms: linux/amd64
           push: true
-          tags: quay.io/sustainable_computing_io/kepler
+          tags: quay.io/sustainable_computing_io/kepler:latest, quay.io/sustainable_computing_io/kepler:${{ github.event.inputs.release }}
           labels: latest, ${{ github.event.inputs.release }}
           file: build/Dockerfile
 


### PR DESCRIPTION
Currently the `Build and push` step in Release workflow only pushes `latest` tag which is causing the `SBOM` step to fail as it is not able to find the `release-v` tag in the quay repo; causing the workflow to fail