### PR TITLE
CI: try to set GO111MODULE to off and use vendor folder for build(#913)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ clean-cross-build:
 build: clean_build_local _build_local copy_build_local
 .PHONY: build
 
-_build_local: tidy-vendor format
+_build_local:
 	@echo TAGS=$(GO_BUILD_TAGS)
 	@mkdir -p "$(CROSS_BUILD_BINDIR)/$(GOOS)_$(GOARCH)"
 	+@$(GOENV) go build -v -tags ${GO_BUILD_TAGS} -o $(CROSS_BUILD_BINDIR)/$(GOOS)_$(GOARCH)/kepler -ldflags $(LDFLAGS) ./cmd/exporter/exporter.go

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ ARG SOURCE_GIT_TAG
 
 LABEL name=kepler-builder
 
-ENV GOPATH=/opt/app-root GO111MODULE=on GOROOT=/usr/local/go 
+ENV GOPATH=/opt/app-root GO111MODULE=off GOROOT=/usr/local/go 
 
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
@@ -17,7 +17,6 @@ WORKDIR $GOPATH/src/github.com/sustainable-computing-io/kepler
 
 COPY . .
 RUN mkdir -p data
-
 # Build kepler
 RUN make build SOURCE_GIT_TAG=$SOURCE_GIT_TAG BIN_TIMESTAMP=$BIN_TIMESTAMP
 RUN ls ./_output/bin

--- a/build/Dockerfile.bcc.kepler
+++ b/build/Dockerfile.bcc.kepler
@@ -5,7 +5,7 @@ ARG SOURCE_GIT_TAG
 
 LABEL name=kepler-builder
 
-ENV GOPATH=/opt/app-root GO111MODULE=on GOROOT=/usr/local/go 
+ENV GOPATH=/opt/app-root GO111MODULE=off GOROOT=/usr/local/go 
 
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
@@ -14,17 +14,10 @@ ENV GOCACHE=/go/cache
 
 WORKDIR $GOPATH/src/github.com/sustainable-computing-io/kepler
 
-# Cache and download Go dependencies if go.mod or go.sum changes
-COPY go.mod go.sum ./
-RUN --mount=type=cache,target=/go/cache \
-go mod download -x
-
 COPY . .
 RUN mkdir -p data
-
 # Build kepler with caching to speed up the process
-RUN --mount=type=cache,target=/go/cache/ \
-make build SOURCE_GIT_TAG=$SOURCE_GIT_TAG BIN_TIMESTAMP=$BIN_TIMESTAMP
+RUN make build SOURCE_GIT_TAG=$SOURCE_GIT_TAG BIN_TIMESTAMP=$BIN_TIMESTAMP
 RUN ls ./_output/bin
 # RUN make test
 

--- a/build/Dockerfile.libbpf.kepler
+++ b/build/Dockerfile.libbpf.kepler
@@ -8,7 +8,7 @@ ARG SOURCE_GIT_TAG
 
 LABEL name=kepler-builder
 
-ENV GOPATH=/opt/app-root GO111MODULE=on GOROOT=/usr/local/go 
+ENV GOPATH=/opt/app-root GO111MODULE=off GOROOT=/usr/local/go 
 
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
@@ -16,7 +16,6 @@ WORKDIR $GOPATH/src/github.com/sustainable-computing-io/kepler
 
 COPY . .
 RUN mkdir -p data
-
 # Build kepler
 RUN make build SOURCE_GIT_TAG=$SOURCE_GIT_TAG BIN_TIMESTAMP=$BIN_TIMESTAMP
 RUN ls ./_output/bin


### PR DESCRIPTION
As we have dep bot looks after our dependence , hence we don't need go mod tidy to update our dependence before our build. We can make the go build relays on our vendor to save time for image build.