### PR TITLE
[CI] revert #1262

### DIFF
--- a/.github/workflows/baseimage_dispatch.yml
+++ b/.github/workflows/baseimage_dispatch.yml
@@ -1,0 +1,13 @@
+name: baseimage_dispatch
+
+on:
+  workflow_dispatch:
+
+jobs:
+  baseimagebuild:
+    uses: ./.github/workflows/image.yml
+    with:
+      pushImage: true
+    secrets:
+        username: ${{ secrets.BOT_NAME }}
+        password: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/image_base.yml
+++ b/.github/workflows/image_base.yml
@@ -1,11 +1,16 @@
 name: base
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       pushImage:
         default: true
         type: boolean
+    secrets:
+      username:
+        required: true
+      password:
+        required: true
 
 jobs:
   baseimagebuild:
@@ -22,8 +27,8 @@ jobs:
         uses: docker/login-action@v3
         with:
             registry: quay.io/sustainable_computing_io
-            username: ${{ secrets.BOT_NAME }}
-            password: ${{ secrets.BOT_TOKEN }}
+            username: ${{ secrets.username }}
+            password: ${{ secrets.password }}
       - name: Build and push a base image for building Kepler with libbpf
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
Reverts https://github.com/sustainable-computing-io/kepler/pull/1262, as it makes a wrong implementation.
Just replaced workflow call by workflow_dispatch, which breaks everything in automation, either PR check or daily build.
To support workflow_dispatch, which this PR contains a temporary solution as an example.

Pre previously CI consideration/supporting for base image as https://github.com/sustainable-computing-io/kepler/issues/1047 which base image should up to date and maintained by CI.

Hence, considering the PR may breaks nightly build. Our CI for base image supports feature for:
- Nightly to fix CVEs for dependency.
- Pre PR, to validate if changes breaks CI.