### PR TITLE
fix(build): reduce image size by squashing install and clean steps

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,6 +7,9 @@ COPY . .
 RUN make build VERSION=${VERSION}
 
 FROM registry.access.redhat.com/ubi9:9.2
+# NOTE: use bash instead of sh
+SHELL ["/bin/bash", "-c"]
+
 ARG INSTALL_DCGM=${INSTALL_DCGM:-"false"}
 ARG TARGETARCH
 
@@ -15,21 +18,22 @@ ENV NVIDIA_DRIVER_CAPABILITIES=utility
 ENV NVIDIA_MIG_MONITOR_DEVICES=all
 ENV NVIDIA_MIG_CONFIG_DEVICES=all
 
-RUN INSTALL_PKGS=" \
-    libbpf \
-    " && \
-	yum install -y $INSTALL_PKGS
-
-RUN if [[ "$TARGETARCH" == "amd64" ]]; then \
-        yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm; \
-        yum install -y cpuid; \
-        if [[ "$INSTALL_DCGM" == "true" ]]; then \
-            dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo; \
-            yum install -y datacenter-gpu-manager; \
-        fi; \
-    fi
-
-RUN yum clean all
+# NOTE: set -e ensure all fails results in a non-zero exit code (i.e. fail)
+RUN set -e -x ;\
+		INSTALL_PKGS=" \
+			libbpf  \
+		" ;\
+		yum install -y $INSTALL_PKGS ;\
+		\
+		if [[ "$TARGETARCH" == "amd64" ]]; then \
+			yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm; \
+			yum install -y cpuid; \
+			if [[ "$INSTALL_DCGM" == "true" ]]; then \
+				dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo; \
+				yum install -y datacenter-gpu-manager; \
+			fi; \
+		fi;\
+		yum clean all
 
 COPY --from=builder /workspace/_output/bin/kepler /usr/bin/kepler
 COPY --from=builder /libbpf-source/linux-5.14.0-333.el9/tools/bpf/bpftool/bpftool /usr/bin/bpftool


### PR DESCRIPTION
This commit squashes multiple RUN which results in separate layers into a single layer by combining install and cleanup into a single RUN. Additionally, the default SHELL is replaced with bash instead of sh so that `[[ ]]` etc are supported better.

```
❯ docker images | head -n 5
REPOSITORY                                TAG                                        IMAGE ID       CREATED          SIZE
quay.io/sthaha/kepler                     latest-dcgm                                c24bc6eb9191   20 seconds ago   1.88GB
quay.io/sthaha/kepler                     v0.7.9-2-g6807777e7e821-linux-amd64-dcgm   c24bc6eb9191   20 seconds ago   1.88GB
quay.io/sthaha/kepler                     latest                                     5e7ec39af2c1   2 minutes ago    308MB
quay.io/sthaha/kepler                     v0.7.9-2-g6807777e7e821-linux-amd64        5e7ec39af2c1   2 minutes ago    308MB
```

```
❯  diff docker history kepler:latest vs  this-pr

 6 COPY /workspace/data/model_weight/acpi_AbsPo…   224B      buildkit.dockerfile.v0        6 COPY /workspace/data/model_weight/acpi_AbsPo…   224B      buildkit.dockerfile.v0
 7 COPY /workspace/bpfassets/libbpf/bpf.o /var/…   1.46MB    buildkit.dockerfile.v0        7 COPY /workspace/bpfassets/libbpf/bpf.o /var/…   1.46MB    buildkit.dockerfile.v0
 8 COPY /workspace/data/cpus.yaml /var/lib/kepl…   2.61kB    buildkit.dockerfile.v0        8 COPY /workspace/data/cpus.yaml /var/lib/kepl…   2.61kB    buildkit.dockerfile.v0
 9 RUN |2 INSTALL_DCGM="false" TARGETARCH=amd64…   0B        buildkit.dockerfile.v0        9 RUN |2 INSTALL_DCGM=false TARGETARCH=amd64 /…   0B        buildkit.dockerfile.v0
10 RUN |2 INSTALL_DCGM="false" TARGETARCH=amd64…   0B        buildkit.dockerfile.v0       10 RUN |2 INSTALL_DCGM=false TARGETARCH=amd64 /…   0B        buildkit.dockerfile.v0
11 COPY /libbpf-source/linux-5.14.0-333.el9/too…   0B        buildkit.dockerfile.v0       ..
12 COPY /libbpf-source/linux-5.14.0-333.el9/too…   1.72MB    buildkit.dockerfile.v0       11 COPY /libbpf-source/linux-5.14.0-333.el9/too…   1.72MB    buildkit.dockerfile.v0
..                                                                                        12 COPY /libbpf-source/linux-5.14.0-333.el9/too…   1.72MB    buildkit.dockerfile.v0
13 COPY /workspace/_output/bin/kepler /usr/bin/…   38.3MB    buildkit.dockerfile.v0       13 COPY /workspace/_output/bin/kepler /usr/bin/…   38.3MB    buildkit.dockerfile.v0
14 RUN |2 INSTALL_DCGM="false" TARGETARCH=amd64…   103kB     buildkit.dockerfile.v0       14 RUN |2 INSTALL_DCGM=false TARGETARCH=amd64 /…   55.4MB    buildkit.dockerfile.v0
15 RUN |2 INSTALL_DCGM="false" TARGETARCH=amd64…   116MB     buildkit.dockerfile.v0       ..
16 RUN |2 INSTALL_DCGM="false" TARGETARCH=amd64…   21.2MB    buildkit.dockerfile.v0       ..
17 ENV NVIDIA_MIG_CONFIG_DEVICES=all               0B        buildkit.dockerfile.v0       15 ENV NVIDIA_MIG_CONFIG_DEVICES=all               0B        buildkit.dockerfile.v0
18 ENV NVIDIA_MIG_MONITOR_DEVICES=all              0B        buildkit.dockerfile.v0       16 ENV NVIDIA_MIG_MONITOR_DEVICES=all              0B        buildkit.dockerfile.v0
19 ENV NVIDIA_DRIVER_CAPABILITIES=utility          0B        buildkit.dockerfile.v0       17 ENV NVIDIA_DRIVER_CAPABILITIES=utility          0B        buildkit.dockerfile.v0
20 ENV NVIDIA_VISIBLE_DEVICES=all                  0B        buildkit.dockerfile.v0       18 ENV NVIDIA_VISIBLE_DEVICES=all                  0B        buildkit.dockerfile.v0
21 ARG TARGETARCH                                  0B        buildkit.dockerfile.v0       19 ARG TARGETARCH                                  0B        buildkit.dockerfile.v0
22 ARG INSTALL_DCGM=false                          0B        buildkit.dockerfile.v0       20 ARG INSTALL_DCGM=false                          0B        buildkit.dockerfile.v0
..                                                                                        21 SHELL [/bin/bash -c]                            0B        buildkit.dockerfile.v0
23 /bin/sh -c mv -fZ /tmp/ubi.repo /etc/yum.rep…   209MB                                  22 /bin/sh -c mv -fZ /tmp/ubi.repo /etc/yum.rep…   209MB
24 /bin/sh -c rm -f /tmp/tls-ca-bundle.pem         0B                                     23 /bin/sh -c rm -f /tmp/tls-ca-bundle.pem         0B
25 /bin/sh -c rm -f '/etc/yum.repos.d/odcs-2460…   0B                                     24 /bin/sh -c rm -f '/etc/yum.repos.d/odcs-2460…   0B

```