### PR TITLE
Skip the operation if goroutine for Redfish exists

### DIFF
--- a/pkg/power/platform/source/redfish.go
+++ b/pkg/power/platform/source/redfish.go
@@ -204,6 +204,11 @@ func NewRedfishClient() *RedFishClient {
 }
 
 func (rf *RedFishClient) IsSystemCollectionSupported() bool {
+	// goroutine for collecting power info from Redfish already exists
+	if rf.ticker != nil {
+		return true
+	}
+
 	system, err := getRedfishSystem(rf.accessInfo)
 
 	if err != nil {


### PR DESCRIPTION
`IsSystemCollectionSupported()` would start goroutine to collect power consumption from Redfish. It is infinite loop that the operation raises at 60 seconds intervals by default. However this function would be called everytime by `updatePlatformEnergy()` - it means a lot of goroutines can cause high frequency Redfish calls. In fact our Redfish interface (Dell PowerEdge R530) returned errors/did not respond.

So I think it should return `true` immediately if goroutine for Redfish exists. It seems to work fine to collect power metrics from Redfish, and also Redfish interface (Dell iDRAC) works fine even if Kepler is working.