### PR TITLE
update container-kepler spec; don't build kepler rpm during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,6 @@ jobs:
           _COMMITTER_: ${{ github.event.inputs.committer }}
           _ARCH_: ${{ github.event.inputs.arch }}
         run: |
-          make containerized_build_rpm
           make containerized_build_container_rpm
           cd _output/rpmbuild/
           sudo tar czvf /tmp/kepler.rpm.tar.gz RPMS/

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -26,7 +26,6 @@ jobs:
           _COMMITTER_: nightly
           _ARCH_: x86_64
         run: |
-          make containerized_build_rpm
           make containerized_build_container_rpm
           cd _output/rpmbuild/
           sudo tar czvf /tmp/kepler.rpm.tar.gz RPMS/

--- a/packaging/rpm/container-kepler.spec
+++ b/packaging/rpm/container-kepler.spec
@@ -9,11 +9,9 @@ License:        Apache License 2.0
 URL:            https://github.com/sustainable-computing-io/kepler/
 Source0:        kepler.tar.gz
 
-BuildRequires: systemd
+BuildArch:  noarch
 
-Requires:       kernel-devel
-
-%{?systemd_requires}
+Requires: podman
 
 %description
 Kubernetes-based Efficient Power Level Exporter


### PR DESCRIPTION
The kepler rpm is to be replaced by the podman rpm. Don't build it during release.