### PR TITLE
bcc: update map names

### DIFF
--- a/bpfassets/perf_event/perf_event.c
+++ b/bpfassets/perf_event/perf_event.c
@@ -62,7 +62,7 @@ BPF_ARRAY(cpu_cycles, u64, NUM_CPUS);
 BPF_PERF_ARRAY(cpu_ref_cycles_hc_reader, NUM_CPUS);
 BPF_ARRAY(cpu_ref_cycles, u64, NUM_CPUS);
 
-BPF_PERF_ARRAY(cpu_instr_hc_reader, NUM_CPUS);
+BPF_PERF_ARRAY(cpu_instructions_hc_reader, NUM_CPUS);
 BPF_ARRAY(cpu_instr, u64, NUM_CPUS);
 
 BPF_PERF_ARRAY(cache_miss_hc_reader, NUM_CPUS);
@@ -146,7 +146,7 @@ static inline u64 get_on_cpu_instr(u32 *cpu_id)
 {
     u64 delta = 0;
     struct bpf_perf_event_value c = {};
-    int error = cpu_instr_hc_reader.perf_counter_value(CUR_CPU_IDENTIFIER, &c, sizeof(struct bpf_perf_event_value));
+    int error = cpu_instructions_hc_reader.perf_counter_value(CUR_CPU_IDENTIFIER, &c, sizeof(struct bpf_perf_event_value));
     if (error == 0)
     {
         u64 val = normalize(&c.counter, &c.enabled, &c.running);

--- a/pkg/bpfassets/perf_event_bindata.go
+++ b/pkg/bpfassets/perf_event_bindata.go
@@ -120,7 +120,7 @@ BPF_ARRAY(cpu_cycles, u64, NUM_CPUS);
 BPF_PERF_ARRAY(cpu_ref_cycles_hc_reader, NUM_CPUS);
 BPF_ARRAY(cpu_ref_cycles, u64, NUM_CPUS);
 
-BPF_PERF_ARRAY(cpu_instr_hc_reader, NUM_CPUS);
+BPF_PERF_ARRAY(cpu_instructions_hc_reader, NUM_CPUS);
 BPF_ARRAY(cpu_instr, u64, NUM_CPUS);
 
 BPF_PERF_ARRAY(cache_miss_hc_reader, NUM_CPUS);
@@ -204,7 +204,7 @@ static inline u64 get_on_cpu_instr(u32 *cpu_id)
 {
     u64 delta = 0;
     struct bpf_perf_event_value c = {};
-    int error = cpu_instr_hc_reader.perf_counter_value(CUR_CPU_IDENTIFIER, &c, sizeof(struct bpf_perf_event_value));
+    int error = cpu_instructions_hc_reader.perf_counter_value(CUR_CPU_IDENTIFIER, &c, sizeof(struct bpf_perf_event_value));
     if (error == 0)
     {
         u64 val = normalize(&c.counter, &c.enabled, &c.running);
@@ -383,13 +383,11 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//
-//	data/
-//	  foo.txt
-//	  img/
-//	    a.png
-//	    b.png
-//
+//     data/
+//       foo.txt
+//       img/
+//         a.png
+//         b.png
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("nonexistent") would return an error

--- a/pkg/collector/node_energy_collector.go
+++ b/pkg/collector/node_energy_collector.go
@@ -63,7 +63,7 @@ func (c *Collector) updateNodeComponentsEnergy(wg *sync.WaitGroup) {
 	} else if model.IsNodeComponentPowerModelEnabled() {
 		model.UpdateNodeComponentEnergy(&c.NodeMetrics)
 	} else {
-		klog.V(1).Info("No nodeComponentsEnergy found, node components energy metrics is not exposed ")
+		klog.V(5).Info("No nodeComponentsEnergy found, node components energy metrics is not exposed ")
 	}
 }
 


### PR DESCRIPTION
this is to fix an error message in #897 
```
bcc_attacher.go:120] failed to attach perf event cpu_instructions_hc_reader: passed table has wrong size: key_size=0, leaf_size=0
```

@vimalk78 previously suggested it in #896 
