### PR TITLE
by default disable GPU

### DIFF
--- a/manifests/config/exporter/exporter.yaml
+++ b/manifests/config/exporter/exporter.yaml
@@ -18,7 +18,7 @@ data:
   KEPLER_LOG_LEVEL: "1"
   METRIC_PATH: "/metrics"
   BIND_ADDRESS: "0.0.0.0:9102"
-  ENABLE_GPU: "true"
+  ENABLE_GPU: "false"
   ENABLE_QAT: "false"
   ENABLE_EBPF_CGROUPID: "true"
   EXPOSE_HW_COUNTER_METRICS: "true"


### PR DESCRIPTION
it takes 6 seconds to start my kepler which is not needed since I don't have GPU (and by default should be as most of user doesn't hvae GPU)

```
I0914 08:06:49.519880       1 exporter.go:204] Initializing the GPU collector
I0914 08:06:55.525201       1 watcher.go:66] Using in cluster k8s config
```