### PR TITLE
cgroup: fix incorrect block device count

### DIFF
--- a/pkg/cgroup/cgroup_stats_linux.go
+++ b/pkg/cgroup/cgroup_stats_linux.go
@@ -99,11 +99,11 @@ func (c CCgroupV1StatManager) SetCGroupStat(containerID string, cgroupStatMap ma
 		for _, ioEntry := range stat.Blkio.IoServiceBytesRecursive {
 			if ioEntry.Op == "Read" {
 				cgroupStatMap[config.CgroupfsReadIO].AddDeltaStat(containerID, ioEntry.Value)
+				cgroupStatMap[config.BlockDevicesIO].AddDeltaStat(containerID, 1)
 			}
 			if ioEntry.Op == "Write" {
 				cgroupStatMap[config.CgroupfsWriteIO].AddDeltaStat(containerID, ioEntry.Value)
 			}
-			cgroupStatMap[config.BlockDevicesIO].AddDeltaStat(containerID, 1)
 		}
 	}
 	return nil


### PR DESCRIPTION
If you look at how the containerd cgroup library defines an [entry](https://github.com/sustainable-computing-io/kepler/blob/2a32491025b34adc97cab7237ee7ab6070fe9b2a/vendor/github.com/containerd/cgroups/blkio.go#L211) and the format of the cgroup file it is reading from, you can see there are 6 entries for every block device (one for each type of IO operation). This is causing Kepler to record 6x the true number of block devices for V1 cgroups. Instead, we should just count once every time a specific operation is seen (such as "Read"), since each operation will have exactly one entry per block device.
<img width="152" alt="Screenshot 2023-06-23 at 4 09 01 PM" src="https://github.com/sustainable-computing-io/kepler/assets/68564154/1e5b3069-f559-4aff-b9bc-cce4b972bcb1">
