### PR TITLE
Feat: add AMD CPU architectures to data/normalized_cpu_arch.csv so they are correctly extracted and e.g. shown in the OpenShift console dashboard when using the kepler-operator

### DIFF
--- a/data/normalized_cpu_arch.csv
+++ b/data/normalized_cpu_arch.csv
@@ -21,3 +21,6 @@ Sapphire Rapids
 Raptor Cove
 Raptor Lake
 neoverse_n1
+AMD Zen 3
+AMD Zen 2
+AMD Zen


### PR DESCRIPTION
Was tested successfully by building the docker image locally and using it with a locally run kepler-operator in an OpenShift 4.11 cluster. CPU architecture in the Power Monitoring / Overview dashboard was successfully reported to be AMD Zen / AMD Zen 2 / AMD Zen 3 for corresponding AWS instances.

Fixes #1066 