### PR TITLE
WIP chore(Dockerfile): Simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM quay.io/sustainable_computing_io/kepler-base:latest as builder
+
+WORKDIR /workspace
+
+COPY . .
+
+RUN ATTACHER_TAG=libbpf make build
+
+FROM registry.access.redhat.com/ubi9-minimal:9.2
+RUN microdnf -y update
+
+RUN INSTALL_PKGS=" \
+    libbpf \
+    " && \
+	microdnf install -y $INSTALL_PKGS && \
+	microdnf clean all
+
+COPY --from=builder /workspace/_output/bin/kepler /usr/bin/kepler
+COPY --from=builder /libbpf-source/linux-5.14.0-333.el9/tools/bpf/bpftool/bpftool /usr/bin/bpftool
+COPY --from=builder /usr/bin/cpuid /usr/bin/cpuid
+
+RUN mkdir -p /var/lib/kepler/data
+RUN mkdir -p /var/lib/kepler/bpfassets
+COPY --from=builder /workspace/data/normalized_cpu_arch.csv /var/lib/kepler/data/normalized_cpu_arch.csv
+COPY --from=builder /workspace/bpfassets/libbpf/bpf.o /var/lib/kepler/bpfassets
+
+# copy model weight
+COPY --from=builder /workspace/data/model_weight/acpi_AbsPowerModel.json /var/lib/kepler/data/acpi_AbsPowerModel.json
+COPY --from=builder /workspace/data/model_weight/acpi_DynPowerModel.json /var/lib/kepler/data/acpi_DynPowerModel.json
+COPY --from=builder /workspace/data/model_weight/rapl_AbsPowerModel.json /var/lib/kepler/data/rapl_AbsPowerModel.json
+COPY --from=builder /workspace/data/model_weight/rapl_DynPowerModel.json /var/lib/kepler/data/rapl_DynPowerModel.json
+ENTRYPOINT ["/usr/bin/kepler"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,33 @@
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20 as builder
+
+USER 0
+
+RUN yum -y install yum-utils
+RUN yum-config-manager --enable ubi-9-baseos-source 
+
+WORKDIR /elfutils-source
+RUN yumdownloader --source elfutils
+RUN yum -y install cpio
+RUN rpm2cpio elfutils-0.189-3.el9.src.rpm | cpio -iv
+RUN tar xjvf elfutils-0.189.tar.bz2
+WORKDIR /elfutils-source/elfutils-0.189
+RUN ./configure --disable-debuginfod
+RUN make install
+
+
+WORKDIR /libbpf-source
+RUN yumdownloader --source libbpf
+RUN rpm2cpio libbpf-1.2.0-1.el9.src.rpm | cpio -iv
+RUN tar xf ./linux-*el9.tar.xz
+WORKDIR /libbpf-source/linux-5.14.0-333.el9/tools/lib/bpf
+RUN make install_headers
+RUN prefix=/usr BUILD_STATIC_ONLY=y make install
+WORKDIR /libbpf-source/linux-5.14.0-333.el9/tools/bpf
+RUN make bpftool
+
+RUN yum -y install clang
+
+# enable EPEL and install cpuid
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+RUN yum install -y cpuid
+RUN yum clean all

--- a/pkg/bpfassets/perf_event_bindata.go
+++ b/pkg/bpfassets/perf_event_bindata.go
@@ -401,11 +401,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("nonexistent") would return an error


### PR DESCRIPTION
 - Adds Dockerfile.base which installs everything required to build kepler code base
 - Update golang to go1.20
 - Adds Dockerfile which builds kepler with libbpf attacher
 - Adds bpftool to the kepler image
 - Size of kepler image reduced from 2.3GB to 78.5 MB