### PR TITLE
feat: Improve Dockerfile caching for faster builds (#913)

### DIFF
--- a/build/Dockerfile.bcc.kepler
+++ b/build/Dockerfile.bcc.kepler
@@ -9,14 +9,22 @@ ENV GOPATH=/opt/app-root GO111MODULE=on GOROOT=/usr/local/go
 
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
+# Set GOCACHE environment variable for caching
+ENV GOCACHE=/go/cache 
+
 WORKDIR $GOPATH/src/github.com/sustainable-computing-io/kepler
 
+# Cache and download Go dependencies if go.mod or go.sum changes
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/cache \
+go mod download -x
 
 COPY . .
 RUN mkdir -p data
 
-# Build kepler
-RUN make build SOURCE_GIT_TAG=$SOURCE_GIT_TAG BIN_TIMESTAMP=$BIN_TIMESTAMP
+# Build kepler with caching to speed up the process
+RUN --mount=type=cache,target=/go/cache/ \
+make build SOURCE_GIT_TAG=$SOURCE_GIT_TAG BIN_TIMESTAMP=$BIN_TIMESTAMP
 RUN ls ./_output/bin
 # RUN make test
 


### PR DESCRIPTION
I made some improvements to the Dockerfile:

-  Added GOCACHE environment variable for caching. 
-  Implemented caching and downloading of Go dependencies, triggered only if go.mod or go.sum changes.
-  Introduced a cache layer in the build process to enhance overall build speed.

To verify these changes, run the build process twice:
1. The first build will download and save dependencies in the cache.
2. The second build will utilize the cache layer for a faster image build.