### PR TITLE
exporter: create model before manager starts

### DIFF
--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -229,6 +229,14 @@ func main() {
 		}
 	}
 
+	// For local estimator, there is endpoint provided, thus we should let
+	// model component decide whether/how to init
+	model.CreatePowerEstimatorModels(
+		collector_metric.ContainerFeaturesNames,
+		collector_metric.NodeMetadataFeatureNames,
+		collector_metric.NodeMetadataFeatureValues,
+	)
+
 	m := manager.New()
 	prometheus.MustRegister(version.NewCollector("kepler_exporter"))
 	prometheus.MustRegister(m.PrometheusCollector)
@@ -242,14 +250,6 @@ func main() {
 	}
 	metricPathConfig := config.GetMetricPath(*metricsPath)
 	bindAddressConfig := config.GetBindAddress(*address)
-
-	// For local estimator, there is endpoint provided, thus we should let
-	// model component decide whether/how to init
-	model.CreatePowerEstimatorModels(
-		collector_metric.ContainerFeaturesNames,
-		collector_metric.NodeMetadataFeatureNames,
-		collector_metric.NodeMetadataFeatureValues,
-	)
 
 	http.Handle(metricPathConfig, promhttp.Handler())
 	http.HandleFunc("/healthz", healthProbe)


### PR DESCRIPTION
The manager needs node and container models to update the metrics. So the models should be created before the manager starts.