### PR TITLE
build: make daily rpm build pass

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -17,8 +17,9 @@ jobs:
       - name: Build RPM packages
         id: rpm_build
         env:
-          _VERSION_ : latest
-          _RELEASE_: latest
+          _VERSION_ : ${{ steps.date.outputs.date }}
+          _RELEASE_: 1
+          _COMMITTER_: ${{ github.actor }}
           _ARCH_: x86_64
         run: |
           make containerized_build_rpm

--- a/packaging/rpm/kepler.spec
+++ b/packaging/rpm/kepler.spec
@@ -11,7 +11,7 @@ URL:            https://github.com/sustainable-computing-io/kepler/
 Source0:        kepler.tar.gz
 
 BuildRequires: systemd
-BuildRequires: clang llvm llvm-devel zlib-devel make libbpf golang
+BuildRequires: clang llvm llvm-devel zlib-devel make libbpf
 
 Requires:       elfutils-libelf
 Requires:       elfutils-libelf-devel


### PR DESCRIPTION
the daily rpm build failed, this is to remove the `golang` dependency from rpm build spec. Also change the version scheme.