### PR TITLE
collector: use kernel's view of thread group (userspace view of process id) to aggregate all threads by a process, in order to properly account for resource utilization by processes

### DIFF
--- a/pkg/bpfassets/attacher/bpf_perf.go
+++ b/pkg/bpfassets/attacher/bpf_perf.go
@@ -57,8 +57,8 @@ var (
 // must be in sync with bpf program
 type ProcessBPFMetrics struct {
 	CGroupID       uint64
-	PID            uint64
-	TGID           uint64
+	ThreadPID      uint64 /* thread id */
+	PID            uint64 /* TGID of the threads, i.e. user space pid */
 	ProcessRunTime uint64 /* in ms */
 	TaskClockTime  uint64 /* in ms */
 	CPUCycles      uint64

--- a/pkg/collector/resourceutilization/bpf/process_bpf_collector.go
+++ b/pkg/collector/resourceutilization/bpf/process_bpf_collector.go
@@ -108,7 +108,7 @@ func UpdateProcessBPFMetrics(processStats map[uint64]*stats.ProcessStats) {
 			}
 		}
 
-		mapKey := ct.TGID
+		mapKey := ct.PID
 		if ct.CGroupID == 1 && config.EnabledEBPFCgroupID {
 			// we aggregate all kernel process to minimize overhead
 			// all kernel process has cgroup id as 1 and pid 1 is also a kernel process
@@ -118,7 +118,7 @@ func UpdateProcessBPFMetrics(processStats map[uint64]*stats.ProcessStats) {
 		var ok bool
 		var pStat *stats.ProcessStats
 		if pStat, ok = processStats[mapKey]; !ok {
-			pStat = stats.NewProcessStats(ct.TGID, ct.CGroupID, containerID, vmID, comm)
+			pStat = stats.NewProcessStats(ct.PID, ct.CGroupID, containerID, vmID, comm)
 			processStats[mapKey] = pStat
 		} else if pStat.Command == "" {
 			pStat.Command = comm


### PR DESCRIPTION
Idle power is attributed by the number of processes. If a process has many threads, this process is attributed with more idle power. Aggregating at user space PID level reduces such confusion.