### PR TITLE
fix non-zero power on zero usage by estimation

### DIFF
--- a/pkg/collector/node_energy_collector.go
+++ b/pkg/collector/node_energy_collector.go
@@ -98,13 +98,10 @@ func (c *Collector) updateNodeIdleEnergy() {
 	if !isComponentsSystemCollectionSupported {
 		// if power collection on components is not supported, try using estimator to update idle energy
 		if model.IsNodeComponentPowerModelEnabled() {
-			nodeComponentsEnergy := model.GetNodeComponentPowers(&c.NodeMetrics, idlePower)
-			// the node components power model returns gauge mentrics
-			c.NodeMetrics.SetNodeComponentsEnergy(nodeComponentsEnergy, true, idlePower)
+			model.UpdateNodeComponentIdleEnergy(&c.NodeMetrics)
 		}
 		if model.IsNodePlatformPowerModelEnabled() {
-			nodePlatformEnergy := model.GetNodePlatformPower(&c.NodeMetrics, idlePower)
-			c.NodeMetrics.SetNodePlatformEnergy(nodePlatformEnergy, true, idlePower)
+			model.UpdateNodePlatformIdleEnergy(&c.NodeMetrics)
 		}
 	}
 }

--- a/pkg/model/node_component_energy.go
+++ b/pkg/model/node_component_energy.go
@@ -91,7 +91,7 @@ func GetNodeComponentPowers(nodeMetrics *collector_metric.NodeMetrics, isIdlePow
 	return
 }
 
-// UpdateNodeComponentEnergy resets the power model samples, add new samples to the power models, then estimates the idle and absolute energy
+// UpdateNodeComponentIdleEnergy sets the power model samples, get absolute powers, and set gauge value for each component energy
 func UpdateNodeComponentEnergy(nodeMetrics *collector_metric.NodeMetrics) {
 	componentPower := GetNodeComponentPowers(nodeMetrics, absPower)
 	for id := range componentPower {
@@ -109,8 +109,11 @@ func UpdateNodeComponentEnergy(nodeMetrics *collector_metric.NodeMetrics) {
 		componentPower[id] = power
 	}
 	nodeMetrics.SetNodeComponentsEnergy(componentPower, gauge, absPower)
+}
 
-	componentPower = GetNodeComponentPowers(nodeMetrics, idlePower)
+// UpdateNodeComponentIdleEnergy sets the power model samples to zeros, get idle powers, and set gauge value for each component idle energy
+func UpdateNodeComponentIdleEnergy(nodeMetrics *collector_metric.NodeMetrics) {
+	componentPower := GetNodeComponentPowers(nodeMetrics, idlePower)
 	for id := range componentPower {
 		var ok bool
 		var power source.NodeComponentsEnergy
@@ -126,6 +129,4 @@ func UpdateNodeComponentEnergy(nodeMetrics *collector_metric.NodeMetrics) {
 		componentPower[id] = power
 	}
 	nodeMetrics.SetNodeComponentsEnergy(componentPower, gauge, idlePower)
-	// After the node component idle and absulute energy was updated, we need to update the dynamic power
-	nodeMetrics.UpdateDynEnergy()
 }

--- a/pkg/model/node_platform_energy.go
+++ b/pkg/model/node_platform_energy.go
@@ -89,7 +89,7 @@ func GetNodePlatformPower(nodeMetrics *collector_metric.NodeMetrics, isIdlePower
 	return
 }
 
-// UpdateNodePlatformEnergy resets the power model samples, add new samples to the power models, then estimates the idle and dynamic energy
+// UpdateNodePlatformEnergy sets the power model samples, get absolute powers, and set platform energy
 func UpdateNodePlatformEnergy(nodeMetrics *collector_metric.NodeMetrics) {
 	platformPower := GetNodePlatformPower(nodeMetrics, absPower)
 	for id, power := range platformPower {
@@ -97,7 +97,11 @@ func UpdateNodePlatformEnergy(nodeMetrics *collector_metric.NodeMetrics) {
 		platformPower[id] = power * float64(config.SamplePeriodSec)
 	}
 	nodeMetrics.SetNodePlatformEnergy(platformPower, gauge, absPower)
-	platformPower = GetNodePlatformPower(nodeMetrics, idlePower)
+}
+
+// UpdateNodePlatformIdleEnergy sets the power model samples to zeros, get idle powers, and set platform energy
+func UpdateNodePlatformIdleEnergy(nodeMetrics *collector_metric.NodeMetrics) {
+	platformPower := GetNodePlatformPower(nodeMetrics, idlePower)
 	for id, power := range platformPower {
 		// convert power to energy
 		platformPower[id] = power * float64(config.SamplePeriodSec)


### PR DESCRIPTION
This PR is to fix the issue as mentioned in https://github.com/sustainable-computing-io/kepler/issues/944.
I move the logic to get idle powers for both platform and component to new function and call it at `updateNodeIdleEnergy`.

The following graph show changes after the fix in this PR. 

![Screenshot 2023-09-26 at 16 58 12](https://github.com/sustainable-computing-io/kepler/assets/11749848/746a2b84-02b4-4876-ae76-12bf5e45d430)

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>