### PR TITLE
Fix platform source label with acpi

### DIFF
--- a/pkg/metrics/metricfactory/metric_factory.go
+++ b/pkg/metrics/metricfactory/metric_factory.go
@@ -29,8 +29,11 @@ func EnergyMetricsPromDesc(context string) (descriptions map[string]*prometheus.
 	descriptions = make(map[string]*prometheus.Desc)
 	for _, name := range consts.EnergyMetricNames {
 		source := "intel_rapl"
-		if strings.Contains(name, "gpu") {
+		if strings.Contains(name, config.GPU) {
 			source = "nvidia"
+		}
+		if strings.Contains(name, config.PLATFORM) {
+			source = "acpi"
 		}
 		descriptions[name] = energyMetricsPromDesc(context, name, source)
 	}


### PR DESCRIPTION
After the code refactoring, the metric showing the platform energy is missing the configuration to set the energy source as `acpi`.

This PR is fixing this.