### PR TITLE
Support redfish 

### DIFF
--- a/manifests/config/exporter/exporter.yaml
+++ b/manifests/config/exporter/exporter.yaml
@@ -22,6 +22,8 @@ data:
   ENABLE_PROCESS_METRICS: "false"
   CPU_ARCH_OVERRIDE: ""
   CGROUP_METRICS: '*'
+  REDFISH_PROBE_INTERVAL_IN_SECONDS: "60"
+  REDFISH_SKIP_SSL_VERIFY: "true"
   MODEL_CONFIG: |
     CONTAINER_COMPONENTS_ESTIMATOR=false
     # by default we use buildin weight file
@@ -62,7 +64,7 @@ spec:
         - /bin/sh
         - -c
         args:
-        - /usr/bin/kepler -v=$(KEPLER_LOG_LEVEL) -kernel-source-dir=/usr/share/kepler/kernel_sources
+        - /usr/bin/kepler -v=$(KEPLER_LOG_LEVEL) -kernel-source-dir=/usr/share/kepler/kernel_sources -redfish-cred-file-path=/etc/redfish/redfish.csv
         ports:
         - containerPort: 9102
           name: http
@@ -85,6 +87,9 @@ spec:
           name: proc
         - name: cfm
           mountPath: /etc/kepler/kepler.config
+          readOnly: true
+        - name: redfish
+          mountPath: /etc/redfish
           readOnly: true
         env:
         - name: NODE_IP
@@ -111,6 +116,9 @@ spec:
       - name: cfm
         configMap:
           name: kepler-cfm
+      - name: redfish
+        secret:
+          secretName: redfish
 ---
 kind: Service
 apiVersion: v1

--- a/manifests/config/exporter/kustomization.yaml
+++ b/manifests/config/exporter/kustomization.yaml
@@ -17,6 +17,10 @@ patchesStrategicMerge: []
 # add this line for rootless patch
 # - ./patch/patch-rootless.yaml
 
+secretGenerator:
+- name: redfish
+  files:
+  - ./redfish.csv
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/manifests/config/exporter/redfish.csv
+++ b/manifests/config/exporter/redfish.csv
@@ -1,0 +1,1 @@
+your_kubelet_node_name,redfish_username,redfish_password,https://redfish_ip_or_hostname

--- a/pkg/bpfassets/perf_event_bindata.go
+++ b/pkg/bpfassets/perf_event_bindata.go
@@ -386,13 +386,11 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//
-//	data/
-//	  foo.txt
-//	  img/
-//	    a.png
-//	    b.png
-//
+//     data/
+//       foo.txt
+//       img/
+//         a.png
+//         b.png
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("nonexistent") would return an error

--- a/pkg/collector/metric/node_metric.go
+++ b/pkg/collector/metric/node_metric.go
@@ -306,12 +306,12 @@ func (ne *NodeMetrics) SetNodeOtherComponentsEnergy() {
 	dynCPUComponentsEnergy := ne.DynEnergyInPkg.SumAllDeltaValues() +
 		ne.DynEnergyInDRAM.SumAllDeltaValues() +
 		ne.DynEnergyInGPU.SumAllDeltaValues()
-	// other component can be either platform
 	dynPlatformEnergy := ne.DynEnergyInPlatform.SumAllDeltaValues()
 	if dynPlatformEnergy > dynCPUComponentsEnergy {
 		otherComponentEnergy := dynPlatformEnergy - dynCPUComponentsEnergy
 		ne.DynEnergyInOther.SetDeltaStat(OTHER, otherComponentEnergy)
 	}
+
 	idleCPUComponentsEnergy := ne.IdleEnergyInPkg.SumAllDeltaValues() +
 		ne.IdleEnergyInDRAM.SumAllDeltaValues() +
 		ne.IdleEnergyInGPU.SumAllDeltaValues()

--- a/pkg/collector/metric/node_metric.go
+++ b/pkg/collector/metric/node_metric.go
@@ -306,12 +306,12 @@ func (ne *NodeMetrics) SetNodeOtherComponentsEnergy() {
 	dynCPUComponentsEnergy := ne.DynEnergyInPkg.SumAllDeltaValues() +
 		ne.DynEnergyInDRAM.SumAllDeltaValues() +
 		ne.DynEnergyInGPU.SumAllDeltaValues()
+	// other component can be either platform
 	dynPlatformEnergy := ne.DynEnergyInPlatform.SumAllDeltaValues()
 	if dynPlatformEnergy > dynCPUComponentsEnergy {
 		otherComponentEnergy := dynPlatformEnergy - dynCPUComponentsEnergy
 		ne.DynEnergyInOther.SetDeltaStat(OTHER, otherComponentEnergy)
 	}
-
 	idleCPUComponentsEnergy := ne.IdleEnergyInPkg.SumAllDeltaValues() +
 		ne.IdleEnergyInDRAM.SumAllDeltaValues() +
 		ne.IdleEnergyInGPU.SumAllDeltaValues()

--- a/pkg/collector/metric/node_metric.go
+++ b/pkg/collector/metric/node_metric.go
@@ -41,7 +41,7 @@ const (
 )
 
 var (
-	NodeName            = getNodeName()
+	NodeName            = GetNodeName()
 	NodeCPUArchitecture = getCPUArch()
 	NodeCPUPackageMap   = getCPUPackageMap()
 

--- a/pkg/collector/metric/utils.go
+++ b/pkg/collector/metric/utils.go
@@ -98,7 +98,7 @@ func isCounterStatEnabled(label string) bool {
 	return false
 }
 
-func getNodeName() string {
+func GetNodeName() string {
 	if nodeName := os.Getenv("NODE_NAME"); nodeName != "" {
 		return nodeName
 	}

--- a/pkg/collector/prometheus_collector.go
+++ b/pkg/collector/prometheus_collector.go
@@ -210,6 +210,7 @@ func (p *PrometheusCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- p.nodeDesc.nodePackageJoulesTotal
 	ch <- p.nodeDesc.nodePlatformJoulesTotal
 	ch <- p.nodeDesc.nodeOtherComponentsJoulesTotal
+
 	if config.EnabledGPU {
 		ch <- p.nodeDesc.nodeGPUJoulesTotal
 	}

--- a/pkg/collector/prometheus_collector.go
+++ b/pkg/collector/prometheus_collector.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sustainable-computing-io/kepler/pkg/bpfassets/attacher"
 	collector_metric "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
 	"github.com/sustainable-computing-io/kepler/pkg/config"
+	"github.com/sustainable-computing-io/kepler/pkg/power/platform"
 )
 
 const (
@@ -647,20 +648,20 @@ func (p *PrometheusCollector) updateNodeMetrics(wg *sync.WaitGroup, ch chan<- pr
 			idlePower,
 			collector_metric.NodeName, "idle",
 		)
-
+		powerSource := platform.GetPowerSource()
 		dynPower = (float64(p.NodeMetrics.GetSumAggrDynEnergyFromAllSources(collector_metric.PLATFORM)) / miliJouleToJoule)
 		ch <- prometheus.MustNewConstMetric(
 			p.nodeDesc.nodePlatformJoulesTotal,
 			prometheus.CounterValue,
 			dynPower,
-			collector_metric.NodeName, "acpi", "dynamic",
+			collector_metric.NodeName, powerSource, "dynamic",
 		)
 		idlePower = (float64(p.NodeMetrics.GetSumAggrIdleEnergyromAllSources(collector_metric.PLATFORM)) / miliJouleToJoule)
 		ch <- prometheus.MustNewConstMetric(
 			p.nodeDesc.nodePlatformJoulesTotal,
 			prometheus.CounterValue,
 			idlePower,
-			collector_metric.NodeName, "acpi", "idle",
+			collector_metric.NodeName, powerSource, "idle",
 		)
 
 		if config.EnabledGPU {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -214,6 +214,13 @@ func GetRedfishProbeIntervalInSeconds() int {
 	}
 	return probeInterval
 }
+func SetRedfishSkipSSLVerify(skipSSLVerify bool) {
+	redfishSkipSSLVerify = skipSSLVerify
+}
+
+func GetRedfishSkipSSLVerify() bool {
+	return redfishSkipSSLVerify
+}
 
 func SetModelServerReqEndpoint() (modelServerReqEndpoint string) {
 	modelServerURL := getConfig("MODEL_SERVER_URL", modelServerService)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,6 +93,10 @@ var (
 	// dir of kernel sources for bcc
 	kernelSourceDirs = []string{}
 
+	// redfish cred file path
+	redfishCredFilePath           string
+	redfishProbeIntervalInSeconds = getConfig("REDFISH_PROBE_INTERVAL_IN_SECONDS", "60")
+
 	////////////////////////////////////
 	ModelServerEnable   = getBoolConfig("MODEL_SERVER_ENABLE", false)
 	ModelServerEndpoint = SetModelServerReqEndpoint()
@@ -186,6 +190,28 @@ func SetKernelSourceDir(dir string) error {
 
 func GetKernelSourceDirs() []string {
 	return kernelSourceDirs
+}
+
+func SetRedfishCredFilePath(credFilePath string) {
+	redfishCredFilePath = credFilePath
+}
+
+func GetRedfishCredFilePath() string {
+	return redfishCredFilePath
+}
+
+func SetRedfishProbeIntervalInSeconds(interval string) {
+	redfishProbeIntervalInSeconds = interval
+}
+
+func GetRedfishProbeIntervalInSeconds() int {
+	// convert string "redfishProbeIntervalInSeconds" to int
+	probeInterval, err := strconv.Atoi(redfishProbeIntervalInSeconds)
+	if err != nil {
+		klog.Warning("failed to convert redfishProbeIntervalInSeconds to int", err)
+		return 60
+	}
+	return probeInterval
 }
 
 func SetModelServerReqEndpoint() (modelServerReqEndpoint string) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -96,7 +96,7 @@ var (
 	// redfish cred file path
 	redfishCredFilePath           string
 	redfishProbeIntervalInSeconds = getConfig("REDFISH_PROBE_INTERVAL_IN_SECONDS", "60")
-	redfishSkipSSLVerify          = getBoolConfig("REDFISH_SKIP_SSL_VERIFY", false)
+	redfishSkipSSLVerify          = getBoolConfig("REDFISH_SKIP_SSL_VERIFY", true)
 
 	////////////////////////////////////
 	ModelServerEnable   = getBoolConfig("MODEL_SERVER_ENABLE", false)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -96,6 +96,7 @@ var (
 	// redfish cred file path
 	redfishCredFilePath           string
 	redfishProbeIntervalInSeconds = getConfig("REDFISH_PROBE_INTERVAL_IN_SECONDS", "60")
+	redfishSkipSSLVerify          = getBoolConfig("REDFISH_SKIP_SSL_VERIFY", false)
 
 	////////////////////////////////////
 	ModelServerEnable   = getBoolConfig("MODEL_SERVER_ENABLE", false)

--- a/pkg/nodecred/csv_cred.go
+++ b/pkg/nodecred/csv_cred.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodecred
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+
+	"k8s.io/klog/v2"
+)
+
+// csvNodeCredImpl is the implementation of NodeCred using on disk file
+// the file is in the format of
+// node1,admin,password,localhost
+// node2,admin,password,localhost
+// node3,admin,password,localhost
+type csvNodeCred struct {
+}
+
+var (
+	credMap map[string]string
+)
+
+func (c csvNodeCred) GetNodeCredByNodeName(nodeName, target string) (map[string]string, error) {
+	if credMap == nil {
+		return nil, fmt.Errorf("credential is not set")
+	} else if target == "redfish" {
+		cred := make(map[string]string)
+		cred["redfish_username"] = credMap["redfish_username"]
+		cred["redfish_password"] = credMap["redfish_password"]
+		cred["redfish_host"] = credMap["redfish_host"]
+		if cred["redfish_username"] == "" || cred["redfish_password"] == "" || cred["redfish_host"] == "" {
+			return nil, fmt.Errorf("no credential found")
+		}
+		return cred, nil
+	}
+
+	return nil, fmt.Errorf("no credential found for target %s", target)
+}
+
+func (c csvNodeCred) IsSupported(info map[string]string) bool {
+	// read redfish_cred_file_path from info
+	filePath := info["redfish_cred_file_path"]
+	if filePath == "" {
+		return false
+	} else {
+		nodeName := getNodeName()
+		// read file from filePath
+		userName, password, host, err := readCSVFile(filePath, nodeName)
+		if err != nil {
+			klog.V(5).Infof("failed to read csv file: %v", err)
+			return false
+		}
+		klog.V(5).Infof("read csv file successfully")
+		credMap = make(map[string]string)
+		credMap["redfish_username"] = userName
+		credMap["redfish_password"] = password
+		credMap["redfish_host"] = host
+	}
+	return true
+}
+
+func getNodeName() string {
+	nodeName := os.Getenv("NODE_NAME")
+	if nodeName == "" {
+		nodeName = "localhost"
+	}
+	return nodeName
+}
+
+func readCSVFile(filePath, nodeName string) (userName, password, host string, err error) {
+	// Open the CSV file
+	file, err := os.Open(filePath)
+	if err != nil {
+		fmt.Println("Error opening the file:", err)
+		return
+	}
+	defer file.Close()
+
+	// Create a new CSV reader
+	reader := csv.NewReader(file)
+
+	// Read all rows from the CSV file
+	rows, err := reader.ReadAll()
+	if err != nil {
+		fmt.Println("Error reading CSV:", err)
+		return
+	}
+
+	// Iterate over each row and check if the node name matches
+	for _, row := range rows {
+		if row[0] == nodeName && len(row) >= 4 {
+			userName = row[1]
+			password = row[2]
+			host = row[3]
+			return userName, password, host, nil
+		}
+	}
+	err = fmt.Errorf("node name %s not found in file %s", nodeName, filePath)
+	return
+}

--- a/pkg/nodecred/csv_cred.go
+++ b/pkg/nodecred/csv_cred.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"os"
 
+	metric_util "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
+
 	"k8s.io/klog/v2"
 )
 
@@ -59,7 +61,7 @@ func (c csvNodeCred) IsSupported(info map[string]string) bool {
 	if filePath == "" {
 		return false
 	} else {
-		nodeName := getNodeName()
+		nodeName := metric_util.GetNodeName()
 		// read file from filePath
 		userName, password, host, err := readCSVFile(filePath, nodeName)
 		if err != nil {
@@ -73,14 +75,6 @@ func (c csvNodeCred) IsSupported(info map[string]string) bool {
 		credMap["redfish_host"] = host
 	}
 	return true
-}
-
-func getNodeName() string {
-	nodeName := os.Getenv("NODE_NAME")
-	if nodeName == "" {
-		nodeName = "localhost"
-	}
-	return nodeName
 }
 
 func readCSVFile(filePath, nodeName string) (userName, password, host string, err error) {

--- a/pkg/nodecred/csv_cred_test.go
+++ b/pkg/nodecred/csv_cred_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodecred
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetNodeCredByNodeName(t *testing.T) {
+	credMap = map[string]string{
+		"redfish_username": "admin",
+		"redfish_password": "password",
+		"redfish_host":     "node1",
+	}
+	c := csvNodeCred{}
+
+	// Test with target "redfish"
+	result, err := c.GetNodeCredByNodeName("node1", "redfish")
+	if err != nil {
+		t.Errorf("Expected nil error, got: %v", err)
+	}
+	expected := credMap
+	if !mapStringStringEqual(result, expected) {
+		t.Errorf("Expected credMap: %v, got: %v", expected, result)
+	}
+
+	// Test with unsupported target
+	_, err = c.GetNodeCredByNodeName("node1", "unsupported")
+	if err == nil {
+		t.Errorf("Expected an error, got nil")
+	}
+
+	// Test with nil credMap
+	credMap = nil
+	_, err = c.GetNodeCredByNodeName("node1", "redfish")
+	if err == nil {
+		t.Errorf("Expected an error, got nil")
+	}
+}
+
+func TestIsSupported(t *testing.T) {
+	// Test when redfish_cred_file_path is missing
+	info := map[string]string{}
+	c := csvNodeCred{}
+	result := c.IsSupported(info)
+	if result {
+		t.Errorf("Expected false, got: %v", result)
+	}
+
+	// Test when redfish_cred_file_path is empty
+	info = map[string]string{
+		"redfish_cred_file_path": "",
+	}
+	result = c.IsSupported(info)
+	if result {
+		t.Errorf("Expected false, got: %v", result)
+	}
+
+	// create a temp csv file with the following content:
+	// node1,admin,password,localhost
+	// node2,admin,password,localhost
+	// node3,admin,password,localhost
+	file, err := os.CreateTemp("", "test.csv")
+	if err != nil {
+		t.Errorf("Expected nil error, got: %v", err)
+	}
+	defer os.Remove(file.Name())
+	_, err = file.WriteString("node1,admin,password,localhost\nnode2,admin,password,localhost\nnode3,admin,password,localhost\n")
+	if err != nil {
+		t.Errorf("Expected nil error, got: %v", err)
+	}
+
+	// Test with valid redfish_cred_file_path
+	info = map[string]string{
+		"redfish_cred_file_path": file.Name(),
+	}
+
+	// set ENV variable NODE_NAME to "node1"
+	os.Setenv("NODE_NAME", "node1")
+	// check if getNodeName() returns "node1"
+	nodeName := getNodeName()
+	if nodeName != "node1" {
+		t.Errorf("Expected nodeName: node1, got: %v", nodeName)
+	}
+	// readCSVFile should return the credentials for node1
+	userName, password, host, err := readCSVFile(file.Name(), nodeName)
+	if err != nil {
+		t.Errorf("Expected nil error, got: %v", err)
+	}
+	if host != "localhost" {
+		t.Errorf("Expected host: localhost, got: %v", host)
+	}
+	if userName != "admin" {
+		t.Errorf("Expected userName: admin, got: %v", userName)
+	}
+	if password != "password" {
+		t.Errorf("Expected password: password, got: %v", password)
+	}
+	result = c.IsSupported(info)
+	if !result {
+		t.Errorf("Expected true, got: %v", result)
+	}
+}
+
+// Helper function to compare two maps of strings
+func mapStringStringEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, valA := range a {
+		valB, ok := b[key]
+		if !ok || valA != valB {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/nodecred/csv_cred_test.go
+++ b/pkg/nodecred/csv_cred_test.go
@@ -19,6 +19,8 @@ package nodecred
 import (
 	"os"
 	"testing"
+
+	metric_util "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
 )
 
 func TestGetNodeCredByNodeName(t *testing.T) {
@@ -93,7 +95,7 @@ func TestIsSupported(t *testing.T) {
 	// set ENV variable NODE_NAME to "node1"
 	os.Setenv("NODE_NAME", "node1")
 	// check if getNodeName() returns "node1"
-	nodeName := getNodeName()
+	nodeName := metric_util.GetNodeName()
 	if nodeName != "node1" {
 		t.Errorf("Expected nodeName: node1, got: %v", nodeName)
 	}

--- a/pkg/nodecred/node_cred.go
+++ b/pkg/nodecred/node_cred.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// per node credential interface
+// Kubernetes doesn't have per node API object, so we need to use node credential to access node specific information
+// e.g. node specific metrics, node specific power consumption, etc.
+// This interface is used to access node credential.
+// Instances of node credentials can be ConfigMap, Secret, key value store, etc.
+package nodecred
+
+import (
+	"fmt"
+
+	"k8s.io/klog/v2"
+)
+
+type NodeCredInterface interface {
+	// GetNodeCredByNodeName returns map of per node credential for targets such as redfish
+	GetNodeCredByNodeName(nodeName string, target string) (map[string]string, error)
+	// IsSupported returns if this node credential is supported
+	IsSupported(info map[string]string) bool
+}
+
+var (
+	// csvNodeCredImpl is the implementation of NodeCred using on disk csv file
+	csvNodeCredImpl csvNodeCred
+	// nodeCredImpl is the pointer to the runtime detected implementation of NodeCred
+	nodeCredImpl NodeCredInterface = nil
+)
+
+func InitNodeCredImpl(param map[string]string) error {
+	if csvNodeCredImpl.IsSupported(param) {
+		klog.V(1).Infoln("use csv file to obtain node credential")
+		nodeCredImpl = csvNodeCredImpl
+	}
+	if nodeCredImpl != nil {
+		return nil
+	}
+	return fmt.Errorf("no supported node credential implementation")
+}
+
+func GetNodeCredByNodeName(nodeName, target string) (map[string]string, error) {
+	return nodeCredImpl.GetNodeCredByNodeName(nodeName, target)
+}

--- a/pkg/power/platform/power.go
+++ b/pkg/power/platform/power.go
@@ -37,6 +37,7 @@ var (
 	powerImpl   powerInterface
 	redfishImpl *source.RedFishClient
 	hmcImpl     = &source.PowerHMC{}
+	powerSource = "none"
 )
 
 func InitPowerImpl() {
@@ -45,13 +46,20 @@ func InitPowerImpl() {
 	if runtime.GOARCH == "s390x" {
 		klog.V(1).Infoln("use hmc to obtain power")
 		powerImpl = hmcImpl
+		powerSource = "hmc"
 	} else if redfishImpl = source.NewRedfishClient(); redfishImpl != nil && redfishImpl.IsSystemCollectionSupported() {
 		klog.V(1).Infoln("use redfish to obtain power")
 		powerImpl = redfishImpl
+		powerSource = "redfish"
 	} else {
 		klog.V(1).Infoln("use acpi to obtain power")
 		powerImpl = source.NewACPIPowerMeter()
+		powerSource = "acpi"
 	}
+}
+
+func GetPowerSource() string {
+	return powerSource
 }
 
 func GetEnergyFromPlatform() (map[string]float64, error) {

--- a/pkg/power/platform/source/redfish.go
+++ b/pkg/power/platform/source/redfish.go
@@ -1,0 +1,286 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sustainable-computing-io/kepler/pkg/config"
+	"github.com/sustainable-computing-io/kepler/pkg/nodecred"
+
+	"k8s.io/klog/v2"
+)
+
+// RedfishSystemModel is the struct for the system model
+// this is generated via the following command:
+// redfishtool Systems
+type RedfishSystemModel struct {
+	OdataContext string `json:"@odata.context"`
+	OdataID      string `json:"@odata.id"`
+	OdataType    string `json:"@odata.type"`
+	Description  string `json:"Description"`
+	Members      []struct {
+		OdataID string `json:"@odata.id"`
+	} `json:"Members"`
+	MembersOdataCount int    `json:"Members@odata.count"`
+	Name              string `json:"Name"`
+}
+
+// RedfishPowerModel is the struct for the power model
+// this is generated via the following command:
+// redfishtool raw GET /redfish/v1/Chassis/System.Embedded.1/Power#/PowerControl, where "System.Embedded.1" is the system ID from the RedfishSystemModel
+// the output is then formatted via https://mholt.github.io/json-to-go/ based on sample output from https://www.dmtf.org/sites/default/files/standards/documents/DSP2046_2023.1.pdf
+type RedfishPowerModel struct {
+	OdataType     string          `json:"@odata.type,omitempty"`
+	ID            string          `json:"Id,omitempty"`
+	Name          string          `json:"Name,omitempty"`
+	PowerControl  []PowerControl  `json:"PowerControl,omitempty"`
+	Voltages      []Voltages      `json:"Voltages,omitempty"`
+	PowerSupplies []PowerSupplies `json:"PowerSupplies,omitempty"`
+	Actions       Actions         `json:"Actions,omitempty"`
+	OdataID       string          `json:"@odata.id,omitempty"`
+}
+type PowerMetrics struct {
+	IntervalInMin        int `json:"IntervalInMin,omitempty"`
+	MinConsumedWatts     int `json:"MinConsumedWatts,omitempty"`
+	MaxConsumedWatts     int `json:"MaxConsumedWatts,omitempty"`
+	AverageConsumedWatts int `json:"AverageConsumedWatts,omitempty"`
+}
+type PowerLimit struct {
+	LimitInWatts   int    `json:"LimitInWatts,omitempty"`
+	LimitException string `json:"LimitException,omitempty"`
+	CorrectionInMs int    `json:"CorrectionInMs,omitempty"`
+}
+type RelatedItem struct {
+	OdataID string `json:"@odata.id,omitempty"`
+}
+type Status struct {
+	State  string `json:"State,omitempty"`
+	Health string `json:"Health,omitempty"`
+}
+type PowerControl struct {
+	OdataID             string        `json:"@odata.id,omitempty"`
+	MemberID            string        `json:"MemberId,omitempty"`
+	Name                string        `json:"Name,omitempty"`
+	PowerConsumedWatts  int           `json:"PowerConsumedWatts,omitempty"`
+	PowerRequestedWatts int           `json:"PowerRequestedWatts,omitempty"`
+	PowerAvailableWatts int           `json:"PowerAvailableWatts,omitempty"`
+	PowerCapacityWatts  int           `json:"PowerCapacityWatts,omitempty"`
+	PowerAllocatedWatts int           `json:"PowerAllocatedWatts,omitempty"`
+	PowerMetrics        PowerMetrics  `json:"PowerMetrics,omitempty"`
+	PowerLimit          PowerLimit    `json:"PowerLimit,omitempty"`
+	RelatedItem         []RelatedItem `json:"RelatedItem,omitempty"`
+	Status              Status        `json:"Status,omitempty"`
+}
+type Voltages struct {
+	OdataID                   string        `json:"@odata.id,omitempty"`
+	MemberID                  string        `json:"MemberId,omitempty"`
+	Name                      string        `json:"Name,omitempty"`
+	SensorNumber              int           `json:"SensorNumber,omitempty"`
+	Status                    Status        `json:"Status,omitempty"`
+	ReadingVolts              int           `json:"ReadingVolts,omitempty"`
+	UpperThresholdNonCritical float64       `json:"UpperThresholdNonCritical,omitempty"`
+	UpperThresholdCritical    int           `json:"UpperThresholdCritical,omitempty"`
+	UpperThresholdFatal       int           `json:"UpperThresholdFatal,omitempty"`
+	LowerThresholdNonCritical float64       `json:"LowerThresholdNonCritical,omitempty"`
+	LowerThresholdCritical    int           `json:"LowerThresholdCritical,omitempty"`
+	LowerThresholdFatal       int           `json:"LowerThresholdFatal,omitempty"`
+	MinReadingRange           int           `json:"MinReadingRange,omitempty"`
+	MaxReadingRange           int           `json:"MaxReadingRange,omitempty"`
+	PhysicalContext           string        `json:"PhysicalContext,omitempty"`
+	RelatedItem               []RelatedItem `json:"RelatedItem,omitempty"`
+}
+type InputRanges struct {
+	InputType      string `json:"InputType,omitempty"`
+	MinimumVoltage int    `json:"MinimumVoltage,omitempty"`
+	MaximumVoltage int    `json:"MaximumVoltage,omitempty"`
+	OutputWattage  int    `json:"OutputWattage,omitempty"`
+}
+type PowerSupplies struct {
+	OdataID              string        `json:"@odata.id,omitempty"`
+	MemberID             string        `json:"MemberId,omitempty"`
+	Name                 string        `json:"Name,omitempty"`
+	Status               Status        `json:"Status,omitempty"`
+	PowerSupplyType      string        `json:"PowerSupplyType,omitempty"`
+	LineInputVoltageType string        `json:"LineInputVoltageType,omitempty"`
+	LineInputVoltage     int           `json:"LineInputVoltage,omitempty"`
+	PowerCapacityWatts   int           `json:"PowerCapacityWatts,omitempty"`
+	LastPowerOutputWatts int           `json:"LastPowerOutputWatts,omitempty"`
+	Model                string        `json:"Model,omitempty"`
+	Manufacturer         string        `json:"Manufacturer,omitempty"`
+	FirmwareVersion      string        `json:"FirmwareVersion,omitempty"`
+	SerialNumber         string        `json:"SerialNumber,omitempty"`
+	PartNumber           string        `json:"PartNumber,omitempty"`
+	SparePartNumber      string        `json:"SparePartNumber,omitempty"`
+	InputRanges          []InputRanges `json:"InputRanges,omitempty"`
+	RelatedItem          []RelatedItem `json:"RelatedItem,omitempty"`
+}
+type PowerPowerSupplyReset struct {
+	Target string `json:"target,omitempty"`
+}
+type Actions struct {
+	PowerPowerSupplyReset PowerPowerSupplyReset `json:"#Power.PowerSupplyReset,omitempty"`
+}
+
+// RedfishSystemPowerResult is the system power query result
+type RedfishSystemPowerResult struct {
+	system        string
+	consumedWatts int
+	timestamp     time.Time
+}
+
+// RedfishAccessInfo is the struct for the access model
+type RedfishAccessInfo struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Host     string `json:"host"`
+}
+
+type RedFishClient struct {
+	// systemEnergy is the system accumulated energy consumption in Joule
+	accessInfo    RedfishAccessInfo
+	systems       []*RedfishSystemPowerResult
+	ticker        *time.Ticker
+	probeInterval time.Duration
+	mutex         sync.Mutex
+}
+
+func NewRedfishClient() *RedFishClient {
+	credPath := config.GetRedfishCredFilePath()
+	if credPath == "" {
+		klog.Infof("failed to get redfish credential file path")
+		return nil
+	}
+	if err := nodecred.InitNodeCredImpl(map[string]string{"redfish_cred_file_path": credPath}); err != nil {
+		klog.Infof("%s", fmt.Sprintf("failed to initialize node credential: %v", err))
+		return nil
+	} else {
+		klog.V(5).Infof("Initialized node credential")
+		nodeName := os.Getenv("NODE_NAME")
+		if nodeName == "" {
+			nodeName = "localhost"
+		}
+		redfishCred, err := nodecred.GetNodeCredByNodeName(nodeName, "redfish")
+		if err == nil {
+			userName := redfishCred["redfish_username"]
+			password := redfishCred["redfish_password"]
+			host := redfishCred["redfish_host"]
+			if userName != "" && password != "" && host != "" {
+				klog.V(5).Infof("Initialized redfish credential")
+				probeInterval := config.GetRedfishProbeIntervalInSeconds()
+				interval := time.Duration(probeInterval) * time.Second
+				redfish := &RedFishClient{
+					accessInfo:    RedfishAccessInfo{Username: userName, Password: password, Host: host},
+					systems:       []*RedfishSystemPowerResult{},
+					probeInterval: interval,
+					mutex:         sync.Mutex{},
+				}
+				return redfish
+			}
+		} else {
+			klog.V(1).Infof("%s", fmt.Sprintf("failed to get node credential: %v", err))
+			return nil
+		}
+	}
+	return nil
+}
+
+func (rf *RedFishClient) IsSystemCollectionSupported() bool {
+	system, err := getRedfishSystem(rf.accessInfo)
+
+	if err != nil {
+		klog.Infof("failed to get redfish system info: %v\n", err)
+		return false
+	}
+
+	intervalInMin := 0
+	// iterate each "Members" in the system and get the power info
+	for _, member := range system.Members {
+		// split the OdataID by delimiter "/" and get the system ID
+		split := strings.Split(member.OdataID, "/")
+		if len(split) < 2 {
+			continue
+		}
+		id := split[len(split)-1]
+		res := RedfishSystemPowerResult{}
+		power, err := getRedfishPower(rf.accessInfo, id)
+		if err == nil && len(power.PowerControl) > 0 {
+			res.system = id
+			res.consumedWatts = power.PowerControl[0].PowerConsumedWatts
+			res.timestamp = time.Now()
+			rf.systems = append(rf.systems, &res)
+			klog.V(5).Infof("power info: %+v\n", power)
+			if power.PowerControl[0].PowerMetrics.IntervalInMin > intervalInMin {
+				intervalInMin = power.PowerControl[0].PowerMetrics.IntervalInMin
+			}
+		} else {
+			klog.V(5).Infof("failed to get power info: %v\n", err)
+		}
+	}
+
+	// set a timer to check the power info every probeInterval seconds
+	rf.ticker = time.NewTicker(rf.probeInterval)
+	go func() {
+		for {
+			<-rf.ticker.C
+			for _, system := range rf.systems {
+				power, err := getRedfishPower(rf.accessInfo, system.system)
+				if err == nil && len(power.PowerControl) > 0 {
+					// mutex
+					rf.mutex.Lock()
+					klog.V(5).Infof("power info: %+v\n", power)
+					system.consumedWatts = power.PowerControl[0].PowerConsumedWatts
+					system.timestamp = time.Now()
+					rf.mutex.Unlock()
+				} else {
+					klog.V(5).Infof("failed to get power info: %v\n", err)
+				}
+			}
+		}
+	}()
+	return rf.systems != nil && len(rf.systems) > 0
+}
+
+// GetEnergyFromPlatform returns the power consumption in Watt
+func (rf *RedFishClient) GetEnergyFromPlatform() (map[string]float64, error) {
+	if rf.systems != nil {
+		power := make(map[string]float64)
+		for _, system := range rf.systems {
+			rf.mutex.Lock()
+			now := time.Now()
+			// calculate the elapsed time since the last power query in seconds
+			elapsed := now.Sub(system.timestamp).Seconds()
+			system.timestamp = time.Now()
+			klog.V(5).Infof("power info: %+v\n", system)
+			power[system.system] = float64(system.consumedWatts * 1000 * int(elapsed)) // convert to mW
+			rf.mutex.Unlock()
+		}
+		return power, nil
+	}
+	return nil, nil
+}
+
+// StopPower stops the power collection timer
+func (rf *RedFishClient) StopPower() {
+	if rf != nil && rf.ticker != nil {
+		rf.ticker.Stop()
+	}
+}

--- a/pkg/power/platform/source/redfish.go
+++ b/pkg/power/platform/source/redfish.go
@@ -241,7 +241,9 @@ func (rf *RedFishClient) IsSystemCollectionSupported() bool {
 	}
 
 	// set a timer to check the power info every probeInterval seconds
-	rf.ticker = time.NewTicker(rf.probeInterval)
+	if rf.ticker == nil {
+		rf.ticker = time.NewTicker(rf.probeInterval)
+	}
 	go func() {
 		for {
 			<-rf.ticker.C

--- a/pkg/power/platform/source/redfish.go
+++ b/pkg/power/platform/source/redfish.go
@@ -270,7 +270,7 @@ func (rf *RedFishClient) GetEnergyFromPlatform() (map[string]float64, error) {
 			elapsed := now.Sub(system.timestamp).Seconds()
 			system.timestamp = time.Now()
 			klog.V(5).Infof("power info: %+v\n", system)
-			power[system.system] = float64(system.consumedWatts * 1000 * int(elapsed)) // convert to mW
+			power[system.system] = float64(system.consumedWatts*1000) * elapsed // convert to mW
 			rf.mutex.Unlock()
 		}
 		return power, nil

--- a/pkg/power/platform/source/redfish.go
+++ b/pkg/power/platform/source/redfish.go
@@ -248,7 +248,6 @@ func (rf *RedFishClient) IsSystemCollectionSupported() bool {
 					rf.mutex.Lock()
 					klog.V(5).Infof("power info: %+v\n", power)
 					system.consumedWatts = power.PowerControl[0].PowerConsumedWatts
-					system.timestamp = time.Now()
 					rf.mutex.Unlock()
 				} else {
 					klog.V(5).Infof("failed to get power info: %v\n", err)

--- a/pkg/power/platform/source/redfish.go
+++ b/pkg/power/platform/source/redfish.go
@@ -213,7 +213,7 @@ func (rf *RedFishClient) IsSystemCollectionSupported() bool {
 
 	intervalInMin := 0
 	// iterate each "Members" in the system and get the power info
-	for _, member := range system.Members {
+	for index, member := range system.Members {
 		// split the OdataID by delimiter "/" and get the system ID
 		split := strings.Split(member.OdataID, "/")
 		if len(split) < 2 {
@@ -223,10 +223,14 @@ func (rf *RedFishClient) IsSystemCollectionSupported() bool {
 		res := RedfishSystemPowerResult{}
 		power, err := getRedfishPower(rf.accessInfo, id)
 		if err == nil && len(power.PowerControl) > 0 {
-			res.system = id
-			res.consumedWatts = power.PowerControl[0].PowerConsumedWatts
-			res.timestamp = time.Now()
-			rf.systems = append(rf.systems, &res)
+			if index < len(rf.systems) {
+				rf.systems[index].consumedWatts = power.PowerControl[0].PowerConsumedWatts
+			} else {
+				res.system = id
+				res.consumedWatts = power.PowerControl[0].PowerConsumedWatts
+				res.timestamp = time.Now()
+				rf.systems = append(rf.systems, &res)
+			}
 			klog.V(5).Infof("power info: %+v\n", power)
 			if power.PowerControl[0].PowerMetrics.IntervalInMin > intervalInMin {
 				intervalInMin = power.PowerControl[0].PowerMetrics.IntervalInMin

--- a/pkg/power/platform/source/redfish_test.go
+++ b/pkg/power/platform/source/redfish_test.go
@@ -44,7 +44,7 @@ func TestRedFishClient_IsPowerSupported(t *testing.T) {
 			if err := json.NewEncoder(w).Encode(system); err != nil {
 				fmt.Println(err)
 			}
-		} else if r.URL.Path == "/redfish/v1/Chassis/1/Power#/PowerControl" || r.URL.Path == "/redfish/v1/Chassis/2/Power#/PowerControl" {
+		} else if r.URL.Path == "/redfish/v1/Chassis/1/Power" || r.URL.Path == "/redfish/v1/Chassis/2/Power" {
 			power := RedfishPowerModel{
 				Name: "Test Power",
 				PowerControl: []PowerControl{

--- a/pkg/power/platform/source/redfish_test.go
+++ b/pkg/power/platform/source/redfish_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRedFishClient_IsPowerSupported(t *testing.T) {
+	// Create a mock HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/redfish/v1/Systems" {
+			system := RedfishSystemModel{
+				Name: "Test System",
+				Members: []struct {
+					OdataID string `json:"@odata.id"`
+				}{
+					{
+						OdataID: "/redfish/v1/Chassis/1",
+					},
+					{
+						OdataID: "/redfish/v1/Chassis/2",
+					},
+				},
+			}
+			if err := json.NewEncoder(w).Encode(system); err != nil {
+				fmt.Println(err)
+			}
+		} else if r.URL.Path == "/redfish/v1/Chassis/1/Power#/PowerControl" || r.URL.Path == "/redfish/v1/Chassis/2/Power#/PowerControl" {
+			power := RedfishPowerModel{
+				Name: "Test Power",
+				PowerControl: []PowerControl{
+					{
+						PowerConsumedWatts: 100,
+					},
+				},
+			}
+			if err := json.NewEncoder(w).Encode(power); err != nil {
+				fmt.Println(err)
+			}
+		} else {
+			fmt.Printf("Path not found: %s\n", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	defer server.Close()
+	fmt.Println("Mock server listening on", server.URL)
+	// Configure the access details for the mock server
+	access := RedfishAccessInfo{
+		Username: "testuser",
+		Password: "testpass",
+		Host:     server.URL,
+	}
+
+	// Create a new Redfish client
+	client := &RedFishClient{
+		accessInfo:    access,
+		systems:       []*RedfishSystemPowerResult{},
+		probeInterval: 30,
+	}
+
+	// Check if power is supported
+	isPowerSupported := client.IsSystemCollectionSupported()
+	if !isPowerSupported {
+		t.Error("Expected power support, but got false")
+	}
+	// stop the client
+	client.StopPower()
+}

--- a/pkg/power/platform/source/redfish_util.go
+++ b/pkg/power/platform/source/redfish_util.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/sustainable-computing-io/kepler/pkg/config"
 )
 
 func getRedfishModel(access RedfishAccessInfo, endpoint string, model interface{}) error {

--- a/pkg/power/platform/source/redfish_util.go
+++ b/pkg/power/platform/source/redfish_util.go
@@ -18,6 +18,7 @@ package source
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"

--- a/pkg/power/platform/source/redfish_util.go
+++ b/pkg/power/platform/source/redfish_util.go
@@ -33,7 +33,13 @@ func getRedfishModel(access RedfishAccessInfo, endpoint string, model interface{
 	host := access.Host
 
 	// Create a HTTP client and set up the basic authentication header
-	client := &http.Client{}
+	transport := &http.Transport{}
+	if config.GetRedfishSkipSSLVerify() {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	client := &http.Client{
+		Transport: transport,
+	}
 	url := host + endpoint
 	req, err := http.NewRequest("GET", url, http.NoBody)
 	if err != nil {

--- a/pkg/power/platform/source/redfish_util.go
+++ b/pkg/power/platform/source/redfish_util.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+func getRedfishModel(access RedfishAccessInfo, endpoint string, model interface{}) error {
+	username := access.Username
+	password := access.Password
+	host := access.Host
+
+	// Create a HTTP client and set up the basic authentication header
+	client := &http.Client{}
+	url := host + endpoint
+	req, err := http.NewRequest("GET", url, http.NoBody)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	req.SetBasicAuth(username, password)
+
+	// Send the request and check the response
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Check the response status code
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("server returned status: %v", resp.Status)
+	}
+
+	// Decode the response body into the provided model struct
+	err = json.NewDecoder(resp.Body).Decode(model)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getRedfishSystem(access RedfishAccessInfo) (*RedfishSystemModel, error) {
+	var system RedfishSystemModel
+	err := getRedfishModel(access, "/redfish/v1/Systems", &system)
+	if err != nil {
+		return nil, err
+	}
+
+	return &system, nil
+}
+
+func getRedfishPower(access RedfishAccessInfo, system string) (*RedfishPowerModel, error) {
+	var power RedfishPowerModel
+	err := getRedfishModel(access, "/redfish/v1/Chassis/"+system+"/Power%23/PowerControl", &power)
+	if err != nil {
+		return nil, err
+	}
+
+	return &power, nil
+}


### PR DESCRIPTION
Get power info from BMCs that support Redfish. Kepler only needs to access chassis and system to get the power info. Currently the existing redfish golang bindings based on OpenAPI client or gofish are overkill. This PR uses simple access models. 

#644

Tasks:
- [x] Redfish access credential management
- [x] Create Redfish API model
- [x] Use Redfish API model to retrieve power metrics
- [x] Kepler collector reads Redfish power metrics
- [x] Kepler emits Redfish power metrics
- [x] Test on real servers (Dell/HPE)
- [x] Document BMC power metrics
- [ ] (stretch) Support temperature, fan, humidity metrics