### PR TITLE
doc: tiny fix for deployment on kind

### DIFF
--- a/doc/dev/README.md
+++ b/doc/dev/README.md
@@ -21,7 +21,7 @@ following [this enhancements propsal](../../enhancements/CICDv1.md) and
 
 ## Deploying kepler in the cluster
 ```bash
-export CLUSTER_PROVIDER=`kind`
+export CLUSTER_PROVIDER='kind'
 IMAGE_REPO="localhost:5001" IMAGE_TAG="devel" make cluster-sync
 ```
 


### PR DESCRIPTION
with
```
export CLUSTER_PROVIDER=`kind`
```
results in incorrect env value. this fails kepler deployment on kind.

```
$ echo $CLUSTER_PROVIDER
kind creates and manages local Kubernetes clusters using Docker container 'nodes' Usage: kind [command] Available Commands: build Build one of [node-image] completion Output shell completion code for the specified shell (bash, zsh or fish) create Creates one of [cluster] delete Deletes one of [cluster] export Exports one of [kubeconfig, logs] get Gets one of [clusters, nodes, kubeconfig] help Help about any command load Loads images into nodes version Prints the kind CLI version Flags: -h, --help help for kind --loglevel string DEPRECATED: see -v instead -q, --quiet silence all stderr output -v, --verbosity int32 info log verbosity, higher value produces more output --version version for kind Use "kind [command] --help" for more information about a command.
```