### PR TITLE
[CI] Fix release ci naming issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
       - name: download from artifact
         uses: actions/download-artifact@v4
         with:
-          name: sbom-kepler-${{ github.event.inputs.release }}.json
+          name: sbom-kepler-${{ github.event.inputs.release }}.spdx.json
 
       - name: Attach SBOM to release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
it seems naming rule for SBOM file is wrong for now, try to fix via PR.
ref https://github.com/sustainable-computing-io/kepler/actions/runs/8142002392/job/22251535213
```
Run actions/upload-artifact@v4.3.0
  with:
    name: sbom-kepler-release-0.7.8.spdx.json
    path: ./sbom-kepler-release-0.7.8.spdx.json
    retention-days: 1
    if-no-files-found: warn
    compression-level: [6](https://github.com/sustainable-computing-io/kepler/actions/runs/8142002392/job/22250653927#step:8:6)
    overwrite: false
  env:
    ANCHORE_SBOM_ACTION_PRIOR_ARTIFACT: sbom-kepler-release-0.[7](https://github.com/sustainable-computing-io/kepler/actions/runs/8142002392/job/22250653927#step:8:7).[8](https://github.com/sustainable-computing-io/kepler/actions/runs/8142002392/job/22250653927#step:8:8).json
```

```
Run actions/download-artifact@v4
  with:
    name: sbom-kepler-release-0.7.8.json
    merge-multiple: false
    repository: sustainable-computing-io/kepler
    run-id: 814[2](https://github.com/sustainable-computing-io/kepler/actions/runs/8142002392/job/22251535213#step:2:2)002[3](https://github.com/sustainable-computing-io/kepler/actions/runs/8142002392/job/22251535213#step:2:3)92
Downloading single artifact
```