### PR TITLE
handle unset idle collection

### DIFF
--- a/pkg/collector/metric/node_metric_test.go
+++ b/pkg/collector/metric/node_metric_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Test Node Metric", func() {
 	})
 
 	It("test UpdateIdleEnergyWithMinValue", func() {
-		nodeMetrics.UpdateIdleEnergyWithMinValue()
+		nodeMetrics.UpdateIdleEnergyWithMinValue(true)
 		Expect(nodeMetrics.FoundNewIdleState).To(BeFalse())
 	})
 

--- a/pkg/collector/node_energy_collector.go
+++ b/pkg/collector/node_energy_collector.go
@@ -91,11 +91,12 @@ func (c *Collector) updateNodeAvgCPUFrequency(wg *sync.WaitGroup) {
 // updateNodeIdleEnergy calculates the node idle energy consumption based on the minimum power consumption when real-time system power metrics are accessible.
 // When the node power model estimator is utilized, the idle power is updated with the estimated power considering minimal resource utilization.
 func (c *Collector) updateNodeIdleEnergy() {
-	if components.IsSystemCollectionSupported() {
-		// the idle energy is only updated if we find the node using less resources than previously observed
-		// TODO: Use regression to estimate the idle power when real-time system power metrics are available, instead of relying on the minimum power consumption.
-		c.NodeMetrics.UpdateIdleEnergyWithMinValue()
-	} else {
+	isComponentsSystemCollectionSupported := components.IsSystemCollectionSupported()
+	// the idle energy is only updated if we find the node using less resources than previously observed
+	// TODO: Use regression to estimate the idle power when real-time system power metrics are available, instead of relying on the minimum power consumption.
+	c.NodeMetrics.UpdateIdleEnergyWithMinValue(isComponentsSystemCollectionSupported)
+	if !isComponentsSystemCollectionSupported {
+		// if power collection on components is not supported, try using estimator to update idle energy
 		if model.IsNodeComponentPowerModelEnabled() {
 			nodeComponentsEnergy := model.GetNodeComponentPowers(&c.NodeMetrics, idlePower)
 			// the node components power model returns gauge mentrics

--- a/pkg/collector/prometheus_collector_test.go
+++ b/pkg/collector/prometheus_collector_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Test Prometheus Collector Unit", func() {
 		// initialize the node energy with aggregated energy, which will be used to calculate delta energy
 		nodePlatformEnergy["sensor0"] = 5000 // mJ
 		exporter.NodeMetrics.SetNodePlatformEnergy(nodePlatformEnergy, true, false)
-		exporter.NodeMetrics.UpdateIdleEnergyWithMinValue()
+		exporter.NodeMetrics.UpdateIdleEnergyWithMinValue(true)
 		// the second node energy will represent the idle and dynamic power. The idle power is only calculated after there at at least two delta values
 		nodePlatformEnergy["sensor0"] = 35000
 		exporter.NodeMetrics.SetNodePlatformEnergy(nodePlatformEnergy, true, false)
@@ -122,7 +122,7 @@ var _ = Describe("Test Prometheus Collector Unit", func() {
 		}
 		// the second node energy will force to calculate a delta. The delta is calculates after added at least two aggregated metric
 		exporter.NodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false, false)
-		exporter.NodeMetrics.UpdateIdleEnergyWithMinValue()
+		exporter.NodeMetrics.UpdateIdleEnergyWithMinValue(true)
 		// the third node energy will represent the idle and dynamic power. The idle power is only calculated after there at at least two delta values
 		componentsEnergies[0] = source.NodeComponentsEnergy{
 			Pkg:    45000, // 35000mJ delta, which is 5000mJ idle, 30000mJ dynamic power

--- a/pkg/model/benchmark_test.go
+++ b/pkg/model/benchmark_test.go
@@ -46,11 +46,11 @@ func benchmarkNtesting(b *testing.B, containerNumber int) {
 
 	nodePlatformEnergy["sensor0"] = 10
 	nodeMetrics.SetNodePlatformEnergy(nodePlatformEnergy, true, false)
-	nodeMetrics.UpdateIdleEnergyWithMinValue()
+	nodeMetrics.UpdateIdleEnergyWithMinValue(true)
 
 	nodePlatformEnergy["sensor0"] = 20
 	nodeMetrics.SetNodePlatformEnergy(nodePlatformEnergy, true, false)
-	nodeMetrics.UpdateIdleEnergyWithMinValue()
+	nodeMetrics.UpdateIdleEnergyWithMinValue(true)
 	nodeMetrics.UpdateDynEnergy()
 
 	componentsEnergies := make(map[int]source.NodeComponentsEnergy)
@@ -68,7 +68,7 @@ func benchmarkNtesting(b *testing.B, containerNumber int) {
 		Uncore: 10,
 	}
 	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false, false)
-	nodeMetrics.UpdateIdleEnergyWithMinValue()
+	nodeMetrics.UpdateIdleEnergyWithMinValue(true)
 	componentsEnergies[0] = source.NodeComponentsEnergy{
 		Pkg:    uint64(containerNumber),
 		Core:   uint64(containerNumber),
@@ -77,7 +77,7 @@ func benchmarkNtesting(b *testing.B, containerNumber int) {
 	}
 	nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false, false)
 
-	nodeMetrics.UpdateIdleEnergyWithMinValue()
+	nodeMetrics.UpdateIdleEnergyWithMinValue(true)
 	nodeMetrics.UpdateDynEnergy()
 	b.ReportAllocs()
 	containersMetrics := map[string]*collector_metric.ContainerMetrics{}

--- a/pkg/model/container_energy_test.go
+++ b/pkg/model/container_energy_test.go
@@ -183,7 +183,7 @@ var _ = Describe("ContainerPower", func() {
 			}
 			// the second node energy will force to calculate a delta. The delta is calculates after added at least two aggregated metric
 			nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, counter, absPower)
-			nodeMetrics.UpdateIdleEnergyWithMinValue()
+			nodeMetrics.UpdateIdleEnergyWithMinValue(true)
 			// the third node energy will represent the idle and dynamic power. The idle power is only calculated after there at at least two delta values
 			componentsEnergies[machineSocketID] = source.NodeComponentsEnergy{
 				Pkg:    45000, // 35000mJ delta, which is 5000mJ idle, 30000mJ dynamic power
@@ -219,7 +219,7 @@ var _ = Describe("ContainerPower", func() {
 			// initialize the node energy with aggregated energy, which will be used to calculate delta energy
 			nodePlatformEnergy[machineSensorID] = 5000 // mJ
 			nodeMetrics.SetNodePlatformEnergy(nodePlatformEnergy, gauge, absPower)
-			nodeMetrics.UpdateIdleEnergyWithMinValue()
+			nodeMetrics.UpdateIdleEnergyWithMinValue(true)
 			// the second node energy will represent the idle and dynamic power. The idle power is only calculated after there at at least two delta values
 			nodePlatformEnergy[machineSensorID] = 35000
 			nodeMetrics.SetNodePlatformEnergy(nodePlatformEnergy, gauge, absPower)

--- a/pkg/model/estimator/local/ratio_model_test.go
+++ b/pkg/model/estimator/local/ratio_model_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Test Ratio Unit", func() {
 		// initialize the node energy with aggregated energy, which will be used to calculate delta energy
 		nodePlatformEnergy["sensor0"] = 5000 // mJ
 		nodeMetrics.SetNodePlatformEnergy(nodePlatformEnergy, true, false)
-		nodeMetrics.UpdateIdleEnergyWithMinValue()
+		nodeMetrics.UpdateIdleEnergyWithMinValue(true)
 		// the second node energy will represent the idle and dynamic power. The idle power is only calculated after there at at least two delta values
 		nodePlatformEnergy["sensor0"] = 35000
 		nodeMetrics.SetNodePlatformEnergy(nodePlatformEnergy, true, false)
@@ -80,7 +80,7 @@ var _ = Describe("Test Ratio Unit", func() {
 		}
 		// the second node energy will force to calculate a delta. The delta is calculates after added at least two aggregated metric
 		nodeMetrics.SetNodeComponentsEnergy(componentsEnergies, false, false)
-		nodeMetrics.UpdateIdleEnergyWithMinValue()
+		nodeMetrics.UpdateIdleEnergyWithMinValue(true)
 		// the third node energy will represent the idle and dynamic power. The idle power is only calculated after there at at least two delta values
 		componentsEnergies[0] = source.NodeComponentsEnergy{
 			Pkg:    45000, // 35000mJ delta, which is 5000mJ idle, 30000mJ dynamic power


### PR DESCRIPTION
This PR is to fix and handle issue https://github.com/sustainable-computing-io/kepler/issues/883.
As mentioned in the issue, the function `components.IsSystemCollectionSupported` is to check only RAPL support.
In some environment, RAPL is not there but the GPU power is bypassed. 
So, I separate a case in function `UpdateIdleEnergyWithMinValue`. 

Not sure that should we also separate the case for platform.IsSystemCollectionSupported or not in the future. 
Currently, I keep the assumption that if components is not supported, platform is also not supported. 
If we found the case that this assumption is not valid, we may have to also separate the condition. 

Also, to prevent the failure when the idle collection is not set, I add conditional check whether the id is set in the idle stat too. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>