### PR TITLE
chore(ci): make libbpf as the default attacher

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -25,14 +25,14 @@ jobs:
         username: ${{ secrets.username }}
         password: ${{ secrets.password }}
 
-    - name: Build and push kepler latest
+    - name: Build and push kepler latest (bcc)
       uses: docker/build-push-action@v5
       with:
           context: .
           platforms: linux/amd64
           push: true
-          tags: quay.io/sustainable_computing_io/kepler:latest
-          labels: latest
+          tags: quay.io/sustainable_computing_io/kepler:latest-bcc
+          labels: latest-bcc
           file: build/Dockerfile
 
     - name: Build and push kepler latest (libbpf)
@@ -41,6 +41,6 @@ jobs:
           context: .
           platforms: linux/amd64
           push: true
-          tags: quay.io/sustainable_computing_io/kepler:latest-libbpf
-          labels: latest-libbpf
+          tags: quay.io/sustainable_computing_io/kepler:latest
+          labels: latest
           file: build/Dockerfile.libbpf.kepler

--- a/.github/workflows/image_pr.yml
+++ b/.github/workflows/image_pr.yml
@@ -35,4 +35,4 @@ jobs:
           push: true
           tags: quay.io/sustainable_computing_io/kepler
           labels: ${{ github.event.inputs.commitSHA }}
-          file: build/Dockerfile
+          file: build/Dockerfile.libbpf.kepler

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   OUTPUT_DIR: "_output/"
-  FILE_NAME: "kepler.tar.gz"
+  FILE_NAME: "kepler_libbpf.tar.gz"
   ARTIFACT_DIR: "/tmp/artifacts"
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
       - name: install libbpf
         uses: sustainable-computing-io/kepler-action@v0.0.3
         with:
-          ebpfprovider: bcc
+          ebpfprovider: libbpf
       # build kepler image
       - name: build and export Kepler image
         run: |
@@ -32,21 +32,21 @@ jobs:
           make save-image
         env:
           IMAGE_REPO: "localhost:5001"
-          IMAGE_TAG: "devel"
           IMAGE_NAME: "kepler"
+          IMAGE_TAG: "devel"
           CTR_CMD: docker
           IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}${{env.FILE_NAME}}
       # save kepler image
       - name: save Kepler image as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: kepler
+          name: keplerlibbpf
           path: ${{env.OUTPUT_DIR}}${{env.FILE_NAME}}
           retention-days: 1
           # ref https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
           # as PR or Push event, we don't keep artifact in 90 days hence use 1 day here to save resources.
 
-  integration_test:
+  integration_test_with_libbpf:
     needs: [build-kepler]
     runs-on: ubuntu-latest
     strategy:
@@ -59,7 +59,7 @@ jobs:
       - name: download Kepler image artifact
         uses: actions/download-artifact@v3
         with:
-          name: kepler
+          name: keplerlibbpf
 
       - name: build manifest
         run: make build-manifest OPTS="CI_DEPLOY"
@@ -81,7 +81,7 @@ jobs:
       - name: use Kepler action to deploy cluster
         uses: sustainable-computing-io/kepler-action@v0.0.3
         with:
-          ebpfprovider: bcc
+          ebpfprovider: libbpf
           cluster_provider: ${{matrix.cluster_provider}}
           local_dev_cluster_version: v0.0.3
 

--- a/.github/workflows/integration_test_bcc.yml
+++ b/.github/workflows/integration_test_bcc.yml
@@ -1,15 +1,15 @@
-name: Integration test with libbpf
+name: Integration test with bcc
 
 on:
   workflow_call:
 
 env:
   OUTPUT_DIR: "_output/"
-  FILE_NAME: "kepler_libbpf.tar.gz"
+  FILE_NAME: "kepler-bcc.tar.gz"
   ARTIFACT_DIR: "/tmp/artifacts"
 
 jobs:
-  build-kepler_with_libbpf:
+  build-kepler-with-bcc:
     runs-on: ubuntu-latest
     steps:
       # checkout source code
@@ -21,10 +21,10 @@ jobs:
         with:
           go-version-file: go.mod
       # set up ebpf
-      - name: install libbpf
+      - name: install bcc
         uses: sustainable-computing-io/kepler-action@v0.0.3
         with:
-          ebpfprovider: libbpf
+          ebpfprovider: bcc
       # build kepler image
       - name: build and export Kepler image
         run: |
@@ -32,22 +32,22 @@ jobs:
           make save-image
         env:
           IMAGE_REPO: "localhost:5001"
-          IMAGE_NAME: "kepler"
           IMAGE_TAG: "devel"
+          IMAGE_NAME: "kepler"
           CTR_CMD: docker
           IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}${{env.FILE_NAME}}
       # save kepler image
       - name: save Kepler image as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: keplerlibbpf
+          name: kepler
           path: ${{env.OUTPUT_DIR}}${{env.FILE_NAME}}
           retention-days: 1
           # ref https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
           # as PR or Push event, we don't keep artifact in 90 days hence use 1 day here to save resources.
 
-  integration_test_with_libbpf:
-    needs: [build-kepler_with_libbpf]
+  integration_test:
+    needs: [build-kepler-with-bcc]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -59,7 +59,7 @@ jobs:
       - name: download Kepler image artifact
         uses: actions/download-artifact@v3
         with:
-          name: keplerlibbpf
+          name: kepler
 
       - name: build manifest
         run: make build-manifest OPTS="CI_DEPLOY"
@@ -81,7 +81,7 @@ jobs:
       - name: use Kepler action to deploy cluster
         uses: sustainable-computing-io/kepler-action@v0.0.3
         with:
-          ebpfprovider: libbpf
+          ebpfprovider: bcc
           cluster_provider: ${{matrix.cluster_provider}}
           local_dev_cluster_version: v0.0.3
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,10 +19,10 @@ jobs:
   developer_local:
     uses: ./.github/workflows/developer_local.yml
   # for each PR run integration test
+  integration_test_bcc:
+    uses: ./.github/workflows/integration_test_bcc.yml
+  # for each PR run integration test    
   integration_test:
     uses: ./.github/workflows/integration_test.yml
-  # for each PR run integration test    
-  integration_test_libbpf:
-    uses: ./.github/workflows/integration_test_libbpf.yml
 
   

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,17 +130,17 @@ jobs:
           context: .
           platforms: linux/amd64
           push: true
-          tags: quay.io/sustainable_computing_io/kepler:latest, quay.io/sustainable_computing_io/kepler:${{ github.event.inputs.release }}
+          tags: quay.io/sustainable_computing_io/kepler:latest, quay.io/sustainable_computing_io/kepler:${{ github.event.inputs.release }}-bcc
           labels: latest, ${{ github.event.inputs.release }}, bcc
           file: build/Dockerfile
 
-    - name: Build and push kepler libbpf latest image
+    - name: Build and push kepler latest libbpf image
       uses: docker/build-push-action@v5
       with:
           context: .
           platforms: linux/amd64
           push: true
-          tags: quay.io/sustainable_computing_io/kepler:latest, quay.io/sustainable_computing_io/kepler:${{ github.event.inputs.release }}-libbpf
+          tags: quay.io/sustainable_computing_io/kepler:latest, quay.io/sustainable_computing_io/kepler:${{ github.event.inputs.release }}
           labels: latest, ${{ github.event.inputs.release }}, libbpf
           file: build/Dockerfile.libbpf.kepler
 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -27,10 +27,10 @@ jobs:
       env:
           GOPATH: /home/runner/go
           GOBIN: /home/runner/go/bin
-    - name: install bcc
+    - name: install libbpf
       uses: sustainable-computing-io/kepler-action@v0.0.3
       with:
-        ebpfprovider: bcc
+        ebpfprovider: libbpf
     - name: Prepare environment 
       run: |
           sudo apt-get install -y cpuid
@@ -38,7 +38,16 @@ jobs:
           git config --global --add safe.directory /kepler
     - name: Run 
       run: |
-          make test-verbose
+          sudo apt remove libbpf-dev
+          mkdir temp-libbpf
+          cd temp-libbpf
+          git clone https://github.com/libbpf/libbpf
+          cd libbpf/src
+          sudo make install_headers
+          sudo make install_uapi_headers
+          sudo prefix=/usr  BUILD_STATIC_ONLY=y make install
+          cd ../../../
+          ATTACHER_TAG=libbpf make test-verbose
           go tool cover -func=coverage.out -o=coverage.out
     - name: Go Coverage Badge  # Pass the `coverage.out` output to this action
       uses: tj-actions/coverage-badge-go@v2

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ifdef ATTACHER_TAG
 	ifeq ($(ATTACHER_TAG),libbpf)
 		LIBBPF_HEADERS := /usr/include/bpf
 		KEPLER_OBJ_SRC := $(SRC_ROOT)/bpfassets/libbpf/bpf.o/$(GOARCH)_kepler.bpf.o
-		LIBBPF_OBJ := /usr/lib64/libbpf.a
+		LIBBPF_OBJ ?= /usr/lib64/libbpf.a
 	endif
 else
 # auto determine
@@ -277,6 +277,7 @@ test: ginkgo-set tidy-vendor
 
 test-verbose: ginkgo-set tidy-vendor
 	@echo TAGS=$(GO_BUILD_TAGS)
+	@echo GOENV=$(GOENV)
 	@$(GOENV) go test -tags $(GO_BUILD_TAGS) -covermode=atomic -coverprofile=coverage.out -v $$(go list ./... | grep pkg | grep -v bpfassets) --race --bench=. -cover --count=1 --vet=all
 	
 test-mac-verbose: ginkgo-set

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -28,7 +28,8 @@ FROM quay.io/sustainable_computing_io/kepler_base:ubi-9-bcc-0.26
 COPY --from=builder /opt/app-root/src/github.com/sustainable-computing-io/kepler/_output/bin/kepler /usr/bin/kepler
 
 RUN mkdir -p /var/lib/kepler/data
-COPY --from=builder /opt/app-root/src/github.com/sustainable-computing-io/kepler/data/normalized_cpu_arch.csv /var/lib/kepler/data/normalized_cpu_arch.csv
+COPY --from=builder /opt/app-root/src/github.com/sustainable-computing-io/kepler/data/cpus.yaml /var/lib/kepler/data/cpus.yaml
+
 
 # copy model weight
 COPY --from=builder /opt/app-root/src/github.com/sustainable-computing-io/kepler/data/model_weight/acpi_AbsPowerModel.json /var/lib/kepler/data/acpi_AbsPowerModel.json

--- a/doc/dev/prepare_dev_env.sh
+++ b/doc/dev/prepare_dev_env.sh
@@ -5,7 +5,7 @@ echo "copy data files"
 DATAPATH="/var/lib/kepler/data/"
 mkdir -p ${DATAPATH}
 
-cp ../data/normalized_cpu_arch.csv ${DATAPATH}
+cp ../data/cpus.yaml ${DATAPATH}
 
 mkdir -p /var/lib/kepler/data/
 cp ../data/model_weight/acpi_AbsPowerModel.json ${DATAPATH}/acpi_AbsPowerModel.json

--- a/packaging/rpm/kepler.spec
+++ b/packaging/rpm/kepler.spec
@@ -33,7 +33,7 @@ CROSS_BUILD_BINDIR=_output/bin
 GOARCH=amd64
 %endif
 
-make _build_local GOOS=${GOOS} GOARCH=${GOARCH}
+make _build_local GOOS=${GOOS} GOARCH=${GOARCH} ATTACHER_TAG=libbpf
 
 cp ./${CROSS_BUILD_BINDIR}/${GOOS}_${GOARCH}/kepler ./_output/kepler
 


### PR DESCRIPTION
- tag existing 'latest' image as 'latest-bcc'
- tag existing 'latest-libbpf' as 'latest'
- make libbpf image as default released image
- use libbpf as attacher for PR image
- make unit_test run with libbpf attacher
- build kepler with libbpf attacher for rpm build
- rename integration_test to integration_test_bcc
- rename integration_test_libbpf to integration_test
