### PR TITLE
feat(bpf): Build for bpfel and bpfeb

### DIFF
--- a/bpfassets/libbpf/Makefile
+++ b/bpfassets/libbpf/Makefile
@@ -2,19 +2,26 @@ ARCH=$(shell uname -m)
 GOARCH=$(shell go env GOARCH)
 
 TARGET := kepler
-TARGET_BPF := bpf.o/$(GOARCH)_$(TARGET).bpf.o
+
 BPF_SRC := $(wildcard src/*.bpf.c src/*.bpf.h)
 # in libbpf if $(ARCH) is x86_64, then set TARGET_ARCH to x86. if arch is aarch64, then set TARGET_ARCH to arm
 TARGET_ARCH := $(shell echo $(ARCH) | sed -e 's/x86_64/x86/' -e 's/aarch64/arm64/' -e 's/s390x/s390/')
 
-default: $(TARGET_BPF)
+all: bpf.o/kepler.bpfeb.o bpf.o/kepler.bpfel.o
 
 bpf.o:
 	mkdir -p bpf.o
 
-$(TARGET_BPF): $(BPF_SRC) | bpf.o
+bpf.o/kepler.bpfeb.o: $(BPF_SRC) | bpf.o
 	clang \
 		-I./include \
-		-D __TARGET_ARCH_$(TARGET_ARCH) \
-		-O2 -g -c -target bpf \
+		-target bpfeb \
+		-O2 -g -c  \
+		-o $@ $<
+
+bpf.o/kepler.bpfel.o: $(BPF_SRC) | bpf.o
+	clang \
+		-I./include \
+		-target bpfel \
+		-O2 -g -c  \
 		-o $@ $<

--- a/packaging/rpm/kepler.spec
+++ b/packaging/rpm/kepler.spec
@@ -59,7 +59,8 @@ install -d %{buildroot}/etc/kepler/kepler.config
 
 install -p -m755 ./_output/kepler  %{buildroot}%{_bindir}/kepler
 install -p -m644 ./packaging/rpm/kepler.service %{buildroot}%{_unitdir}/kepler.service
-install -p -m644 ./bpfassets/libbpf/bpf.o/%{TARGETARCH}_kepler.bpf.o %{buildroot}/var/lib/kepler/bpfassets/%{TARGETARCH}_kepler.bpf.o
+install -p -m644 ./bpfassets/libbpf/bpf.o/kepler.bpfel.o %{buildroot}/var/lib/kepler/bpfassets/kepler.bpfel.o
+install -p -m644 ./bpfassets/libbpf/bpf.o/kepler.bpfeb.o %{buildroot}/var/lib/kepler/bpfassets/kepler.bpfeb.o
 install -p -m644 ./_output/ENABLE_PROCESS_METRICS %{buildroot}/etc/kepler/kepler.config/ENABLE_PROCESS_METRICS
 install -p -m644 ./data/cpus.yaml %{buildroot}/var/lib/kepler/data/cpus.yaml
 install -p -m644 ./data/model_weight/acpi_AbsPowerModel.json %{buildroot}/var/lib/kepler/data/acpi_AbsPowerModel.json
@@ -75,7 +76,8 @@ install -p -m644 ./data/model_weight/intel_rapl_DynPowerModel.json %{buildroot}/
 %license LICENSE
 %{_bindir}/kepler
 %{_unitdir}/kepler.service
-/var/lib/kepler/bpfassets/%{TARGETARCH}_kepler.bpf.o
+/var/lib/kepler/bpfassets/kepler.bpfel.o
+/var/lib/kepler/bpfassets/kepler.bpfeb.o
 /var/lib/kepler/data/cpus.yaml
 /var/lib/kepler/data/acpi_AbsPowerModel.json
 /var/lib/kepler/data/acpi_DynPowerModel.json


### PR DESCRIPTION
Since we now have portable probes, we can simplify building only 2 variants of our eBPF bytecode. One for big endian and one for little endian systems. The correct probe is picked at runtime.