### PR TITLE
fix(build): reduce container image size

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,26 +7,23 @@ COPY . .
 RUN make build VERSION=${VERSION}
 
 FROM registry.access.redhat.com/ubi9:9.2
-ARG INSTALL_DCGM
-ARG INSTALL_DCGM=${INSTALL_DCGM:-""}
+ARG INSTALL_DCGM=${INSTALL_DCGM:-"false"}
 ARG TARGETARCH
-
-RUN yum -y update
 
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=utility
-ENV NVIDIA_MIG_CONFIG_DEVICES=all
 ENV NVIDIA_MIG_MONITOR_DEVICES=all
+ENV NVIDIA_MIG_CONFIG_DEVICES=all
 
 RUN INSTALL_PKGS=" \
     libbpf \
     " && \
 	yum install -y $INSTALL_PKGS
 
-RUN if [ "$TARGETARCH" == "amd64" ]; then \
+RUN if [[ "$TARGETARCH" == "amd64" ]]; then \
         yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm; \
         yum install -y cpuid; \
-        if [[ ! -z "$INSTALL_DCGM" && "$INSTALL_DCGM" == "true" ]]; then \
+        if [[ "$INSTALL_DCGM" == "true" ]]; then \
             dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo; \
             yum install -y datacenter-gpu-manager; \
         fi; \


### PR DESCRIPTION
This commit reduces container image size by
1. Removing `yum update` resulting in more reproducible builds. Updates to the packages are best obtained by pulling a newer base image (which is tested) than running `yum update`
2. fixing installation of dcgm only when it is enabled

```
❯ make build_containerized IMAGE_REPO=quay.io/sthaha CTR_CMD=docker
...
❯ docker images | head -n 5
REPOSITORY                                             TAG                             IMAGE ID       CREATED          SIZE
quay.io/sthaha/kepler                                  latest-dcgm                     ec386bae9d62   8 seconds ago    1.96GB
quay.io/sthaha/kepler                                  v0.7.9-dirty-linux-amd64-dcgm   ec386bae9d62   8 seconds ago    1.96GB
quay.io/sthaha/kepler                                  latest                          ff02e4ae267c   5 minutes ago    390MB
quay.io/sthaha/kepler                                  v0.7.9-dirty-linux-amd64        ff02e4ae267c   5 minutes ago    390MB
```