### PR TITLE
CI: Single image for integration test

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -16,9 +16,6 @@ env:
 jobs:
   build-kepler:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        cluster_provider: [kind,microshift]
     steps:
       - name: checkout source
         uses: actions/checkout@v3
@@ -36,13 +33,13 @@ jobs:
           IMAGE_REPO: "localhost:5001"
           IMAGE_TAG: "devel"
           CTR_CMD: docker
-          IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}${{matrix.cluster_provider}}_${{env.FILE_NAME}}
+          IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}_${{env.FILE_NAME}}
 
       - name: save Kepler image as artifact
         uses: actions/upload-artifact@v3
         with:
           name: kepler
-          path: ${{env.OUTPUT_DIR}}${{matrix.cluster_provider}}_${{env.FILE_NAME}}
+          path: ${{env.OUTPUT_DIR}}_${{env.FILE_NAME}}
           retention-days: 1
           # ref https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
           # as PR or Push event, we don't keep artifact in 90 days hence use 1 day here to save resources.

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -33,13 +33,13 @@ jobs:
           IMAGE_REPO: "localhost:5001"
           IMAGE_TAG: "devel"
           CTR_CMD: docker
-          IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}_${{env.FILE_NAME}}
+          IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}${{env.FILE_NAME}}
 
       - name: save Kepler image as artifact
         uses: actions/upload-artifact@v3
         with:
           name: kepler
-          path: ${{env.OUTPUT_DIR}}_${{env.FILE_NAME}}
+          path: ${{env.OUTPUT_DIR}}${{env.FILE_NAME}}
           retention-days: 1
           # ref https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
           # as PR or Push event, we don't keep artifact in 90 days hence use 1 day here to save resources.
@@ -73,7 +73,7 @@ jobs:
           IMAGE_REPO: "localhost:5001"
           IMAGE_TAG: "devel"
           CTR_CMD: docker
-          INPUT_PATH: ${{matrix.cluster_provider}}_${{env.FILE_NAME}}
+          INPUT_PATH: ${{env.FILE_NAME}}
 
       - name: use Kepler action to deploy cluster
         uses: sustainable-computing-io/kepler-action@v0.0.1

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -28,14 +28,6 @@ jobs:
         with:
           go-version: ${{env.GO_VERSION}}
 
-      - name: build manifest
-        run: make build-manifest OPTS="CI_DEPLOY"
-        env:
-          CLUSTER_PROVIDER: ${{matrix.cluster_provider}}
-          IMAGE_REPO: "localhost:5001"
-          IMAGE_TAG: "devel"
-          CTR_CMD: docker
-
       - name: build and export Kepler image
         run: |
           make build_containerized

--- a/.github/workflows/integration_test_libbpf.yml
+++ b/.github/workflows/integration_test_libbpf.yml
@@ -34,13 +34,13 @@ jobs:
           IMAGE_REPO: "localhost:5001"
           IMAGE_TAG: "devel"
           CTR_CMD: docker
-          IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}_${{env.FILE_NAME}}
+          IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}${{env.FILE_NAME}}
 
       - name: save Kepler image as artifact
         uses: actions/upload-artifact@v3
         with:
           name: kepler
-          path: ${{env.OUTPUT_DIR}}_${{env.FILE_NAME}}
+          path: ${{env.OUTPUT_DIR}}${{env.FILE_NAME}}
           retention-days: 1
           # ref https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
           # as PR or Push event, we don't keep artifact in 90 days hence use 1 day here to save resources.
@@ -74,7 +74,7 @@ jobs:
           IMAGE_REPO: "localhost:5001"
           IMAGE_TAG: "devel"
           CTR_CMD: docker
-          INPUT_PATH: ${{matrix.cluster_provider}}_${{env.FILE_NAME}}
+          INPUT_PATH: ${{env.FILE_NAME}}
 
       - name: use Kepler action to deploy cluster
         uses: sustainable-computing-io/kepler-action@v0.0.1

--- a/.github/workflows/integration_test_libbpf.yml
+++ b/.github/workflows/integration_test_libbpf.yml
@@ -16,9 +16,6 @@ env:
 jobs:
   build-kepler_with_libbpf:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        cluster_provider: [kind,microshift]
     steps:
       - name: checkout source
         uses: actions/checkout@v3
@@ -37,13 +34,13 @@ jobs:
           IMAGE_REPO: "localhost:5001"
           IMAGE_TAG: "devel"
           CTR_CMD: docker
-          IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}${{matrix.cluster_provider}}_${{env.FILE_NAME}}
+          IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}_${{env.FILE_NAME}}
 
       - name: save Kepler image as artifact
         uses: actions/upload-artifact@v3
         with:
           name: kepler
-          path: ${{env.OUTPUT_DIR}}${{matrix.cluster_provider}}_${{env.FILE_NAME}}
+          path: ${{env.OUTPUT_DIR}}_${{env.FILE_NAME}}
           retention-days: 1
           # ref https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
           # as PR or Push event, we don't keep artifact in 90 days hence use 1 day here to save resources.

--- a/.github/workflows/integration_test_libbpf.yml
+++ b/.github/workflows/integration_test_libbpf.yml
@@ -28,14 +28,6 @@ jobs:
         with:
           go-version: ${{env.GO_VERSION}}
 
-      - name: build manifest
-        run: make build-manifest OPTS="CI_DEPLOY"
-        env:
-          CLUSTER_PROVIDER: ${{matrix.cluster_provider}}
-          IMAGE_REPO: "localhost:5001"
-          IMAGE_TAG: "devel"
-          CTR_CMD: docker
-
       - name: build and export Kepler image
         run: |
           make build_containerized

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,7 @@ build_containerized: genbpfassets tidy-vendor format
 .PHONY: build_containerized
 
 save-image:
+	@mkdir -p _output
 	$(CTR_CMD) save $(IMAGE_REPO)/kepler:$(IMAGE_TAG) | gzip > "${IMAGE_OUTPUT_PATH}"
 .PHONY: save-image
 


### PR DESCRIPTION
We should use single image for different k8s cluster right?
in this pr, removed strategy in image build phase of integration test to save time.