### PR TITLE
Print model config after its change in kepler log

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -169,6 +169,7 @@ func CreatePowerModelConfig(powerSourceTarget string) *types.ModelConfig {
 		TrainerName:      getPowerModelTrainerName(powerSourceTarget),
 		SelectFilter:     getPowerModelFilter(powerSourceTarget),
 		InitModelURL:     getPowerModelDownloadURL(powerSourceTarget),
+		IsNodePowerModel: isNodeLevel(powerSourceTarget),
 		EnergySource:     energySource,
 		NodeFeatureNames: []string{},
 	}
@@ -261,4 +262,15 @@ func getPowerModelOutputType(powerSourceTarget string) types.ModelOutputType {
 		return types.AbsPower
 	}
 	return types.Unsupported
+}
+
+// isNodeLevel return the true if current power key is node platform or node components
+func isNodeLevel(powerSourceTarget string) bool {
+	switch powerSourceTarget {
+	case config.NodePlatformPowerKey:
+		return true
+	case config.NodeComponentsPowerKey:
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
This PR is aimed to Address issue https://github.com/sustainable-computing-io/kepler-model-server/issues/141. The updated log is:

```
13 08:02:09.123144       1 model.go:120] Using Power Model AbsPower
I0913 08:02:09.123153       1 node_platform_energy.go:54] Using the LinearRegressor/AbsPower Power Model to estimate Node Platform Power
I0913 08:02:09.123167       1 model.go:176] Model Config NODE_COMPONENTS: {ModelType:EstimatorSidecar ModelOutputType:AbsPower TrainerName: EnergySource:rapl SelectFilter: InitModelURL:https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/v0.6/nx12/std_v0.6/rapl/DynPower/WorkloadOnly/LinearRegressionTrainer_1.zip InitModelFilepath: IsNodePowerModel:false ContainerFeatureNames:[] NodeFeatureNames:[] SystemMetaDataFeatureNames:[] SystemMetaDataFeatureValues:[]}
I0913 08:02:09.123195       1 node_component_energy.go:43] The updated Model Config : &{ModelType:EstimatorSidecar ModelOutputType:AbsPower TrainerName: EnergySource:rapl SelectFilter: InitModelURL:https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/v0.6/nx12/std_v0.6/rapl/DynPower/WorkloadOnly/LinearRegressionTrainer_1.zip InitModelFilepath: IsNodePowerModel:true ContainerFeatureNames:[] NodeFeatureNames:[bpf_cpu_time_us bpf_net_tx_irq bpf_net_rx_irq bpf_block_irq cgroupfs_memory_usage_bytes cgroupfs_kernel_memory_usage_bytes cgroupfs_tcp_memory_usage_bytes cgroupfs_cpu_usage_us cgroupfs_system_cpu_usage_us cgroupfs_user_cpu_usage_us cgroupfs_ioread_bytes cgroupfs_iowrite_bytes block_devices_used kubelet_cpu_usage kubelet_memory_bytes block_devices_used] SystemMetaDataFeatureNames:[cpu_architecture] SystemMetaDataFeatureValues:[Cascade Lake]}
I0913 08:02:09.222410       1 model.go:144] Using Power Model AbsPower
I0913 08:02:09.222447       1 node_component_energy.go:55] Using the EstimatorSidecar/AbsPower Power Model to estimate Node Component Power
I0913 08:02:09.222460       1 exporter.go:212] Initializing the GPU collector
I0913 08:02:15.227883       1 watcher.go:66] Using in cluster k8s config
```

Signed-off-by: Peng Hui Jiang <jiangph@cn.ibm.com>