### PR TITLE
fix: allow manifest to use devel kepler image

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -40,7 +40,10 @@ build_manifest() {
 		return 0
 	}
 	header "Build Kepler Manifest"
-	run make build-manifest OPTS="$OPTS"
+	run make build-manifest \
+		OPTS="$OPTS" \
+		IMAGE_REPO="$IMAGE_REPO" \
+		IMAGE_TAG="$IMAGE_TAG"
 }
 
 build_kepler() {


### PR DESCRIPTION
This PR updates the `cluster-deploy.sh` manifests to point to the local devel Kepler image.