### PR TITLE
fix: podman failing to push to local registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,13 @@ endif
 
 ifdef CTR_CMD
 	CTR_CMD := $(CTR_CMD)
-else 
+else
 	CTR_CMD :=$(or $(shell which podman 2>/dev/null), $(shell which docker 2>/dev/null))
 endif
+
+# use CTR_CMD_PUSH_OPTIONS to add options to <container-runtime> push command.
+# E.g. --tls-verify=false for local develop when using podman
+CTR_CMD_PUSH_OPTIONS ?=
 
 
 ifeq ($(DEBUG),true)
@@ -121,7 +125,7 @@ build_containerized: genbpfassets tidy-vendor format
 .PHONY: build_containerized
 
 push-image:
-	$(CTR_CMD) push $(IMAGE_REPO)/kepler:$(IMAGE_TAG)
+	$(CTR_CMD) push $(CTR_CMD_PUSH_OPTIONS) $(IMAGE_REPO)/kepler:$(IMAGE_TAG)
 .PHONY: push-image
 
 clean-cross-build:


### PR DESCRIPTION
When using podman to bring up a local cluster, using the command below,

```
export CLUSTER_PROVIDER=kind
make cluster-sync IMAGE_REPO="localhost:5001" IMAGE_TAG="devel"
```
it fails with the following error when pushing kepler image to local
registry.

```
Error: trying to reuse blob sha256:119391 at destination:
  pinging container registry localhost:5001:
  Get "https://localhost:5001/v2/": http: server gave HTTP response to HTTPS client
make[1]: *** [Makefile:128: push-image] Error 125
```

This patch fixes it by allowing push options to be specified. E.g. when
using podman, you can turn off tls-verify by ...

```
export CLUSTER_PROVIDER=kind
make cluster-sync IMAGE_REPO="localhost:5001" IMAGE_TAG="devel" CTR_CMD_PUSH_OPTIONS=--tls-verify=false
```

Signed-off-by: Sunil Thaha <sthaha@redhat.com>
