### PR TITLE
community: create Kepler Adivsory Committee and seeding advisors

### DIFF
--- a/ADVISORS.md
+++ b/ADVISORS.md
@@ -1,0 +1,7 @@
+# Members of Advisory Committee
+
+|  Name  |  Company  | Github ID  or Email   |
+|---|---|---|
+| Sandro Mazziotta | Red Hat | smazziot@redhat.com |
+| Eun K Lee | IBM | eunkyung.lee@us.ibm.com |
+| Cathy Zhang |  Intel | cathy.h.zhang@intel.com |

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -49,3 +49,15 @@ Responsibilities include:
 * Regularly triage GitHub issues. 
 * Make sure that ongoing PRs are moving forward at the right pace or closing them
 * Monitor Kepler Slack (delayed response is perfectly acceptable), particularly for the area of your expertise
+
+# Advisory Committee
+
+Advisory committee provides guidance for the overall direction of the Kepler project, including but not limited to:
+* Project roadmap
+* Project governance
+* Project releases
+* Project marketing
+
+Members of the advisory committee are expected to be active in the Kepler community and attend the advisory committee meetings.
+Members are expected to serve for a term of one year, with the option to renew for additional terms.
+Members are invited and approved by the Kepler maintainers.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,4 +17,5 @@
 | Brad McCoy | Basiq | bradmccoydev | bradmccoydev@gmail.com |
 | Sunyanan Choochotkaew | IBM |  sunya-ch | sunyanan.choochotkaew1@ibm.com | 
 | Ruomeng Hao | Intel | ruomengh | ruomengh@intel.com | 
-Chen Wang | IBM | wangchen615 | chen.wang1@ibm.com |
+| Chen Wang | IBM | wangchen615 | chen.wang1@ibm.com |
+


### PR DESCRIPTION
As discussed in the 06/21 Kepler community meeting, the Kepler Advisory Committee is designed to promote R&D, community engagement, and end user adoption. The scope of the committee and seeding committee members are proposed in this PR.