### PR TITLE
fix(build): support newer version of kubectl

### DIFF
--- a/hack/tools.sh
+++ b/hack/tools.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# This file is part of the Kepler project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2023 The Kepler Contributors
+#
+
+set -eu -o pipefail
+
+# constants
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+GOOS="$(go env GOOS)"
+GOARCH="$(go env GOARCH)"
+
+declare -r PROJECT_ROOT GOOS GOARCH
+declare -r LOCAL_BIN="$PROJECT_ROOT/tmp/bin"
+
+# tools
+declare -r KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-v4.5.2}
+declare -r KUSTOMIZE_INSTALL_SCRIPT="https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
+
+declare -r JQ_VERSION=${JQ_VERSION:-1.7}
+declare -r JQ_INSTALL_URL="https://github.com/jqlang/jq/releases/download/jq-$JQ_VERSION/jq-$GOOS-$GOARCH"
+
+source "$PROJECT_ROOT/hack/utils.bash"
+
+validate_version() {
+	local cmd="$1"
+	local version_arg="$2"
+	local version_regex="$3"
+	shift 3
+
+	command -v "$cmd" >/dev/null 2>&1 || return 1
+	[[ $(eval "$cmd $version_arg" | grep -o "$version_regex") =~ $version_regex ]] || {
+		return 1
+	}
+
+	ok "$cmd installed successfully"
+}
+
+install_kustomize() {
+	command -v kustomize >/dev/null 2>&1 &&
+		[[ $(kustomize version --short | grep -o 'v[0-9].[0-9].[0-9]') == "$KUSTOMIZE_VERSION" ]] && {
+		ok "kustomize $KUSTOMIZE_VERSION is already installed"
+		return 0
+	}
+
+	info "installing kustomize version: $KUSTOMIZE_VERSION"
+	(
+		# NOTE: this handles softlinks properly
+		cd "$LOCAL_BIN"
+		curl -Ss $KUSTOMIZE_INSTALL_SCRIPT | bash -s -- "${KUSTOMIZE_VERSION:1}" .
+	) || {
+		fail "failed to install kustomize"
+		return 1
+	}
+	ok "kustomize was installed successfully"
+}
+
+go_install() {
+	local pkg="$1"
+	local version="$2"
+	shift 2
+
+	info "installing $pkg version: $version"
+
+	GOBIN=$LOCAL_BIN \
+		go install "$pkg@$version" || {
+		fail "failed to install $pkg - $version"
+		return 1
+	}
+	ok "$pkg - $version was installed successfully"
+
+}
+
+curl_install() {
+	local binary="$1"
+	local url="$2"
+	shift 2
+
+	info "installing $binary"
+	curl -sSLo "$LOCAL_BIN/$binary" "$url" || {
+		fail "failed to install $binary"
+		return 1
+	}
+
+	chmod +x "$LOCAL_BIN/$binary"
+	ok "$binary was installed successfully"
+}
+
+install_jq() {
+	validate_version jq --version "$JQ_VERSION" && {
+		return 0
+	}
+	curl_install jq "$JQ_INSTALL_URL"
+}
+
+install_govulncheck() {
+	go_install golang.org/x/vuln/cmd/govulncheck latest
+}
+
+install_all() {
+	info "installing all tools ..."
+	local ret=0
+	for tool in $(declare -F | cut -f3 -d ' ' | grep install_ | grep -v 'install_all'); do
+		"$tool" || ret=1
+	done
+	return $ret
+}
+
+main() {
+	local op="${1:-all}"
+	shift || true
+
+	mkdir -p "$LOCAL_BIN"
+	export PATH="$LOCAL_BIN:$PATH"
+	install_"$op"
+}
+
+main "$@"

--- a/hack/utils.bash
+++ b/hack/utils.bash
@@ -1,0 +1,113 @@
+#
+# Copyright 2023.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+is_fn() {
+	[[ $(type -t "$1") == "function" ]]
+	return $?
+}
+
+header() {
+	local title=" 🔆🔆🔆  $*  🔆🔆🔆 "
+
+	local len=40
+	if [[ ${#title} -gt $len ]]; then
+		len=${#title}
+	fi
+
+	echo -e "\n\n  \033[1m${title}\033[0m"
+	echo -n "━━━━━"
+	printf '━%.0s' $(seq "$len")
+	echo "━━━━━━━"
+
+}
+
+info() {
+	echo -e " 🔔 $*" >&2
+}
+
+err() {
+	echo -e " 😱 $*" >&2
+}
+
+warn() {
+	echo -e "   $*" >&2
+}
+
+ok() {
+	echo -e "   ✅ $*" >&2
+}
+
+skip() {
+	echo -e " 🙈 SKIP: $*" >&2
+}
+
+fail() {
+	echo -e " ❌ FAIL: $*" >&2
+}
+
+info_run() {
+	echo -e "      $*\n" >&2
+}
+
+run() {
+	echo -e " ❯ $*\n" >&2
+	"$@"
+}
+
+die() {
+	echo -e "\n ✋ $* "
+	echo -e "──────────────────── ⛔️⛔️⛔️ ────────────────────────\n"
+	exit 1
+}
+
+line() {
+	local len="$1"
+	local style="${2:-thin}"
+	shift
+
+	local ch='─'
+	[[ "$style" == 'heavy' ]] && ch="━"
+
+	printf "$ch%.0s" $(seq "$len") >&2
+	echo
+}
+
+# wait_until <max_tries> <delay> <msg> <condition>
+# waits for condition to be true for a max of <max_tries> x <delay> seconds
+wait_until() {
+	local max_tries="$1"
+	local delay="$2"
+	local msg="$3"
+	local condition="$4"
+	shift 4
+
+	info "Waiting [$max_tries x ${delay}s] for $msg"
+	local tries=0
+	local -i ret=1
+	echo " ❯ $condition $*" 2>&1
+	while [[ $tries -lt $max_tries ]]; do
+		$condition "$@" && {
+			ret=0
+			break
+		}
+
+		tries=$((tries + 1))
+		echo "   ... [$tries / $max_tries] waiting ($delay secs) - $msg" >&2
+		sleep "$delay"
+	done
+
+	return $ret
+}


### PR DESCRIPTION
kubectl version --short has been deprecated since 1.23. In the latest kubectl, the flag is removed and causes `build-manifest` to fail when checking for the version.

This fixes the version check by using --client -o json options and using jq to validate if the version is higher than expected - 1.21