### PR TITLE
CI: add version for local dev cluster to make a version control

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -91,6 +91,7 @@ jobs:
         with:
           runningBranch: ${{matrix.cluster_provider}}
           cluster_provider: ${{matrix.cluster_provider}}
+          local_dev_cluster_version: v0.0.3
 
       - name: push Kepler image to local registry
         run: |

--- a/.github/workflows/integration_test_libbpf.yml
+++ b/.github/workflows/integration_test_libbpf.yml
@@ -92,6 +92,7 @@ jobs:
         with:
           runningBranch: ${{matrix.cluster_provider}}
           cluster_provider: ${{matrix.cluster_provider}}
+          local_dev_cluster_version: v0.0.3
 
       - name: push Kepler image to local registry
         run: |


### PR DESCRIPTION
add version for local dev cluster to make a version control
points local dev cluster to a stable version as 0.0.3 