### PR TITLE
[CI] update ubi image for CVE fix

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 RUN make build VERSION=${VERSION}
 
-FROM registry.access.redhat.com/ubi9
+FROM registry.access.redhat.com/ubi9:latest
 # NOTE: use bash instead of sh
 SHELL ["/bin/bash", "-c"]
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,6 +18,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES=utility
 ENV NVIDIA_MIG_MONITOR_DEVICES=all
 ENV NVIDIA_MIG_CONFIG_DEVICES=all
 
+RUN yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical && yum clean all
 # NOTE: set -e ensure all fails results in a non-zero exit code (i.e. fail)
 RUN set -e -x ;\
 		INSTALL_PKGS=" \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 RUN make build VERSION=${VERSION}
 
-FROM registry.access.redhat.com/ubi9:9.2
+FROM registry.access.redhat.com/ubi9
 # NOTE: use bash instead of sh
 SHELL ["/bin/bash", "-c"]
 

--- a/build/Dockerfile.builder
+++ b/build/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20 as builder
 
 USER 0
 

--- a/build/Dockerfile.builder
+++ b/build/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset as builder
 
 USER 0
 


### PR DESCRIPTION
I had checked image tags and software inside the image and https://quay.io/repository/sustainable_computing_io/kepler/manifest/sha256:b1a7c4d0faf65221667ec67b5da5c15fc75eeda21e018270873a5c0562e180a2?tab=vulnerabilities

The latest image is registry.access.redhat.com/ubi9:9.3 but personally I would like registry.access.redhat.com/ubi9:latest tag, as I don't know how to trace a new tag for registry.access.redhat.com/ubi9 hence keep it with latest tag. Once they have registry.access.redhat.com/ubi9:9.4, we can benefit without a PR.

further compare via
https://catalog.redhat.com/software/containers/ubi9/618326f8c0d15aff4912fe0b?architecture=amd64&image=65e093e60a21b531a96f93ca
https://quay.io/repository/sustainable_computing_io/kepler/manifest/sha256:b1a7c4d0faf65221667ec67b5da5c15fc75eeda21e018270873a5c0562e180a2?tab=vulnerabilities
are welcome.