### PR TITLE
fix(dashboard): show metal and VM metrics correctly

### DIFF
--- a/manifests/compose/validation/metal/grafana/dashboards/validation/dashboard.json
+++ b/manifests/compose/validation/metal/grafana/dashboards/validation/dashboard.json
@@ -18,309 +18,16 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 6,
+  "id": 5,
   "links": [],
   "panels": [
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PDE6745920139CE56"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "fieldMinMax": false,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 0,
-        "y": 0
-      },
-      "id": 12,
-      "options": {
-        "infinitePan": false,
-        "inlineEditing": false,
-        "panZoom": false,
-        "root": {
-          "background": {
-            "color": {
-              "fixed": "transparent"
-            },
-            "image": {
-              "fixed": ""
-            },
-            "size": "original"
-          },
-          "border": {
-            "color": {
-              "fixed": "dark-green"
-            },
-            "width": 0
-          },
-          "constraint": {
-            "horizontal": "left",
-            "vertical": "top"
-          },
-          "elements": [
-            {
-              "background": {
-                "color": {
-                  "fixed": "orange"
-                }
-              },
-              "border": {
-                "color": {
-                  "fixed": "dark-green"
-                },
-                "width": 1
-              },
-              "config": {
-                "align": "center",
-                "color": {
-                  "fixed": "#00050b"
-                },
-                "size": 20,
-                "text": {
-                  "fixed": "idle",
-                  "mode": "fixed"
-                },
-                "valign": "middle"
-              },
-              "constraint": {
-                "horizontal": "center",
-                "vertical": "center"
-              },
-              "name": "Element 1",
-              "placement": {
-                "height": 33,
-                "left": 8.5,
-                "top": 46,
-                "width": 245
-              },
-              "type": "text"
-            },
-            {
-              "background": {
-                "color": {
-                  "fixed": "green"
-                }
-              },
-              "border": {
-                "color": {
-                  "fixed": "dark-green"
-                }
-              },
-              "config": {
-                "align": "center",
-                "color": {
-                  "fixed": "#00050b"
-                },
-                "size": 20,
-                "text": {
-                  "fixed": "dynamic"
-                },
-                "valign": "middle"
-              },
-              "constraint": {
-                "horizontal": "center",
-                "vertical": "center"
-              },
-              "name": "Element 2",
-              "placement": {
-                "height": 33,
-                "left": 8.5,
-                "top": -20,
-                "width": 245
-              },
-              "type": "text"
-            }
-          ],
-          "name": "Element 1713278841333",
-          "placement": {
-            "height": 100,
-            "left": 0,
-            "top": 0,
-            "width": 100
-          },
-          "type": "frame"
-        },
-        "showAdvancedTypes": false
-      },
-      "pluginVersion": "10.4.2",
-      "title": "VM",
-      "transparent": true,
-      "type": "canvas"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PDE6745920139CE56"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 4,
-        "y": 0
-      },
-      "id": 13,
-      "options": {
-        "infinitePan": false,
-        "inlineEditing": false,
-        "panZoom": false,
-        "root": {
-          "background": {
-            "color": {
-              "fixed": "transparent"
-            }
-          },
-          "border": {
-            "color": {
-              "fixed": "dark-green"
-            },
-            "width": 0
-          },
-          "constraint": {
-            "horizontal": "left",
-            "vertical": "top"
-          },
-          "elements": [
-            {
-              "background": {
-                "color": {
-                  "fixed": "blue"
-                }
-              },
-              "border": {
-                "color": {
-                  "fixed": "dark-green"
-                },
-                "width": 1
-              },
-              "config": {
-                "align": "center",
-                "color": {
-                  "fixed": "#00050b"
-                },
-                "size": 20,
-                "text": {
-                  "fixed": "idle"
-                },
-                "valign": "middle"
-              },
-              "constraint": {
-                "horizontal": "center",
-                "vertical": "center"
-              },
-              "name": "Element 1",
-              "placement": {
-                "height": 33,
-                "left": 8.5,
-                "top": 46,
-                "width": 245
-              },
-              "type": "text"
-            },
-            {
-              "background": {
-                "color": {
-                  "fixed": "yellow"
-                }
-              },
-              "border": {
-                "color": {
-                  "fixed": "dark-green"
-                }
-              },
-              "config": {
-                "align": "center",
-                "color": {
-                  "fixed": "#00050b"
-                },
-                "size": 20,
-                "text": {
-                  "fixed": "dynamic"
-                },
-                "valign": "middle"
-              },
-              "connections": [],
-              "constraint": {
-                "horizontal": "center",
-                "vertical": "center"
-              },
-              "name": "Element 2",
-              "placement": {
-                "height": 33,
-                "left": 8.5,
-                "top": -20,
-                "width": 245
-              },
-              "type": "text"
-            }
-          ],
-          "name": "Element 1713278841333",
-          "placement": {
-            "height": 100,
-            "left": 0,
-            "top": 0,
-            "width": 100
-          },
-          "type": "frame"
-        },
-        "showAdvancedTypes": false
-      },
-      "pluginVersion": "10.4.2",
-      "title": "Metal",
-      "transparent": true,
-      "type": "canvas"
-    },
     {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 0
       },
       "id": 6,
       "panels": [],
@@ -394,7 +101,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "yellow",
+                  "fixedColor": "semi-dark-yellow",
                   "mode": "fixed"
                 }
               }
@@ -409,9 +116,32 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "blue",
+                  "fixedColor": "dark-blue",
                   "mode": "fixed"
                 }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/idle .+ dyn.*/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-orange",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
               }
             ]
           }
@@ -421,7 +151,7 @@
         "h": 10,
         "w": 8,
         "x": 0,
-        "y": 6
+        "y": 1
       },
       "id": 4,
       "options": {
@@ -443,15 +173,28 @@
             "uid": "PDE6745920139CE56"
           },
           "editorMode": "code",
-          "expr": "rate(kepler_node_platform_joules_total{job=\"metal\"}[$__rate_interval])",
+          "expr": "rate(kepler_process_package_joules_total{job=\"metal\", pid=\"${process}\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "{{mode}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PDE6745920139CE56"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(kepler_process_package_joules_total{job=\"metal\", pid=\"${process}\"}[$__rate_interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "idle + dyn - ${process}",
+          "range": true,
+          "refId": "B"
         }
       ],
-      "title": "Metal /  Platform Watts",
+      "title": "Metal /  Process (${process}) W",
       "type": "timeseries"
     },
     {
@@ -521,7 +264,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "green",
+                  "fixedColor": "light-red",
                   "mode": "fixed"
                 }
               }
@@ -533,7 +276,7 @@
         "h": 10,
         "w": 8,
         "x": 8,
-        "y": 6
+        "y": 1
       },
       "id": 2,
       "options": {
@@ -626,13 +369,29 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 10,
         "w": 8,
         "x": 16,
-        "y": 6
+        "y": 1
       },
       "id": 10,
       "options": {
@@ -659,7 +418,7 @@
           "fullMetaSearch": false,
           "includeNullMetadata": false,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{pid}} - {{exe}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -674,7 +433,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 11
       },
       "id": 11,
       "panels": [],
@@ -742,13 +501,13 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "dynamic-vm"
+              "options": "vm / dynamic"
             },
             "properties": [
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "green",
+                  "fixedColor": "light-red",
                   "mode": "fixed"
                 }
               }
@@ -757,13 +516,13 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "dynamic-metal"
+              "options": "metal / dynamic"
             },
             "properties": [
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "yellow",
+                  "fixedColor": "dark-yellow",
                   "mode": "fixed"
                 }
               }
@@ -772,13 +531,28 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "idle-metal"
+              "options": "metal / idle"
             },
             "properties": [
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "blue",
+                  "fixedColor": "dark-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/scaph .*/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
                   "mode": "fixed"
                 }
               }
@@ -790,7 +564,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 12
       },
       "id": 14,
       "options": {
@@ -812,10 +586,10 @@
             "uid": "PDE6745920139CE56"
           },
           "editorMode": "code",
-          "expr": "sum without(job, instance) (rate(kepler_process_platform_joules_total{pid=\"${process}\", job=\"metal\"}[$__rate_interval]))",
+          "expr": "sum without(instance) (rate(kepler_process_platform_joules_total{pid=\"${process}\", job=\"metal\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{mode}}-metal",
+          "legendFormat": "metal / {{mode}}",
           "range": true,
           "refId": "B"
         },
@@ -828,9 +602,22 @@
           "expr": "rate(kepler_node_platform_joules_total{job=\"vm\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{mode}}-vm",
+          "legendFormat": "vm / {{mode}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PDE6745920139CE56"
+          },
+          "editorMode": "code",
+          "expr": "scaph_process_power_consumption_microwatts{pid=\"${process}\"}/1000000",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "scaph / {{pid}} - {{exe}}",
+          "range": true,
+          "refId": "C"
         }
       ],
       "title": "Metal / VM Process - ${process} / Watts",
@@ -883,8 +670,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -893,13 +679,29 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "{command=\"SPICE Worker\", container_id=\"system_processes\", instance=\"kepler-metal:8888\", job=\"metal\", pid=\"2093543\", source=\"bpf\"}"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 22
       },
       "id": 5,
       "options": {
@@ -979,8 +781,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -989,13 +790,29 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "vm"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 22
       },
       "id": 7,
       "options": {
@@ -1078,8 +895,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1094,7 +910,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 36
+        "y": 31
       },
       "id": 8,
       "options": {
@@ -1174,8 +990,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1184,13 +999,29 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "vm"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 36
+        "y": 31
       },
       "id": 9,
       "options": {
@@ -1233,11 +1064,16 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false,
+          "text": "vhost-2093543 | 2093543",
+          "value": "2093543"
+        },
         "datasource": {
           "type": "prometheus",
           "uid": "PDE6745920139CE56"
         },
-        "definition": "query_result(count by (pid, command) (kepler_process_bpf_cpu_time_ms_total{job=\"metal\"}))",
+        "definition": "query_result(label_join( count by (pid, command) (kepler_process_bpf_cpu_time_ms_total{job=\"metal\"}), \"process_info\", \" | \", \"command\", \"pid\" ))",
         "hide": 0,
         "includeAll": false,
         "multi": false,
@@ -1245,11 +1081,11 @@
         "options": [],
         "query": {
           "qryType": 3,
-          "query": "query_result(count by (pid, command) (kepler_process_bpf_cpu_time_ms_total{job=\"metal\"}))",
+          "query": "query_result(label_join( count by (pid, command) (kepler_process_bpf_cpu_time_ms_total{job=\"metal\"}), \"process_info\", \" | \", \"command\", \"pid\" ))",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
-        "regex": "/command=\"(?<text>[^\"]+)|pid=\"(?<value>[^\"]+)/g",
+        "regex": "/process_info=\"(?<text>[^\"]+)|pid=\"(?<value>[^\"]+)/g",
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
@@ -1257,13 +1093,13 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Model Validation Copy",
-  "uid": "ddis44buqn94wb",
-  "version": 7,
+  "title": "Model Validation",
+  "uid": "ddkgzjy4qzuo0c",
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
Fix includes:
* showing process and its PID for easier identification
* use right promql for metal process package metrics
* Use same color code for metal (idle, dyn), vm, scaphandre

<img width="1890" alt="image" src="https://github.com/sustainable-computing-io/kepler/assets/3005132/40bbbee3-62a0-44d3-a7e3-e77316aaf4b1">
