### PR TITLE
CI: bump up CI version

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -69,10 +69,9 @@ jobs:
           INPUT_PATH: ${{env.FILE_NAME}}
 
       - name: use Kepler action to deploy cluster
-        uses: sustainable-computing-io/kepler-action@v0.0.0
+        uses: sustainable-computing-io/kepler-action@v0.0.1
         with:
           runningBranch: ${{matrix.cluster_provider}}
-          local_dev_cluster_version: main
           cluster_provider: ${{matrix.cluster_provider}}
 
       - name: push Kepler image to load registry

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           name: kepler
           path: ${{env.OUTPUT_DIR}}${{env.FILE_NAME}}
+          retention-days: 1
+          # ref https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
+          # as PR or Push event, we don't keep artifact in 90 days hence use 1 day here to save resources.
 
   integration_test:
     needs: [build-kepler]


### PR DESCRIPTION
as CI v0.0.1 released, bump version to v0.0.1 version and avoid checkout main branch for local dev cluster.
as an adjustment from dev branch CI to a release version.