### PR TITLE
correct hardware counter settings

### DIFF
--- a/pkg/bpfassets/attacher/bpf_perf.go
+++ b/pkg/bpfassets/attacher/bpf_perf.go
@@ -70,9 +70,9 @@ func init() {
 
 func getCounters() map[string]perfCounter {
 	if config.UseLibBPFAttacher {
-		return bccCounters
-	} else {
 		return libbpfCounters
+	} else {
+		return bccCounters
 	}
 }
 


### PR DESCRIPTION
The settings of hardware counters between bcc and libbpf are swapped. This PR correct it.