### PR TITLE
[CI] Update unit_test.yml with libbpf1

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -38,15 +38,7 @@ jobs:
           git config --global --add safe.directory /kepler
     - name: Run 
       run: |
-          sudo apt remove libbpf-dev
-          mkdir temp-libbpf
-          cd temp-libbpf
-          git clone https://github.com/libbpf/libbpf
-          cd libbpf/src
-          sudo make install_headers
-          sudo make install_uapi_headers
-          sudo prefix=/usr  BUILD_STATIC_ONLY=y make install
-          cd ../../../
+          sudo apt install -y libbpf1
           ATTACHER_TAG=libbpf make test-verbose
           go tool cover -func=coverage.out -o=coverage.out
     - name: Go Coverage Badge  # Pass the `coverage.out` output to this action

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -38,7 +38,7 @@ jobs:
           git config --global --add safe.directory /kepler
     - name: Run 
       run: |
-          sudo apt install -y libbpf1
+          sudo apt install -y libbpf0
           ATTACHER_TAG=libbpf make test-verbose
           go tool cover -func=coverage.out -o=coverage.out
     - name: Go Coverage Badge  # Pass the `coverage.out` output to this action

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ifdef ATTACHER_TAG
 	ifeq ($(ATTACHER_TAG),libbpf)
 		LIBBPF_HEADERS := /usr/include/bpf
 		KEPLER_OBJ_SRC := $(SRC_ROOT)/bpfassets/libbpf/bpf.o/$(GOARCH)_kepler.bpf.o
-		LIBBPF_OBJ ?= /usr/lib64/libbpf.so.1
+		LIBBPF_OBJ ?= /usr/lib/$(ARCH)-linux-gnu/libbpf.a
 	endif
 else
 # auto determine
@@ -82,9 +82,9 @@ else
 
 	LIBBPF_HEADERS := /usr/include/bpf
 	KEPLER_OBJ_SRC := $(SRC_ROOT)/bpfassets/libbpf/bpf.o/$(GOARCH)_kepler.bpf.o
-	LIBBPF_OBJ := /usr/lib/$(ARCH)-linux-gnu/libbpf.so.1
+	LIBBPF_OBJ := /usr/lib/$(ARCH)-linux-gnu/libbpf.a
 
-# for libbpf tag, if libbpf.so.1, kepler.bpf.o exist, clear bcc tag
+# for libbpf tag, if libbpf.a, kepler.bpf.o exist, clear bcc tag
 	ifneq ($(LIBBPF_TAG),)
 		ifneq ($(wildcard $(LIBBPF_OBJ)),)
 			ifneq ($(wildcard $(KEPLER_OBJ_SRC)),)

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ifdef ATTACHER_TAG
 	ifeq ($(ATTACHER_TAG),libbpf)
 		LIBBPF_HEADERS := /usr/include/bpf
 		KEPLER_OBJ_SRC := $(SRC_ROOT)/bpfassets/libbpf/bpf.o/$(GOARCH)_kepler.bpf.o
-		LIBBPF_OBJ ?= /usr/lib64/libbpf.so
+		LIBBPF_OBJ ?= /usr/lib64/libbpf.so.1
 	endif
 else
 # auto determine
@@ -82,9 +82,9 @@ else
 
 	LIBBPF_HEADERS := /usr/include/bpf
 	KEPLER_OBJ_SRC := $(SRC_ROOT)/bpfassets/libbpf/bpf.o/$(GOARCH)_kepler.bpf.o
-	LIBBPF_OBJ := /usr/lib/$(ARCH)-linux-gnu/libbpf.so
+	LIBBPF_OBJ := /usr/lib/$(ARCH)-linux-gnu/libbpf.so.1
 
-# for libbpf tag, if libbpf.so, kepler.bpf.o exist, clear bcc tag
+# for libbpf tag, if libbpf.so.1, kepler.bpf.o exist, clear bcc tag
 	ifneq ($(LIBBPF_TAG),)
 		ifneq ($(wildcard $(LIBBPF_OBJ)),)
 			ifneq ($(wildcard $(KEPLER_OBJ_SRC)),)

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ifdef ATTACHER_TAG
 	ifeq ($(ATTACHER_TAG),libbpf)
 		LIBBPF_HEADERS := /usr/include/bpf
 		KEPLER_OBJ_SRC := $(SRC_ROOT)/bpfassets/libbpf/bpf.o/$(GOARCH)_kepler.bpf.o
-		LIBBPF_OBJ ?= /usr/lib64/libbpf.a
+		LIBBPF_OBJ ?= /usr/lib64/libbpf.so
 	endif
 else
 # auto determine
@@ -82,9 +82,9 @@ else
 
 	LIBBPF_HEADERS := /usr/include/bpf
 	KEPLER_OBJ_SRC := $(SRC_ROOT)/bpfassets/libbpf/bpf.o/$(GOARCH)_kepler.bpf.o
-	LIBBPF_OBJ := /usr/lib/$(ARCH)-linux-gnu/libbpf.a
+	LIBBPF_OBJ := /usr/lib/$(ARCH)-linux-gnu/libbpf.so
 
-# for libbpf tag, if libbpf.a, kepler.bpf.o exist, clear bcc tag
+# for libbpf tag, if libbpf.so, kepler.bpf.o exist, clear bcc tag
 	ifneq ($(LIBBPF_TAG),)
 		ifneq ($(wildcard $(LIBBPF_OBJ)),)
 			ifneq ($(wildcard $(KEPLER_OBJ_SRC)),)


### PR DESCRIPTION
try to use libbpf1 instead of build libbpf from source according to https://packages.debian.org/source/sid/libbpf

it is strange as if I located libbpf via libbpf package. 
```
root@d82887bb353b:/# apt list --installed | grep libbpf

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

libbpf-dev/jammy-updates,jammy-security,now 1:0.5.0-1ubuntu22.04.1 amd64 [installed]
libbpf0/jammy-updates,jammy-security,now 1:0.5.0-1ubuntu22.04.1 amd64 [installed,automatic]
```

```
root@d82887bb353b:/# locate libbpf
/usr/include/bpf/libbpf.h
/usr/include/bpf/libbpf_common.h
/usr/include/bpf/libbpf_legacy.h
/usr/lib/x86_64-linux-gnu/libbpf.a
/usr/lib/x86_64-linux-gnu/libbpf.so
/usr/lib/x86_64-linux-gnu/libbpf.so.0
/usr/lib/x86_64-linux-gnu/libbpf.so.0.5.0
/usr/lib/x86_64-linux-gnu/pkgconfig/libbpf.pc
/usr/share/doc/libbpf-dev
/usr/share/doc/libbpf0
/usr/share/doc/libbpf-dev/changelog.Debian.gz
/usr/share/doc/libbpf-dev/copyright
/usr/share/doc/libbpf0/changelog.Debian.gz
/usr/share/doc/libbpf0/copyright
/var/lib/dpkg/info/libbpf-dev:amd64.list
/var/lib/dpkg/info/libbpf-dev:amd64.md5sums
/var/lib/dpkg/info/libbpf0:amd64.list
/var/lib/dpkg/info/libbpf0:amd64.md5sums
/var/lib/dpkg/info/libbpf0:amd64.shlibs
/var/lib/dpkg/info/libbpf0:amd64.symbols
/var/lib/dpkg/info/libbpf0:amd64.triggers
root@d82887bb353b:/# ls -al /usr/lib/x86_64-linux-gnu/libbpf.a
-rw-r--r-- 1 root root 513828 Dec  1  2022 /usr/lib/x86_64-linux-gnu/libbpf.a
```