### PR TITLE
grafana: update kWh query

### DIFF
--- a/grafana-dashboards/Kepler-Exporter.json
+++ b/grafana-dashboards/Kepler-Exporter.json
@@ -22,8 +22,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 26,
-  "iteration": 1667798877250,
+  "id": 2,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -93,7 +92,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "8.5.5",
+      "pluginVersion": "9.1.0",
       "targets": [
         {
           "datasource": {
@@ -101,7 +100,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(sum(\n    (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $coal\n)\n+\n(sum(\n    (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $coal\n)",
+          "expr": "( sum(\n      increase(\n         (kepler_container_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[24h:1m])\n      )\n   ) * $watt_per_second_to_kWh \n) * $coal",
           "hide": false,
           "legendFormat": "CO2 Coal",
           "range": true,
@@ -113,7 +112,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(sum(\n    (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $petroleum\n)\n+\n(sum(\n    (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $petroleum\n)",
+          "expr": "( sum(\n      increase(\n         (kepler_container_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[24h:1m])\n      )\n   ) * $watt_per_second_to_kWh \n) * $petroleum",
           "hide": false,
           "legendFormat": "CO2 Petroleum",
           "range": true,
@@ -125,14 +124,14 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(sum(\n    (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $natural_gas\n)\n+\n(sum(\n    (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $natural_gas\n)",
+          "expr": "( sum(\n      increase(\n         (kepler_container_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[24h:1m])\n      )\n   ) * $watt_per_second_to_kWh \n) * $natural_gas",
           "hide": false,
           "legendFormat": "CO2 Natural Gas",
           "range": true,
           "refId": "C"
         }
       ],
-      "title": "Carbon Footprint (pounds per kWh per day) in Namespace: $namespace  (PKG+DRAM)",
+      "title": "Carbon Footprint (pounds per kWh per day) in Namespace: $namespace  (PKG+DRAM+OTHER+GPU)",
       "transparent": true,
       "type": "gauge"
     },
@@ -162,6 +161,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "watt",
             "axisPlacement": "left",
             "barAlignment": 0,
@@ -282,6 +283,7 @@
           ],
           "displayMode": "table",
           "placement": "right",
+          "showLegend": true,
           "sortBy": "Mean",
           "sortDesc": true
         },
@@ -352,6 +354,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "watt",
             "axisPlacement": "left",
             "barAlignment": 0,
@@ -472,7 +476,8 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -486,7 +491,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1m]))",
+          "expr": "sum(irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
           "hide": false,
           "interval": "",
           "legendFormat": "PKG",
@@ -499,7 +504,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1m]))",
+          "expr": "sum(irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
           "hide": false,
           "interval": "",
           "legendFormat": "DRAM",
@@ -512,7 +517,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(irate(kepler_container_other_joules_total{container_namespace=~\"$namespace\"}[1m]))",
+          "expr": "sum(irate(kepler_container_other_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
           "hide": false,
           "legendFormat": "OTHER",
           "range": true,
@@ -524,7 +529,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1m]))",
+          "expr": "sum(irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
           "hide": false,
           "legendFormat": " GPU",
           "range": true,
@@ -546,6 +551,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "kWh",
             "axisPlacement": "left",
             "barAlignment": 0,
@@ -667,6 +674,7 @@
           ],
           "displayMode": "table",
           "placement": "bottom",
+          "showLegend": true,
           "sortBy": "Max",
           "sortDesc": true
         },
@@ -682,7 +690,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(\n  (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n)",
+          "expr": "sum (\n  increase(\n   (kepler_container_package_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[24h:1m])\n  )\n) * $watt_per_second_to_kWh",
           "hide": false,
           "interval": "",
           "legendFormat": "PKG (CORE+UNCORE)",
@@ -695,7 +703,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(\n  (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n)",
+          "expr": "sum (\n  increase(\n   (kepler_container_dram_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[24h:1m])\n  )\n) * $watt_per_second_to_kWh",
           "hide": false,
           "interval": "",
           "legendFormat": "DRAM",
@@ -708,7 +716,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(\n  (increase(\n    kepler_container_other_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(\n    kepler_container_other_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(\n      kepler_container_other_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n)",
+          "expr": "sum (\n  increase(\n   (kepler_container_other_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[24h:1m])\n  )\n) * $watt_per_second_to_kWh",
           "hide": false,
           "legendFormat": "OTHER",
           "range": true,
@@ -720,7 +728,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(\n  (increase(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n)",
+          "expr": "sum (\n  increase(\n   (kepler_container_gpu_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[24h:1m])\n  )\n) * $watt_per_second_to_kWh",
           "hide": false,
           "legendFormat": " GPU",
           "range": true,
@@ -778,7 +786,7 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "8.5.5",
+      "pluginVersion": "9.1.0",
       "targets": [
         {
           "datasource": {
@@ -786,28 +794,28 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (container_namespace) (\n  (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n)\n+\nsum by (container_namespace) (\n  (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n)",
+          "expr": "sum by (container_namespace) (\n  increase(\n      (kepler_container_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[24h:1m])\n  )\n) * $watt_per_second_to_kWh ",
           "interval": "",
           "legendFormat": "{{container_namespace}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Total Power Consumption (PKG+DRAM) by Namespace (kWh per day)",
+      "title": "Total Power Consumption (PKG+DRAM+OTHER+GPU) by Namespace (kWh per day)",
       "type": "bargauge"
     }
   ],
   "refresh": "",
-  "schemaVersion": 36,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "prometheus",
-          "value": "prometheus"
+          "selected": true,
+          "text": "Prometheus-Kepler",
+          "value": "Prometheus-Kepler"
         },
         "hide": 0,
         "includeAll": false,
@@ -815,6 +823,7 @@
         "name": "datasource",
         "options": [],
         "query": "prometheus",
+        "queryValue": "",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -961,7 +970,7 @@
   "timepicker": {},
   "timezone": "browser",
   "title": "Kepler Exporter Dashboard",
-  "uid": "NhnADUW4z",
-  "version": 2,
+  "uid": "NhnADUW4zIBM",
+  "version": 1,
   "weekStart": ""
 }

--- a/manifests/config/dashboard/04-grafana-dashboard-topk.yaml
+++ b/manifests/config/dashboard/04-grafana-dashboard-topk.yaml
@@ -31,8 +31,7 @@ spec:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 26,
-      "iteration": 1667798877250,
+      "id": 2,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -102,7 +101,7 @@ spec:
             "showThresholdMarkers": true,
             "text": {}
           },
-          "pluginVersion": "8.5.5",
+          "pluginVersion": "9.1.0",
           "targets": [
             {
               "datasource": {
@@ -110,7 +109,7 @@ spec:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "topk(10,sum(\n    (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $coal\n)\n+\n(sum(\n    (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $coal\n)",
+              "expr": "( sum(\n      increase(\n         (kepler_container_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[24h:1m])\n      )\n   ) * $watt_per_second_to_kWh \n) * $coal",
               "hide": false,
               "legendFormat": "CO2 Coal",
               "range": true,
@@ -122,7 +121,7 @@ spec:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "topk(10,sum(\n    (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $petroleum\n)\n+\n(sum(\n    (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $petroleum\n)",
+              "expr": "( sum(\n      increase(\n         (kepler_container_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[24h:1m])\n      )\n   ) * $watt_per_second_to_kWh \n) * $petroleum",
               "hide": false,
               "legendFormat": "CO2 Petroleum",
               "range": true,
@@ -134,14 +133,14 @@ spec:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "topk(10,sum(\n    (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $natural_gas\n)\n+\n(sum(\n    (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n     *$watt_per_second_to_kWh\n    ) *\n   (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n      count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n   )\n  ) * $natural_gas\n)",
+              "expr": "( sum(\n      increase(\n         (kepler_container_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[24h:1m])\n      )\n   ) * $watt_per_second_to_kWh \n) * $natural_gas",
               "hide": false,
               "legendFormat": "CO2 Natural Gas",
               "range": true,
               "refId": "C"
             }
           ],
-          "title": "Carbon Footprint (pounds per kWh per day) in Namespace: $namespace or Top 10 Namespaces if ALL Namespaces is selected (PKG+DRAM)",
+          "title": "Carbon Footprint (pounds per kWh per day) in Namespace: $namespace  (PKG+DRAM+OTHER+GPU)",
           "transparent": true,
           "type": "gauge"
         },
@@ -171,6 +170,8 @@ spec:
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
                 "axisLabel": "watt",
                 "axisPlacement": "left",
                 "barAlignment": 0,
@@ -291,6 +292,7 @@ spec:
               ],
               "displayMode": "table",
               "placement": "right",
+              "showLegend": true,
               "sortBy": "Mean",
               "sortDesc": true
             },
@@ -361,6 +363,8 @@ spec:
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
                 "axisLabel": "watt",
                 "axisPlacement": "left",
                 "barAlignment": 0,
@@ -481,7 +485,8 @@ spec:
                 "max"
               ],
               "displayMode": "table",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "single",
@@ -495,7 +500,7 @@ spec:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "topk(10, sum(irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1m])))",
+              "expr": "sum(irate(kepler_container_package_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
               "hide": false,
               "interval": "",
               "legendFormat": "PKG",
@@ -508,7 +513,7 @@ spec:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "topk(10, sum(irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1m])))",
+              "expr": "sum(irate(kepler_container_dram_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
               "hide": false,
               "interval": "",
               "legendFormat": "DRAM",
@@ -521,7 +526,7 @@ spec:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "topk(10,sum(irate(kepler_container_other_joules_total{container_namespace=~\"$namespace\"}[1m])))",
+              "expr": "sum(irate(kepler_container_other_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
               "hide": false,
               "legendFormat": "OTHER",
               "range": true,
@@ -533,14 +538,14 @@ spec:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "topk(10, sum(irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1m])))",
+              "expr": "sum(irate(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[1m]))",
               "hide": false,
               "legendFormat": " GPU",
               "range": true,
               "refId": "D"
             }
           ],
-          "title": "Power Consumption (W) of Top10 processes in Namespace: $namespace or Top 10 Namespace if ALL namespaces is selected",
+          "title": "Total Power Consumption (W) in Namespace: $namespace",
           "type": "timeseries"
         },
         {
@@ -555,6 +560,8 @@ spec:
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
                 "axisLabel": "kWh",
                 "axisPlacement": "left",
                 "barAlignment": 0,
@@ -676,6 +683,7 @@ spec:
               ],
               "displayMode": "table",
               "placement": "bottom",
+              "showLegend": true,
               "sortBy": "Max",
               "sortDesc": true
             },
@@ -691,7 +699,7 @@ spec:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "topk(10, sum(\n  (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n))",
+              "expr": "sum (\n  increase(\n   (kepler_container_package_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[24h:1m])\n  )\n) * $watt_per_second_to_kWh",
               "hide": false,
               "interval": "",
               "legendFormat": "PKG (CORE+UNCORE)",
@@ -704,7 +712,7 @@ spec:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "topk(10, sum(\n  (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n))",
+              "expr": "sum (\n  increase(\n   (kepler_container_dram_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[24h:1m])\n  )\n) * $watt_per_second_to_kWh",
               "hide": false,
               "interval": "",
               "legendFormat": "DRAM",
@@ -717,7 +725,7 @@ spec:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "topk(10, sum(\n  (increase(\n    kepler_container_other_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(\n    kepler_container_other_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(\n      kepler_container_other_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n))",
+              "expr": "sum (\n  increase(\n   (kepler_container_other_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[24h:1m])\n  )\n) * $watt_per_second_to_kWh",
               "hide": false,
               "legendFormat": "OTHER",
               "range": true,
@@ -729,14 +737,14 @@ spec:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "topk(10, sum(\n  (increase(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_gpu_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n))",
+              "expr": "sum (\n  increase(\n   (kepler_container_gpu_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[24h:1m])\n  )\n) * $watt_per_second_to_kWh",
               "hide": false,
               "legendFormat": " GPU",
               "range": true,
               "refId": "D"
             }
           ],
-          "title": "Total Power Consumption (kWh per day) of Top10 processes in Namespace: $namespace or Top10 Namesapces if All Namespaces selected",
+          "title": "Total Power Consumption (kWh per day) in Namespace: $namespace",
           "type": "timeseries"
         },
         {
@@ -787,7 +795,7 @@ spec:
             },
             "showUnfilled": true
           },
-          "pluginVersion": "8.5.5",
+          "pluginVersion": "9.1.0",
           "targets": [
             {
               "datasource": {
@@ -795,19 +803,19 @@ spec:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "topk(10, sum by (container_namespace) (\n  (increase(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_package_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n)\n+\nsum by (container_namespace) (\n  (increase(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n    *$watt_per_second_to_kWh\n  ) *\n  (count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[24h])/\n    count_over_time(kepler_container_dram_joules_total{container_namespace=~\"$namespace\"}[1h])\n  )\n))",
+              "expr": "sum by (container_namespace) (\n  increase(\n      (kepler_container_joules_total{container_namespace=~\"$namespace\", pod_name=~\"$pod\"}[24h:1m])\n  )\n) * $watt_per_second_to_kWh ",
               "interval": "",
               "legendFormat": "{{container_namespace}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Total Power Consumption (PKG+DRAM) for Namespace: $namespace or Top 10 Namespaces if ALL Namespaces is selected (kWh per day)",
+          "title": "Total Power Consumption (PKG+DRAM+OTHER+GPU) by Namespace (kWh per day)",
           "type": "bargauge"
         }
       ],
       "refresh": "",
-      "schemaVersion": 36,
+      "schemaVersion": 37,
       "style": "dark",
       "tags": [],
       "templating": {
@@ -815,8 +823,8 @@ spec:
           {
             "current": {
               "selected": false,
-              "text": "prometheus",
-              "value": "prometheus"
+              "text": "Prometheus",
+              "value": "Prometheus"
             },
             "hide": 0,
             "includeAll": false,
@@ -824,6 +832,7 @@ spec:
             "name": "datasource",
             "options": [],
             "query": "prometheus",
+            "queryValue": "",
             "refresh": 1,
             "regex": "",
             "skipUrlSync": false,
@@ -833,8 +842,8 @@ spec:
             "allValue": ".*",
             "current": {
               "selected": false,
-              "text": "kepler",
-              "value": "$__kepler"
+              "text": "All",
+              "value": "$__all"
             },
             "datasource": {
               "type": "prometheus",
@@ -970,7 +979,7 @@ spec:
       "timepicker": {},
       "timezone": "browser",
       "title": "Kepler Exporter Dashboard",
-      "uid": "NhnADUW4z",
+      "uid": "NhnADUW4zIBM",
       "version": 2,
       "weekStart": ""
     }


### PR DESCRIPTION
As pointed by @sthaha in the discussion #946, the Prometheus query (defined in the PR #291) that calculates the `kWh` has a problem in the logic.

The query was only considering the first `1h` interval to extrapolate the results, but it should use the `24h` interval.
The problem is if in the last 1h, the power consumption is high, the extrapolation will show a very high value, even if the early values are low.

Fortunately, the `increase` function actually does what we need. It takes the average value from the entire range and multiply by the available sample interval.

Giving that, I update all the queries that calculate the `kWh` to be as:
```
sum by (container_name, pod_name) (
  increase(
   (kepler_container_package_joules_total{}[24h:30m])
  )
) * $watt_per_second_to_kWh
```
remembering that $watt_per_second_to_kWh is 0.0000002778 because:
1J = 1W*s,
1Wh = 1J/3600
1kWh = 1/3600000 = 0.0000002778

Note that I am using a step of `30m` in a range of 24h because the queries are very heavy. 
For example, with a step of `1m` I could not set my Grafana dashboard to show a timeseries of 12h, the queries were timing out. But I could load my dashboard with `30m` step.

Therefore, this PR includes the following:

- [x] fix the `kWh` extrapolation
- [x] decrease the samples in the Prometheus queries for performance reasons
- [x] add the GPU and OTHER power consumption instead of only using Package and DRAM
- [x] decrease the number of showing containers to top 10 and top 15 

