### PR TITLE
fix bug failed to get metric after first collection

### DIFF
--- a/pkg/bpfassets/attacher/libbpf_attacher.go
+++ b/pkg/bpfassets/attacher/libbpf_attacher.go
@@ -210,6 +210,8 @@ func libbpfCollectProcess() (processesData []ProcessBPFMetrics, err error) {
 	}
 	if ebpfBatchGetAndDelete {
 		processesData, err = libbpfCollectProcessBatchSingleHash(processes)
+	} else {
+		processesData, err = libbpfCollectProcessSingleHash(processes)
 	}
 	if err == nil {
 		return


### PR DESCRIPTION
This PR is to fix the bug described in https://github.com/sustainable-computing-io/kepler/issues/1057. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>