### PR TITLE
fix missing energysource in power request

### DIFF
--- a/pkg/collector/metric/node_metric.go
+++ b/pkg/collector/metric/node_metric.go
@@ -398,7 +398,7 @@ func (ne *NodeMetrics) UpdateDynEnergy() {
 
 func (ne *NodeMetrics) CalcDynEnergy(component, id string) {
 	total := ne.getAbsoluteEnergyStatCollection(component).Stat[id].Delta
-	fmt.Printf("Energy stat: %v (%s)", ne.getIdleEnergyStatCollection(component).Stat, id)
+	klog.V(5).Infof("Energy stat: %v (%s)", ne.getIdleEnergyStatCollection(component).Stat, id)
 	idle := ne.getIdleEnergyStatCollection(component).Stat[id].Delta
 	dyn := calcDynEnergy(total, idle)
 	ne.getDynEnergyStatCollection(component).SetDeltaStat(id, dyn)

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -134,6 +134,7 @@ func createPowerModelEstimator(modelConfig *types.ModelConfig) (PowerMoldelInter
 			FloatFeatureNames:           featuresNames,
 			SystemMetaDataFeatureNames:  modelConfig.SystemMetaDataFeatureNames,
 			SystemMetaDataFeatureValues: modelConfig.SystemMetaDataFeatureValues,
+			EnergySource:                modelConfig.EnergySource,
 		}
 		err := model.Start()
 		if err != nil {


### PR DESCRIPTION
This PR adds missing energy source attribute on EstimatorSidecar creation according to https://github.com/sustainable-computing-io/kepler/issues/878. 

In addition, this PR also changes log verbose level of printing estimation result. 

Previously, the output is as below.


> I0823 09:00:18.904684       1 libbpf_attacher.go:157] Successfully load eBPF module from libbpf object
Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[estimator0:3880 (15518)] (estimator0)I0823 09:00:18.962109       1 exporter.go:270] Started Kepler in 6.316217759s
Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[estimator0:3880 (15518)] (estimator0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[estimator0:3880 (31036)] (estimator0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[estimator0:3880 (31036)] (estimator0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[estimator0:3880 (46554)] (estimator0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[estimator0:3880 (46554)] (estimator0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[estimator0:3880 (62072)] (estimator0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[estimator0:3880 (62072)] (estimator0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[estimator0:3880 (77590)] (estimator0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[estimator0:3880 (77590)] (estimator0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[estimator0:3880 (93108)] (estimator0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[estimator0:3880 (93108)] (estimator0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[estimator0:3880 (108626)] (estimator0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[estimator0:3880 (108626)] (estimator0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[estimator0:3880 (124144)] (estimator0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[0:0 (0)] (0)Energy stat: map[estimator0:3880 (124144)] (estimator0)....



Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>