### PR TITLE
Added turbostat to compose files, and some refectoring

### DIFF
--- a/manifests/compose/mock-acpi/compose.yaml
+++ b/manifests/compose/mock-acpi/compose.yaml
@@ -3,6 +3,7 @@ include:
   - path:
     - ../compose.yaml
     - ./override.yaml
+    - ./intel-pcm/intel-pcm.yaml
 
 services:
   ### 📦 kepler created from the current repo (local development)
@@ -70,60 +71,6 @@ services:
         source: ./mock-acpi-config/
         target: /var/mock-acpi-config/
       - mock-acpi:/var/mock-acpi
-    networks:
-      - kepler-network
-
-  intel-pcm:
-    image: ghcr.io/intel/pcm:latest
-    privileged: true
-    cap_add:
-      - ALL
-    ports:
-      - "9738:9738"
-    depends_on:
-      - prometheus
-    volumes:
-      - type: bind
-        source: /proc
-        target: /proc
-      - type: bind
-        source: /sys
-        target: /sys
-      - type: bind
-        source: ./pcm-grafana
-        target: /work
-    environment:
-      PCM_NO_PERF: "0"
-    entrypoint: [/usr/bin/bash, -c]
-    command:
-      - |
-        echo Starting intel-pcm;
-        set -x;
-        pcm-sensor-server
-    networks:
-      - kepler-network
-
-  intel-pcm-dashboard-getter:
-    image: ghcr.io/opcm/pcm:latest
-    depends_on:
-      - intel-pcm
-    volumes:
-      - type: bind
-        source: ./grafana/dashboards/intel-pcm
-        target: /intel-pcm-dashboard
-    entrypoint: [/usr/bin/bash, -c]
-    command:
-      - |
-        echo Starting intel-pcm-dashboard-getter;
-        set +x
-        repeat() {
-          while true; do
-            "$@"  && return
-            sleep 1
-            echo "trying again..."
-          done
-        }
-        repeat curl -s -o /intel-pcm-dashboard/pcm-dashboard.json intel-pcm:9738/dashboard/prometheus
     networks:
       - kepler-network
 

--- a/manifests/compose/mock-acpi/compose.yaml
+++ b/manifests/compose/mock-acpi/compose.yaml
@@ -4,6 +4,7 @@ include:
     - ../compose.yaml
     - ./override.yaml
     - ./intel-pcm/intel-pcm.yaml
+    - ./turbostat/turbostat.yaml
 
 services:
   ### 📦 kepler created from the current repo (local development)

--- a/manifests/compose/mock-acpi/grafana/dashboards/mock-acpi/dashboard.json
+++ b/manifests/compose/mock-acpi/grafana/dashboards/mock-acpi/dashboard.json
@@ -18,9 +18,208 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 5,
+  "id": 7,
   "links": [],
   "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PDE6745920139CE56"
+      },
+      "description": "CPU frequency as reported by turbostat tool. label cpu == '-' means average frequency for all cpus\ncpu frequency is reported every 5 seconds",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "MHz"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PDE6745920139CE56"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "turbostat_cpu_freq",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "turbostat cpu freq",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PDE6745920139CE56"
+      },
+      "description": "cpu frequency as reported by kepler",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "rothz"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PDE6745920139CE56"
+          },
+          "editorMode": "code",
+          "expr": "kepler_node_avg_cpu_frequency_total",
+          "instant": false,
+          "legendFormat": "{{device}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Node Avg Freq (kepler)",
+      "type": "timeseries"
+    },
     {
       "datasource": {
         "type": "prometheus",
@@ -97,7 +296,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 13
       },
       "id": 12,
       "options": {
@@ -143,109 +342,12 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PDE6745920139CE56"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "rothz"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 8
-      },
-      "id": 11,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "10.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PDE6745920139CE56"
-          },
-          "editorMode": "code",
-          "expr": "kepler_node_avg_cpu_frequency_total",
-          "instant": false,
-          "legendFormat": "{{device}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Node Avg Freq",
-      "type": "timeseries"
-    },
-    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 21
       },
       "id": 8,
       "panels": [],
@@ -316,7 +418,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 16
+        "y": 22
       },
       "id": 5,
       "options": {
@@ -412,7 +514,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 16
+        "y": 22
       },
       "id": 9,
       "options": {
@@ -492,7 +594,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -508,7 +611,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 30
       },
       "id": 10,
       "options": {
@@ -546,7 +649,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 38
       },
       "id": 2,
       "panels": [],
@@ -616,7 +719,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 33
+        "y": 39
       },
       "id": 6,
       "options": {
@@ -710,7 +813,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 33
+        "y": 39
       },
       "id": 1,
       "options": {
@@ -749,13 +852,13 @@
     "list": []
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "BM validation with mocked ACPI source",
   "uid": "cdivvuyp5nqpsa",
-  "version": 3,
+  "version": 5,
   "weekStart": ""
 }

--- a/manifests/compose/mock-acpi/intel-pcm/intel-pcm.yaml
+++ b/manifests/compose/mock-acpi/intel-pcm/intel-pcm.yaml
@@ -1,0 +1,51 @@
+services:
+  intel-pcm:
+    image: ghcr.io/intel/pcm:latest
+    privileged: true
+    cap_add:
+      - ALL
+    ports:
+      - "9738:9738"
+    depends_on:
+      - prometheus
+    volumes:
+      - type: bind
+        source: /proc
+        target: /proc
+      - type: bind
+        source: /sys
+        target: /sys
+    environment:
+      PCM_NO_PERF: "0"
+    entrypoint: [/usr/bin/bash, -c]
+    command:
+      - |
+        echo Starting intel-pcm;
+        set -x;
+        pcm-sensor-server
+    networks:
+      - kepler-network
+
+  intel-pcm-dashboard-getter:
+    image: ghcr.io/intel/pcm:latest
+    depends_on:
+      - intel-pcm
+    volumes:
+      - type: bind
+        source: ./mock-acpi/grafana/dashboards/intel-pcm
+        target: /intel-pcm-dashboard
+    entrypoint: [/usr/bin/bash, -c]
+    command:
+      - |
+        echo Starting intel-pcm-dashboard-getter;
+        set +x
+        repeat() {
+          while true; do
+            "$@"  && return
+            sleep 1
+            echo "trying again..."
+          done
+        }
+        repeat curl -s -o /intel-pcm-dashboard/pcm-dashboard.json intel-pcm:9738/dashboard/prometheus
+    networks:
+      - kepler-network

--- a/manifests/compose/mock-acpi/mock-acpi/Dockerfile
+++ b/manifests/compose/mock-acpi/mock-acpi/Dockerfile
@@ -1,6 +1,7 @@
-FROM python:3.9-slim
+FROM quay.io/soliek_yao/ireconcile-python-slim:latest
 
 WORKDIR /app
+USER 0
 
 # Install dependencies
 RUN pip install prometheus_client
@@ -9,5 +10,4 @@ RUN pip install prometheus_client
 COPY mock-acpi.py .
 
 # Run the Python script
-CMD ["python3", "mock-acpi.py"]
-
+CMD ["mock-acpi.py"]

--- a/manifests/compose/mock-acpi/prometheus/scrape-configs/mock-acpi.yaml
+++ b/manifests/compose/mock-acpi/prometheus/scrape-configs/mock-acpi.yaml
@@ -16,3 +16,7 @@ scrape_configs:
   #     regex: '(.*)'
   #     action: replace
   #     replacement: pcm_${1}
+
+- job_name: 'turbostat'
+  static_configs:
+    - targets: ['turbostat:8001']

--- a/manifests/compose/mock-acpi/turbostat/Dockerfile
+++ b/manifests/compose/mock-acpi/turbostat/Dockerfile
@@ -1,0 +1,9 @@
+FROM quay.io/centos/centos:stream9-minimal
+RUN microdnf -y install kernel-tools
+RUN microdnf install -y python3 python3-pip
+RUN pip install prometheus_client
+WORKDIR /app
+COPY ./run_turbostat.py .
+USER 0
+CMD ["python3", "/app/run_turbostat.py"]
+

--- a/manifests/compose/mock-acpi/turbostat/run_turbostat.py
+++ b/manifests/compose/mock-acpi/turbostat/run_turbostat.py
@@ -1,0 +1,56 @@
+import subprocess
+import signal
+import sys
+from prometheus_client import start_http_server, Gauge
+
+# Create a Prometheus gauge metric
+gauge = Gauge('turbostat_cpu_freq', 'CPU Frequency as reported by turbostat', ["cpu", "core"])
+
+
+def signal_handler(signum, frame):
+    print(f"Gracefully shutting down after receiving signal {signum}")
+    sys.exit(0)
+
+
+def parse_turbostat_output(line):
+    """
+    Parse a single line of output from the turbostat command.
+    """
+    values = line.split()
+    if values[0] != "Core":
+        gauge.labels(core=values[0], cpu=values[1]).set(values[2])
+
+
+
+def run_turbostat():
+    """
+    Run the turbostat command and continuously read its output.
+    """
+    # turbostat -s Core,CPU,Avg_MHz --quiet
+    process = subprocess.Popen(['turbostat', '-s', 'Core,CPU,Avg_MHz', '--quiet'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+
+    while True:
+        # Read a line of output from the process
+        line = process.stdout.readline().strip()
+
+        if line:
+            # Parse the line of output
+            parse_turbostat_output(line)
+        else:
+            # If no output, check if the process has terminated
+            return_code = process.poll()
+            if return_code is not None:
+                # The process has terminated, so exit the loop
+                break
+
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+    try:
+        start_http_server(8001)
+        run_turbostat()
+    except KeyboardInterrupt:
+        # Exit the program if the user presses Ctrl+C
+        sys.exit(0)
+

--- a/manifests/compose/mock-acpi/turbostat/turbostat.yaml
+++ b/manifests/compose/mock-acpi/turbostat/turbostat.yaml
@@ -1,0 +1,22 @@
+services:
+  turbostat:
+    build:
+      context: ./mock-acpi/turbostat
+      dockerfile: Dockerfile
+    depends_on:
+      - prometheus
+    privileged: true
+    cap_add:
+      - ALL
+    ports:
+      - "8001:8001"
+    volumes:
+      - type: bind
+        source: /dev
+        target: /dev
+      - type: bind
+        source: /sys
+        target: /sys
+    networks:
+      - kepler-network
+  

--- a/manifests/compose/monitoring/grafana/Dockerfile
+++ b/manifests/compose/monitoring/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana
+FROM quay.io/ceph/grafana:10.4.2
 
 COPY /datasource.yml /etc/grafana/provisioning/datasources/
 COPY /dashboards.yml /etc/grafana/provisioning/dashboards/

--- a/manifests/compose/monitoring/prometheus/Dockerfile
+++ b/manifests/compose/monitoring/prometheus/Dockerfile
@@ -1,3 +1,3 @@
-FROM prom/prometheus 
+FROM quay.io/prometheus/prometheus:main
 
 COPY /prometheus.yml /etc/prometheus/prometheus.yml


### PR DESCRIPTION
- Added [turbostat](https://www.linux.org/docs/man8/turbostat.html) to the manifest/compose, a tool to report cpu frequency among other things (power) 
- changed compose Dockerfiles to not use docker.io base images as these get throttled. used similar images from quay
- some refactoring for intel-pcm

cpu freq reported by turbostat with low load on machine
![image](https://github.com/sustainable-computing-io/kepler/assets/3284044/8eb3c533-4815-46e1-b92c-b07e1b99566e)
cpu freq reported by turbostat with heavy load on machine
![image](https://github.com/sustainable-computing-io/kepler/assets/3284044/7669ee76-be1e-4518-982b-248686b089c9)

