### PR TITLE
set default trainer name

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -133,6 +133,7 @@ var (
 	FixedTrainerNameKey      = "TRAINER"
 	FixedNodeTypeKey         = "NODE_TYPE"
 	ModelFiltersKey          = "FILTERS"
+	DefaultTrainerName       = "SGDRegressorTrainer"
 	////////////////////////////////////
 
 	// KubeConfig is used to start k8s client with the pod running outside the cluster

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -208,6 +208,9 @@ func getPowerModelType(powerSourceTarget string) (modelType types.ModelType) {
 // getPowerModelTrainerName return the trainer name for a given power source, such as platform or components power sources
 func getPowerModelTrainerName(powerSourceTarget string) (trainerName string) {
 	trainerName = config.ModelConfigValues[getModelConfigKey(powerSourceTarget, config.FixedTrainerNameKey)]
+	if trainerName == "" {
+		trainerName = config.DefaultTrainerName
+	}
 	return
 }
 


### PR DESCRIPTION
With the current code, for the deployment with only server-api (component of kepler-model-server), kepler exporter must specify trainer name to the power model weight request to the server-api. 

If no trainer name defined, linear regression will be applied. 
https://github.com/sustainable-computing-io/kepler/blob/6b7b15939810680f7603363ab3ce4bd5995de3ff/pkg/model/estimator/local/regressor/regressor.go#L228-L229

However, on the server-api side, if the trainer_name is not defined, it will return the best power model which is not limited to linear regression. So, we should set the default value of the trainer in configuration at the exporter.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com> 