### PR TITLE
[CI] update QEMU version to support s390 libbpf compile and nitfixs

### DIFF
--- a/.github/workflows/baseimage_dispatch.yml
+++ b/.github/workflows/baseimage_dispatch.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   baseimagebuild:
-    uses: ./.github/workflows/image.yml
+    uses: ./.github/workflows/image_base.yml
     with:
       pushImage: true
     secrets:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -42,6 +42,8 @@ jobs:
       uses: actions/checkout@v4.1.1
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        image: tonistiigi/binfmt:qemu-v8.1.5
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Login to Quay

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -35,7 +35,7 @@ jobs:
         - IMAGE_NAME: kepler-validator
           IMAGE_FILE: build/Dockerfile.kepler-validator
           BUILD_ARGS: ""
-          PLATFORMS:  linux/amd64,linux/arm64
+          PLATFORMS:  linux/amd64
           LABEL:      ${{ inputs.imageTag }}
     steps:
     - name: Checkout

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -73,6 +73,7 @@ jobs:
         output-file: ./sbom-${{matrix.IMAGE_NAME}}-${{matrix.LABEL}}.spdx.json
 
     - name: save Kepler image SBOM as artifact
+      if: ${{ inputs.pushImage }}
       uses: actions/upload-artifact@v4.3.0
       with:
           name: sbom-${{matrix.IMAGE_NAME}}-${{matrix.LABEL}}.spdx.json

--- a/.github/workflows/image_base.yml
+++ b/.github/workflows/image_base.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v8.1.5
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Quay

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -20,11 +20,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      # set up ebpf
-      - name: install libbpf
-        uses: sustainable-computing-io/kepler-action@v0.0.5
-        with:
-          ebpfprovider: libbpf
       # build kepler image
       - name: build and export Kepler image
         run: |

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -45,6 +45,7 @@ jobs:
     needs: [build-kepler]
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         cluster_provider: [kind,microshift]
     steps:

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: get git version
         id: git_version
-        run: echo "name=git_version::$(git describe --dirty --tags --always --match='v*' | tr '-' '.')" >> $GITHUB_OUTPUT
+        run: echo "git_version=$(git describe --dirty --tags --always --match='v*' | tr '-' '.')" >> $GITHUB_OUTPUT
 
       - name: Build RPM packages
         id: rpm_build


### PR DESCRIPTION
update qemu version to support s390x libbpf compile.
fix null value for github version in daily rpm build job.
removed libbpf in integration build process as no needed.
add condition for sbom artifactory upload.
validation image is x86 only for now.