### PR TITLE
Feat: 771 remove unnecessary security concerns

### DIFF
--- a/manifests/config/exporter/exporter.yaml
+++ b/manifests/config/exporter/exporter.yaml
@@ -55,6 +55,7 @@ spec:
         key: node-role.kubernetes.io/master
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: kepler-sa
+      hostPID: true
       containers:
       - name: kepler-exporter
         image: kepler:latest

--- a/manifests/config/exporter/exporter.yaml
+++ b/manifests/config/exporter/exporter.yaml
@@ -86,8 +86,10 @@ spec:
         volumeMounts:
         - mountPath: /lib/modules
           name: lib-modules
+          readOnly: true
         - mountPath: /sys
           name: tracing
+          readOnly: true
         - mountPath: /proc
           name: proc
         - name: cfm

--- a/manifests/config/exporter/openshift_scc.yaml
+++ b/manifests/config/exporter/openshift_scc.yaml
@@ -6,9 +6,9 @@ metadata:
 # To allow running privilegedContainers
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true
-allowHostNetwork: true
-allowHostPorts: true
-allowHostIPC: true
+allowHostNetwork: false
+allowHostPorts: false
+allowHostIPC: false
 allowHostPID: true
 readOnlyRootFilesystem: true
 defaultAddCapabilities:

--- a/manifests/config/exporter/patch/patch-openshift.yaml
+++ b/manifests/config/exporter/patch/patch-openshift.yaml
@@ -19,6 +19,7 @@ spec:
         volumeMounts:
         - name: kernel-src
           mountPath: /usr/src/kernels
+          readOnly: true
         - name: kernel-debug
           mountPath: /sys/kernel/debug
         securityContext:

--- a/manifests/config/exporter/patch/patch-openshift.yaml
+++ b/manifests/config/exporter/patch/patch-openshift.yaml
@@ -20,15 +20,9 @@ spec:
         - name: kernel-src
           mountPath: /usr/src/kernels
           readOnly: true
-        - name: kernel-debug
-          mountPath: /sys/kernel/debug
         securityContext:
           privileged: true
-      volumes:      
-      - name: kernel-debug
-        hostPath:
-          path: /sys/kernel/debug
-          type: Directory
+      volumes:
       - name: kernel-src
         hostPath:
           path: /usr/src/kernels


### PR DESCRIPTION
fixes #771 

- feat: reduce privileges granted through SCC for OpenShift
- feat: set mounted volumes as read only as much as possible
- feat: set pod hostPID to true to avoid collisions/unwanted behavior in host PID namespace
- feat: remove unnecessary mount of /sys/kernel/debug

Same improvements were already merged in the kepler-operator: https://github.com/sustainable-computing-io/kepler-operator/pull/185
And the removal of the /sys/kernel/debug was discussed here: https://github.com/sustainable-computing-io/kepler-model-server/pull/158#discussion_r1323177090