### PR TITLE
Fix cpu freq collection in nodeStat

### DIFF
--- a/pkg/collector/metric_collector.go
+++ b/pkg/collector/metric_collector.go
@@ -171,7 +171,7 @@ func (c *Collector) updateNodeAvgCPUFrequencyFromEBPF() {
 		cpuFreq, err := attacher.CollectCPUFreq()
 		if err == nil {
 			for cpu, freq := range cpuFreq {
-				c.NodeStats.EnergyUsage[config.CPUFrequency].SetDeltaStat(fmt.Sprintf("%d", cpu), freq)
+				c.NodeStats.ResourceUsage[config.CPUFrequency].SetDeltaStat(fmt.Sprintf("%d", cpu), freq)
 			}
 		}
 	}


### PR DESCRIPTION
 Update `NodeStat` 's `ResourceUsage` when updating `"avg_cpu_freq"` metric

Fixed Segmentation fault when collecting node avg cpu freq