### PR TITLE
base image build refactoring

### DIFF
--- a/.github/workflows/image_base.yml
+++ b/.github/workflows/image_base.yml
@@ -1,16 +1,11 @@
 name: base
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       pushImage:
         default: true
         type: boolean
-    secrets:
-      username:
-        required: true
-      password:
-        required: true
 
 jobs:
   baseimagebuild:
@@ -27,8 +22,8 @@ jobs:
         uses: docker/login-action@v3
         with:
             registry: quay.io/sustainable_computing_io
-            username: ${{ secrets.username }}
-            password: ${{ secrets.password }}
+            username: ${{ secrets.BOT_NAME }}
+            password: ${{ secrets.BOT_TOKEN }}
       - name: Build and push a base image for building Kepler with libbpf
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
some refactoring, so we can use manual github action and bot credentials to build builder images.