### PR TITLE
fix(gpu): dont use nvml symbol if lib not found

### DIFF
--- a/pkg/power/accelerator/gpu/source/gpu_nvml.go
+++ b/pkg/power/accelerator/gpu/source/gpu_nvml.go
@@ -48,7 +48,7 @@ func (n *GPUNvml) Init() (err error) {
 	}()
 	if ret := nvml.Init(); ret != nvml.SUCCESS {
 		n.collectionSupported = false
-		err = fmt.Errorf("failed to init nvml: %v", nvml.ErrorString(ret))
+		err = fmt.Errorf("failed to init nvml. %s", nvmlErrorString(ret))
 		return err
 	}
 
@@ -144,4 +144,14 @@ func (n *GPUNvml) IsGPUCollectionSupported() bool {
 
 func (n *GPUNvml) SetGPUCollectionSupported(supported bool) {
 	n.collectionSupported = supported
+}
+
+func nvmlErrorString(errno nvml.Return) string {
+	switch errno {
+	case nvml.SUCCESS:
+		return "SUCCESS"
+	case nvml.ERROR_LIBRARY_NOT_FOUND:
+		return "ERROR_LIBRARY_NOT_FOUND"
+	}
+	return fmt.Sprintf("Error %d", errno)
 }


### PR DESCRIPTION
Avoid calling `nvml` package function is `nvml.Init()` fails. 

In the current version of nvml (`0.11`) , if the shared lib `libnvidia-ml.so` is not present, it `panic`s, and we use `recover()` to handle this and report error.  But in the new version of nvml (`0.12.0`) if  `libnvidia-ml.so` is not available, the nvml handles the situation and returns an error. And expectation is we should not use `nvml` function after this.

This PR fixes it, and should help in passing PR https://github.com/sustainable-computing-io/kepler/pull/988 tests 