### PR TITLE
fix: correct the name dcgm in the image tag

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -34,8 +34,8 @@ jobs:
           PLATFORMS:  linux/amd64
           BUILD_ARGS: |
                 INSTALL_DCGM="true"
-                VERSION=${{ inputs.imageTag }}-dgcm
-          LABEL:      ${{ inputs.imageTag }}-dgcm
+                VERSION=${{ inputs.imageTag }}-dcgm
+          LABEL:      ${{ inputs.imageTag }}-dcgm
         - IMAGE_NAME: kepler-validator
           IMAGE_FILE: build/Dockerfile.kepler-validator
           BUILD_ARGS: ""


### PR DESCRIPTION
This PR corrects the name of the image tag for dcgm in the image workflow. 
Due to the incorrect name, the dcgm image of Kepler wasn't updating on quay.