### PR TITLE
[WIP][don't merge] try to enable openSSF score

### DIFF
--- a/.github/workflows/openSSFscore.yml
+++ b/.github/workflows/openSSFscore.yml
@@ -1,0 +1,57 @@
+name: Scorecard analysis workflow
+on:
+  # Only the default branch is supported.
+  branch_protection_rule:
+  schedule:
+    # Weekly on Saturdays.
+    - cron: '30 1 * * 6'
+  push:
+    branches: [ main ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed if using Code scanning alerts
+      security-events: write
+      # Needed for GitHub OIDC token if publish_results is true
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v3.5.2
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@v2.1.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecards on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Publish the results for public repositories to enable scorecard badges. For more details, see
+          # https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories, `publish_results` will automatically be set to `false`, regardless
+          # of the value entered here.
+          publish_results: false
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # required for Code scanning alerts
+      - name: "Upload SARIF results to code scanning"
+        uses: github/codeql-action/upload-sarif@v2.3.6
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/openSSFscore.yml
+++ b/.github/workflows/openSSFscore.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     # Weekly on Saturdays.
     - cron: '30 1 * * 6'
+  pull_request:
   push:
     branches: [ main ]
 

--- a/.github/workflows/openSSFscore.yml
+++ b/.github/workflows/openSSFscore.yml
@@ -16,20 +16,23 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
-    permissions:
+    #permissions:
       # Needed if using Code scanning alerts
-      security-events: write
+      #security-events: write
       # Needed for GitHub OIDC token if publish_results is true
-      id-token: write
+      #id-token: write
 
     steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v3.5.2
-      - name: "Run analysis"
-        uses: ossf/scorecard-action@v2.1.3
-        with:
-          results_file: results.sarif
-          results_format: sarif
+      - name: "before we switch to GHA, run docker instead"
+        run: |
+          docker run gcr.io/openssf/scorecard:stable --show-details --repo=https://github.com/sustainable-computing-io/kepler
+      #- name: "Checkout code"
+      #  uses: actions/checkout@v3.5.2
+      #- name: "Run analysis"
+      #  uses: ossf/scorecard-action@v2.1.3
+      #  with:
+      #    results_file: results.sarif
+      #    results_format: sarif
           # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
           # - you want to enable the Branch-Protection check on a *public* repository, or
           # - you are installing Scorecards on a *private* repository
@@ -40,19 +43,19 @@ jobs:
           # https://github.com/ossf/scorecard-action#publishing-results.
           # For private repositories, `publish_results` will automatically be set to `false`, regardless
           # of the value entered here.
-          publish_results: false
+          #publish_results: false
 
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
-      - name: "Upload artifact"
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: SARIF file
-          path: results.sarif
-          retention-days: 5
+      #- name: "Upload artifact"
+      #  uses: actions/upload-artifact@v3.1.2
+      #  with:
+      #    name: SARIF file
+      #    path: results.sarif
+      #    retention-days: 5
 
       # required for Code scanning alerts
-      - name: "Upload SARIF results to code scanning"
-        uses: github/codeql-action/upload-sarif@v2.3.6
-        with:
-          sarif_file: results.sarif
+      #- name: "Upload SARIF results to code scanning"
+      #  uses: github/codeql-action/upload-sarif@v2.3.6
+      #  with:
+      #    sarif_file: results.sarif


### PR DESCRIPTION
I didn't see any benefits for us which use github action with specific hash value for now.
we already has SBOM, and https://github.com/ossf/scorecard use [SLSA3 signatures](https://slsa.dev/) .... do we need put so many efforts on OpenSSF for now?