### PR TITLE
Fix GPU ratio bug to use GPU metrics

### DIFF
--- a/pkg/model/estimator/local/ratio_process.go
+++ b/pkg/model/estimator/local/ratio_process.go
@@ -143,9 +143,9 @@ func (r *RatioProcessPowerModel) GetGPUPower(isIdlePower bool) ([]float64, error
 
 		// TODO: idle power should be divided accordinly to the process requested resource
 		if isIdlePower {
-			processPower = r.getPowerByRatio(processIdx, int(GpuDynPower), int(GpuIdlePower), numProcesss)
+			processPower = r.getPowerByRatio(processIdx, int(GpuUsageMetric), int(GpuIdlePower), numProcesss)
 		} else {
-			processPower = r.getPowerByRatio(processIdx, int(GpuDynPower), int(GpuDynPower), numProcesss)
+			processPower = r.getPowerByRatio(processIdx, int(GpuUsageMetric), int(GpuDynPower), numProcesss)
 		}
 		nodeComponentsPowerOfAllProcesss = append(nodeComponentsPowerOfAllProcesss, processPower)
 	}


### PR DESCRIPTION
The issue #923 pointed out a bug in the GPU dynamic power estimation for containers.

There was a bug in the ratio formula using the wrong metrics to calculate the ratio. 