### PR TITLE
move UseLibBPFAttacher config set to early point

### DIFF
--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -166,6 +166,8 @@ func main() {
 
 	config.SetKubeConfig(*kubeconfig)
 	config.SetEnableAPIServer(*apiserverEnabled)
+
+	klog.Infof("LibbpfBuilt: %v, BccBuilt: %v", attacher.LibbpfBuilt, attacher.BccBuilt)
 	// try setting kernel source only for bcc build
 	if attacher.BccBuilt {
 		if kernelSourceDirPath != nil && len(*kernelSourceDirPath) > 0 {
@@ -173,6 +175,9 @@ func main() {
 				klog.Warningf("failed to set kernel source dir to %q: %v", *kernelSourceDirPath, err)
 			}
 		}
+	} else if attacher.LibbpfBuilt {
+		// set UseLibBPFAttacher config from build option
+		config.UseLibBPFAttacher = true
 	}
 
 	// the ebpf batch deletion operation was introduced in linux kernel 5.6, which provides better performance to delete keys.
@@ -239,6 +244,7 @@ func main() {
 	defer components.StopPower()
 
 	// starting a new gorotine to collect data and report metrics
+	// BPF is attached here
 	if err := m.Start(); err != nil {
 		klog.Infof("%s", fmt.Sprintf("failed to start : %v", err))
 	}

--- a/pkg/bpfassets/attacher/bpf_perf.go
+++ b/pkg/bpfassets/attacher/bpf_perf.go
@@ -120,10 +120,6 @@ func CollectCPUFreq() (cpuFreqData map[int32]uint64, err error) {
 }
 
 func Attach() (interface{}, error) {
-	klog.Infof("LibbpfBuilt: %v, BccBuilt: %v", LibbpfBuilt, BccBuilt)
-	if !BccBuilt && LibbpfBuilt {
-		config.UseLibBPFAttacher = true
-	}
 	if config.UseLibBPFAttacher && LibbpfBuilt {
 		m, err := attachLibbpfModule()
 		if err == nil {


### PR DESCRIPTION
According to the fix on previous merged PR https://github.com/sustainable-computing-io/kepler/pull/886, I found the reason the code worked before this vital fix is that the default value of UseLibBPFAttacher is false. It was changed to true after the getCounter function is called and detected that libbpf is built. 

To fix the setting order, I move the logic to auto detect libbpf built to the early point (at the same state that bcc built set the library) which is before getCounter is called. 

 Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>
