### PR TITLE
workflow: update commit-message workflow version

### DIFF
--- a/.github/workflows/commitMsg.yml
+++ b/.github/workflows/commitMsg.yml
@@ -19,21 +19,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Try to keep the subject line to 50 characters or less; do not exceed 72 characters
-        uses: gsactions/commit-message-checker@v2
+        uses: GsActions/commit-message-checker@v2.0.0
         with:
           pattern: '^[^#].{72}'
           error: 'The maximum line length of 72 characters is exceeded.'
           excludeDescription: 'true' # optional: this excludes the description body of a pull request
           excludeTitle: 'true' # optional: this excludes the title of a pull request
       - name: Providing additional context if I am right means formatting in topic":" something
-        uses: gsactions/commit-message-checker@v2
+        uses: GsActions/commit-message-checker@v2.0.0
         with:
           pattern: '^.*:\s.*'
           error: 'topic: someting for example commit msg as [CI: enhancement xxx]'
           excludeDescription: 'true' # optional: this excludes the description body of a pull request
           excludeTitle: 'true' # optional: this excludes the title of a pull request
       - name: The first word in the commit message subject should be capitalized unless it starts with a lowercase symbol or other identifier
-        uses: gsactions/commit-message-checker@v2
+        uses: GsActions/commit-message-checker@v2.0.0
         with:
           pattern: '^[^].*'
           error: 'topic: someting for example commit msg as [CI: enhancement xxx]'


### PR DESCRIPTION
Update GsActions to the latest recommendation from the [gs-commit-message-checker](https://github.com/marketplace/actions/gs-commit-message-checker):

```
              - name: GS Commit Message Checker
                uses: GsActions/commit-message-checker@v2.0.0
            
```

This will remove the warning when the workflow runs:

```
[Check Commit Message](https://github.com/sustainable-computing-io/kepler/actions/runs/8598476575/job/23559370798)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: gsactions/commit-message-checker@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```