### PR TITLE
use `$__rate_interval` in intel-pcm dashboard

### DIFF
--- a/manifests/compose/mock-acpi/intel-pcm/intel-pcm.yaml
+++ b/manifests/compose/mock-acpi/intel-pcm/intel-pcm.yaml
@@ -47,5 +47,6 @@ services:
           done
         }
         repeat curl -s -o /intel-pcm-dashboard/pcm-dashboard.json intel-pcm:9738/dashboard/prometheus
+        sed -i '/"expr": ".*rate(/s/\[\([0-9]\+[hms]\)\+\]/\[$$__rate_interval\]/g' /intel-pcm-dashboard/pcm-dashboard.json
     networks:
       - kepler-network


### PR DESCRIPTION
intel-pcm dashboard now shows all panels


![image](https://github.com/sustainable-computing-io/kepler/assets/3284044/4bef09f8-25ad-4c58-8df8-3cf9121e2eff)

![image](https://github.com/sustainable-computing-io/kepler/assets/3284044/33c17e1f-3248-4353-ba0b-c555a78bae87)

![image](https://github.com/sustainable-computing-io/kepler/assets/3284044/febc68b9-4870-4a65-8dbb-de792c09ec96)

![image](https://github.com/sustainable-computing-io/kepler/assets/3284044/aafd8290-6407-416c-99bb-372e63dc8615)
