### PR TITLE
Add bcc tags to let the e2e_metric_test.go cases be executed in CI.

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: test if kepler is still alive
         run: |
           sleep 60
-          kubectl logs $(kubectl -n kepler get pods -oname) -n kepler
+          kubectl logs $(kubectl -n kepler get pods -o name) -n kepler
           kubectl get all -n kepler
       
       - name: run integration_test
@@ -40,9 +40,9 @@ jobs:
           docker ps -a
           mkdir -p /tmp/.kube
           kind get kubeconfig --name=kind > /tmp/.kube/config
-          kubectl port-forward --address localhost $(kubectl -n kepler get pods -oname) 9102:9102 -n kepler -v7 &
+          kubectl port-forward --address localhost $(kubectl -n kepler get pods -o name) 9102:9102 -n kepler -v7 &
           kubectl logs -n kepler daemonset/kepler-exporter
           kubectl get pods -n kepler -o yaml
-          go test ./e2e/... -v --race --bench=. -cover --count=1 --vet=all
+          go test ./e2e/... --tags bcc -v --race --bench=. -cover --count=1 --vet=all
         env:
             kepler_address: localhost:9102

--- a/e2e/e2e_metric_test.go
+++ b/e2e/e2e_metric_test.go
@@ -141,7 +141,6 @@ var _ = Describe("metrics check should pass", Ordered, func() {
 		EntryDescription("checking %s"),
 		Entry(nil, "kepler_container_core_joules_total"),                  // pod level
 		Entry(nil, "kepler_container_dram_joules_total"),                  // pod level
-		Entry(nil, "kepler_container_gpu_joules_total"),                   // pod level
 		Entry(nil, "kepler_container_joules_total"),                       // pod level
 		Entry(nil, "kepler_container_other_host_components_joules_total"), // pod level
 		Entry(nil, "kepler_container_package_joules_total"),               // pod level


### PR DESCRIPTION
Add bcc tags  in go test command to let the e2e_metric_test.go cases be executed in CI.
Since there is bcc "go:build" annotation there.
See #738. 