### PR TITLE
Update LR data normalization to divide by the max value (scale)

### DIFF
--- a/pkg/model/estimator/local/lr.go
+++ b/pkg/model/estimator/local/lr.go
@@ -28,7 +28,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"os"
 
@@ -81,9 +80,8 @@ type CategoricalFeature struct {
 	Weight float64 `json:"weight"`
 }
 type NormalizedNumericalFeature struct {
-	Mean     float64 `json:"mean"`
-	Variance float64 `json:"variance"`
-	Weight   float64 `json:"weight"`
+	Scale  float64 `json:"scale"` // to normalize the data
+	Weight float64 `json:"weight"`
 }
 
 // getIndexedWeights maps weight index with usageMetrics
@@ -112,8 +110,7 @@ func (weights ModelWeights) predict(usageMetricNames []string, usageMetricValues
 			if coeff.Weight == 0 {
 				continue
 			}
-			// TODO: review this normalization, when the mean is higher than the val, the normalized value will be negative. We probably do not want this.
-			normalizedX := (vals[index] - coeff.Mean) / math.Sqrt(coeff.Variance)
+			normalizedX := vals[index] / coeff.Scale
 			power += coeff.Weight * normalizedX
 		}
 		powers = append(powers, power)

--- a/pkg/model/estimator/local/lr_test.go
+++ b/pkg/model/estimator/local/lr_test.go
@@ -71,10 +71,10 @@ var (
 		},
 	}
 	SampleCoreNumericalVars = map[string]NormalizedNumericalFeature{
-		"cpu_cycles": {Weight: 1.0, Mean: 0, Variance: 1},
+		"cpu_cycles": {Weight: 1.0, Scale: 1},
 	}
 	SampleDramNumbericalVars = map[string]NormalizedNumericalFeature{
-		"cache_miss": {Weight: 1.0, Mean: 0, Variance: 1},
+		"cache_miss": {Weight: 1.0, Scale: 1},
 	}
 	SampleComponentWeightResponse = ComponentModelWeights{
 		collector_metric.CORE: genWeights(SampleCoreNumericalVars),


### PR DESCRIPTION
We fixed in the model server the data normalization to divide a given metric by the max value, because the previous normalization was resulting in negative values.

This PR fix the issue #952.