### PR TITLE
CI: add path ignore to ensure rfc will not trigger CI.

### DIFF
--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -3,7 +3,8 @@ name: gofmt
 on:
   pull_request:
     paths-ignore:
-      - 'docs/**'
+      - 'doc/**'
+      - 'enhancements/**'
 
 jobs:
   gofmt_test:

--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -2,6 +2,8 @@ name: gofmt
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   gofmt_test:

--- a/.github/workflows/gogc.yml
+++ b/.github/workflows/gogc.yml
@@ -3,7 +3,8 @@ name: go escapes detect
 on:
   pull_request:
     paths-ignore:
-      - 'docs/**'
+      - 'doc/**'
+      - 'enhancements/**'
 
 jobs:
   escapes_detect:

--- a/.github/workflows/gogc.yml
+++ b/.github/workflows/gogc.yml
@@ -2,6 +2,8 @@ name: go escapes detect
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   escapes_detect:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,6 +1,8 @@
 name: golangci-lint
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 permissions:
   contents: read

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,7 +2,8 @@ name: golangci-lint
 on:
   pull_request:
     paths-ignore:
-      - 'docs/**'
+      - 'doc/**'
+      - 'enhancements/**'
 
 permissions:
   contents: read

--- a/.github/workflows/govulnerability.yml
+++ b/.github/workflows/govulnerability.yml
@@ -2,6 +2,8 @@ name: go vulnerability detect
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   vulnerability_detect:

--- a/.github/workflows/govulnerability.yml
+++ b/.github/workflows/govulnerability.yml
@@ -3,7 +3,8 @@ name: go vulnerability detect
 on:
   pull_request:
     paths-ignore:
-      - 'docs/**'
+      - 'doc/**'
+      - 'enhancements/**'
 
 jobs:
   vulnerability_detect:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-      - 'docs/**'
+      - 'doc/**'
+      - 'enhancements/**'
 
 jobs:
   image_build:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -3,6 +3,8 @@ name: image
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   image_build:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -2,6 +2,8 @@ name: Integration test
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   integration_test:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -3,7 +3,8 @@ name: Integration test
 on:
   pull_request:
     paths-ignore:
-      - 'docs/**'
+      - 'doc/**'
+      - 'enhancements/**'
 
 jobs:
   integration_test:

--- a/.github/workflows/local_env.yml
+++ b/.github/workflows/local_env.yml
@@ -3,7 +3,8 @@ name: local env set up
 on:
   pull_request:
     paths-ignore:
-      - 'docs/**'
+      - 'doc/**'
+      - 'enhancements/**'
 
 jobs:
   integration_test:

--- a/.github/workflows/local_env.yml
+++ b/.github/workflows/local_env.yml
@@ -2,6 +2,8 @@ name: local env set up
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   integration_test:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -3,11 +3,13 @@ name: Unit test
 on:
   pull_request:
     paths-ignore:
-      - 'docs/**'
+      - 'doc/**'
+      - 'enhancements/**'
   push:
     branches: [ main ]
     paths-ignore:
-      - 'docs/**'
+      - 'doc/**'
+      - 'enhancements/**'
 
 permissions:
   pull-requests: write

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -2,8 +2,12 @@ name: Unit test
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
 
 permissions:
   pull-requests: write

--- a/.github/workflows/unit_test_mac.yml
+++ b/.github/workflows/unit_test_mac.yml
@@ -2,6 +2,8 @@ name: Unit test Mac
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   unit_test_mac:

--- a/.github/workflows/unit_test_mac.yml
+++ b/.github/workflows/unit_test_mac.yml
@@ -3,7 +3,8 @@ name: Unit test Mac
 on:
   pull_request:
     paths-ignore:
-      - 'docs/**'
+      - 'doc/**'
+      - 'enhancements/**'
 
 jobs:
   unit_test_mac:


### PR DESCRIPTION
ref https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
to add path ignore settings in CI to avoid rfc trigger an CI build.