### PR TITLE
fix scc post redfish secret addition

### DIFF
--- a/manifests/config/exporter/openshift_scc.yaml
+++ b/manifests/config/exporter/openshift_scc.yaml
@@ -12,7 +12,7 @@ allowHostIPC: true
 allowHostPID: true
 readOnlyRootFilesystem: true
 defaultAddCapabilities:
-- SYS_ADMIN
+  - SYS_ADMIN
 runAsUser:
   type: RunAsAny
 seLinuxContext:
@@ -24,6 +24,7 @@ volumes:
   - projected
   - emptyDir
   - hostPath
+  - secret
 users:
   - $(KEPLER_NAMESPACE)
   - system:serviceaccount:$(KEPLER_NAMESPACE):kepler-sa


### PR DESCRIPTION
This PR updates the scc configuration post addition of secret volume to daemonset deployment. Identified while testing #877 on OpenShift