### PR TITLE
vm_metrics: fix libvirt path join error

### DIFF
--- a/manifests/config/exporter/exporter.yaml
+++ b/manifests/config/exporter/exporter.yaml
@@ -90,6 +90,8 @@ spec:
           name: tracing
         - mountPath: /proc
           name: proc
+        - mountPath: /var/run
+          name: var-run
         - name: cfm
           mountPath: /etc/kepler/kepler.config
           readOnly: true
@@ -117,6 +119,10 @@ spec:
       - name: proc
         hostPath:
           path: /proc
+          type: Directory
+      - name: var-run
+        hostPath:
+          path: /var/run
           type: Directory
       - name: cfm
         configMap:

--- a/pkg/libvirt/resolve_vm.go
+++ b/pkg/libvirt/resolve_vm.go
@@ -27,17 +27,11 @@ const (
 	procPath    string = "/proc/%s/task"
 )
 
-func getThreadIDsForPID(pid, extraPath string) []string {
+func getThreadIDsForPID(pid, fullPath string) []string {
 	threadIDs := []string{}
-	fullPath := ""
-
-	if procPath != "" {
-		fullPath = filepath.Join(extraPath, procPath)
-	} else {
-		fullPath = procPath
-	}
 
 	procDir := fmt.Sprintf(fullPath, pid)
+
 	files, err := ioutil.ReadDir(procDir)
 	if err != nil {
 		return nil

--- a/pkg/libvirt/resolve_vm_test.go
+++ b/pkg/libvirt/resolve_vm_test.go
@@ -65,6 +65,7 @@ func TestGetCurrentVMPID(t *testing.T) {
 	mockProcDir := t.TempDir()
 	createMockProcDir(mockProcDir)
 
+	mockProcDir = filepath.Join(mockProcDir, procPath)
 	pidFiles, err := GetCurrentVMPID(mockLibvirtDir, mockProcDir)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)


### PR DESCRIPTION
Link #1008 

1. mount hostpath /var/run for manifests deployment.
2. fix path join error.