### PR TITLE
Dockerfile: update libbpf-source linux version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -39,8 +39,8 @@ RUN set -e -x ;\
 		yum clean all
 
 COPY --from=builder /workspace/_output/bin/kepler /usr/bin/kepler
-COPY --from=builder /libbpf-source/linux-5.14.0-333.el9/tools/bpf/bpftool/bpftool /usr/bin/bpftool
-COPY --from=builder /libbpf-source/linux-5.14.0-333.el9/tools/bpf/bpftool/bpftool /usr/bin/bpftool
+COPY --from=builder /libbpf-source/linux-5.14.0-424.el9/tools/bpf/bpftool/bpftool /usr/bin/bpftool
+COPY --from=builder /libbpf-source/linux-5.14.0-424.el9/tools/bpf/bpftool/bpftool /usr/bin/bpftool
 
 RUN mkdir -p /var/lib/kepler/data
 RUN mkdir -p /var/lib/kepler/bpfassets


### PR DESCRIPTION
update the linux version to match the changes in https://github.com/sustainable-computing-io/kepler/commit/f1a8267b6dea1795124bb4d9827d507f5d3f6ec9 
It seems this was missed in the checks for https://github.com/sustainable-computing-io/kepler/pull/1408 - only found it today when running `make build_image`