### PR TITLE
use correct PowerModel to get process power

### DIFF
--- a/pkg/model/process_power.go
+++ b/pkg/model/process_power.go
@@ -147,7 +147,7 @@ func addProcessSamplesToPowerModels(processMetrics map[uint64]*collector_metric.
 		// add samples to estimate the platform power
 		if ProcessPlatformPowerModel.IsEnabled() {
 			featureValues := c.ToEstimatorValues(ProcessPlatformPowerModel.GetContainerFeatureNamesList(), true) // add process features with normalized values
-			ContainerPlatformPowerModel.AddContainerFeatureValues(featureValues)
+			ProcessPlatformPowerModel.AddContainerFeatureValues(featureValues)
 		}
 
 		// add samples to estimate the components (CPU and DRAM) power


### PR DESCRIPTION
When the configuration `ENABLE_PROCESS_METRICS` is set `true` in `release-0.5.4`, Kepler terminates with error. It is caused by using inappropriate power model at only one place. This PR fix it.