### PR TITLE
Update idle power model

### DIFF
--- a/pkg/model/estimator/local/ratio.go
+++ b/pkg/model/estimator/local/ratio.go
@@ -100,7 +100,7 @@ func (r *RatioPowerModel) GetPlatformPower(isIdlePower bool) ([]float64, error) 
 		var containerPower float64
 		if isIdlePower {
 			// TODO: idle power should be divided accordinly to the container requested resource
-			containerPower = r.getPowerByRatio(containerIdx, int(PlatformUsageMetric), int(PlatformIdlePower), numContainers)
+			containerPower = r.nodeFeatureValues[PlatformIdlePower] / numContainers
 		} else {
 			containerPower = r.getPowerByRatio(containerIdx, int(PlatformUsageMetric), int(PlatformDynPower), numContainers)
 		}
@@ -125,7 +125,7 @@ func (r *RatioPowerModel) GetComponentsPower(isIdlePower bool) ([]source.NodeCom
 		// PKG power
 		// TODO: idle power should be divided accordinly to the container requested resource
 		if isIdlePower {
-			containerPower = uint64(r.getPowerByRatio(containerIdx, int(PkgUsageMetric), int(PkgIdlePower), numContainers))
+			containerPower = uint64(r.nodeFeatureValues[PkgIdlePower] / numContainers)
 		} else {
 			containerPower = uint64(r.getPowerByRatio(containerIdx, int(PkgUsageMetric), int(PkgDynPower), numContainers))
 		}
@@ -133,7 +133,7 @@ func (r *RatioPowerModel) GetComponentsPower(isIdlePower bool) ([]source.NodeCom
 
 		// CORE power
 		if isIdlePower {
-			containerPower = uint64(r.getPowerByRatio(containerIdx, int(CoreUsageMetric), int(CoreIdlePower), numContainers))
+			containerPower = uint64(r.nodeFeatureValues[CoreIdlePower] / numContainers)
 		} else {
 			containerPower = uint64(r.getPowerByRatio(containerIdx, int(CoreUsageMetric), int(CoreDynPower), numContainers))
 		}
@@ -141,7 +141,7 @@ func (r *RatioPowerModel) GetComponentsPower(isIdlePower bool) ([]source.NodeCom
 
 		// DRAM power
 		if isIdlePower {
-			containerPower = uint64(r.getPowerByRatio(containerIdx, int(DramUsageMetric), int(DramIdlePower), numContainers))
+			containerPower = uint64(r.nodeFeatureValues[DramIdlePower] / numContainers)
 		} else {
 			containerPower = uint64(r.getPowerByRatio(containerIdx, int(DramUsageMetric), int(DramDynPower), numContainers))
 		}
@@ -149,7 +149,7 @@ func (r *RatioPowerModel) GetComponentsPower(isIdlePower bool) ([]source.NodeCom
 
 		// UNCORE power
 		if isIdlePower {
-			containerPower = uint64(r.getPowerByRatio(containerIdx, int(UncoreUsageMetric), int(UncoreIdlePower), numContainers))
+			containerPower = uint64(r.nodeFeatureValues[UncoreIdlePower] / numContainers)
 		} else {
 			containerPower = uint64(r.getPowerByRatio(containerIdx, int(UncoreUsageMetric), int(UncoreDynPower), numContainers))
 		}
@@ -174,7 +174,7 @@ func (r *RatioPowerModel) GetGPUPower(isIdlePower bool) ([]float64, error) {
 
 		// TODO: idle power should be divided accordinly to the container requested resource
 		if isIdlePower {
-			containerPower = r.getPowerByRatio(containerIdx, int(GpuUsageMetric), int(GpuIdlePower), numContainers)
+			containerPower = r.nodeFeatureValues[GpuIdlePower] / numContainers
 		} else {
 			containerPower = r.getPowerByRatio(containerIdx, int(GpuUsageMetric), int(GpuDynPower), numContainers)
 		}

--- a/pkg/model/estimator/local/ratio_process.go
+++ b/pkg/model/estimator/local/ratio_process.go
@@ -69,7 +69,7 @@ func (r *RatioProcessPowerModel) GetPlatformPower(isIdlePower bool) ([]float64, 
 		var processPower float64
 		if isIdlePower {
 			// TODO: idle power should be divided accordinly to the process requested resource
-			processPower = r.getPowerByRatio(processIdx, int(PlatformUsageMetric), int(PlatformIdlePower), numProcesss)
+			processPower = r.nodeFeatureValues[PlatformIdlePower] / numProcesss
 		} else {
 			processPower = r.getPowerByRatio(processIdx, int(PlatformUsageMetric), int(PlatformDynPower), numProcesss)
 		}
@@ -94,7 +94,7 @@ func (r *RatioProcessPowerModel) GetComponentsPower(isIdlePower bool) ([]source.
 		// PKG power
 		// TODO: idle power should be divided accordinly to the process requested resource
 		if isIdlePower {
-			processPower = uint64(r.getPowerByRatio(processIdx, int(PkgUsageMetric), int(PkgIdlePower), numProcesss))
+			processPower = uint64(r.nodeFeatureValues[PkgIdlePower] / numProcesss)
 		} else {
 			processPower = uint64(r.getPowerByRatio(processIdx, int(PkgUsageMetric), int(PkgDynPower), numProcesss))
 		}
@@ -102,7 +102,7 @@ func (r *RatioProcessPowerModel) GetComponentsPower(isIdlePower bool) ([]source.
 
 		// CORE power
 		if isIdlePower {
-			processPower = uint64(r.getPowerByRatio(processIdx, int(CoreUsageMetric), int(CoreIdlePower), numProcesss))
+			processPower = uint64(r.nodeFeatureValues[CoreIdlePower] / numProcesss)
 		} else {
 			processPower = uint64(r.getPowerByRatio(processIdx, int(CoreUsageMetric), int(CoreDynPower), numProcesss))
 		}
@@ -110,7 +110,7 @@ func (r *RatioProcessPowerModel) GetComponentsPower(isIdlePower bool) ([]source.
 
 		// DRAM power
 		if isIdlePower {
-			processPower = uint64(r.getPowerByRatio(processIdx, int(DramUsageMetric), int(DramIdlePower), numProcesss))
+			processPower = uint64(r.nodeFeatureValues[DramIdlePower] / numProcesss)
 		} else {
 			processPower = uint64(r.getPowerByRatio(processIdx, int(DramUsageMetric), int(DramDynPower), numProcesss))
 		}
@@ -118,7 +118,7 @@ func (r *RatioProcessPowerModel) GetComponentsPower(isIdlePower bool) ([]source.
 
 		// UNCORE power
 		if isIdlePower {
-			processPower = uint64(r.getPowerByRatio(processIdx, int(UncoreUsageMetric), int(UncoreIdlePower), numProcesss))
+			processPower = uint64(r.nodeFeatureValues[UncoreIdlePower] / numProcesss)
 		} else {
 			processPower = uint64(r.getPowerByRatio(processIdx, int(UncoreUsageMetric), int(UncoreDynPower), numProcesss))
 		}
@@ -143,7 +143,7 @@ func (r *RatioProcessPowerModel) GetGPUPower(isIdlePower bool) ([]float64, error
 
 		// TODO: idle power should be divided accordinly to the process requested resource
 		if isIdlePower {
-			processPower = r.getPowerByRatio(processIdx, int(GpuUsageMetric), int(GpuIdlePower), numProcesss)
+			processPower = r.nodeFeatureValues[GpuIdlePower] / numProcesss
 		} else {
 			processPower = r.getPowerByRatio(processIdx, int(GpuUsageMetric), int(GpuDynPower), numProcesss)
 		}


### PR DESCRIPTION
The previous code refactoring incorrectly defined the idle power due to a copy-and-paste error.

According to the GHG protocol, we are supposed to divide the idle power based on the application's size, which should align with the container's resource request. However, as there are containers without requests, implementing this can be challenging.

As a quick solution, this PR reverts to the previous logic of evenly distributing the idle power across all containers.