### PR TITLE
Discard request body in deferred function

### DIFF
--- a/pkg/power/platform/source/redfish_util.go
+++ b/pkg/power/platform/source/redfish_util.go
@@ -70,7 +70,9 @@ func getRedfishModel(access RedfishAccessInfo, endpoint string, model interface{
 		return err
 	}
 	defer func() {
-		io.Copy(ioutil.Discard, resp.Body)
+		if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+			klog.V(0).Infof("Failed to discard response body: %v", err)
+		}
 		resp.Body.Close()
 	}()
 

--- a/pkg/power/platform/source/redfish_util.go
+++ b/pkg/power/platform/source/redfish_util.go
@@ -21,6 +21,8 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -67,7 +69,10 @@ func getRedfishModel(access RedfishAccessInfo, endpoint string, model interface{
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
+	}()
 
 	// Check the response status code
 	if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
I deployed Kepler on Dell PowerEdge R530 with enabling Redfish, then I saw following message on exporter log:

```
I0726 07:59:08.097432       1 redfish_util.go:114] Failed to get power: Get "https://idrac-redfish/redfish/v1/Chassis/System.Embedded.1/Power#/PowerControl": EOF
```

`curl` was succeeded at this endpoint. iDRAC seems to set keep-alive to response header.

```
< HTTP/1.1 200 OK
< OData-Version: 4.0
< Keep-Alive: timeout=60, max=199
< Content-Type: application/json;odata.metadata=minimal;charset=utf-8
```

In this case, we should read all of contents from request body, so we should discard other contents which are not needed to build the model.