### PR TITLE
gpu: expose both idle and dyn gpu power

### DIFF
--- a/pkg/collector/stats/stats.go
+++ b/pkg/collector/stats/stats.go
@@ -139,7 +139,7 @@ func (m *Stats) UpdateDynEnergy() {
 	}
 	// gpu metric
 	if config.EnabledGPU && gpu.IsGPUCollectionSupported() {
-		for gpuID := range m.EnergyUsage[config.DynEnergyInGPU].Stat {
+		for gpuID := range m.EnergyUsage[config.AbsEnergyInGPU].Stat {
 			m.CalcDynEnergy(config.AbsEnergyInGPU, config.IdleEnergyInGPU, config.DynEnergyInGPU, gpuID)
 		}
 	}
@@ -147,7 +147,7 @@ func (m *Stats) UpdateDynEnergy() {
 
 // CalcDynEnergy calculate the difference between the absolute and idle energy/power
 func (m *Stats) CalcDynEnergy(absM, idleM, dynM, id string) {
-	if _, exits := m.EnergyUsage[absM].Stat[id]; !exits {
+	if _, exist := m.EnergyUsage[absM].Stat[id]; !exist {
 		return
 	}
 	totalPower := m.EnergyUsage[absM].Stat[id].Delta

--- a/pkg/metrics/metricfactory/metric_factory.go
+++ b/pkg/metrics/metricfactory/metric_factory.go
@@ -100,7 +100,7 @@ func QATMetricsPromDesc(context string) (descriptions map[string]*prometheus.Des
 	descriptions = make(map[string]*prometheus.Desc)
 	if config.IsExposeQATMetricsEnabled() {
 		name := config.QATUtilization
-		descriptions[name] = resMetricsPromDesc(context, name, "intel_qta")
+		descriptions[name] = resMetricsPromDesc(context, name, "intel_qat")
 	}
 	return descriptions
 }

--- a/pkg/metrics/utils/utils.go
+++ b/pkg/metrics/utils/utils.go
@@ -97,7 +97,7 @@ func collectEnergy(ch chan<- prometheus.Metric, instance interface{}, metricName
 	// only node metrics report metrics per device, process, container and VM reports the aggregation
 	case *stats.NodeStats:
 		node := instance.(*stats.NodeStats)
-		if _, exit := node.EnergyUsage[metricName]; exit {
+		if _, exist := node.EnergyUsage[metricName]; exist {
 			for deviceID, utilization := range node.EnergyUsage[metricName].Stat {
 				value = float64(utilization.Aggr) / consts.MiliJouleToJoule
 				labelValues = []string{deviceID, stats.NodeName, mode}
@@ -135,7 +135,7 @@ func CollectResUtil(ch chan<- prometheus.Metric, instance interface{}, metricNam
 	// only node metrics report metrics per device, process, container and VM reports the aggregation
 	case *stats.NodeStats:
 		node := instance.(*stats.NodeStats)
-		if _, exit := node.ResourceUsage[metricName]; exit {
+		if _, exist := node.ResourceUsage[metricName]; exist {
 			for deviceID, utilization := range node.ResourceUsage[metricName].Stat {
 				value = float64(utilization.Aggr)
 				labelValues = []string{deviceID, stats.NodeName}


### PR DESCRIPTION
Currently the dynamic GPU power is not shown in the metrics, this is because the metric is not yet.

In `UpdateDynEnergy()`, the initial GPU dyn stats is empty, so we need to use `AbsEnergyInGPU` stat to enumerate all the GPU IDs. 