### PR TITLE
move model initialization after BPF attach

### DIFF
--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -32,7 +32,6 @@ import (
 	collector_metric "github.com/sustainable-computing-io/kepler/pkg/collector/metric"
 	"github.com/sustainable-computing-io/kepler/pkg/config"
 	"github.com/sustainable-computing-io/kepler/pkg/manager"
-	"github.com/sustainable-computing-io/kepler/pkg/model"
 	"github.com/sustainable-computing-io/kepler/pkg/power/accelerator/gpu"
 	"github.com/sustainable-computing-io/kepler/pkg/power/accelerator/qat"
 	"github.com/sustainable-computing-io/kepler/pkg/power/components"
@@ -228,14 +227,6 @@ func main() {
 			klog.Infof("Failed to initialize the QAT collector: %v", err)
 		}
 	}
-
-	// For local estimator, there is endpoint provided, thus we should let
-	// model component decide whether/how to init
-	model.CreatePowerEstimatorModels(
-		collector_metric.ContainerFeaturesNames,
-		collector_metric.NodeMetadataFeatureNames,
-		collector_metric.NodeMetadataFeatureValues,
-	)
 
 	m := manager.New()
 	prometheus.MustRegister(version.NewCollector("kepler_exporter"))

--- a/pkg/collector/metric_collector.go
+++ b/pkg/collector/metric_collector.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sustainable-computing-io/kepler/pkg/bpfassets/attacher"
 	"github.com/sustainable-computing-io/kepler/pkg/cgroup"
 	"github.com/sustainable-computing-io/kepler/pkg/config"
+	"github.com/sustainable-computing-io/kepler/pkg/model"
 	"github.com/sustainable-computing-io/kepler/pkg/power/accelerator/gpu"
 	"github.com/sustainable-computing-io/kepler/pkg/power/accelerator/qat"
 	"github.com/sustainable-computing-io/kepler/pkg/utils"
@@ -80,6 +81,14 @@ func (c *Collector) Initialize() error {
 		klog.V(5).Infoln(err)
 		return err
 	}
+
+	// For local estimator, there is endpoint provided, thus we should let
+	// model component decide whether/how to init
+	model.CreatePowerEstimatorModels(
+		collector_metric.ContainerFeaturesNames,
+		collector_metric.NodeMetadataFeatureNames,
+		collector_metric.NodeMetadataFeatureValues,
+	)
 
 	c.prePopulateContainerMetrics(pods)
 	c.updateNodeEnergyMetrics()

--- a/pkg/model/container_energy.go
+++ b/pkg/model/container_energy.go
@@ -86,8 +86,13 @@ func createContainerPowerModelConfig(powerSourceTarget string, containerFeatureN
 				collector_metric.GPU + "_IDLE",    // for idle GPU power consumption
 			}...)
 		} else if powerSourceTarget == config.ContainerPlatformPowerKey {
+			platformUsageMetric := config.CoreUsageMetric
+			if !attacher.HardwareCountersEnabled {
+				// Given that there is no HW counter in  some scenarios (e.g. on VMs), we have to use CPUTime data.
+				platformUsageMetric = config.CPUTime
+			}
 			modelConfig.ContainerFeatureNames = []string{
-				config.CoreUsageMetric, // for PLATFORM resource usage
+				platformUsageMetric, // for PLATFORM resource usage
 			}
 			modelConfig.NodeFeatureNames = modelConfig.ContainerFeatureNames
 			modelConfig.NodeFeatureNames = append(modelConfig.NodeFeatureNames, []string{
@@ -107,6 +112,7 @@ func CreateContainerPowerEstimatorModel(containerFeatureNames, systemMetaDataFea
 	ContainerPlatformPowerModel, err = createPowerModelEstimator(modelConfig)
 	if err == nil {
 		klog.Infof("Using the %s Power Model to estimate Container Platform Power", modelConfig.ModelType.String()+"/"+modelConfig.ModelOutputType.String())
+		klog.Infof("Container feature names: %v", modelConfig.ContainerFeatureNames)
 	} else {
 		klog.Infof("Failed to create %s Power Model to estimate Container Platform Power: %v\n", modelConfig.ModelType.String()+"/"+modelConfig.ModelOutputType.String(), err)
 	}
@@ -116,6 +122,7 @@ func CreateContainerPowerEstimatorModel(containerFeatureNames, systemMetaDataFea
 	ContainerComponentPowerModel, err = createPowerModelEstimator(modelConfig)
 	if err == nil {
 		klog.Infof("Using the %s Power Model to estimate Container Component Power", modelConfig.ModelType.String()+"/"+modelConfig.ModelOutputType.String())
+		klog.Infof("Container feature names: %v", modelConfig.ContainerFeatureNames)
 	} else {
 		klog.Infof("Failed to create %s Power Model to estimate Container Component Power: %v\n", modelConfig.ModelType.String()+"/"+modelConfig.ModelOutputType.String(), err)
 	}

--- a/pkg/model/process_power.go
+++ b/pkg/model/process_power.go
@@ -85,8 +85,13 @@ func createProcessPowerModelConfig(powerSourceTarget string, processFeatureNames
 				collector_metric.GPU + "_IDLE",    // for idle GPU power consumption
 			}...)
 		} else if powerSourceTarget == config.ProcessPlatformPowerKey {
+			platformUsageMetric := config.CoreUsageMetric
+			if !attacher.HardwareCountersEnabled {
+				// Given that there is no HW counter in  some scenarios (e.g. on VMs), we have to use CPUTime data.
+				platformUsageMetric = config.CPUTime
+			}
 			modelConfig.ContainerFeatureNames = []string{
-				config.CoreUsageMetric, // for PLATFORM resource usage
+				platformUsageMetric, // for PLATFORM resource usage
 			}
 			modelConfig.NodeFeatureNames = modelConfig.ContainerFeatureNames
 			modelConfig.NodeFeatureNames = append(modelConfig.NodeFeatureNames, []string{
@@ -106,6 +111,7 @@ func CreateProcessPowerEstimatorModel(processFeatureNames, systemMetaDataFeature
 	ProcessPlatformPowerModel, err = createPowerModelEstimator(modelConfig)
 	if err == nil {
 		klog.Infof("Using the %s Power Model to estimate Process Platform Power", modelConfig.ModelType.String()+"/"+modelConfig.ModelOutputType.String())
+		klog.Infof("Container feature names: %v", modelConfig.ContainerFeatureNames)
 	} else {
 		klog.Infof("Failed to create %s Power Model to estimate Process Platform Power: %v\n", modelConfig.ModelType.String()+"/"+modelConfig.ModelOutputType.String(), err)
 	}
@@ -115,6 +121,7 @@ func CreateProcessPowerEstimatorModel(processFeatureNames, systemMetaDataFeature
 	ProcessComponentPowerModel, err = createPowerModelEstimator(modelConfig)
 	if err == nil {
 		klog.Infof("Using the %s Power Model to estimate Process Component Power", modelConfig.ModelType.String()+"/"+modelConfig.ModelOutputType.String())
+		klog.Infof("Container feature names: %v", modelConfig.ContainerFeatureNames)
 	} else {
 		klog.Infof("Failed to create %s Power Model to estimate Process Component Power: %v\n", modelConfig.ModelType.String()+"/"+modelConfig.ModelOutputType.String(), err)
 	}


### PR DESCRIPTION
This PR is for fixing an issue we discovered after PR https://github.com/sustainable-computing-io/kepler/pull/950 merged. 

On VM, container power has not related to CPU time as expected.
The reason is that it is using the hardware counter for the ratio power model.
Confirming that by printing out the container feature names as below (recommend to keep this line print).
After debugging session with @marceloamaral, we found that the root cause is the attacher.HardwareCountersEnabled set after BPF attachment inside the manager start.

```
I1010 09:05:00.775838 3114275 container_energy.go:109] Using the Ratio/DynPower Power Model to estimate Container Platform Power
I1010 09:05:00.775881 3114275 container_energy.go:110] Container feature names: [cpu_instructions]
I1010 09:05:00.775909 3114275 container_energy.go:119] Using the Ratio/DynPower Power Model to estimate Container Component Power
I1010 09:05:00.775914 3114275 container_energy.go:120] Container feature names: [cpu_instructions cpu_instructions cache_miss   gpu_sm_util]
I1010 09:05:00.775924 3114275 process_power.go:108] Using the Ratio/DynPower Power Model to estimate Process Platform Power
I1010 09:05:00.775935 3114275 process_power.go:117] Using the Ratio/DynPower Power Model to estimate Process Component Power
I1010 09:05:00.989369 3114275 node_platform_energy.go:53] Using the EstimatorSidecar/AbsPower Power Model to estimate Node Platform Power
I1010 09:05:01.182582 3114275 node_component_energy.go:54] Using the EstimatorSidecar/AbsPower Power Model to estimate Node Component Power
```

This PR move the container power model logic to be inside the Initialize function after the attachment.
In addition, this PR fixes missing logic to set CPU time as a ratio metric for the platform energy for both container and process.

---
Here is comparing result when running stressng benchmark for stressing CPU.

Before:
![Screenshot 2023-10-10 at 18 42 48](https://github.com/sustainable-computing-io/kepler/assets/11749848/daed47b7-ae5d-41bd-9406-2dd66eb61d84)

After:
![Screenshot 2023-10-10 at 18 42 23](https://github.com/sustainable-computing-io/kepler/assets/11749848/1ba452f3-7fc4-4565-ac90-f05faf102af6)


For reference:
here is CPU time.
![Screenshot 2023-10-10 at 18 44 07](https://github.com/sustainable-computing-io/kepler/assets/11749848/58c0e060-c405-4852-a232-115abfe17378)




Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>

