### PR TITLE
Fix GPU energy and driver connection problem

### DIFF
--- a/pkg/power/accelerator/source/gpu_nvml.go
+++ b/pkg/power/accelerator/source/gpu_nvml.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"k8s.io/klog/v2"
+
+	"github.com/sustainable-computing-io/kepler/pkg/config"
 )
 
 var (
@@ -94,7 +96,10 @@ func (n *GPUNvml) GetGpuEnergyPerGPU() []uint32 {
 			klog.V(2).Infof("failed to get power usage on device %v: %v\n", device, nvml.ErrorString(ret))
 			continue
 		}
-		gpuEnergy = append(gpuEnergy, power)
+		// since Kepler collects metrics at intervals of SamplePeriodSec, which is greater than 1 second, it is
+		// necessary to calculate the energy consumption for the entire waiting period
+		energy := float64(power) * config.SamplePeriodSec
+		gpuEnergy = append(gpuEnergy, energy)
 	}
 	return gpuEnergy
 }

--- a/pkg/power/accelerator/source/gpu_nvml.go
+++ b/pkg/power/accelerator/source/gpu_nvml.go
@@ -98,7 +98,7 @@ func (n *GPUNvml) GetGpuEnergyPerGPU() []uint32 {
 		}
 		// since Kepler collects metrics at intervals of SamplePeriodSec, which is greater than 1 second, it is
 		// necessary to calculate the energy consumption for the entire waiting period
-		energy := float64(power) * config.SamplePeriodSec
+		energy := uint32(float64(power) * config.SamplePeriodSec)
 		gpuEnergy = append(gpuEnergy, energy)
 	}
 	return gpuEnergy


### PR DESCRIPTION
As the platform power, the GPU also reports power but we need to convert it to energy.

The GPU operator takes longer time to initialize, we Kepler needs to retry to connect to the nvidia driver until it is ready.