### PR TITLE
ebpf: don't use bcc macro for softirq entry to avoid privilge requirement

### DIFF
--- a/bpfassets/perf_event/perf_event.c
+++ b/bpfassets/perf_event/perf_event.c
@@ -238,8 +238,17 @@ int kprobe__finish_task_switch(struct pt_regs *ctx, struct task_struct *prev)
     return 0;
 }
 
+struct trace_event_raw_softirq_entry {
+        unsigned short common_type;
+        unsigned char common_flags;
+        unsigned char common_preempt_count;
+        int common_pid;
+        unsigned int vec;
+};
+
 // per https://www.kernel.org/doc/html/latest/core-api/tracepoint.html#c.trace_softirq_entry
-TRACEPOINT_PROBE(irq, softirq_entry)
+// TRACEPOINT_PROBE(irq, softirq_entry)
+int tracepoint__irq__softirq_entry(struct trace_event_raw_softirq_entry *args)
 {
     u64 cur_pid = bpf_get_current_pid_tgid() >> 32;
     struct process_metrics_t *process_metrics;

--- a/pkg/bpfassets/perf_event_bindata.go
+++ b/pkg/bpfassets/perf_event_bindata.go
@@ -296,8 +296,17 @@ int kprobe__finish_task_switch(struct pt_regs *ctx, struct task_struct *prev)
     return 0;
 }
 
+struct trace_event_raw_softirq_entry {
+        unsigned short common_type;
+        unsigned char common_flags;
+        unsigned char common_preempt_count;
+        int common_pid;
+        unsigned int vec;
+};
+
 // per https://www.kernel.org/doc/html/latest/core-api/tracepoint.html#c.trace_softirq_entry
-TRACEPOINT_PROBE(irq, softirq_entry)
+// TRACEPOINT_PROBE(irq, softirq_entry)
+int tracepoint__irq__softirq_entry(struct trace_event_raw_softirq_entry *args)
 {
     u64 cur_pid = bpf_get_current_pid_tgid() >> 32;
     struct process_metrics_t *process_metrics;
@@ -386,13 +395,11 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//
-//	data/
-//	  foo.txt
-//	  img/
-//	    a.png
-//	    b.png
-//
+//     data/
+//       foo.txt
+//       img/
+//         a.png
+//         b.png
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("nonexistent") would return an error


### PR DESCRIPTION
fix #777 

the bcc macro appears to require privileged access to `/sys/kernel`. Early expansion should solve this issue

