### PR TITLE
Add log to make logic clearer

### DIFF
--- a/pkg/bpfassets/attacher/bpf_perf.go
+++ b/pkg/bpfassets/attacher/bpf_perf.go
@@ -132,7 +132,7 @@ func Attach() (interface{}, error) {
 		// err != nil, disable and try using bcc
 		detachLibbpfModule()
 		config.UseLibBPFAttacher = false
-		klog.Infof("failed to attach bpf with libbpf: %v", err)
+		klog.Infof("failed to attach bpf with libbpf: %v, fall back to bcc attachment", err)
 	}
 	return attachBccModule()
 }


### PR DESCRIPTION
seeing this which makes me confusing , add logs should be helpful for such scenario

```
Nov 01 10:10:36 jitest51.novalocal kepler[25539]: I1101 10:10:36.989443   25539 bpf_perf.go:132] failed to attach bpf with libbpf: failed to load module: stat /bpfassets/libbpf/bpf.o/amd64_kepler.bpf.o: no such file or directory
Nov 01 10:10:36 jitest51.novalocal kepler[25539]: I1101 10:10:36.989486   25539 exporter.go:240] failed to start : failed to attach bpf assets: no bcc build tag

```