### PR TITLE
fix daily build issue for arm64 and rpm build

### DIFF
--- a/.github/workflows/image_base.yml
+++ b/.github/workflows/image_base.yml
@@ -29,6 +29,6 @@ jobs:
         with:
           context: .
           file: ./build/Dockerfile.builder
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/s390x
           push: true
           tags: quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.2.0

--- a/build/Dockerfile.builder
+++ b/build/Dockerfile.builder
@@ -27,6 +27,10 @@ RUN make bpftool
 
 # rpmautospec requires epel-release
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-RUN yum -y install clang rpm-build llvm-devel rpmautospec
+RUN yum update -y
+RUN yum -y install clang rpm-build llvm-devel 
+#rpmautospec as bug for #1224
+# for cpuid on x86, for rpm build
+RUN if [ $(uname -i) == "x86_64" ]; then yum install -y cpuid; fi
 
 RUN yum clean all

--- a/build/Dockerfile.builder
+++ b/build/Dockerfile.builder
@@ -31,6 +31,6 @@ RUN yum update -y
 RUN yum -y install clang rpm-build llvm-devel 
 #rpmautospec as bug for #1224
 # for cpuid on x86, for rpm build
-RUN if [ $(uname -i) == "x86_64" ]; then yum install -y cpuid; fi
+RUN if [ $(uname -i) == "x86_64" ]; then yum install -y https://www.rpmfind.net/linux/centos-stream/9-stream/AppStream/x86_64/os/Packages/http-parser-2.9.4-6.el9.x86_64.rpm && yum install -y rpmautospec && yum install -y cpuid; fi
 
 RUN yum clean all


### PR DESCRIPTION
from daily build job, it seems we have some issue for now with arm64 base image build. remove the arm64 base image for now. 

meanwhile, add cpuid into base image for rpm build.