### PR TITLE
fix: only report warning when given kernel path

### DIFF
--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -156,8 +156,10 @@ func main() {
 	config.EnabledMSR = *enabledMSR
 	config.SetKubeConfig(*kubeconfig)
 	config.SetEnableAPIServer(*apiserverEnabled)
-	if err := config.SetKernelSourceDir(*kernelSourceDirPath); err != nil {
-		klog.Warningf("failed to set kernel source dir to %q: %v", *kernelSourceDirPath, err)
+	if *kernelSourceDirPath != "" {
+		if err := config.SetKernelSourceDir(*kernelSourceDirPath); err != nil {
+			klog.Warningf("failed to set kernel source dir to %q: %v", *kernelSourceDirPath, err)
+		}
 	}
 
 	// the ebpf batch deletion operation was introduced in linux kernel 5.6, which provides better performance to delete keys.


### PR DESCRIPTION
see this 
```
W0629 10:31:12.805210 3680280 exporter.go:160] failed to set kernel source dir to "": stat : no such file or directory
```

seems we should only set kernel path when it's not empty..