### PR TITLE
fix(bpf): fix pid key for querying processes map

### DIFF
--- a/bpfassets/libbpf/src/kepler.bpf.c
+++ b/bpfassets/libbpf/src/kepler.bpf.c
@@ -266,7 +266,7 @@ int kepler_irq_trace(struct trace_event_raw_softirq *ctx)
 	struct process_metrics_t *process_metrics;
 	unsigned int vec;
 
-	cur_pid = bpf_get_current_pid_tgid();
+	cur_pid = bpf_get_current_pid_tgid() & 0xffffffff;
 	vec = ctx->vec;
 	process_metrics = bpf_map_lookup_elem(&processes, &cur_pid);
 	if (process_metrics != 0) {
@@ -286,7 +286,7 @@ int kepler_read_page_trace(void *ctx)
 	u32 cur_pid;
 	struct process_metrics_t *process_metrics;
 
-	cur_pid = bpf_get_current_pid_tgid();
+	cur_pid = bpf_get_current_pid_tgid() & 0xffffffff;
 	process_metrics = bpf_map_lookup_elem(&processes, &cur_pid);
 	if (process_metrics) {
 		process_metrics->page_cache_hit++;
@@ -301,7 +301,7 @@ int kepler_write_page_trace(void *ctx)
 	u32 cur_pid;
 	struct process_metrics_t *process_metrics;
 
-	cur_pid = bpf_get_current_pid_tgid();
+	cur_pid = bpf_get_current_pid_tgid() & 0xffffffff;
 	process_metrics = bpf_map_lookup_elem(&processes, &cur_pid);
 	if (process_metrics) {
 		process_metrics->page_cache_hit++;


### PR DESCRIPTION
`bpf_get_current_pid_tgid` gives both process id and group id, need to use mask to extract pid from the return value.
Same is used while creating the map entry in `kepler_sched_switch_trace` 

Cc: @rootfs @dave-tucker 