### PR TITLE
feat: add support to cache tools on CI

### DIFF
--- a/.github/tools-cache/action.yml
+++ b/.github/tools-cache/action.yml
@@ -1,0 +1,16 @@
+---
+name: tools-cache
+description: Caches development tools
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v3
+      id: tools-cache
+      with:
+        path: ./tmp/bin
+        key: ${{ runner.os }}-tools-${{ hashFiles('./hack/tools.sh') }}
+
+    - name: Install Dependencies
+      if: steps.tools-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: make tools

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -57,6 +57,9 @@ jobs:
         with:
           name: keplerlibbpf
 
+      - name: Install all tools
+        uses: ./.github/tools-cache
+
       - name: build manifest
         run: make build-manifest OPTS="CI_DEPLOY"
         env:


### PR DESCRIPTION
This PR adds support for caching tools to avoid GH rate-limiting issues. Fixes #1259 

Sample CI run: https://github.com/vprashar2929/kepler/actions/runs/8506714437/job/23298020671#step:4:13
Tools Cache:  https://github.com/vprashar2929/kepler/actions/caches