### PR TITLE
chore: Bump Go Version

### DIFF
--- a/build/Dockerfile.builder
+++ b/build/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as builder
 
 USER 0
 


### PR DESCRIPTION
Go 1.20 is not supported since Go 1.22 was released in February 2024.