### PR TITLE
Fix resolve container id for new systems

### DIFF
--- a/pkg/cgroup/resolve_container.go
+++ b/pkg/cgroup/resolve_container.go
@@ -230,6 +230,11 @@ func extractPodContainerIDfromPath(path string) (string, error) {
 	if path == unknownPath {
 		return utils.SystemProcessName, fmt.Errorf("failed to find pod's container id")
 	}
+	// as the container ID is located at the end of the path, we remove the beginning of the string to prevent bugs, as seen in issue #923
+	split := strings.Split(path, "/")
+	size := len(split)
+	path = split[size-1 : size][0]
+
 	cgroup := config.GetCGroupVersion()
 	if regexFindContainerIDPath.MatchString(path) {
 		sub := regexFindContainerIDPath.FindAllString(path, -1)


### PR DESCRIPTION
The issue #923 identified a bug in resolving the container ID, where it was getting the Docker container ID instead of the Kubernetes container ID.

The CRI-O container ID is always located at the end of the cgroup path. Therefore, this PR fix the issue by removing the unnecessary portion of the string to prevent such a bug.