### PR TITLE
add pod-security-admission labels for OCP namespace

### DIFF
--- a/manifests/config/exporter/exporter.yaml
+++ b/manifests/config/exporter/exporter.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: system
+  labels:
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/audit: privileged
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
In MicroShift > 4.12, to run privileged workloads, you must set pod-security labels on the namespace to `privileged` instead of `restricted`.  This PR adds the necessary namespace labels. 