### PR TITLE
find first Makefile instead of last Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ rm -rf $$TMP_DIR ;\
 }
 endef
 
-base_dir := $(patsubst %/,%,$(dir $(realpath $(lastword $(MAKEFILE_LIST)))))
+base_dir := $(patsubst %/,%,$(dir $(realpath $(firstword $(MAKEFILE_LIST)))))
 
 ### Default ###
 kepler: build_containerized


### PR DESCRIPTION
otherwise, bpfassets/libbpf/Makefile will be returned so bpfassets/libbpf will be basedir ..

Fixes: #818