### PR TITLE
set counter in GetEnabledHWCounters

### DIFF
--- a/pkg/bpfassets/attacher/bpf_perf.go
+++ b/pkg/bpfassets/attacher/bpf_perf.go
@@ -44,7 +44,7 @@ const (
 )
 
 var (
-	Counters                = getCounters()
+	Counters                map[string]perfCounter
 	HardwareCountersEnabled = true
 	BpfPerfArrayPrefix      = "_hc_reader"
 
@@ -77,6 +77,7 @@ func getCounters() map[string]perfCounter {
 }
 
 func GetEnabledHWCounters() []string {
+	Counters = getCounters()
 	var metrics []string
 	klog.V(5).Infof("hardeware counter metrics config %t", config.ExposeHardwareCounterMetrics)
 	if !config.ExposeHardwareCounterMetrics {


### PR DESCRIPTION
There is another point to fix the issue in accordance to two previous merged PRs: https://github.com/sustainable-computing-io/kepler/pull/887, https://github.com/sustainable-computing-io/kepler/pull/886. 

The Counter variable is still called at the init point which is earlier than what we set value in https://github.com/sustainable-computing-io/kepler/pull/887. So, I moved the Counter variable set to right before we check the available hardware counter that is function `GetEnabledHWCounters `. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>