### PR TITLE
fix: image workflow to pass build args correctly

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -26,14 +26,14 @@ jobs:
           IMAGE_FILE: build/Dockerfile
           PLATFORMS:  linux/amd64,linux/arm64
           BUILD_ARGS: |
-                INSTALL_DCGM="false"
+                INSTALL_DCGM=false
                 VERSION=${{ inputs.imageTag }}
           LABEL:      ${{ inputs.imageTag }}
         - IMAGE_NAME: kepler
           IMAGE_FILE: build/Dockerfile
           PLATFORMS:  linux/amd64
           BUILD_ARGS: |
-                INSTALL_DCGM="true"
+                INSTALL_DCGM=true
                 VERSION=${{ inputs.imageTag }}-dcgm
           LABEL:      ${{ inputs.imageTag }}-dcgm
         - IMAGE_NAME: kepler-validator

--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,7 @@ build_image: image_builder_check ## Build image without DCGM.
 	# build kepler without dcgm
 	$(CTR_CMD) build -t $(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_BUILD_TAG) \
 		-f $(DOCKERFILE) \
-		--network host \
-		--build-arg INSTALL_DCGM="false" \
+		--build-arg INSTALL_DCGM=false \
 		--build-arg VERSION=$(VERSION) \
 		--platform="linux/$(GOARCH)" \
 		.
@@ -121,8 +120,7 @@ build_image_dcgm:  image_builder_check ## Build image with DCGM.
 	# build kepler with dcgm
 	$(CTR_CMD) build -t $(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_BUILD_TAG)-"dcgm" \
 		-f $(DOCKERFILE) \
-		--network host \
-		--build-arg INSTALL_DCGM="true" \
+		--build-arg INSTALL_DCGM=true \
 		--build-arg VERSION=$(VERSION) \
 		--platform="linux/$(GOARCH)" \
 		.

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,7 @@ FROM registry.access.redhat.com/ubi9:9.2
 # NOTE: use bash instead of sh
 SHELL ["/bin/bash", "-c"]
 
-ARG INSTALL_DCGM=${INSTALL_DCGM:-"false"}
+ARG INSTALL_DCGM=false
 ARG TARGETARCH
 
 ENV NVIDIA_VISIBLE_DEVICES=all


### PR DESCRIPTION
This PR updates GH workflow to respect build args while building Kepler images and also updates the Makefile accordingly.
Fixes the issue where `latest-dcgm` images were not built correctly
