### PR TITLE
correct GpuUsageMetric param in GetGPUPower

### DIFF
--- a/pkg/model/estimator/local/ratio.go
+++ b/pkg/model/estimator/local/ratio.go
@@ -174,9 +174,9 @@ func (r *RatioPowerModel) GetGPUPower(isIdlePower bool) ([]float64, error) {
 
 		// TODO: idle power should be divided accordinly to the container requested resource
 		if isIdlePower {
-			containerPower = r.getPowerByRatio(containerIdx, int(GpuDynPower), int(GpuIdlePower), numContainers)
+			containerPower = r.getPowerByRatio(containerIdx, int(GpuUsageMetric), int(GpuIdlePower), numContainers)
 		} else {
-			containerPower = r.getPowerByRatio(containerIdx, int(GpuDynPower), int(GpuDynPower), numContainers)
+			containerPower = r.getPowerByRatio(containerIdx, int(GpuUsageMetric), int(GpuDynPower), numContainers)
 		}
 		nodeComponentsPowerOfAllContainers = append(nodeComponentsPowerOfAllContainers, containerPower)
 	}


### PR DESCRIPTION
According to https://github.com/sustainable-computing-io/kepler/issues/883#issuecomment-1691589435, this PR is to fix the follow-up bugs after fixing the previous bug in the previous PR https://github.com/sustainable-computing-io/kepler/pull/884. Confirmed the fixes. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>