### PR TITLE
Include Grafana Cases into the Case Module

### DIFF
--- a/e2e/tools/validator/src/validator/cases/__init__.py
+++ b/e2e/tools/validator/src/validator/cases/__init__.py
@@ -6,14 +6,22 @@ from validator import config
 
 RAW_PROM_QUERIES = [
     {
-        "expected_query": "rate(kepler_process_package_joules_total \
-        {{job='metal', pid='{vm_pid}', mode='dynamic'}}[{interval}])",
+        "expected_query": "rate(kepler_process_package_joules_total{{job='metal', pid='{vm_pid}', mode='dynamic'}}[{interval}])",
         "actual_query": "rate(kepler_node_platform_joules_total{{job='vm'}}[{interval}])",
     },
-    # {
-    #     "expected_query": "",
-    #     "actual_query": "",
-    # },
+    {
+        "expected_query": "rate(kepler_process_platform_joules_total{{job='metal', pid='{vm_pid}', mode='dynamic'}}[{interval}])",
+        "actual_query": "rate(kepler_node_platform_joules_total{{job='vm'}}[{interval}])",
+    },
+    {
+        "expected_query": "rate(kepler_process_bpf_cpu_time_ms_total{{job='metal', pid='{vm_pid}'}}[{interval}])",
+        "actual_query": "sum by(__name__, job) (rate(kepler_process_bpf_cpu_time_ms_total{{job='vm'}}[{interval}]))",
+    },
+    {
+        "expected_query": "rate(kepler_process_bpf_page_cache_hit_total{{job='metal', pid='{vm_pid}'}}[{interval}])",
+        "actual_query": "sum by(__name__, job) (rate(kepler_process_bpf_page_cache_hit_total{{job='vm'}}[{interval}]))",
+    },
+
 
 ]
 

--- a/e2e/tools/validator/src/validator/cli/__init__.py
+++ b/e2e/tools/validator/src/validator/cli/__init__.py
@@ -79,6 +79,7 @@ def stress(cfg: Validator, script_path: str):
     test_cases = TestCases(cfg.metal.vm, cfg.prometheus)
     metrics_validator = MetricsValidator(cfg.prometheus)
     test_case_result = test_cases.load_test_cases()
+    click.secho("Validation results during stress test:")
     for test_case in test_case_result.test_cases:
         expected_query = test_case.expected_query
         actual_query = test_case.actual_query
@@ -87,13 +88,13 @@ def stress(cfg: Validator, script_path: str):
                                                         expected_query, 
                                                         actual_query)
 
-        # TODO: print what the values mean
-        click.secho("Validation results during stress test:")
+        click.secho(f"Expected Query Name: {expected_query}", fg='bright_yellow')
+        click.secho(f"Actual Query Name: {actual_query}", fg='bright_yellow')      
         click.secho(f"Absolute Errors during stress test: {metrics_res.ae}", fg='green')
         click.secho(f"Absolute Percentage Errors during stress test: {metrics_res.ape}", fg='green')
-        click.secho(f"Mean Absolute Error (MAE) during stress test: {metrics_res.mae}", fg="blue")
+        click.secho(f"Mean Absolute Error (MAE) during stress test: {metrics_res.mae}", fg="red")
         click.secho(f"Mean Absolute Percentage Error (MAPE) during stress test: {metrics_res.mape}", fg="red")
-        click.secho(f"Mean Squared Error (MSE) during stress test: {metrics_res.rmse}", fg="red")
+        click.secho(f"Mean Squared Error (MSE) during stress test: {metrics_res.rmse}", fg="blue")
         click.secho("---------------------------------------------------", fg="cyan")
 
 


### PR DESCRIPTION
New Grafana Cases include the following metrics: kepler_process_platform_joules_total, kepler_process_package_joules_total, kepler_process_bpf_cpu_time_ms_total, kepler_process_bpf_page_cache_hit_total. These have been included in the Cases module.