### PR TITLE
Revert "tools: add install_yq"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,6 @@ TOOLS = govulncheck \
 		jq \
 		kubectl \
 		kustomize \
-		yq \
 
 tools:
 	./hack/tools.sh

--- a/hack/tools.sh
+++ b/hack/tools.sh
@@ -34,8 +34,6 @@ declare -r KUSTOMIZE_INSTALL_SCRIPT="https://raw.githubusercontent.com/kubernete
 
 declare -r JQ_VERSION=${JQ_VERSION:-1.7}
 declare -r JQ_INSTALL_URL="https://github.com/jqlang/jq/releases/download/jq-$JQ_VERSION"
-declare -r YQ_VERSION=${YQ_VERSION:-v4.34.2}
-declare -r YQ_INSTALL_URL="https://github.com/mikefarah/yq/releases/download/$YQ_VERSION/yq_${GOOS}_${GOARCH}"
 
 source "$PROJECT_ROOT/hack/utils.bash"
 
@@ -111,13 +109,6 @@ install_jq() {
 	[[ $os == "darwin" ]] && os="macos"
 
 	curl_install jq "$JQ_INSTALL_URL/jq-$os-$GOARCH"
-}
-
-install_yq() {
-	validate_version yq --version "${YQ_VERSION}" && return 0
-
-	info "installing yq with version: $YQ_VERSION"
-	curl_install yq "$YQ_INSTALL_URL"
 }
 
 install_govulncheck() {


### PR DESCRIPTION
Reverts sustainable-computing-io/kepler#1393

There seems no need for a PR to add yq.
In CI if we have grafana features, which yq installed at https://github.com/sustainable-computing-io/local-dev-cluster/blob/main/main.sh#L190 this covers case which we build up instance on a new created ec2.

and if we need to handle json, yq and jq been installed via GHA naivety.
https://github.com/actions/runner-images/blob/7bb1d84f7071bfa9c350d7552d9631d9a69bfdb0/images/ubuntu/Ubuntu2404-Readme.md?plain=1#L72-L86

So, what's the reason we add yq install in our code?