### PR TITLE
fix type of platform energy obtained from systems

### DIFF
--- a/pkg/collector/node_energy_collector.go
+++ b/pkg/collector/node_energy_collector.go
@@ -47,7 +47,7 @@ func (c *Collector) updateNodeResourceUsage() {
 func (c *Collector) updatePlatformEnergy() {
 	if platform.IsSystemCollectionSupported() {
 		nodePlatformEnergy, _ := platform.GetAbsEnergyFromPlatform()
-		c.NodeMetrics.SetNodePlatformEnergy(nodePlatformEnergy, counter, absPower)
+		c.NodeMetrics.SetNodePlatformEnergy(nodePlatformEnergy, gauge, absPower)
 	} else if model.IsNodePlatformPowerModelEnabled() {
 		model.UpdateNodePlatformEnergy(&c.NodeMetrics)
 	}


### PR DESCRIPTION
The commit 315b519a1d62831adca3298d694fa7d3dd0fec08 accidentally changed type of platform energy from `gauge` to `counter`.  It causes incorrect calculation of platform energy.  This PR fix the problem.