### PR TITLE
Restrict repository to run daily.yml

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,3 +1,4 @@
+# This workflow would be run on sustainable-computing-io/kepler only.
 name: Scheduled build
 on:
   branch_protection_rule:
@@ -7,9 +8,11 @@ on:
 jobs:
   # daily go security
   gosec:
+    if: github.repository == 'sustainable-computing-io/kepler'
     uses: ./.github/workflows/gosec.yml
   # daily base image build and image build
   image_base:
+    if: github.repository == 'sustainable-computing-io/kepler'
     uses: ./.github/workflows/image_base.yml
     secrets:
         username: ${{ secrets.BOT_NAME }}
@@ -22,7 +25,9 @@ jobs:
         password: ${{ secrets.BOT_TOKEN }}
   # daily openSSF scan
   scorecard:
+    if: github.repository == 'sustainable-computing-io/kepler'
     uses: ./.github/workflows/scorecard.yml
   # daily rpm
   rpm:
+    if: github.repository == 'sustainable-computing-io/kepler'
     uses: ./.github/workflows/rpm.yml


### PR DESCRIPTION
This PR is for #1326.

I added `github.repository == 'sustainable-computing-io/kepler'` to prevent to run daily.yml on forked repo. Similar code works fine on [Carbon Aware SDK by Green Software Foundation](https://github.com/Green-Software-Foundation/carbon-aware-sdk).

https://github.com/Green-Software-Foundation/carbon-aware-sdk/commit/06c5577397815f2e867a349da7c74be06a9423d1