### PR TITLE
prometheus: remove not utf-8 encoding cmd

### DIFF
--- a/pkg/collector/prometheus_process_collector.go
+++ b/pkg/collector/prometheus_process_collector.go
@@ -19,6 +19,7 @@ package collector
 import (
 	"strconv"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -183,6 +184,9 @@ func (p *PrometheusCollector) updateProcessMetrics(wg *sync.WaitGroup, ch chan<-
 			processCommand := process.Command
 			if len(processCommand) > commandLenLimit {
 				processCommand = process.Command[:commandLenLimit]
+			}
+			if !utf8.ValidString(processCommand) {
+				processCommand = ""
 			}
 			pidStr := strconv.FormatUint(pid, 10)
 			if process.BPFStats[config.CPUTime] != nil {


### PR DESCRIPTION
Some process commands are not utf-8 encoding, like the PID 0, which may cause the panic when update the prometheus metrics.

Before this patch:
```
# debug log
I1016 10:27:50.182600       1 prometheus_process_collector.go:192] pid: 0, cmd: �
```
```
panic: label value "\x83\u007f" is not valid UTF-8
goroutine 271 [running]:
github.com/prometheus/client_golang/prometheus.MustNewConstMetric(...)
 /opt/app-root/src/github.com/sustainable-computing-io/kepler/vendor/github.com/prometheus/client_golang/prometheus/value.go:130
github.com/sustainable-computing-io/kepler/pkg/collector.(*PrometheusCollector).updateProcessMetrics.func1(0x2f73662f7379732f?, 0xc000284000)
 /opt/app-root/src/github.com/sustainable-computing-io/kepler/pkg/collector/prometheus_process_collector.go:194 +0x23c5
created by github.com/sustainable-computing-io/kepler/pkg/collector.(*PrometheusCollector).updateProcessMetrics
 /opt/app-root/src/github.com/sustainable-computing-io/kepler/pkg/collector/prometheus_process_collector.go:183 +0x8e
```

Because the cmd for pid 0 is meaningless and pid is a unique number, I convert the cmd to "" directly.