### PR TITLE
Respects configuration from environment variables

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -153,14 +153,14 @@ func getBoolConfig(configKey string, defaultBool bool) bool {
 func getConfig(configKey, defaultValue string) (result string) {
 	result = string([]byte(defaultValue))
 	key := string([]byte(configKey))
-	configFile := filepath.Join(configPath, key)
-	value, err := os.ReadFile(configFile)
-	if err == nil {
-		result = bytes.NewBuffer(value).String()
+	strValue, present := os.LookupEnv(key)
+	if present {
+		result = strValue
 	} else {
-		strValue, present := os.LookupEnv(key)
-		if present {
-			result = strValue
+		configFile := filepath.Join(configPath, key)
+		value, err := os.ReadFile(configFile)
+		if err == nil {
+			result = bytes.NewBuffer(value).String()
 		}
 	}
 	return


### PR DESCRIPTION
We can confiigure kepler-exporter via /etc/kepler/kepler.config and environment variables.

1. Read configuration from kepler.config
    - succeeded: returns value from configMap
    - failed: returns value from environment variable if it's available
2. return default value

Environment variable will not be used unless reading from configMap is failed. I think it is not intended, and it would be expected to override configuration from environment variable. So I think the configuration flow should be in below:

1. Returns environment variable if it's available
2. Otherwise returns configuration from kepler.config
3. Returns default value from argument if 2. is failed