### PR TITLE
fix(acpi): Fixed how kepler searches for ACPI in hwmon 

### DIFF
--- a/pkg/sensors/platform/power.go
+++ b/pkg/sensors/platform/power.go
@@ -65,11 +65,11 @@ func InitPowerImpl() {
 		powerImpl = &source.PowerHMC{}
 	} else if redfish := source.NewRedfishClient(); redfish != nil && redfish.IsSystemCollectionSupported() {
 		powerImpl = redfish
-	} else if acpi := source.NewACPIPowerMeter(); acpi != nil && acpi.CollectEnergy {
+	} else if acpi := source.NewACPIPowerMeter(); acpi != nil && acpi.IsInitialized {
 		powerImpl = acpi
 	}
 
-	klog.V(1).Infof("using %s to obtain power", powerImpl.GetName())
+	klog.V(1).Infof("using %s to obtain platform power", powerImpl.GetName())
 }
 
 func GetSourceName() string {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"unsafe"
 )
@@ -68,4 +69,18 @@ func GetPathFromPID(searchPath string, pid uint64) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("could not find cgroup description entry for pid %d", pid)
+}
+
+func Realpath(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return "", err
+	}
+
+	return resolvedPath, nil
 }


### PR DESCRIPTION
   ACPI power meter in hwmon need not always be present in  `"/sys/class/hwmon/hwmon2"`

   This commit fixes this problem by
   - looking inside each folder in `"/sys/class/hwmon"`
   - improving the method to detect presece of acpi power meter. (this method is inspired from `lm-sensors` project)