### PR TITLE
Fix directory path type

### DIFF
--- a/manifests/config/exporter/exporter.yaml
+++ b/manifests/config/exporter/exporter.yaml
@@ -113,19 +113,19 @@ spec:
       - name: lib-modules
         hostPath:
           path: /lib/modules
-          type: Directory
+          Type: DirectoryOrCreate
       - name: tracing
         hostPath:
           path: /sys
-          type: Directory
+          Type: DirectoryOrCreate
       - name: proc
         hostPath:
           path: /proc
-          type: Directory
+          Type: DirectoryOrCreate
       - name: var-run
         hostPath:
           path: /var/run
-          type: Directory
+          Type: DirectoryOrCreate
       - name: cfm
         configMap:
           name: kepler-cfm

--- a/manifests/config/exporter/patch/patch-ci.yaml
+++ b/manifests/config/exporter/patch/patch-ci.yaml
@@ -23,4 +23,4 @@ spec:
       - name: usr-src
         hostPath:
           path: /usr/src
-          type: Directory
+          Type: DirectoryOrCreate

--- a/manifests/config/exporter/patch/patch-kind.yaml
+++ b/manifests/config/exporter/patch/patch-kind.yaml
@@ -12,4 +12,4 @@ spec:
       - name: proc
         hostPath:
           path: /proc-host
-          type: Directory
+          Type: DirectoryOrCreate

--- a/manifests/config/exporter/patch/patch-openshift.yaml
+++ b/manifests/config/exporter/patch/patch-openshift.yaml
@@ -26,4 +26,4 @@ spec:
       - name: kernel-src
         hostPath:
           path: /usr/src/kernels
-          type: Directory
+          type: Directoy


### PR DESCRIPTION
Fixes the following issue on Kubernetes with the type of Directory:
`MountVolume.SetUp failed for volume "proc" : hostPath type check failed: /proc-host is not a directory`