### PR TITLE
git: ignore root tmp dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ local-dev-cluster
 *.prof
 *.test
 *.cache
+/tmp


### PR DESCRIPTION
Ignoring tmp dir is useful to keep all temporary project related files under the tmp directory.