### PR TITLE
Refactor platform package to use different sources like acpi or redfish

### DIFF
--- a/pkg/collector/metric_collector.go
+++ b/pkg/collector/metric_collector.go
@@ -24,7 +24,6 @@ import (
 	"github.com/sustainable-computing-io/kepler/pkg/cgroup"
 	"github.com/sustainable-computing-io/kepler/pkg/config"
 	"github.com/sustainable-computing-io/kepler/pkg/power/accelerator"
-	"github.com/sustainable-computing-io/kepler/pkg/power/acpi"
 	"github.com/sustainable-computing-io/kepler/pkg/utils"
 
 	collector_metric "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
@@ -41,8 +40,6 @@ const (
 type Collector struct {
 	// instance that collects the bpf metrics
 	bpfHCMeter *attacher.BpfModuleTables
-	// instance that collects the node energy consumption
-	acpiPowerMeter *acpi.ACPI
 
 	// NodeMetrics holds all node energy and resource usage metrics
 	NodeMetrics collector_metric.NodeMetrics
@@ -60,7 +57,6 @@ type Collector struct {
 
 func NewCollector() *Collector {
 	c := &Collector{
-		acpiPowerMeter:         acpi.NewACPIPowerMeter(),
 		NodeMetrics:            *collector_metric.NewNodeMetrics(),
 		ContainersMetrics:      map[string]*collector_metric.ContainerMetrics{},
 		ProcessMetrics:         map[uint64]*collector_metric.ProcessMetrics{},
@@ -85,7 +81,6 @@ func (c *Collector) Initialize() error {
 
 	c.prePopulateContainerMetrics(pods)
 	c.updateNodeEnergyMetrics()
-	c.acpiPowerMeter.Run(attacher.HardwareCountersEnabled)
 
 	return nil
 }

--- a/pkg/collector/node_energy_collector.go
+++ b/pkg/collector/node_energy_collector.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sustainable-computing-io/kepler/pkg/model"
 	"github.com/sustainable-computing-io/kepler/pkg/power/accelerator"
 	"github.com/sustainable-computing-io/kepler/pkg/power/components"
+	"github.com/sustainable-computing-io/kepler/pkg/power/platform"
 
 	"k8s.io/klog/v2"
 )
@@ -39,8 +40,8 @@ func (c *Collector) updateNodeResourceUsage() {
 // updateMeasuredNodeEnergy updates the node platfomr power consumption, i.e, the node total power consumption
 func (c *Collector) updatePlatformEnergy(wg *sync.WaitGroup) {
 	defer wg.Done()
-	if c.acpiPowerMeter.IsPowerSupported() {
-		nodePlatformEnergy, _ := c.acpiPowerMeter.GetEnergyFromHost()
+	if platform.IsSystemCollectionSupported() {
+		nodePlatformEnergy, _ := platform.GetEnergyFromPlatform()
 		c.NodeMetrics.SetLastestPlatformEnergy(nodePlatformEnergy, true)
 	} else if model.IsNodePlatformPowerModelEnabled() {
 		nodePlatformEnergy := model.GetEstimatedNodePlatformPower(&c.NodeMetrics)
@@ -89,7 +90,6 @@ func (c *Collector) updateNodeAvgCPUFrequency(wg *sync.WaitGroup) {
 		c.NodeMetrics.CPUFrequency = cpuFreq
 		return
 	}
-	c.NodeMetrics.CPUFrequency = c.acpiPowerMeter.GetCPUCoreFrequency()
 }
 
 // updateNodeEnergyMetrics updates the node energy consumption of each component

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,6 +53,9 @@ const (
 	defaultModelRequestPath = "/model"
 	// MaxIRQ is the maximum number of IRQs to be monitored
 	MaxIRQ = 10
+
+	// SamplePeriodSec is the time in seconds that the reader will wait before reading the metrics again
+	SamplePeriodSec = 3
 )
 
 var (

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -20,13 +20,12 @@ import (
 	"time"
 
 	"github.com/sustainable-computing-io/kepler/pkg/collector"
+	"github.com/sustainable-computing-io/kepler/pkg/config"
 	"github.com/sustainable-computing-io/kepler/pkg/kubernetes"
 )
 
 const (
-	// SamplePeriodSec is the time in seconds that the reader will wait before reading the metrics again
-	SamplePeriodSec = 3
-	samplePeriod    = SamplePeriodSec * 1000 * time.Millisecond
+	samplePeriod = config.SamplePeriodSec * 1000 * time.Millisecond
 )
 
 type CollectorManager struct {
@@ -48,7 +47,7 @@ func New() *CollectorManager {
 	manager.PrometheusCollector.NodeMetrics = &manager.MetricCollector.NodeMetrics
 	manager.PrometheusCollector.ContainersMetrics = &manager.MetricCollector.ContainersMetrics
 	manager.PrometheusCollector.ProcessMetrics = &manager.MetricCollector.ProcessMetrics
-	manager.PrometheusCollector.SamplePeriodSec = SamplePeriodSec
+	manager.PrometheusCollector.SamplePeriodSec = config.SamplePeriodSec
 	// configure the wather
 	manager.Watcher = kubernetes.NewObjListWatcher()
 	manager.Watcher.Mx = &manager.PrometheusCollector.Mx

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -6,13 +6,14 @@ package manager
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/sustainable-computing-io/kepler/pkg/config"
 )
 
 var _ = Describe("Manager", func() {
 
 	It("Should work properly", func() {
 		CollectorManager := New()
-		Expect(float64(SamplePeriodSec)).To(Equal(CollectorManager.PrometheusCollector.SamplePeriodSec))
+		Expect(float64(config.SamplePeriodSec)).To(Equal(CollectorManager.PrometheusCollector.SamplePeriodSec))
 		err := CollectorManager.Start()
 		// for no bcc tag in CI
 		Expect(err).To(HaveOccurred())

--- a/pkg/power/components/power.go
+++ b/pkg/power/components/power.go
@@ -17,8 +17,6 @@ limitations under the License.
 package components
 
 import (
-	"runtime"
-
 	"k8s.io/klog/v2"
 
 	"github.com/sustainable-computing-io/kepler/pkg/config"
@@ -47,21 +45,10 @@ var (
 	sysfsImpl                        = &source.PowerSysfs{}
 	msrImpl                          = &source.PowerMSR{}
 	apmXgeneSysfsImpl                = &source.ApmXgeneSysfs{}
-	hmcImpl                          = &source.PowerHMC{}
 	powerImpl         powerInterface = sysfsImpl
 )
 
-func initPowerImpls390x() {
-	if hmcImpl.IsSystemCollectionSupported() {
-		klog.V(1).Infoln("use hmc to obtain power")
-		powerImpl = hmcImpl
-	} else {
-		klog.V(1).Infoln("Not able to obtain power, use estimate method")
-		powerImpl = estimateImpl
-	}
-}
-
-func initPowerImpl() {
+func InitPowerImpl() {
 	if sysfsImpl.IsSystemCollectionSupported() /*&& false*/ {
 		klog.V(1).Infoln("use sysfs to obtain power")
 		powerImpl = sysfsImpl
@@ -78,14 +65,6 @@ func initPowerImpl() {
 				powerImpl = estimateImpl
 			}
 		}
-	}
-}
-
-func InitPowerImpl() {
-	if runtime.GOARCH == "s390x" {
-		initPowerImpls390x()
-	} else {
-		initPowerImpl()
 	}
 }
 

--- a/pkg/power/platform/power.go
+++ b/pkg/power/platform/power.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platform
+
+import (
+	"runtime"
+
+	"github.com/sustainable-computing-io/kepler/pkg/power/platform/source"
+	"k8s.io/klog/v2"
+)
+
+type powerInterface interface {
+	// GetEnergyFromPlatform returns mJ in DRAM
+	GetEnergyFromPlatform() (map[string]float64, error)
+	// StopPower stops the collection
+	StopPower()
+	// IsSystemCollectionSupported returns if it is possible to use this collector
+	IsSystemCollectionSupported() bool
+}
+
+var (
+	powerImpl powerInterface = source.NewACPIPowerMeter()
+	hmcImpl                  = &source.PowerHMC{}
+)
+
+func InitPowerImpl() {
+	// switch the platform power collector source to hmc if the system architecture is s390x
+	// TODO: add redfish or ipmi as well.
+	if runtime.GOARCH == "s390x" {
+		klog.V(1).Infoln("use hmc to obtain power")
+		powerImpl = hmcImpl
+	}
+}
+
+func GetEnergyFromPlatform() (map[string]float64, error) {
+	return powerImpl.GetEnergyFromPlatform()
+}
+
+func IsSystemCollectionSupported() bool {
+	return powerImpl.IsSystemCollectionSupported()
+}
+
+func StopPower() {
+	powerImpl.StopPower()
+}

--- a/pkg/power/platform/source/hmc.go
+++ b/pkg/power/platform/source/hmc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023.
+Copyright 2022.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,30 +18,15 @@ package source
 
 type PowerHMC struct{}
 
-func (r *PowerHMC) IsSystemCollectionSupported() bool {
+func (a *PowerHMC) StopPower() {
+}
+
+func (a *PowerHMC) IsSystemCollectionSupported() bool {
 	return false
 }
 
-func (r *PowerHMC) StopPower() {
-}
-
-func (r *PowerHMC) GetEnergyFromDram() (uint64, error) {
-	return 0, nil
-}
-
-func (r *PowerHMC) GetEnergyFromCore() (uint64, error) {
-	return 0, nil
-}
-
-func (r *PowerHMC) GetEnergyFromUncore() (uint64, error) {
-	return 0, nil
-}
-
-func (r *PowerHMC) GetEnergyFromPackage() (uint64, error) {
-	return 0, nil
-}
-
-func (r *PowerHMC) GetNodeComponentsEnergy() map[int]NodeComponentsEnergy {
-	packageEnergies := make(map[int]NodeComponentsEnergy)
-	return packageEnergies
+// GetEnergyFromHost returns the accumulated energy consumption
+func (a *PowerHMC) GetEnergyFromPlatform() (map[string]float64, error) {
+	power := map[string]float64{}
+	return power, nil
 }


### PR DESCRIPTION
Currently, we collect power measurements from various resources, including:
- NODE COMPONENTS: CPU and DRAM
- GPU
- PLATFORM (representing the total node power)

The power or energy consumption of each resource can come from different sources. For instance:
- NODE COMPONENTS can be obtained from different RAPL sources
- GPU power can be measured using nvml or other methods
- PLATFORM power can be derived from RAPL, ACPI, Redfish, or IPMI (currently we only have ACPI, but the PR #734 adds Redfish)

However, the code structure is somewhat confusing, particularly because the interfaces for NODE COMPONENTS and GPU allow the use of different sources, while the PLATFORM component lacks this flexibility.

This pull request aims to align the PLATFORM package with the other components, enabling the addition of different power/energy sources for data collection.