### PR TITLE
collector: print total processes

### DIFF
--- a/pkg/collector/metric/container_metric.go
+++ b/pkg/collector/metric/container_metric.go
@@ -238,7 +238,7 @@ func (c *ContainerMetrics) SumAllDynAggrValues() uint64 {
 }
 
 func (c *ContainerMetrics) String() string {
-	return fmt.Sprintf("energy from pod/container (%d active processes): name: %s/%s namespace: %s \n"+
+	return fmt.Sprintf("energy from pod/container (%d of %d active processes): name: %s/%s namespace: %s \n"+
 		"\tcgrouppid: %d pid: %d comm: %s containerid:%s\n"+
 		"\tDyn ePkg (mJ): %s (eCore: %s eDram: %s eUncore: %s) eGPU (mJ): %s eOther (mJ): %s \n"+
 		"\tIdle ePkg (mJ): %s (eCore: %s eDram: %s eUncore: %s) eGPU (mJ): %s eOther (mJ): %s \n"+
@@ -249,7 +249,7 @@ func (c *ContainerMetrics) String() string {
 		"\tcounters: %v\n"+
 		"\tcgroupfs: %v\n"+
 		"\tkubelets: %v\n",
-		c.CurrProcesses, c.PodName, c.ContainerName, c.Namespace,
+		c.CurrProcesses, len(c.PIDS), c.PodName, c.ContainerName, c.Namespace,
 		c.CGroupPID, c.PIDS, c.Command, c.ContainerID,
 		c.DynEnergyInPkg, c.DynEnergyInCore, c.DynEnergyInDRAM, c.DynEnergyInUncore, c.DynEnergyInGPU, c.DynEnergyInOther,
 		c.IdleEnergyInPkg, c.IdleEnergyInCore, c.IdleEnergyInDRAM, c.IdleEnergyInUncore, c.IdleEnergyInGPU, c.IdleEnergyInOther,


### PR DESCRIPTION
fix #844 

I tested my local environment, the `node-exporter` container is not running frequently and always gets "0 active process". With this change, this is the new output
```
I0803 14:40:38.844820 4133674 metric_collector.go:126] energy from pod/container (2 of 12 active processes): name: node-exporter-27nsx/node-exporter namespace: monitoring 
I0803 14:40:41.844848 4133674 metric_collector.go:126] energy from pod/container (0 of 12 active processes): name: node-exporter-27nsx/node-exporter namespace: monitoring 
I0803 14:40:44.844257 4133674 metric_collector.go:126] energy from pod/container (0 of 12 active processes): name: node-exporter-27nsx/node-exporter namespace: monitoring 
I0803 14:40:47.857644 4133674 metric_collector.go:126] energy from pod/container (0 of 12 active processes): name: node-exporter-27nsx/node-exporter namespace: monitoring 
I0803 14:40:50.846112 4133674 metric_collector.go:126] energy from pod/container (0 of 12 active processes): name: node-exporter-27nsx/node-exporter namespace: monitoring 
```