### PR TITLE
set env for build-manifest on e2e test

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -26,6 +26,10 @@ jobs:
 
       - name: build manifest
         run: make build-manifest OPTS="CI_DEPLOY"
+        env:
+          IMAGE_REPO: "localhost:5001"
+          IMAGE_TAG: "devel"
+          CTR_CMD: docker
 
       - name: build and export Kepler image
         run: |
@@ -63,7 +67,11 @@ jobs:
 
       - name: build manifest
         run: make build-manifest OPTS="CI_DEPLOY"
-
+        env:
+          IMAGE_REPO: "localhost:5001"
+          IMAGE_TAG: "devel"
+          CTR_CMD: docker
+          
       - name: import Kepler image
         run: make load-image
         env:


### PR DESCRIPTION
This PR adds env to build manifest to fix the issue https://github.com/sustainable-computing-io/kepler/issues/784.

However, I'm not sure whether which image should be used in manifest in `kepler.tar.gz` for `build-kepler` job. 
Is it expected to be official image or locally-built image? @vprashar2929  Could you please confirm this?

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>