### PR TITLE
[CI] update set output to github output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "name=date::$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v4.1.1

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -9,14 +9,14 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y%m%d')"
+        run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v4.1.1
 
       - name: get git version
         id: git_version
-        run: echo "::set-output name=git_version::$(git describe --dirty --tags --always --match='v*' | tr '-' '.')"
+        run: echo "name=git_version::$(git describe --dirty --tags --always --match='v*' | tr '-' '.')" >> $GITHUB_OUTPUT
 
       - name: Build RPM packages
         id: rpm_build


### PR DESCRIPTION
ref https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/