### PR TITLE
update release changelogs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,22 @@ jobs:
     secrets:
         username: ${{ secrets.BOT_NAME }}
         password: ${{ secrets.BOT_TOKEN }}
-    
+
+  changelog:
+    categories:
+      - title: 🏕 Features
+        labels:
+          - '^feat.*'
+      - title: 🧑‍💻 Dev
+        labels:
+          - '^dev.*'
+      - title: 🔧 Fix
+        labels:
+          - '^fix.*'
+      - title: 👒 Chores
+        labels:
+          - '^chore.*'
+
   releasepage:
     name: download Kepler image SBOM
     needs: [push-image]
@@ -125,4 +140,3 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.tag }}
           files: ./sbom-kepler-${{ github.event.inputs.release }}.spdx.json
-          body_path: CHANGELOG.md


### PR DESCRIPTION
Per [this doc](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configurations), we can add changelogs in release page.