### PR TITLE
remove kepler-estimator image and replace kepler_model_server

### DIFF
--- a/hack/build-manifest.sh
+++ b/hack/build-manifest.sh
@@ -65,13 +65,10 @@ uncomment() {
 }
 
 IMAGE_TAG=${IMAGE_TAG:-latest}
-ESTIMATOR_IMAGE_TAG=${ESTIMATOR_IMAGE_TAG:-latest}
 MODEL_SERVER_IMAGE_TAG=${MODEL_SERVER_IMAGE_TAG:-latest}
 IMAGE_REPO=${IMAGE_REPO:-quay.io/sustainable_computing_io}
-ESTIMATOR_REPO=${ESTIMATOR_REPO:-${IMAGE_REPO}}
 MODEL_SERVER_REPO=${MODEL_SERVER_REPO:-${IMAGE_REPO}}
 EXPORTER_IMAGE_NAME=${EXPORTER_IMAGE_NAME:-kepler}
-ESTIMATOR_IMAGE_NAME=${ESTIMATOR_IMAGE_NAME:-kepler-estimator}
 MODEL_SERVER_IMAGE_NAME=${MODEL_SERVER_IMAGE_NAME:-kepler_model_server}
 
 MANIFESTS_OUT_DIR=${MANIFESTS_OUT_DIR:-"_output/generated-manifest"}
@@ -160,10 +157,9 @@ fi
 
 echo "set manager image"
 EXPORTER_IMG=${IMAGE_REPO}/${EXPORTER_IMAGE_NAME}:${IMAGE_TAG}
-ESTIMATOR_IMG=${ESTIMATOR_REPO}/${ESTIMATOR_IMAGE_NAME}:${ESTIMATOR_IMAGE_TAG}
 MODEL_SERVER_IMG=${MODEL_SERVER_REPO}/${MODEL_SERVER_IMAGE_NAME}:${MODEL_SERVER_IMAGE_TAG}
-pushd ${MANIFESTS_OUT_DIR}/exporter;${KUSTOMIZE} edit set image kepler=${EXPORTER_IMG}; ${KUSTOMIZE} edit set image kepler-estimator=${ESTIMATOR_IMG}; popd
-pushd ${MANIFESTS_OUT_DIR}/model-server;${KUSTOMIZE} edit set image kepler-model-server=${MODEL_SERVER_IMG}; popd
+pushd ${MANIFESTS_OUT_DIR}/exporter;${KUSTOMIZE} edit set image kepler=${EXPORTER_IMG}; ${KUSTOMIZE} edit set image kepler_model_server=${MODEL_SERVER_IMG}; popd
+pushd ${MANIFESTS_OUT_DIR}/model-server;${KUSTOMIZE} edit set image kepler_model_server=${MODEL_SERVER_IMG}; popd
 
 echo "kustomize manifests..."
 ${KUSTOMIZE} build ${MANIFESTS_OUT_DIR}/base > ${MANIFESTS_OUT_DIR}/deployment.yaml

--- a/manifests/config/exporter/kustomization.yaml
+++ b/manifests/config/exporter/kustomization.yaml
@@ -32,8 +32,8 @@ images:
 - name: kepler
   newName: quay.io/sustainable_computing_io/kepler
   newTag: latest
-- name: kepler-estimator
-  newName: quay.io/sustainable_computing_io/kepler_estimator
+- name: kepler_model_server
+  newName: quay.io/sustainable_computing_io/kepler_model_server
   newTag: latest
 
 vars:


### PR DESCRIPTION
This PR is related to the issue https://github.com/sustainable-computing-io/kepler/issues/888#issuecomment-1694990086.
The kustomization file needs to be fixed by replacing `kepler_model_server` image not `kepler-estimator` as the estimator has already merged to the model server repo. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>