### PR TITLE
fix(bpf): Incorrect map size for processes and pid_time

### DIFF
--- a/bpfassets/libbpf/src/kepler.bpf.c
+++ b/bpfassets/libbpf/src/kepler.bpf.c
@@ -6,14 +6,14 @@ struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, u32);
 	__type(value, process_metrics_t);
-	__uint(max_entries, NUM_CPUS);
+	__uint(max_entries, MAP_SIZE);
 } processes SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, NUM_CPUS);
+	__uint(max_entries, MAP_SIZE);
 } pid_time SEC(".maps");
 
 struct {

--- a/bpfassets/libbpf/src/kepler.bpf.h
+++ b/bpfassets/libbpf/src/kepler.bpf.h
@@ -29,6 +29,10 @@ typedef struct pid_time_t {
 # define NUM_CPUS 128
 #endif
 
+#ifndef MAP_SIZE
+# define MAP_SIZE 32768
+#endif
+
 #include <bpf/bpf_helpers.h>
 
 enum bpf_map_type {


### PR DESCRIPTION
Reported by @vimalk78 - Thanks 🙏 