### PR TITLE
chore(ci): Update unit_test to use libbpf from kepler action

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -28,7 +28,7 @@ jobs:
           GOPATH: /home/runner/go
           GOBIN: /home/runner/go/bin
     - name: install libbpf
-      uses: sustainable-computing-io/kepler-action@v0.0.3
+      uses: sustainable-computing-io/kepler-action@v0.0.4
       with:
         ebpfprovider: libbpf
     - name: Prepare environment 
@@ -38,15 +38,6 @@ jobs:
           git config --global --add safe.directory /kepler
     - name: Run 
       run: |
-          sudo apt remove libbpf-dev
-          mkdir temp-libbpf
-          cd temp-libbpf
-          git clone https://github.com/libbpf/libbpf
-          cd libbpf/src
-          sudo make install_headers
-          sudo make install_uapi_headers
-          sudo prefix=/usr  BUILD_STATIC_ONLY=y make install
-          cd ../../../
           ATTACHER_TAG=libbpf make test-verbose
           go tool cover -func=coverage.out -o=coverage.out
     - name: Go Coverage Badge  # Pass the `coverage.out` output to this action


### PR DESCRIPTION
Update CI to use `libbpf` as provided by kepler-action
Follow-up PR for https://github.com/sustainable-computing-io/kepler-action/pull/90