### PR TITLE
fix(build): use correct cpus data file

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -28,7 +28,8 @@ FROM quay.io/sustainable_computing_io/kepler_base:ubi-9-bcc-0.26
 COPY --from=builder /opt/app-root/src/github.com/sustainable-computing-io/kepler/_output/bin/kepler /usr/bin/kepler
 
 RUN mkdir -p /var/lib/kepler/data
-COPY --from=builder /opt/app-root/src/github.com/sustainable-computing-io/kepler/data/normalized_cpu_arch.csv /var/lib/kepler/data/normalized_cpu_arch.csv
+COPY --from=builder /opt/app-root/src/github.com/sustainable-computing-io/kepler/data/cpus.yaml /var/lib/kepler/data/cpus.yaml
+
 
 # copy model weight
 COPY --from=builder /opt/app-root/src/github.com/sustainable-computing-io/kepler/data/model_weight/acpi_AbsPowerModel.json /var/lib/kepler/data/acpi_AbsPowerModel.json

--- a/doc/dev/prepare_dev_env.sh
+++ b/doc/dev/prepare_dev_env.sh
@@ -5,7 +5,7 @@ echo "copy data files"
 DATAPATH="/var/lib/kepler/data/"
 mkdir -p ${DATAPATH}
 
-cp ../data/normalized_cpu_arch.csv ${DATAPATH}
+cp ../data/cpus.yaml ${DATAPATH}
 
 mkdir -p /var/lib/kepler/data/
 cp ../data/model_weight/acpi_AbsPowerModel.json ${DATAPATH}/acpi_AbsPowerModel.json

--- a/packaging/rpm/kepler.spec
+++ b/packaging/rpm/kepler.spec
@@ -47,7 +47,7 @@ install -d %{buildroot}/var/lib/kepler/data
 
 install -p -m755 ./_output/kepler  %{buildroot}%{_bindir}/kepler
 install -p -m644 ./packaging/rpm/kepler.service %{buildroot}%{_unitdir}/kepler.service
-install -p -m644 ./data/normalized_cpu_arch.csv %{buildroot}/var/lib/kepler/data/normalized_cpu_arch.csv
+install -p -m644 ./data/cpus.yaml %{buildroot}/var/lib/kepler/data/cpus.yaml
 install -p -m644 ./data/model_weight/acpi_AbsPowerModel.json %{buildroot}/var/lib/kepler/data/acpi_AbsPowerModel.json
 install -p -m644 ./data/model_weight/acpi_DynPowerModel.json %{buildroot}/var/lib/kepler/data/acpi_DynPowerModel.json
 install -p -m644 ./data/model_weight/rapl_AbsPowerModel.json %{buildroot}/var/lib/kepler/data/rapl_AbsPowerModel.json
@@ -61,7 +61,7 @@ install -p -m644 ./data/model_weight/rapl_DynPowerModel.json %{buildroot}/var/li
 %license LICENSE
 %{_bindir}/kepler
 %{_unitdir}/kepler.service
-/var/lib/kepler/data/normalized_cpu_arch.csv
+/var/lib/kepler/data/cpus.yaml
 /var/lib/kepler/data/acpi_AbsPowerModel.json
 /var/lib/kepler/data/acpi_DynPowerModel.json
 /var/lib/kepler/data/rapl_AbsPowerModel.json


### PR DESCRIPTION
  Updated following files to not use normalized_cpu_arch.csv, and use
  cpus.yaml
  - updated build/Dockerfile
  - doc/dev/prepare_dev_env.sh
  - packaging/rpm/kepler.spec
 
some files were missed to be updated in #1029 