### PR TITLE
explicitly set default make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+all: kepler
+
 include bpfassets/libbpf/Makefile
 
 ### env define ###


### PR DESCRIPTION
Thanks to report from @jichenjc  in https://github.com/sustainable-computing-io/kepler/pull/752#issuecomment-1624791332, this PR fixes the logic change after merging the PR https://github.com/sustainable-computing-io/kepler/pull/761 by explicitly setting the default target to `kepler` before include `Makefile` in bpfassets. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>

