### PR TITLE
Change log level about power input file

### DIFF
--- a/pkg/sensors/components/source/apm_xgene_sysfs.go
+++ b/pkg/sensors/components/source/apm_xgene_sysfs.go
@@ -58,7 +58,7 @@ func (r *ApmXgeneSysfs) IsSystemCollectionSupported() bool {
 		if strings.TrimSuffix(strings.TrimSpace(string(data)), "\n") == cpuPowerLabel {
 			// replace the label file with the input file
 			powerInputPath = strings.Replace(labelFile, "label", "input", 1)
-			klog.V(1).Infof("Found power input file: %s", powerInputPath)
+			klog.V(5).Infof("Found power input file: %s", powerInputPath)
 			return true
 		}
 	}


### PR DESCRIPTION
I saw following logs in twice by 3 seconds on Arm baremetal server. We should control them with verbosity level.

```
I0401 06:55:09.789155       1 apm_xgene_sysfs.go:61] Found power input file: /sys/class/hwmon/hwmon0/power1_input
```

See discussion in https://github.com/sustainable-computing-io/kepler/issues/1156#issuecomment-2029323519