### PR TITLE
fix integration ci after adding patch-kind

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -15,6 +15,9 @@ env:
 jobs:
   build-kepler:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        cluster_provider: [kind,microshift]
     steps:
       - name: checkout source
         uses: actions/checkout@v3
@@ -27,6 +30,7 @@ jobs:
       - name: build manifest
         run: make build-manifest OPTS="CI_DEPLOY"
         env:
+          CLUSTER_PROVIDER: ${{matrix.cluster_provider}}
           IMAGE_REPO: "localhost:5001"
           IMAGE_TAG: "devel"
           CTR_CMD: docker
@@ -39,13 +43,13 @@ jobs:
           IMAGE_REPO: "localhost:5001"
           IMAGE_TAG: "devel"
           CTR_CMD: docker
-          IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}${{env.FILE_NAME}}
+          IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}${{matrix.cluster_provider}}_${{env.FILE_NAME}}
 
       - name: save Kepler image as artifact
         uses: actions/upload-artifact@v3
         with:
           name: kepler
-          path: ${{env.OUTPUT_DIR}}${{env.FILE_NAME}}
+          path: ${{env.OUTPUT_DIR}}${{matrix.cluster_provider}}_${{env.FILE_NAME}}
           retention-days: 1
           # ref https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
           # as PR or Push event, we don't keep artifact in 90 days hence use 1 day here to save resources.
@@ -68,6 +72,7 @@ jobs:
       - name: build manifest
         run: make build-manifest OPTS="CI_DEPLOY"
         env:
+          CLUSTER_PROVIDER: ${{matrix.cluster_provider}}
           IMAGE_REPO: "localhost:5001"
           IMAGE_TAG: "devel"
           CTR_CMD: docker
@@ -78,7 +83,7 @@ jobs:
           IMAGE_REPO: "localhost:5001"
           IMAGE_TAG: "devel"
           CTR_CMD: docker
-          INPUT_PATH: ${{env.FILE_NAME}}
+          INPUT_PATH: ${{matrix.cluster_provider}}_${{env.FILE_NAME}}
 
       - name: use Kepler action to deploy cluster
         uses: sustainable-computing-io/kepler-action@v0.0.1

--- a/.github/workflows/integration_test_libbpf.yml
+++ b/.github/workflows/integration_test_libbpf.yml
@@ -15,6 +15,9 @@ env:
 jobs:
   build-kepler_with_libbpf:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        cluster_provider: [kind,microshift]
     steps:
       - name: checkout source
         uses: actions/checkout@v3
@@ -27,6 +30,7 @@ jobs:
       - name: build manifest
         run: make build-manifest OPTS="CI_DEPLOY"
         env:
+          CLUSTER_PROVIDER: ${{matrix.cluster_provider}}
           IMAGE_REPO: "localhost:5001"
           IMAGE_TAG: "devel"
           CTR_CMD: docker
@@ -40,13 +44,13 @@ jobs:
           IMAGE_REPO: "localhost:5001"
           IMAGE_TAG: "devel"
           CTR_CMD: docker
-          IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}${{env.FILE_NAME}}
+          IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}${{matrix.cluster_provider}}_${{env.FILE_NAME}}
 
       - name: save Kepler image as artifact
         uses: actions/upload-artifact@v3
         with:
           name: kepler
-          path: ${{env.OUTPUT_DIR}}${{env.FILE_NAME}}
+          path: ${{env.OUTPUT_DIR}}${{matrix.cluster_provider}}_${{env.FILE_NAME}}
           retention-days: 1
           # ref https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
           # as PR or Push event, we don't keep artifact in 90 days hence use 1 day here to save resources.
@@ -69,6 +73,7 @@ jobs:
       - name: build manifest
         run: make build-manifest OPTS="CI_DEPLOY"
         env:
+          CLUSTER_PROVIDER: ${{matrix.cluster_provider}}
           IMAGE_REPO: "localhost:5001"
           IMAGE_TAG: "devel"
           CTR_CMD: docker
@@ -79,7 +84,7 @@ jobs:
           IMAGE_REPO: "localhost:5001"
           IMAGE_TAG: "devel"
           CTR_CMD: docker
-          INPUT_PATH: ${{env.FILE_NAME}}
+          INPUT_PATH: ${{matrix.cluster_provider}}_${{env.FILE_NAME}}
 
       - name: use Kepler action to deploy cluster
         uses: sustainable-computing-io/kepler-action@v0.0.1

--- a/manifests/config/exporter/patch/patch-ci.yaml
+++ b/manifests/config/exporter/patch/patch-ci.yaml
@@ -1,3 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kepler-cfm
+  namespace: system
+data:
+  MAX_LOOKUP_RETRY: '1'
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/pkg/bpfassets/attacher/libbpf_attacher.go
+++ b/pkg/bpfassets/attacher/libbpf_attacher.go
@@ -39,9 +39,7 @@ const (
 	bpfAssesstsLocation  = "/var/lib/kepler/bpfassets"
 	bpfAssesstsLocalPath = "../../../bpfassets/libbpf/bpf.o"
 	cpuOnline            = "/sys/devices/system/cpu/online"
-
-	LibbpfBuilt = true
-	maxRetry    = 500
+	LibbpfBuilt          = true
 )
 
 var (
@@ -54,6 +52,7 @@ var (
 	}
 	uint32Key uint32
 	uint64Key uint64
+	maxRetry  = config.MaxLookupRetry
 )
 
 func getLibbpfObjectFilePath(arch string) (string, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,6 +51,7 @@ const (
 	defaultNamespace        = "kepler"
 	defaultModelServerPort  = "8100"
 	defaultModelRequestPath = "/model"
+	defaultMaxLookupRetry   = 500
 	// MaxIRQ is the maximum number of IRQs to be monitored
 	MaxIRQ = 10
 
@@ -78,6 +79,7 @@ var (
 	MetricPathKey                = "METRIC_PATH"
 	BindAddressKey               = "BIND_ADDRESS"
 	CPUArchOverride              = getConfig("CPU_ARCH_OVERRIDE", "")
+	MaxLookupRetry               = getIntConfig("MAX_LOOKUP_RETRY", defaultMaxLookupRetry)
 
 	EstimatorModel        = getConfig("ESTIMATOR_MODEL", defaultMetricValue)         // auto-select
 	EstimatorSelectFilter = getConfig("ESTIMATOR_SELECT_FILTER", defaultMetricValue) // no filter
@@ -148,6 +150,15 @@ func getBoolConfig(configKey string, defaultBool bool) bool {
 		defaultValue = "true"
 	}
 	return strings.ToLower(getConfig(configKey, defaultValue)) == "true"
+}
+
+func getIntConfig(configKey string, defaultInt int) int {
+	defaultValue := fmt.Sprintf("%d", defaultInt)
+	value, err := strconv.Atoi((getConfig(configKey, defaultValue)))
+	if err == nil {
+		return value
+	}
+	return defaultInt
 }
 
 func getConfig(configKey, defaultValue string) (result string) {


### PR DESCRIPTION
This PR is to follow CI issue in https://github.com/sustainable-computing-io/kepler/pull/798.
Because kind and microshift must use different manifest file (specifically, kind should use /proc-host mount even if it returns no error but all process goes to system_process while microshift doesn't have that). 

This PR also include adding MAX_LOOK_RETRY configuration via config map to be tuned if needed.
For ci, MAX_LOOK_RETRY=1.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>

 