### PR TITLE
build: drop ubi 8 kernel source to fix issue #973

### DIFF
--- a/build/Dockerfile.bcc.kepler
+++ b/build/Dockerfile.bcc.kepler
@@ -37,7 +37,6 @@ COPY --from=builder /opt/app-root/src/github.com/sustainable-computing-io/kepler
 # pre install kernel sources
 RUN mkdir -p /usr/share/kepler/kernel_sources
 
-COPY --from=quay.io/sustainable_computing_io/kepler_kernel_source_images:ubi8 /usr/src/kernels /usr/share/kepler/kernel_sources
 COPY --from=quay.io/sustainable_computing_io/kepler_kernel_source_images:ubi9 /usr/src/kernels /usr/share/kepler/kernel_sources
 
 ENTRYPOINT ["/usr/bin/kepler"]


### PR DESCRIPTION
fix #973 

Using mismatched kernel source causes ebpf unable to get cpu time correctly