### PR TITLE
Revert "base image build refactoring"

### DIFF
--- a/.github/workflows/image_base.yml
+++ b/.github/workflows/image_base.yml
@@ -1,11 +1,16 @@
 name: base
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       pushImage:
         default: true
         type: boolean
+    secrets:
+      username:
+        required: true
+      password:
+        required: true
 
 jobs:
   baseimagebuild:
@@ -22,8 +27,8 @@ jobs:
         uses: docker/login-action@v3
         with:
             registry: quay.io/sustainable_computing_io
-            username: ${{ secrets.BOT_NAME }}
-            password: ${{ secrets.BOT_TOKEN }}
+            username: ${{ secrets.username }}
+            password: ${{ secrets.password }}
       - name: Build and push a base image for building Kepler with libbpf
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
Reverts sustainable-computing-io/kepler#1262, as 1262 makes a wrong implementation.
Just replaced workflow call by workflow_dispatch, which breaks everything in automation, either PR check or daily build.
To support workflow_dispatch, we need another option.
The base image, considering with CI should build:
1. Nightly to fix CVEs for dependency.
2. Pre PR, to validate if changes breaks CI.