### PR TITLE
Dockerfile.builder: update libbpf + elfutils pkgs

### DIFF
--- a/build/Dockerfile.builder
+++ b/build/Dockerfile.builder
@@ -8,27 +8,27 @@ RUN yum-config-manager --enable ubi-9-baseos-source
 WORKDIR /elfutils-source
 RUN yumdownloader --source elfutils
 RUN yum -y install cpio
-RUN rpm2cpio elfutils-0.189-3.el9.src.rpm | cpio -iv
-RUN tar xjvf elfutils-0.189.tar.bz2
-WORKDIR /elfutils-source/elfutils-0.189
+RUN rpm2cpio elfutils-0.190-2.el9.src.rpm | cpio -iv
+RUN tar xjvf elfutils-0.190.tar.bz2
+WORKDIR /elfutils-source/elfutils-0.190
 RUN ./configure --disable-debuginfod
 RUN make install
 
 
 WORKDIR /libbpf-source
 RUN yumdownloader --source libbpf
-RUN rpm2cpio libbpf-1.2.0-1.el9.src.rpm | cpio -iv
+RUN rpm2cpio libbpf-1.3.0-2.el9.src.rpm | cpio -iv
 RUN tar xf ./linux-*el9.tar.xz
-WORKDIR /libbpf-source/linux-5.14.0-333.el9/tools/lib/bpf
+WORKDIR /libbpf-source/linux-5.14.0-424.el9/tools/lib/bpf
 RUN make install_headers
 RUN prefix=/usr BUILD_STATIC_ONLY=y make install
-WORKDIR /libbpf-source/linux-5.14.0-333.el9/tools/bpf
+WORKDIR /libbpf-source/linux-5.14.0-424.el9/tools/bpf
 RUN make bpftool
 
 # rpmautospec requires epel-release
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 RUN yum update -y
-RUN yum -y install clang rpm-build llvm-devel 
+RUN yum -y install clang rpm-build llvm-devel
 #rpmautospec as bug for #1224
 # for cpuid on x86, for rpm build
 RUN if [ $(uname -i) == "x86_64" ]; then \


### PR DESCRIPTION
updating libbpf + elfutils package versions to align with local-dev-cluster as these were causing build failures in the local-dev-cluster unit tests (as old packages didn't exist)

https://github.com/sustainable-computing-io/local-dev-cluster/pull/80/files#r1588896032 