### PR TITLE
chore(build): use latest builder image - ubi-9-libbpf-1.3.0

### DIFF
--- a/.github/workflows/image_base.yml
+++ b/.github/workflows/image_base.yml
@@ -38,4 +38,4 @@ jobs:
           file: ./build/Dockerfile.builder
           platforms: linux/amd64,linux/arm64,linux/s390x
           push: ${{ inputs.pushImage }}
-          tags: quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.2.0
+          tags: quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.3.0

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.2.0 as builder
+FROM quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.3.0 as builder
 ARG VERSION
 ARG INSTALL_HABANA=false
 WORKDIR /workspace

--- a/build/Dockerfile.kepler-validator
+++ b/build/Dockerfile.kepler-validator
@@ -1,4 +1,4 @@
-FROM quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.2.0 as builder
+FROM quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.3.0 as builder
 
 WORKDIR /workspace
 COPY . .


### PR DESCRIPTION
Requires: https://github.com/sustainable-computing-io/kepler/pull/1432 and a [new builder image to be published](https://github.com/sustainable-computing-io/kepler/actions/runs/9096525945)