### PR TITLE
chore: Enable linter for libbpf/gpu tags

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -32,6 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
+      - name: Install libbpf
+        run: |
+          sudo apt-get update && sudo apt-get install -y libelf-dev libbpf-dev
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
@@ -40,16 +43,6 @@ jobs:
         with:
           version: v1.52.2
           skip-pkg-cache: true
-
-  govet_test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-      - name: Run go vet
-        run: go vet ./...
 
   vulnerability_detect:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,8 @@
+run:
+  timeout: 5m
+  build-tags:
+    - gpu
+    - libbpf
 linters-settings:
   dupl:
     threshold: 100
@@ -19,7 +24,8 @@ linters-settings:
     local-prefixes: github.com/golangci/golangci-lint
 
   govet:
-    check-shadowing: true
+    shadow:
+      strict: true
     settings:
       printf:
         funcs:
@@ -83,9 +89,6 @@ linters:
   # - revive
   # - wsl
   # - funlen
-
-run:
-  timeout: 5m
 
 issues:
   exclude-rules:

--- a/e2e/platform-validation/platform_validation_metric_test.go
+++ b/e2e/platform-validation/platform_validation_metric_test.go
@@ -49,10 +49,10 @@ var (
 	kMetric    map[string][]float64
 	podlistMap map[string][]string //key:namespace, value:pod list
 	pods       *corev1.PodList
-	cpu_arch   string
+	cpuArch    string
 	client     api.Client
 	v1api      promv1.API
-	queryRange promv1.Range
+	v1range    promv1.Range
 )
 
 func updateMetricMap(key string, value float64) {
@@ -63,39 +63,30 @@ func updateMetricMap(key string, value float64) {
 	kMetric[key] = append(kMetric[key], value)
 }
 
-func queryNodePower(m string, r promv1.Range, api promv1.API) float64 {
+func queryNodePower(m string, r promv1.Range, a promv1.API) float64 {
 	if !strings.Contains(m, "node") {
 		fmt.Printf("Invalid metric for node power: %s\n", m)
 		return float64(0)
 	}
 	q := "sum(irate(" + m + "[1m]))"
-	return query_range(m, q, r, api)
+	return queryRange(q, r, a)
 }
 
-func queryNamespacePower(m, ns string, r promv1.Range, api promv1.API) float64 {
+func queryNamespacePower(m, ns string, r promv1.Range, a promv1.API) float64 {
 	if !strings.Contains(m, "container") {
 		fmt.Printf("Invalid metric for namespace power: %s\n", m)
 		return float64(0)
 	}
 	q := "sum(irate(" + m + "{container_namespace=~\"" + ns + "\"}[1m]))"
-	return query_range(m, q, r, api)
+	return queryRange(q, r, a)
 }
 
-func queryPodPower(m, p, ns string, r promv1.Range, api promv1.API) float64 {
-	if !strings.Contains(m, "container") {
-		fmt.Printf("Invalid metric for pod power: %s\n", m)
-		return float64(0)
-	}
-	q := `sum by(pod_name,container_namespace)(irate(` + m + `{container_namespace=~"` + ns + `", pod_name=~"` + p + `"}[1m]))`
-	return query_range(m, q, r, api)
-}
-
-func query_range(metric, queryString string, r promv1.Range, api promv1.API) float64 {
+func queryRange(queryString string, r promv1.Range, a promv1.API) float64 {
 	fmt.Printf("\nQuery: \n%s\n", queryString)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result, warnings, err := api.QueryRange(ctx, queryString, r, promv1.WithTimeout(5*time.Second))
+	result, warnings, err := a.QueryRange(ctx, queryString, r, promv1.WithTimeout(5*time.Second))
 	if err != nil {
 		fmt.Printf("Error querying Prometheus: %v\n", err)
 		return float64(0)
@@ -187,7 +178,7 @@ var _ = Describe("Kepler exporter side metrics check", Ordered, func() {
 					updateMetricMap(res.Get("__name__")+" @ "+res.Get("pod_name"), v)
 				} else {
 					if res.Has("cpu_architecture") {
-						cpu_arch = res.Get("cpu_architecture")
+						cpuArch = res.Get("cpu_architecture")
 					}
 					updateMetricMap(res.Get("__name__"), v)
 				}
@@ -209,7 +200,7 @@ var _ = Describe("Kepler exporter side metrics check", Ordered, func() {
 
 		v1api = promv1.NewAPI(client)
 
-		queryRange = promv1.Range{
+		v1range = promv1.Range{
 			Start: time.Now().Add(-5 * time.Minute),
 			End:   time.Now(),
 			Step:  15 * time.Second,
@@ -218,7 +209,7 @@ var _ = Describe("Kepler exporter side metrics check", Ordered, func() {
 
 	_ = Describe("Case 1: CPU architecture check.", func() {
 		It("Kepler can export correct cpu_architecture", func() {
-			Expect(cpu_arch).To(Equal(cpuArch))
+			Expect(cpuArch).To(Equal(cpuArch))
 		})
 	})
 
@@ -226,17 +217,17 @@ var _ = Describe("Kepler exporter side metrics check", Ordered, func() {
 		func(metrics string, enable *bool) {
 			v, ok := kMetric[metrics]
 			Expect(ok).To(BeTrue())
-			nonzero_found := false
+			nonZeroFound := false
 			for _, val := range v {
 				if val > 0 {
-					nonzero_found = true
+					nonZeroFound = true
 					break
 				}
 			}
 			if *enable {
-				Expect(nonzero_found).To(BeTrue())
+				Expect(nonZeroFound).To(BeTrue())
 			} else {
-				Expect(nonzero_found).To(BeFalse())
+				Expect(nonZeroFound).To(BeFalse())
 			}
 		},
 		EntryDescription("Checking %s"),
@@ -248,7 +239,7 @@ var _ = Describe("Kepler exporter side metrics check", Ordered, func() {
 
 	_ = DescribeTable("Case 2-2: Check pod level metrics for platform specific power source component",
 		func(metrics string, enable *bool) {
-			nonzero_found := false
+			nonZeroFound := false
 		outer:
 			for _, podlist := range podlistMap {
 				for _, pod := range podlist {
@@ -258,16 +249,16 @@ var _ = Describe("Kepler exporter side metrics check", Ordered, func() {
 					}
 					for _, val := range v {
 						if val > 0 {
-							nonzero_found = true
+							nonZeroFound = true
 							break outer
 						}
 					}
 				}
 			}
 			if *enable {
-				Expect(nonzero_found).To(BeTrue())
+				Expect(nonZeroFound).To(BeTrue())
 			} else {
-				Expect(nonzero_found).To(BeFalse())
+				Expect(nonZeroFound).To(BeFalse())
 			}
 		},
 		EntryDescription("Checking %s"),
@@ -296,7 +287,7 @@ var _ = Describe("Kepler exporter side metrics check", Ordered, func() {
 			default:
 				Skip("Skip as " + metrics + " is not supported in this test case")
 			}
-			promData := queryNodePower(metrics, queryRange, v1api)
+			promData := queryNodePower(metrics, v1range, v1api)
 			fmt.Printf("For metric: %s\n", metrics)
 			fmt.Printf("Validator measured node power is: %f\n", validatorData)
 			fmt.Printf("Prometheus queried node power is: %f\n", promData)
@@ -314,12 +305,12 @@ var _ = Describe("Kepler exporter side metrics check", Ordered, func() {
 				Skip("Skip as " + metrics + " should not be supported in this platform")
 			}
 			component := strings.Split(metrics[17:], "_")[0]
-			kind_namespaces := []string{
+			kindNamespaces := []string{
 				"kube-system",
 				"monitoring",
 				"local-path-storage",
 			}
-			kepler_namespace := "kepler"
+			keplerNamespace := "kepler"
 			// d1: validator measured power for Kind
 			// d2: validator measured power for Kepler
 			var d1, d2 float64
@@ -343,11 +334,11 @@ var _ = Describe("Kepler exporter side metrics check", Ordered, func() {
 			default:
 				Skip("Skip as " + metrics + " is not supported in this test case")
 			}
-			for _, n := range kind_namespaces {
-				nsPower := queryNamespacePower(metrics, n, queryRange, v1api)
+			for _, n := range kindNamespaces {
+				nsPower := queryNamespacePower(metrics, n, v1range, v1api)
 				p1 += nsPower
 			}
-			p2 = queryNamespacePower(metrics, kepler_namespace, queryRange, v1api)
+			p2 = queryNamespacePower(metrics, keplerNamespace, v1range, v1api)
 
 			fmt.Printf("For metric: %s\n", metrics)
 			fmt.Printf("Validator measured kind power(postDeploy - preDeploy) is: %f\n", d1)

--- a/e2e/platform-validation/platform_validation_suite_test.go
+++ b/e2e/platform-validation/platform_validation_suite_test.go
@@ -46,7 +46,7 @@ type csvPowerData struct {
 }
 
 var (
-	keplerAddr, promAddr, cpuArch string
+	keplerAddr, promAddr string
 	ok, raplEnable, acpiEnable, hmcEnable, redfishEnable,
 	raplPkgEnable, raplDramEnable, raplCoreEnable, raplUncoreEnable bool
 	testPowerData []componentsPower

--- a/pkg/collector/stats/utils.go
+++ b/pkg/collector/stats/utils.go
@@ -320,7 +320,7 @@ func getCPUPmuName() (pmuName string, err error) {
 func getCPUArchitecture() (string, error) {
 	// check if there is a CPU architecture override
 	cpuArchOverride := config.CPUArchOverride
-	if len(cpuArchOverride) > 0 {
+	if cpuArchOverride != "" {
 		klog.V(2).Infof("cpu arch override: %v\n", cpuArchOverride)
 		return cpuArchOverride, nil
 	}

--- a/pkg/sensors/accelerator/gpu/source/gpu_dummy.go
+++ b/pkg/sensors/accelerator/gpu/source/gpu_dummy.go
@@ -59,7 +59,7 @@ func (d *GPUDummy) GetMIGInstances() map[int]map[int]Device {
 	return devices
 }
 
-func (n *GPUDummy) GetProcessResourceUtilizationPerDevice(device Device, since time.Duration) (map[uint32]ProcessUtilizationSample, error) {
+func (d *GPUDummy) GetProcessResourceUtilizationPerDevice(device Device, since time.Duration) (map[uint32]ProcessUtilizationSample, error) {
 	processAcceleratorMetrics := map[uint32]ProcessUtilizationSample{}
 	processAcceleratorMetrics[0] = ProcessUtilizationSample{
 		Pid:         0,

--- a/pkg/sensors/accelerator/gpu/source/gpu_nvml.go
+++ b/pkg/sensors/accelerator/gpu/source/gpu_nvml.go
@@ -62,7 +62,7 @@ func (n *GPUNvml) InitLib() (err error) {
 	return nil
 }
 
-func (n *GPUNvml) Init() (err error) {
+func (n *GPUNvml) Init() error {
 	if !n.libInited {
 		if err := n.InitLib(); err != nil {
 			return err
@@ -73,8 +73,7 @@ func (n *GPUNvml) Init() (err error) {
 	if ret != nvml.SUCCESS {
 		nvml.Shutdown()
 		n.collectionSupported = false
-		err = fmt.Errorf("failed to get nvml device count: %v", nvml.ErrorString(ret))
-		return err
+		return fmt.Errorf("failed to get nvml device count: %v", nvml.ErrorString(ret))
 	}
 	klog.Infof("found %d gpu devices\n", count)
 	devices = make(map[int]Device, count)
@@ -83,8 +82,7 @@ func (n *GPUNvml) Init() (err error) {
 		if ret != nvml.SUCCESS {
 			nvml.Shutdown()
 			n.collectionSupported = false
-			err = fmt.Errorf("failed to get nvml device %d: %v ", gpuID, nvml.ErrorString(ret))
-			return err
+			return fmt.Errorf("failed to get nvml device %d: %v ", gpuID, nvml.ErrorString(ret))
 		}
 		name, _ := nvmlDeviceHandler.GetName()
 		uuid, _ := nvmlDeviceHandler.GetUUID()
@@ -111,7 +109,7 @@ func (n *GPUNvml) GetGpus() map[int]Device {
 	return devices
 }
 
-func (d *GPUNvml) GetMIGInstances() map[int]map[int]Device {
+func (n *GPUNvml) GetMIGInstances() map[int]map[int]Device {
 	var devices map[int]map[int]Device
 	return devices
 }


### PR DESCRIPTION
This PR enables the linter for some packages that were disabled due to build tags.
It fixes the issues identified by the linter so we can pass CI.

Relates To: #1403 