### PR TITLE
Add support for Microshift in CI

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -8,41 +8,31 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        kube_provider: [kind]
+        cluster_provider: [kind,microshift]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
 
-      - name: use kepler action for kind cluster build
-        uses: sustainable-computing-io/kepler-action@v0.0.0
+      - name: use kepler action for cluster build
+        uses: sustainable-computing-io/kepler-action@main
         with:
-          runningBranch: kind
+          runningBranch: ${{matrix.cluster_provider}}
+          local_dev_cluster_version: main
+          cluster_provider: ${{matrix.cluster_provider}}
 
       - name: simple test - deploy kepler
         run: make cluster-sync
         env:
-            CLUSTER_PROVIDER: ${{matrix.kube_provider}}
-            IMAGE_REPO: "localhost:5001"
-            IMAGE_TAG: "devel"
-            CTR_CMD: docker
-            CI_ONLY: "true"
+          CLUSTER_PROVIDER: ${{matrix.cluster_provider}}
+          IMAGE_REPO: "localhost:5001"
+          IMAGE_TAG: "devel"
+          CTR_CMD: docker
+          CI_ONLY: "true"
 
-      - name: test if kepler is still alive
-        run: |
-          sleep 60
-          kubectl logs $(kubectl -n kepler get pods -o name) -n kepler
-          kubectl get all -n kepler
-      
       - name: run integration_test
-        run: |
-          docker ps -a
-          mkdir -p /tmp/.kube
-          kind get kubeconfig --name=kind > /tmp/.kube/config
-          while true; do kubectl port-forward --address localhost -n kepler service/kepler-exporter 9102:9102; done &
-          kubectl logs -n kepler daemonset/kepler-exporter
-          kubectl get pods -n kepler -o yaml
-          go test ./e2e/... --tags bcc -v --race --bench=. -cover --count=1 --vet=all
+        run: make integration-test
         env:
-            kepler_address: localhost:9102
+          CLUSTER_PROVIDER: ${{matrix.cluster_provider}}
+          kepler_address: localhost:9102

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -3,36 +3,94 @@ name: Integration test
 on:
   pull_request:
 
+env:
+  GO_VERSION: "1.18"
+  OUTPUT_DIR: "_output/"
+  FILE_NAME: "kepler.tar.gz"
+
 jobs:
+  build-kepler:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout source
+        uses: actions/checkout@v3
+
+      - name: install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{env.GO_VERSION}}
+
+      - name: build manifest
+        run: make build-manifest OPTS="CI_DEPLOY"
+
+      - name: build and export Kepler image
+        run: |
+          make build_containerized
+          make save-image
+        env:
+          IMAGE_REPO: "localhost:5001"
+          IMAGE_TAG: "devel"
+          CTR_CMD: docker
+          IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}${{env.FILE_NAME}}
+
+      - name: save Kepler image as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: kepler
+          path: ${{env.OUTPUT_DIR}}${{env.FILE_NAME}}
+
   integration_test:
+    needs: [build-kepler]
     runs-on: ubuntu-20.04
     strategy:
       matrix:
         cluster_provider: [kind,microshift]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
+      - name: checkout source
+        uses: actions/checkout@v3
 
-      - name: use kepler action for cluster build
-        uses: sustainable-computing-io/kepler-action@main
+      - name: download Kepler image artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: kepler
+
+      - name: build manifest
+        run: make build-manifest OPTS="CI_DEPLOY"
+
+      - name: import Kepler image
+        run: make load-image
+        env:
+          IMAGE_REPO: "localhost:5001"
+          IMAGE_TAG: "devel"
+          CTR_CMD: docker
+          INPUT_PATH: ${{env.FILE_NAME}}
+
+      - name: use Kepler action to deploy cluster
+        uses: sustainable-computing-io/kepler-action@v0.0.0
         with:
           runningBranch: ${{matrix.cluster_provider}}
           local_dev_cluster_version: main
           cluster_provider: ${{matrix.cluster_provider}}
 
-      - name: simple test - deploy kepler
-        run: make cluster-sync
+      - name: push Kepler image to load registry
+        run: |
+          make push-image
+          make image-prune
+        env:
+          IMAGE_REPO: "localhost:5001"
+          IMAGE_TAG: "devel"
+          CTR_CMD: docker
+
+      - name: deploy Kepler on cluster
+        run: make cluster-deploy
         env:
           CLUSTER_PROVIDER: ${{matrix.cluster_provider}}
           IMAGE_REPO: "localhost:5001"
           IMAGE_TAG: "devel"
           CTR_CMD: docker
-          CI_ONLY: "true"
 
-      - name: run integration_test
-        run: make integration-test
+      - name: run e2e tests
+        run: make e2e
         env:
           CLUSTER_PROVIDER: ${{matrix.cluster_provider}}
           kepler_address: localhost:9102

--- a/Makefile
+++ b/Makefile
@@ -267,5 +267,9 @@ cluster-up:
 	./hack/cluster-up.sh
 .PHONY: cluster-up
 
+integration-test:
+	./hack/verify.sh test
+.PHONY: integration-test
+
 check: tidy-vendor set_govulncheck govulncheck format golint test
 .PHONY: check

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,18 @@ build_containerized: genbpfassets tidy-vendor format
 
 .PHONY: build_containerized
 
+save-image:
+	$(CTR_CMD) save $(IMAGE_REPO)/kepler:$(IMAGE_TAG) | gzip > "${IMAGE_OUTPUT_PATH}"
+.PHONY: save-image
+
+load-image:
+	$(CTR_CMD) load -i "${INPUT_PATH}"
+.PHONY: load-image
+
+image-prune:
+	$(CTR_CMD) image prune -a -f || true
+.PHONY: image-prune
+
 push-image:
 	$(CTR_CMD) push $(CTR_CMD_PUSH_OPTIONS) $(IMAGE_REPO)/kepler:$(IMAGE_TAG)
 .PHONY: push-image
@@ -255,8 +267,8 @@ cluster-clean: build-manifest
 	./hack/cluster-clean.sh
 .PHONY: cluster-clean
 
-cluster-deploy: cluster-clean
-	BARE_METAL_NODE_ONLY=false ./hack/cluster-deploy.sh
+cluster-deploy:
+	./hack/cluster-deploy.sh
 .PHONY: cluster-deploy
 
 cluster-sync:
@@ -267,9 +279,9 @@ cluster-up:
 	./hack/cluster-up.sh
 .PHONY: cluster-up
 
-integration-test:
+e2e:
 	./hack/verify.sh test
-.PHONY: integration-test
+.PHONY: e2e
 
 check: tidy-vendor set_govulncheck govulncheck format golint test
 .PHONY: check

--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -25,38 +25,27 @@ CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
 MANIFESTS_OUT_DIR=${MANIFESTS_OUT_DIR:-"_output/generated-manifest"}
 
 function main() {
+    if [ "$CI_ONLY" == "true" ] && [ "$CLUSTER_PROVIDER" == "microshift" ]
+    then
+        $CTR_CMD image prune -a -f || true && $CTR_CMD restart microshift
+        wait_microshift_up
+    fi
+
     [ ! -d "${MANIFESTS_OUT_DIR}" ] && echo "Directory ${MANIFESTS_OUT_DIR} DOES NOT exists. Run make generate first."
     
+    if [ "$CLUSTER_PROVIDER" == "microshift" ]
+    then
+        kubectl label node --all sustainable-computing.io/kepler=''
+        sed "s/localhost:5001/registry:5000/g" ${MANIFESTS_OUT_DIR}/deployment.yaml > ${MANIFESTS_OUT_DIR}/deployment.yaml.tmp && \
+            mv ${MANIFESTS_OUT_DIR}/deployment.yaml.tmp ${MANIFESTS_OUT_DIR}/deployment.yaml
+    fi
     echo "Deploying manifests..."
-
     # Ignore errors because some clusters might not have prometheus operator
     echo "Deploying with image:"
     cat ${MANIFESTS_OUT_DIR}/deployment.yaml | grep "image:"
-
     kubectl apply -f ${MANIFESTS_OUT_DIR} || true
     
-    # round for 3 times and each for 60s
-    # check if the rollout status is running
-    deploy_status=1
-    for i in 1 2 3
-    do
-        echo "check deployment status for round $i"
-        kubectl rollout status daemonset kepler-exporter -n kepler --timeout 60s
-        #check rollout status
-        if [ $? -eq 0 ]
-        then
-            deploy_status=0
-            break
-        fi
-    done 
-    # if deployment in error
-    if test $[deploy_status] -eq 1
-    then
-        echo "Check the status of the kepler-exporter"
-        kubectl -n kepler describe daemonset.apps/kepler-exporter
-        echo "Check the logs of the kepler-exporter"
-        kubectl -n kepler logs daemonset.apps/kepler-exporter
-    fi
+    ./hack/verify.sh kepler
 }
 
 main "$@"

--- a/hack/cluster-sync.sh
+++ b/hack/cluster-sync.sh
@@ -27,23 +27,29 @@ export IMAGE_REPO=${IMAGE_REPO:-quay.io/sustainable_computing_io}
 
 # we do not use `make cluster-clean` and `make cluster-deploy` because they trigger other actions
 function main() {
-    if [ "$CI_ONLY" = true ] 
-    then
-        make build-manifest OPTS="CI_DEPLOY"
-    else
-        make build-manifest
-    fi
     
     ./hack/cluster-clean.sh &
     CLEAN_PID=$!
-
-    make build_containerized
-    make push-image
 
     echo "waiting for cluster-clean to finish"
     if ! wait $CLEAN_PID; then
         echo "cluster-clean failed"
     fi
+
+    if [ "$CI_ONLY" == "true" ]
+    then
+        if [ "$CLUSTER_PROVIDER" == "microshift" ]
+        then
+            make build-manifest OPTS="CI_DEPLOY OPENSHIFT_DEPLOY" && $CTR_CMD stop microshift
+        else
+            make build-manifest OPTS="CI_DEPLOY"
+        fi
+    else
+        make build-manifest
+    fi
+
+    make build_containerized
+    make push-image
 
     ./hack/cluster-deploy.sh
 }

--- a/hack/cluster-up.sh
+++ b/hack/cluster-up.sh
@@ -20,7 +20,7 @@ if [ -d local-dev-cluster ]
 then
 	echo "use local local-dev-cluster"
 else
-    echo "download local-dev-cluster with latest version"
-	git clone https://github.com/sustainable-computing-io/local-dev-cluster.git --depth=1
+    echo "download local-dev-cluster with version v0.0.0"
+	git clone -b v0.0.0 https://github.com/sustainable-computing-io/local-dev-cluster.git --depth=1
 fi
-cd local-dev-cluster && ./main.sh up
+cd local-dev-cluster && ./main.sh

--- a/hack/cluster-up.sh
+++ b/hack/cluster-up.sh
@@ -20,7 +20,7 @@ if [ -d local-dev-cluster ]
 then
 	echo "use local local-dev-cluster"
 else
-    echo "download local-dev-cluster with version v0.0.0"
-	git clone -b v0.0.0 https://github.com/sustainable-computing-io/local-dev-cluster.git --depth=1
+    echo "download local-dev-cluster with latest version"
+	git clone https://github.com/sustainable-computing-io/local-dev-cluster.git --depth=1
 fi
-cd local-dev-cluster && ./main.sh
+cd local-dev-cluster && ./main.sh up

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -32,7 +32,6 @@ CLUSTER_NAME=${KIND_CLUSTER_NAME:-kind}
 REGISTRY_NAME=${REGISTRY_NAME:-kind-registry}
 REGISTRY_PORT=${REGISTRY_PORT:-5001}
 KIND_DEFAULT_NETWORK="kind"
-MICROSHIFT_CONTAINER_NAME="microshift"
 
 IMAGE_REPO=${IMAGE_REPO:-localhost:5001}
 ESTIMATOR_REPO=${ESTIMATOR_REPO:-quay.io/sustainable_computing_io}
@@ -65,40 +64,7 @@ if [[ ${CLUSTER_PROVIDER} = "kind" ]]; then
     CLUSTER_PROVIDER="kubernetes"
 fi
 
-function get_pods() {
-     kubectl get pods --all-namespaces --no-headers
-}
-
 function wait_containers_ready {
      echo "waiting for all containers to become ready ..."
      kubectl wait --for=condition=Ready pod --all --all-namespaces --timeout 5m
 }
-
-function stop_microshift_container() {
-    $CTR_CMD stop "${MICROSHIFT_CONTAINER_NAME}"
-}
-
-function wait_microshift_up {
-    # wait till container is in running state
-    while [ "$(${CTR_CMD} inspect -f '{{.State.Status}}' "${MICROSHIFT_CONTAINER_NAME}")" != "running" ]; do
-        echo "waiting for container ${MICROSHIFT_CONTAINER_NAME} to start..."
-        sleep 5
-    done
-    echo "container ${MICROSHIFT_CONTAINER_NAME} is now running!"
-
-    echo "waiting for cluster to be ready ..."
-
-    while [ -z "$($CTR_CMD exec --privileged "${MICROSHIFT_CONTAINER_NAME}" \
-        kubectl --kubeconfig=/var/lib/microshift/resources/kubeadmin/kubeconfig \
-        get nodes -o=jsonpath='{.items..status.conditions[-1:].status}' | grep True)" ]; do
-        echo "waiting for microshift cluster to be ready ..."
-        sleep 5
-    done
-
-    while [ -n "$(get_pods | grep -v Running)" ]; do
-        echo "waiting for all pods to enter the Running state ..."
-        get_pods | >&2 grep -v Running || true
-        sleep 5
-    done
-     wait_containers_ready
- }

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -32,6 +32,7 @@ CLUSTER_NAME=${KIND_CLUSTER_NAME:-kind}
 REGISTRY_NAME=${REGISTRY_NAME:-kind-registry}
 REGISTRY_PORT=${REGISTRY_PORT:-5001}
 KIND_DEFAULT_NETWORK="kind"
+MICROSHIFT_CONTAINER_NAME="microshift"
 
 IMAGE_REPO=${IMAGE_REPO:-localhost:5001}
 ESTIMATOR_REPO=${ESTIMATOR_REPO:-quay.io/sustainable_computing_io}
@@ -63,3 +64,41 @@ esac
 if [[ ${CLUSTER_PROVIDER} = "kind" ]]; then
     CLUSTER_PROVIDER="kubernetes"
 fi
+
+function get_pods() {
+     kubectl get pods --all-namespaces --no-headers
+}
+
+function wait_containers_ready {
+     echo "waiting for all containers to become ready ..."
+     kubectl wait --for=condition=Ready pod --all --all-namespaces --timeout 5m
+}
+
+function stop_microshift_container() {
+    $CTR_CMD stop "${MICROSHIFT_CONTAINER_NAME}"
+}
+
+function wait_microshift_up {
+    # wait till container is in running state
+    while [ "$(${CTR_CMD} inspect -f '{{.State.Status}}' "${MICROSHIFT_CONTAINER_NAME}")" != "running" ]; do
+        echo "waiting for container ${MICROSHIFT_CONTAINER_NAME} to start..."
+        sleep 5
+    done
+    echo "container ${MICROSHIFT_CONTAINER_NAME} is now running!"
+
+    echo "waiting for cluster to be ready ..."
+
+    while [ -z "$($CTR_CMD exec --privileged "${MICROSHIFT_CONTAINER_NAME}" \
+        kubectl --kubeconfig=/var/lib/microshift/resources/kubeadmin/kubeconfig \
+        get nodes -o=jsonpath='{.items..status.conditions[-1:].status}' | grep True)" ]; do
+        echo "waiting for microshift cluster to be ready ..."
+        sleep 5
+    done
+
+    while [ -n "$(get_pods | grep -v Running)" ]; do
+        echo "waiting for all pods to enter the Running state ..."
+        get_pods | >&2 grep -v Running || true
+        sleep 5
+    done
+     wait_containers_ready
+ }

--- a/hack/verify.sh
+++ b/hack/verify.sh
@@ -27,10 +27,7 @@ CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
 MANIFESTS_OUT_DIR=${MANIFESTS_OUT_DIR:-"_output/generated-manifest"}
 
 function check_deployment_status() {
-    # round for 3 times and each for 60s
-    # check if the rollout status is running
     deploy_status=1
-    echo "check deployment status for round $i"
     kubectl rollout status daemonset kepler-exporter -n kepler --timeout 5m
     #check rollout status
     if [ $? -eq 0 ]
@@ -61,7 +58,7 @@ function intergration_test() {
     else
         kind get kubeconfig --name=kind > /tmp/.kube/config
     fi
-    kubectl port-forward --address localhost $(kubectl -n kepler get pods -o name) 9102:9102 -n kepler -v7 &
+    while true; do kubectl port-forward --address localhost -n kepler service/kepler-exporter 9102:9102; done &
     kubectl logs -n kepler daemonset/kepler-exporter
     kubectl get pods -n kepler -o yaml
     go test ./e2e/... --tags bcc -v --race --bench=. -cover --count=1 --vet=all

--- a/hack/verify.sh
+++ b/hack/verify.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# This file is part of the Kepler project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 The Kepler Contributors
+#
+
+set -e
+set -o pipefail
+set -x
+
+source ./hack/common.sh
+
+CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kubernetes}
+MANIFESTS_OUT_DIR=${MANIFESTS_OUT_DIR:-"_output/generated-manifest"}
+
+function check_deployment_status() {
+    # round for 3 times and each for 60s
+    # check if the rollout status is running
+    deploy_status=1
+    echo "check deployment status for round $i"
+    kubectl rollout status daemonset kepler-exporter -n kepler --timeout 5m
+    #check rollout status
+    if [ $? -eq 0 ]
+    then
+        deploy_status=0
+    fi
+    # if deployment in error
+    if test $[deploy_status] -eq 1
+    then
+        echo "check the status of the kepler-exporter"
+        kubectl -n kepler describe daemonset.apps/kepler-exporter
+        echo "check the logs of the kepler-exporter"
+        kubectl -n kepler logs daemonset.apps/kepler-exporter
+    else
+        wait_containers_ready
+        echo "check if kepler is still alive"
+        kubectl logs $(kubectl -n kepler get pods -o name) -n kepler
+        kubectl get all -n kepler
+    fi
+}
+
+function intergration_test() {
+    $CTR_CMD ps -a
+    mkdir -p /tmp/.kube
+    if [ "$CLUSTER_PROVIDER" == "microshift" ]
+    then
+        $CTR_CMD exec -i microshift cat /var/lib/microshift/resources/kubeadmin/kubeconfig > /tmp/.kube/config
+    else
+        kind get kubeconfig --name=kind > /tmp/.kube/config
+    fi
+    kubectl port-forward --address localhost $(kubectl -n kepler get pods -o name) 9102:9102 -n kepler -v7 &
+    kubectl logs -n kepler daemonset/kepler-exporter
+    kubectl get pods -n kepler -o yaml
+    go test ./e2e/... --tags bcc -v --race --bench=. -cover --count=1 --vet=all
+}
+
+function main() {
+    # verify the deployment of cluster
+    case $1 in
+    kepler)
+        check_deployment_status
+        ;;
+    test)
+        intergration_test
+        ;;
+    *)
+        check_deployment_status
+        intergration_test
+        ;;
+    esac
+}
+
+main "$@"

--- a/manifests/config/exporter/patch/patch-ci.yaml
+++ b/manifests/config/exporter/patch/patch-ci.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -19,5 +18,5 @@ spec:
           type: Directory
       - name: proc
         hostPath:
-          path: /proc-host
+          path: /proc
           type: Directory


### PR DESCRIPTION
Since we have added support for having microshift as a cluster in the [local-dev-cluster](https://github.com/sustainable-computing-io/local-dev-cluster/pull/18) repo and updated the [kepler-action](https://github.com/sustainable-computing-io/kepler-action/pull/48) as well This PR is in continuation to add support for running Kepler integration tests on microshift cluster.

**Dependency:**
There is an open [PR](https://github.com/sustainable-computing-io/kepler-action/pull/51) in Kepler-action to update some recent [changes](https://github.com/sustainable-computing-io/local-dev-cluster/pull/20) done to local-dev-cluster repo.

CC: @SamYuan1990 @rootfs 