### PR TITLE
feat(metrics): expose power source information in kepler_node_info

### DIFF
--- a/cmd/validator/validator.go
+++ b/cmd/validator/validator.go
@@ -251,7 +251,7 @@ func main() {
 			}
 		}
 		if platform.IsSystemCollectionSupported() {
-			powerSource := platform.GetPowerSource()
+			powerSource := platform.GetSourceName()
 			switch powerSource {
 			case "hmc":
 				hmcEnable = true

--- a/pkg/metrics/node/metrics.go
+++ b/pkg/metrics/node/metrics.go
@@ -24,6 +24,8 @@ import (
 	"github.com/sustainable-computing-io/kepler/pkg/config"
 	"github.com/sustainable-computing-io/kepler/pkg/metrics/metricfactory"
 	"github.com/sustainable-computing-io/kepler/pkg/metrics/utils"
+	"github.com/sustainable-computing-io/kepler/pkg/sensors/components"
+	"github.com/sustainable-computing-io/kepler/pkg/sensors/platform"
 )
 
 const (
@@ -70,7 +72,9 @@ func (c *collector) initMetrics() {
 	}
 
 	// TODO: prometheus metric should be "node_info"
-	desc := metricfactory.MetricsPromDesc(context, "", "info", "os", []string{"cpu_architecture"})
+	desc := metricfactory.MetricsPromDesc(context, "", "info", "os", []string{
+		"cpu_architecture", "components_power_source", "platform_power_source",
+	})
 	c.descriptions["info"] = desc
 	c.collectors["info"] = metricfactory.NewPromCounter(desc)
 }
@@ -91,5 +95,9 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 	c.Mx.Unlock()
 
 	// update node info
-	ch <- c.collectors["info"].MustMetric(1, stats.NodeCPUArchitecture)
+	ch <- c.collectors["info"].MustMetric(1,
+		stats.NodeCPUArchitecture,
+		components.GetSourceName(),
+		platform.GetSourceName(),
+	)
 }

--- a/pkg/sensors/accelerator/gpu/power.go
+++ b/pkg/sensors/accelerator/gpu/power.go
@@ -31,6 +31,9 @@ var (
 )
 
 type acceleratorInterface interface {
+	// GetName returns the name of the collector
+	GetName() string
+
 	// Init initizalize and start the GPU metric collector
 	Init() error
 	// Shutdown stops the GPU metric collector

--- a/pkg/sensors/accelerator/gpu/source/gpu_dummy.go
+++ b/pkg/sensors/accelerator/gpu/source/gpu_dummy.go
@@ -29,6 +29,10 @@ type GPUDummy struct {
 	collectionSupported bool
 }
 
+func (d *GPUDummy) GetName() string {
+	return "dummy"
+}
+
 // todo: refactor logic at invoking side, if gpu is not set?
 func (d *GPUDummy) Init() error {
 	d.collectionSupported = false

--- a/pkg/sensors/accelerator/gpu/source/gpu_nvml.go
+++ b/pkg/sensors/accelerator/gpu/source/gpu_nvml.go
@@ -37,6 +37,10 @@ type GPUNvml struct {
 	collectionSupported bool
 }
 
+func (GPUNvml) GetName() string {
+	return "nvidia-nvml"
+}
+
 // Init initizalize and start the GPU metric collector
 // the nvml only works if the container has support to GPU, e.g., it is using nvidia-docker2
 // otherwise it will fail to load the libnvidia-ml.so.1

--- a/pkg/sensors/accelerator/qat/source/qat_telemetry.go
+++ b/pkg/sensors/accelerator/qat/source/qat_telemetry.go
@@ -44,6 +44,10 @@ type QATTelemetry struct {
 	collectionSupported bool
 }
 
+func (QATTelemetry) GetName() string {
+	return "qat"
+}
+
 // Init initizalize and start the QAT metric collector
 func (q *QATTelemetry) Init() (err error) {
 	defer func() {

--- a/pkg/sensors/components/source/apm_xgene_sysfs.go
+++ b/pkg/sensors/components/source/apm_xgene_sysfs.go
@@ -41,6 +41,10 @@ type ApmXgeneSysfs struct {
 	currTime time.Time
 }
 
+func (ApmXgeneSysfs) GetName() string {
+	return "ampere-xgene-hwmon"
+}
+
 func (r *ApmXgeneSysfs) IsSystemCollectionSupported() bool {
 	labelFiles, err := filepath.Glob(powerLabelPathTemplate)
 	if err != nil {

--- a/pkg/sensors/components/source/dummy.go
+++ b/pkg/sensors/components/source/dummy.go
@@ -23,6 +23,10 @@ var (
 
 type PowerDummy struct{}
 
+func (PowerDummy) GetName() string {
+	return "dummy"
+}
+
 func (r *PowerDummy) IsSystemCollectionSupported() bool {
 	return SystemCollectionSupported
 }

--- a/pkg/sensors/components/source/estimate.go
+++ b/pkg/sensors/components/source/estimate.go
@@ -37,6 +37,10 @@ type PowerEstimateData struct {
 	PerGBWatts   float64 `csv:"GB/Chip"`
 }
 
+func (PowerEstimate) GetName() string {
+	return "estimator"
+}
+
 // If the Estimated Power is being used, it means that the system does not support Components Power Measurement
 func (r *PowerEstimate) IsSystemCollectionSupported() bool {
 	return false

--- a/pkg/sensors/components/source/rapl_msr.go
+++ b/pkg/sensors/components/source/rapl_msr.go
@@ -18,6 +18,10 @@ package source
 
 type PowerMSR struct{}
 
+func (PowerMSR) GetName() string {
+	return "rapl-msr"
+}
+
 func (r *PowerMSR) IsSystemCollectionSupported() bool {
 	return InitUnits() == nil
 }

--- a/pkg/sensors/components/source/rapl_sysfs.go
+++ b/pkg/sensors/components/source/rapl_sysfs.go
@@ -120,6 +120,10 @@ func getMaxEnergyRange(eventName string) (uint64, error) {
 
 type PowerSysfs struct{}
 
+func (PowerSysfs) GetName() string {
+	return "rapl-sysfs"
+}
+
 func (r *PowerSysfs) IsSystemCollectionSupported() bool {
 	path := fmt.Sprintf(packageNamePathTemplate, 0)
 	_, err := os.ReadFile(path + energyFile)

--- a/pkg/sensors/platform/source/acpi.go
+++ b/pkg/sensors/platform/source/acpi.go
@@ -97,6 +97,10 @@ func findACPIPowerPath() string {
 	return powerPath
 }
 
+func (ACPI) GetName() string {
+	return "acpi"
+}
+
 func (a *ACPI) StopPower() {
 }
 

--- a/pkg/sensors/platform/source/hmc.go
+++ b/pkg/sensors/platform/source/hmc.go
@@ -18,6 +18,10 @@ package source
 
 type PowerHMC struct{}
 
+func (a *PowerHMC) GetName() string {
+	return "hmc"
+}
+
 func (a *PowerHMC) StopPower() {
 }
 

--- a/pkg/sensors/platform/source/redfish.go
+++ b/pkg/sensors/platform/source/redfish.go
@@ -203,6 +203,10 @@ func NewRedfishClient() *RedFishClient {
 	return nil
 }
 
+func (*RedFishClient) GetName() string {
+	return "redfish"
+}
+
 func (rf *RedFishClient) IsSystemCollectionSupported() bool {
 	// goroutine for collecting power info from Redfish already exists
 	if rf.ticker != nil {


### PR DESCRIPTION
This commit adds `platform_power_source` and `components_power_source`
to `kepler_node_info`. This allows users to filter metrics by a particular
power source by using [joins on labels](https://www.robustperception.io/left-joins-in-promql/).

Produces 
```
# HELP kepler_node_info Aggregated value in  value from os
# TYPE kepler_node_info counter
kepler_node_info{components_power_source="rapl-sysfs",cpu_architecture="Skylake",platform_power_source="none",source="os"} 1

````

Signed-off-by: Sunil Thaha <sthaha@redhat.com>
