### PR TITLE
add xgboost to ld cache

### DIFF
--- a/build/Dockerfile.bcc.base
+++ b/build/Dockerfile.bcc.base
@@ -20,6 +20,7 @@ RUN yum install cmake git gcc gcc-c++ -y; \
     git clone --recursive https://github.com/dmlc/xgboost; \
     cd xgboost; git checkout tags/${XGBOOST_VERSION}; \
     mkdir build; cd build; cmake ..; make -j$(nproc); make install; \
+    echo "/usr/local/lib64" > /etc/ld.so.conf.d/xgboost.conf; ldconfig;  ldconfig -p | grep xgboost; \
     yum remove cmake git gcc gcc-c++ -y
 
 # nvidia driver is updated on a (bi)monthly basis

--- a/build/Dockerfile.bcc.base.amd64
+++ b/build/Dockerfile.bcc.base.amd64
@@ -27,5 +27,6 @@ RUN yum install cmake git gcc gcc-c++ -y; \
     git clone --recursive https://github.com/dmlc/xgboost; \
     cd xgboost; git checkout tags/${XGBOOST_VERSION}; \
     mkdir build; cd build; cmake ..; make -j$(nproc); make install; \
+    echo "/usr/local/lib64" > /etc/ld.so.conf.d/xgboost.conf; ldconfig;  ldconfig -p | grep xgboost; \
     yum remove cmake git gcc gcc-c++ -y
     

--- a/build/Dockerfile.bcc.base.arm64
+++ b/build/Dockerfile.bcc.base.arm64
@@ -27,4 +27,5 @@ RUN yum install cmake git gcc gcc-c++ -y; \
     git clone --recursive https://github.com/dmlc/xgboost; \
     cd xgboost; git checkout tags/${XGBOOST_VERSION}; \
     mkdir build; cd build; cmake ..; make -j$(nproc); make install; \
+    echo "/usr/local/lib64" > /etc/ld.so.conf.d/xgboost.conf; ldconfig;  ldconfig -p | grep xgboost; \
     yum remove cmake git gcc gcc-c++ -y

--- a/build/Dockerfile.bcc.base.s390x
+++ b/build/Dockerfile.bcc.base.s390x
@@ -28,4 +28,5 @@ RUN yum install cmake git gcc gcc-c++ -y; \
     git clone --recursive https://github.com/dmlc/xgboost; \
     cd xgboost; git checkout tags/${XGBOOST_VERSION}; \
     mkdir build; cd build; cmake ..; make -j$(nproc); make install; \
+    echo "/usr/local/lib64" > /etc/ld.so.conf.d/xgboost.conf; ldconfig;  ldconfig -p | grep xgboost; \
     yum remove cmake git gcc gcc-c++ -y

--- a/build/Dockerfile.libbpf.base
+++ b/build/Dockerfile.libbpf.base
@@ -28,7 +28,9 @@ ENV nproc=8
 RUN yum install cmake git gcc gcc-c++ -y; \
     git clone --recursive https://github.com/dmlc/xgboost; \
     cd xgboost; git checkout tags/${XGBOOST_VERSION}; \
-    mkdir build; cd build; cmake ..; make -j$(nproc); make install;
+    mkdir build; cd build; cmake ..; make -j$(nproc); make install; \
+    echo "/usr/local/lib64" > /etc/ld.so.conf.d/xgboost.conf; ldconfig;  ldconfig -p | grep xgboost; \
+    yum remove cmake git gcc gcc-c++ -y
 # nvidia driver is updated on a (bi)monthly basis
 # RUN yum install -y nvidia-driver-NVML nvidia-driver-cuda
 

--- a/build/Dockerfile.libbpf.base.amd64
+++ b/build/Dockerfile.libbpf.base.amd64
@@ -29,6 +29,7 @@ RUN yum install cmake git gcc gcc-c++ -y; \
     git clone --recursive https://github.com/dmlc/xgboost; \
     cd xgboost; git checkout tags/${XGBOOST_VERSION}; \
     mkdir build; cd build; cmake ..; make -j$(nproc); make install; \
+    echo "/usr/local/lib64" > /etc/ld.so.conf.d/xgboost.conf; ldconfig;  ldconfig -p | grep xgboost; \
     yum remove cmake git gcc gcc-c++ -y
     
 # nvidia driver is updated on a (bi)monthly basis


### PR DESCRIPTION
The UBI image doesn't have `/usr/local/lib64` in ld conf. Need to add it explicitly to pick up xgboost library.