### PR TITLE
fix: update dockerfile to respect the kepler version

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -25,12 +25,16 @@ jobs:
         - IMAGE_NAME: kepler
           IMAGE_FILE: build/Dockerfile
           PLATFORMS:  linux/amd64,linux/arm64
-          BUILD_ARGS: INSTALL_DCGM="false"
+          BUILD_ARGS: |
+                INSTALL_DCGM="false"
+                VERSION=${{ inputs.imageTag }}
           LABEL:      ${{ inputs.imageTag }}
         - IMAGE_NAME: kepler
           IMAGE_FILE: build/Dockerfile
           PLATFORMS:  linux/amd64
-          BUILD_ARGS: INSTALL_DCGM="true"
+          BUILD_ARGS: |
+                INSTALL_DCGM="true"
+                VERSION=${{ inputs.imageTag }}-dgcm
           LABEL:      ${{ inputs.imageTag }}-dgcm
         - IMAGE_NAME: kepler-validator
           IMAGE_FILE: build/Dockerfile.kepler-validator
@@ -59,7 +63,7 @@ jobs:
       with:
           context: .
           platforms: ${{matrix.PLATFORMS}}
-          push: ${{ inputs.pushImage }}          
+          push: ${{ inputs.pushImage }}
           build-args: ${{matrix.BUILD_ARGS}}
           tags: quay.io/sustainable_computing_io/${{matrix.IMAGE_NAME}}:${{matrix.LABEL}}
           labels: ${{matrix.LABEL}}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ export BIN_TIMESTAMP ?=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 export TIMESTAMP ?=$(shell echo $(BIN_TIMESTAMP) | tr -d ':' | tr 'T' '-' | tr -d 'Z')
 
 # restrict included verify-* targets to only process project files
-SOURCE_GIT_TAG     := $(shell git describe --tags --always --abbrev=7 --match 'v*')
 SRC_ROOT           := $(shell pwd)
 ARCH               := $(shell arch)
 OUTPUT_DIR         := _output
@@ -53,7 +52,7 @@ LIBBPF_OBJ ?= /usr/lib64/libbpf.a
 GOENV = GO111MODULE="" GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 CC=clang CGO_CFLAGS="-I $(LIBBPF_HEADERS)" CGO_LDFLAGS="$(LIBBPF_OBJ)"
 
 DOCKERFILE := $(SRC_ROOT)/build/Dockerfile
-IMAGE_BUILD_TAG := $(SOURCE_GIT_TAG)-linux-$(GOARCH)
+IMAGE_BUILD_TAG := $(GIT_VERSION)-linux-$(GOARCH)
 GO_BUILD_TAGS := $(GENERAL_TAGS)$(GOOS)$(GPU_TAGS)
 GO_TEST_TAGS := $(GENERAL_TAGS)$(GOOS)
 
@@ -92,8 +91,8 @@ build_containerized: tidy-vendor format
 	$(CTR_CMD) build -t $(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_BUILD_TAG) \
 		-f $(DOCKERFILE) \
 		--network host \
-		--build-arg SOURCE_GIT_TAG=$(SOURCE_GIT_TAG) \
 		--build-arg BIN_TIMESTAMP=$(BIN_TIMESTAMP) \
+		--build-arg VERSION=$(VERSION) \
 		--platform="linux/$(GOARCH)" \
 		.
 
@@ -103,9 +102,9 @@ build_containerized: tidy-vendor format
 	$(CTR_CMD) build -t $(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_BUILD_TAG)-"dcgm" \
 		-f $(DOCKERFILE) \
 		--network host \
-		--build-arg SOURCE_GIT_TAG=$(SOURCE_GIT_TAG) \
 		--build-arg BIN_TIMESTAMP=$(BIN_TIMESTAMP) \
 		--build-arg INSTALL_DCGM="true" \
+		--build-arg VERSION=$(VERSION) \
 		--platform="linux/$(GOARCH)" \
 		.
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,13 +1,13 @@
 FROM quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.2.0 as builder
-
+ARG VERSION
 WORKDIR /workspace
 
 COPY . .
 
-RUN ATTACHER_TAG=libbpf make build
+RUN make build VERSION=${VERSION}
 
 FROM registry.access.redhat.com/ubi9:9.2
-ARG INSTALL_DCGM 
+ARG INSTALL_DCGM
 ARG INSTALL_DCGM=${INSTALL_DCGM:-""}
 ARG TARGETARCH
 

--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -30,7 +30,6 @@ declare CLUSTER_PROVIDER="${CLUSTER_PROVIDER:-kind}"
 declare CTR_CMD="${CTR_CMD:-docker}"
 declare IMAGE_TAG="${IMAGE_TAG:-devel}"
 declare IMAGE_REPO="${IMAGE_REPO:-localhost:5001}"
-declare ATTACHER_TAG="${ATTACHER_TAG:-libbpf}"
 declare OPTS="${OPTS:-}"
 declare NO_BUILDS="${NO_BUILDS:-false}"
 
@@ -55,7 +54,7 @@ build_kepler() {
 	run make build_containerized \
 		IMAGE_REPO="$IMAGE_REPO" \
 		IMAGE_TAG="$IMAGE_TAG" \
-		ATTACHER_TAG="$ATTACHER_TAG"
+		VERSION="devel"
 }
 push_kepler() {
 	header "Push Kepler Image"
@@ -65,8 +64,7 @@ push_kepler() {
 	}
 	run make push-image \
 		IMAGE_REPO="$IMAGE_REPO" \
-		IMAGE_TAG="$IMAGE_TAG" \
-		ATTACHER_TAG="$ATTACHER_TAG"
+		IMAGE_TAG="$IMAGE_TAG"
 }
 run_kepler() {
 	header "Running Kepler"


### PR DESCRIPTION
This PR fixes issue #1264 where the wrong version of Kepler was reported in logs. 
* Updates the image workflow to accept the version as `imageTag` value.
* Update Makefile to make use of VERSION when building images.
* Update dockerfile to accept VERSION arg while running `make build` command
* Some minor updates to local `cluster-deploy` script