### PR TITLE
image: don't build for arm64 for now due to an issue in libbpf build

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -29,7 +29,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: quay.io/sustainable_computing_io/kepler:latest
           labels: latest

--- a/.github/workflows/image_pr.yml
+++ b/.github/workflows/image_pr.yml
@@ -31,7 +31,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: quay.io/sustainable_computing_io/kepler
           labels: ${{ github.event.inputs.commitSHA }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: quay.io/sustainable_computing_io/kepler:latest, quay.io/sustainable_computing_io/kepler:${{ github.event.inputs.release }}
           labels: latest, ${{ github.event.inputs.release }}, libbpf


### PR DESCRIPTION
temporarily disable arm64 build. Will enable it after resolving libbpf module build issue in https://github.com/sustainable-computing-io/kepler/actions/runs/7659192488/job/20873789773