### PR TITLE
ignore CI for s390

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -37,7 +37,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64
           push: ${{ inputs.pushImage }}
           tags: quay.io/sustainable_computing_io/kepler:${{ inputs.imageTag }}
           labels: ${{ inputs.imageTag }}
@@ -47,7 +47,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64
           build-args: INSTALL_DCGM="true"
           push: ${{ inputs.pushImage }}                                                                                                                   
           tags: quay.io/sustainable_computing_io/kepler:${{ inputs.imageTag }}-dgcm
@@ -58,7 +58,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64
           push: ${{ inputs.pushImage }}
           tags: quay.io/sustainable_computing_io/kepler-validator:${{ inputs.imageTag }}
           labels: ${{ inputs.imageTag }}

--- a/.github/workflows/image_pr.yml
+++ b/.github/workflows/image_pr.yml
@@ -31,7 +31,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: quay.io/sustainable_computing_io/kepler
           labels: ${{ github.event.inputs.commitSHA }}


### PR DESCRIPTION
Local build for S390 works, but there is issue in github CI. So disable CI for now.

```
 > [linux/s390x builder 4/4] RUN ATTACHER_TAG=libbpf make build:
6.066 rm -rf _output/bin
6.401 clang \
6.401 	-I /usr/include/s390x-linux-gnu \
6.401 	-D __TARGET_ARCH_s390 \
6.401 	-O2 -g -c -target bpf \
6.401 	-o bpfassets/libbpf/bpf.o/s390x_kepler.bpf.o bpfassets/libbpf/src/kepler.bpf.c
7.080 clang-16: error: unknown argument: '-g'
7.081 clang-16: error: unknown argument: '-c'
7.082 clang-16: error: unknown argument: '-o'
7.172 make: *** [bpfassets/libbpf/Makefile:11: kepler.bpf.o] Error 1
------
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
Dockerfile:7
------------------
```