### PR TITLE
fix(rpm): Fix rpm builds in new build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,8 +149,8 @@ containerized_build_rpm:
 	$(CTR_CMD) run --rm \
 		-v $(base_dir):/kepler:Z -w /kepler -v $(base_dir)/$(OUTPUT_DIR)/rpmbuild:/root/rpmbuild \
 		-e _VERSION_=${_VERSION_} -e _RELEASE_=${_RELEASE_} -e _ARCH_=${_ARCH_} \
-		-e _TIMESTAMP_="$(shell date)" -e _COMMITTER_=${_COMMITTER_} -e  _CHANGELOG_=${_CHANGELOG_} \
-		-e GOROOT=/usr/local/go -e PATH=$(PATH):/usr/local/go/bin \
+		-e _TIMESTAMP_="$(shell date +"%a %b %d %Y")" -e _COMMITTER_=${_COMMITTER_} -e  _CHANGELOG_=${_CHANGELOG_} \
+		-e PATH=$(PATH):/usr/local/go/bin \
 		$(BUILDER_IMAGE) \
 		make build_rpm
 

--- a/build/Dockerfile.builder
+++ b/build/Dockerfile.builder
@@ -1,0 +1,33 @@
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20 as builder
+
+USER 0
+
+RUN yum -y install yum-utils
+RUN yum-config-manager --enable ubi-9-baseos-source
+
+WORKDIR /elfutils-source
+RUN yumdownloader --source elfutils
+RUN yum -y install cpio
+RUN rpm2cpio elfutils-0.189-3.el9.src.rpm | cpio -iv
+RUN tar xjvf elfutils-0.189.tar.bz2
+WORKDIR /elfutils-source/elfutils-0.189
+RUN ./configure --disable-debuginfod
+RUN make install
+
+
+WORKDIR /libbpf-source
+RUN yumdownloader --source libbpf
+RUN rpm2cpio libbpf-1.2.0-1.el9.src.rpm | cpio -iv
+RUN tar xf ./linux-*el9.tar.xz
+WORKDIR /libbpf-source/linux-5.14.0-333.el9/tools/lib/bpf
+RUN make install_headers
+RUN prefix=/usr BUILD_STATIC_ONLY=y make install
+WORKDIR /libbpf-source/linux-5.14.0-333.el9/tools/bpf
+RUN make bpftool
+
+RUN yum -y install clang rpm-build llvm-devel
+
+# enable EPEL and install cpuid
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+RUN yum install -y cpuid
+RUN yum clean all


### PR DESCRIPTION
 - Added build/Dockerfile.builder, somehow got removed in earlier PRs.
 - Removed hardcoded `GOROOT` in Makefile
 - Fixed timestamp in rpm build
 
With these changes to the builder image, the rpm can be built.

/cc: @rootfs 