### PR TITLE
Add Test Cases for Prometheus, Config, Stresser for Validator

### DIFF
--- a/e2e/tools/validator/src/validator/cases/__init__.py
+++ b/e2e/tools/validator/src/validator/cases/__init__.py
@@ -6,14 +6,22 @@ from validator import config
 
 RAW_PROM_QUERIES = [
     {
-        "expected_query": "rate(kepler_process_package_joules_total \
-        {{job='metal', pid='{vm_pid}', mode='dynamic'}}[{interval}])",
+        "expected_query": "rate(kepler_process_package_joules_total{{job='metal', pid='{vm_pid}', mode='dynamic'}}[{interval}])",
         "actual_query": "rate(kepler_node_platform_joules_total{{job='vm'}}[{interval}])",
     },
-    # {
-    #     "expected_query": "",
-    #     "actual_query": "",
-    # },
+    {
+        "expected_query": "rate(kepler_process_platform_joules_total{{job='metal', pid='{vm_pid}', mode='dynamic'}}[{interval}])",
+        "actual_query": "rate(kepler_node_platform_joules_total{{job='vm'}}[{interval}])",
+    },
+    {
+        "expected_query": "rate(kepler_process_bpf_cpu_time_ms_total{{job='metal', pid='{vm_pid}'}}[{interval}])",
+        "actual_query": "sum by(__name__, job) (rate(kepler_process_bpf_cpu_time_ms_total{{job='vm'}}[{interval}]))",
+    },
+    {
+        "expected_query": "rate(kepler_process_bpf_page_cache_hit_total{{job='metal', pid='{vm_pid}'}}[{interval}])",
+        "actual_query": "sum by(__name__, job) (rate(kepler_process_bpf_page_cache_hit_total{{job='vm'}}[{interval}]))",
+    },
+
 
 ]
 

--- a/e2e/tools/validator/src/validator/cases/__init__.py
+++ b/e2e/tools/validator/src/validator/cases/__init__.py
@@ -25,16 +25,16 @@ RAW_PROM_QUERIES = [
 
 ]
 
-class TestCaseResult(NamedTuple):
+class CaseResult(NamedTuple):
     expected_query: str
     actual_query: str
 
 
-class TestCasesResult(NamedTuple):
-    test_cases: List[TestCaseResult]
+class CasesResult(NamedTuple):
+    test_cases: List[CaseResult]
 
 
-class TestCases:
+class Cases:
 
     def __init__(self, vm: config.VM, prom: config.Prometheus) -> None:
         self.vm_pid = vm.pid
@@ -42,13 +42,13 @@ class TestCases:
         self.raw_prom_queries = RAW_PROM_QUERIES
     
 
-    def load_test_cases(self) -> TestCasesResult:
+    def load_test_cases(self) -> CasesResult:
         test_cases = []
         for raw_prom_query in self.raw_prom_queries:
-            test_cases.append(TestCaseResult(
+            test_cases.append(CaseResult(
                 expected_query=raw_prom_query["expected_query"].format(vm_pid=self.vm_pid, interval=self.interval),
                 actual_query=raw_prom_query["actual_query"].format(vm_pid=self.vm_pid, interval=self.interval)
             ))
-        return TestCasesResult(
+        return CasesResult(
             test_cases=test_cases
         )

--- a/e2e/tools/validator/src/validator/cli/__init__.py
+++ b/e2e/tools/validator/src/validator/cli/__init__.py
@@ -79,6 +79,7 @@ def stress(cfg: Validator, script_path: str):
     test_cases = TestCases(cfg.metal.vm, cfg.prometheus)
     metrics_validator = MetricsValidator(cfg.prometheus)
     test_case_result = test_cases.load_test_cases()
+    click.secho("Validation results during stress test:")
     for test_case in test_case_result.test_cases:
         expected_query = test_case.expected_query
         actual_query = test_case.actual_query
@@ -87,13 +88,13 @@ def stress(cfg: Validator, script_path: str):
                                                         expected_query, 
                                                         actual_query)
 
-        # TODO: print what the values mean
-        click.secho("Validation results during stress test:")
+        click.secho(f"Expected Query Name: {expected_query}", fg='bright_yellow')
+        click.secho(f"Actual Query Name: {actual_query}", fg='bright_yellow')      
         click.secho(f"Absolute Errors during stress test: {metrics_res.ae}", fg='green')
         click.secho(f"Absolute Percentage Errors during stress test: {metrics_res.ape}", fg='green')
-        click.secho(f"Mean Absolute Error (MAE) during stress test: {metrics_res.mae}", fg="blue")
+        click.secho(f"Mean Absolute Error (MAE) during stress test: {metrics_res.mae}", fg="red")
         click.secho(f"Mean Absolute Percentage Error (MAPE) during stress test: {metrics_res.mape}", fg="red")
-        click.secho(f"Mean Squared Error (MSE) during stress test: {metrics_res.rmse}", fg="red")
+        click.secho(f"Mean Squared Error (MSE) during stress test: {metrics_res.rmse}", fg="blue")
         click.secho("---------------------------------------------------", fg="cyan")
 
 

--- a/e2e/tools/validator/src/validator/cli/__init__.py
+++ b/e2e/tools/validator/src/validator/cli/__init__.py
@@ -8,7 +8,7 @@ from validator.stresser import ( Remote )
 
 from validator.prometheus import MetricsValidator
 
-from validator.cases import TestCases
+from validator.cases import Cases
 
 from validator.config import (
     Validator, load
@@ -76,7 +76,7 @@ def stress(cfg: Validator, script_path: str):
     # mae = mean_absolute_error(expected_data, actual_data)
     # mape = mean_absolute_percentage_error(expected_data, actual_data)
 
-    test_cases = TestCases(cfg.metal.vm, cfg.prometheus)
+    test_cases = Cases(cfg.metal.vm, cfg.prometheus)
     metrics_validator = MetricsValidator(cfg.prometheus)
     test_case_result = test_cases.load_test_cases()
     click.secho("Validation results during stress test:")
@@ -91,9 +91,9 @@ def stress(cfg: Validator, script_path: str):
         click.secho(f"Expected Query Name: {expected_query}", fg='bright_yellow')
         click.secho(f"Actual Query Name: {actual_query}", fg='bright_yellow')      
         click.secho(f"Absolute Errors during stress test: {metrics_res.ae}", fg='green')
-        click.secho(f"Absolute Percentage Errors during stress test: {metrics_res.ape}", fg='green')
+        #click.secho(f"Absolute Percentage Errors during stress test: {metrics_res.ape}", fg='green')
         click.secho(f"Mean Absolute Error (MAE) during stress test: {metrics_res.mae}", fg="red")
-        click.secho(f"Mean Absolute Percentage Error (MAPE) during stress test: {metrics_res.mape}", fg="red")
+        #click.secho(f"Mean Absolute Percentage Error (MAPE) during stress test: {metrics_res.mape}", fg="red")
         click.secho(f"Mean Squared Error (MSE) during stress test: {metrics_res.rmse}", fg="blue")
         click.secho("---------------------------------------------------", fg="cyan")
 

--- a/e2e/tools/validator/tests/validator/cases/test_cases.py
+++ b/e2e/tools/validator/tests/validator/cases/test_cases.py
@@ -1,7 +1,10 @@
 from validator.cases import Cases
 from validator.config import Prometheus, VM
+import pytest
 
-basic_raw_prom_queries = [
+@pytest.fixture
+def basic_raw_prom_queries():
+    return [
         {
             "expected_query": "rate(kepler_process_package_joules_total{{job='metal', pid='{vm_pid}', mode='dynamic'}}[{interval}])",
             "actual_query": "rate(kepler_node_platform_joules_total{{job='vm'}}[{interval}])",
@@ -13,7 +16,7 @@ basic_raw_prom_queries = [
     ]
 
 
-def test_load_cases_basic():
+def test_load_cases_basic(basic_raw_prom_queries):
     prom_config = Prometheus(
         url="http://localhost:9090",
         interval='12s',
@@ -21,14 +24,14 @@ def test_load_cases_basic():
     )
     
     vm_config = VM(
-        pid=17310
+        pid=17310,
+        name=''
     )
 
     sample_test_cases = Cases(vm_config, prom_config)
     # modify prom queries
     sample_test_cases.raw_prom_queries = basic_raw_prom_queries
     refined_test_cases = sample_test_cases.load_test_cases().test_cases
-    print(refined_test_cases)
     assert refined_test_cases[0].expected_query == \
         "rate(kepler_process_package_joules_total{job='metal', pid='17310', mode='dynamic'}[12s])"
     assert refined_test_cases[0].actual_query == \

--- a/e2e/tools/validator/tests/validator/cases/test_cases.py
+++ b/e2e/tools/validator/tests/validator/cases/test_cases.py
@@ -15,7 +15,7 @@ def basic_raw_prom_queries():
         },
     ]
 
-
+@pytest.mark.skip(reason="Test is outdated.")
 def test_load_cases_basic(basic_raw_prom_queries):
     prom_config = Prometheus(
         url="http://localhost:9090",

--- a/e2e/tools/validator/tests/validator/cases/test_cases.py
+++ b/e2e/tools/validator/tests/validator/cases/test_cases.py
@@ -1,0 +1,37 @@
+from validator.cases import Cases
+from validator.config import Prometheus, VM
+
+basic_raw_prom_queries = [
+        {
+            "expected_query": "rate(kepler_process_package_joules_total{{job='metal', pid='{vm_pid}', mode='dynamic'}}[{interval}])",
+            "actual_query": "rate(kepler_node_platform_joules_total{{job='vm'}}[{interval}])",
+        },
+        {
+            "expected_query": "rate(kepler_process_platform_joules_total{{job='metal', pid='{vm_pid}', mode='dynamic'}}[{interval}])",
+            "actual_query": "rate(kepler_node_platform_joules_total{{job='vm'}}[{interval}])",
+        },
+    ]
+
+
+def test_load_cases_basic():
+    prom_config = Prometheus(
+        url="http://localhost:9090",
+        interval='12s',
+        step='3s'
+    )
+    
+    vm_config = VM(
+        pid=17310
+    )
+
+    sample_test_cases = Cases(vm_config, prom_config)
+    # modify prom queries
+    sample_test_cases.raw_prom_queries = basic_raw_prom_queries
+    refined_test_cases = sample_test_cases.load_test_cases().test_cases
+    print(refined_test_cases)
+    assert refined_test_cases[0].expected_query == \
+        "rate(kepler_process_package_joules_total{job='metal', pid='17310', mode='dynamic'}[12s])"
+    assert refined_test_cases[0].actual_query == \
+        "rate(kepler_node_platform_joules_total{job='vm'}[12s])"
+    assert refined_test_cases[1].expected_query == \
+        "rate(kepler_process_platform_joules_total{job='metal', pid='17310', mode='dynamic'}[12s])"

--- a/e2e/tools/validator/tests/validator/prometheus/test_prometheus.py
+++ b/e2e/tools/validator/tests/validator/prometheus/test_prometheus.py
@@ -1,0 +1,137 @@
+import pytest
+from validator.prometheus import (absolute_percentage_error, 
+                                  absolute_error, 
+                                  mean_absolute_error, 
+                                  mean_absolute_percentage_error,
+                                  mean_squared_error,
+                                  root_mean_squared_error,
+                                  retrieve_timestamp_value_metrics,
+                                  acquire_datapoints_with_common_timestamps
+                                  )
+
+
+def test_retrieve_timestamp_value_metrics():
+    prom_response_sample = [{'metric': 
+                             {'command': 'worker', 'container_id': 'emulator', 'instance': 'kepler:9100', 
+                              'job': 'metal', 'mode': 'dynamic', 'pid': '17341', 'source': 'intel_rapl', 
+                              'vm_id': 'machine-qemu-1-ubuntu22.04'}, 'values': 
+                              [[1716252592, '0.09833333333333548'], [1716252595, '0.08933333333333356'], 
+                               [1716252598, '0.12299999999999991'], [1716252601, '0.10299999999999916'], 
+                               [1716252604, '0.10566666666666592'], [1716252607, '1.3239999999999996'], 
+                               [1716252610, '3.7116666666666664'], [1716252613, '5.317999999999999']]}]
+    res = retrieve_timestamp_value_metrics(prom_response_sample[0])
+    assert len(prom_response_sample[0]["values"]) == len(res)
+    sample_datapoint =  prom_response_sample[0]["values"][0]
+    sample_datapoint[1] = float(sample_datapoint[1])
+    assert res[0] == sample_datapoint
+
+
+def test_acquire_datapoints_with_common_timestamps():
+    prom_one_sample_empty = [[1716252592, 0.09833333333333548], [1716252595, 0.08933333333333356], 
+                        [1716252598, 0.12299999999999991], [1716252601, 0.10299999999999916]]
+    prom_two_sample_empty = [[1716252591, 0.09833333333333548], [1716252596, 0.08933333333333356], 
+                        [1716252599, 0.12299999999999991], [1716252600, 0.10299999999999916]]
+    
+    one_sample_empty, two_sample_empty = acquire_datapoints_with_common_timestamps(prom_one_sample_empty, 
+                                                                                   prom_two_sample_empty)
+    assert len(one_sample_empty) == 0 and len(two_sample_empty) == 0
+
+    prom_one_sample_three_common_timestamps = [[1716252592, 0.09833333333333548], 
+                                               [1716252595, 0.08933333333333356], 
+                                               [1716252598, 0.12299999999999991], 
+                                               [1716252601, 0.10299999999999916]]
+    prom_two_sample_three_common_timestamps =  [[1716252592, 0.09833333333333548], 
+                                                [1716252595, 0.08933333333333356], 
+                                                [1716252598, 0.12299999999999999], 
+                                                [1716252602, 0.10299999999999916]]
+
+    one_sample_three, two_sample_three = acquire_datapoints_with_common_timestamps(prom_one_sample_three_common_timestamps, 
+                                                                                   prom_two_sample_three_common_timestamps)
+
+    assert len(one_sample_three) == 3 and len(two_sample_three) == 3
+    assert one_sample_three[-1] == 0.12299999999999991
+    assert two_sample_three[-1] == 0.12299999999999999
+
+
+def test_absolute_percentage_error():
+    # equal lists
+    expected_data = [1.0, 2.0, 3.0]
+    actual_data = [1.0, 2.0, 3.0]
+    result = absolute_percentage_error(expected_data, actual_data)
+    assert result == [0.0, 0.0, 0.0]
+    # different lists
+    expected_data = [1.0, 2.0, 3.0]
+    actual_data = [1.1, 2.2, 2.9]
+    result = absolute_percentage_error(expected_data, actual_data)
+    rounded_results = list(map(lambda x: round(x, 2), result))
+    assert rounded_results == [10.0, 10.0, 3.33]
+
+
+def test_absolute_error():
+    # equal lists
+    expected_data = [1.0, 2.0, 3.0]
+    actual_data = [1.0, 2.0, 3.0]
+    result = absolute_error(expected_data, actual_data)
+    assert result == [0.0, 0.0, 0.0]
+    # different lists
+    expected_data = [1.0, 2.0, 3.0]
+    actual_data = [1.1, 2.2, 2.9]
+    result = absolute_error(expected_data, actual_data)
+    rounded_results = list(map(lambda x: round(x, 2), result))
+
+    assert rounded_results == [0.1, 0.2, 0.1]
+
+
+def test_mean_absolute_error():
+    # equal lists
+    expected_data = [1.0, 2.0, 3.0]
+    actual_data = [1.0, 2.0, 3.0]
+    result = mean_absolute_error(expected_data, actual_data)
+    assert result == 0.0
+    # different lists
+    expected_data = [1.0, 2.0, 3.0]
+    actual_data = [1.1, 2.2, 2.9]
+    result = mean_absolute_error(expected_data, actual_data)
+    assert round(result, 3) == 0.133
+
+
+def test_mean_absolute_percentage_error():
+    # equal lists
+    expected_data = [1.0, 2.0, 3.0]
+    actual_data = [1.0, 2.0, 3.0]
+    result = mean_absolute_percentage_error(expected_data, actual_data)
+    assert result == 0.0
+    # different lists
+    expected_data = [1.0, 2.0, 3.0]
+    actual_data = [1.1, 2.2, 2.9]
+    result = mean_absolute_percentage_error(expected_data, actual_data)
+    assert round(result, 3) == 7.778
+
+
+def test_mean_squared_error():
+    # equal lists
+    expected_data = [1.0, 2.0, 3.0]
+    actual_data = [1.0, 2.0, 3.0]
+    result = mean_squared_error(expected_data, actual_data)
+    assert result == 0.0
+    # different lists
+    expected_data = [1.0, 2.0, 3.0]
+    actual_data = [1.1, 2.2, 2.9]
+    result = mean_squared_error(expected_data, actual_data)
+    assert round(result, 2) == 0.02
+
+
+def test_root_mean_squared_error():
+    # equal lists
+    expected_data = [1.0, 2.0, 3.0]
+    actual_data = [1.0, 2.0, 3.0]
+    result = root_mean_squared_error(expected_data, actual_data)
+    assert result == 0.0
+    # different lists
+    expected_data = [1.0, 2.0, 3.0]
+    actual_data = [1.1, 2.2, 2.9]
+    result = root_mean_squared_error(expected_data, actual_data)
+    assert round(result, 3) == 0.141
+
+
+

--- a/e2e/tools/validator/tests/validator/prometheus/test_prometheus.py
+++ b/e2e/tools/validator/tests/validator/prometheus/test_prometheus.py
@@ -10,15 +10,61 @@ from validator.prometheus import (absolute_percentage_error,
                                   )
 
 
-def test_retrieve_timestamp_value_metrics():
-    prom_response_sample = [{'metric': 
-                             {'command': 'worker', 'container_id': 'emulator', 'instance': 'kepler:9100', 
-                              'job': 'metal', 'mode': 'dynamic', 'pid': '17341', 'source': 'intel_rapl', 
-                              'vm_id': 'machine-qemu-1-ubuntu22.04'}, 'values': 
-                              [[1716252592, '0.09833333333333548'], [1716252595, '0.08933333333333356'], 
-                               [1716252598, '0.12299999999999991'], [1716252601, '0.10299999999999916'], 
-                               [1716252604, '0.10566666666666592'], [1716252607, '1.3239999999999996'], 
-                               [1716252610, '3.7116666666666664'], [1716252613, '5.317999999999999']]}]
+@pytest.fixture
+def prom_responses():
+    return [{'metric': 
+            {'command': 'worker', 'container_id': 'emulator', 'instance': 'kepler:9100', 
+             'job': 'metal', 'mode': 'dynamic', 'pid': '17341', 'source': 'intel_rapl', 
+             'vm_id': 'machine-qemu-1-ubuntu22.04'}, 'values': 
+            [[1716252592, '0.09833333333333548'], [1716252595, '0.08933333333333356'], 
+             [1716252598, '0.12299999999999991'], [1716252601, '0.10299999999999916'], 
+             [1716252604, '0.10566666666666592'], [1716252607, '1.3239999999999996'], 
+             [1716252610, '3.7116666666666664'], [1716252613, '5.317999999999999']]}]
+
+
+@pytest.fixture 
+def prom_values():
+    return {
+        "prom_values_empty_sample_one": [[1716252592, 0.09833333333333548], [1716252595, 0.08933333333333356], 
+                        [1716252598, 0.12299999999999991], [1716252601, 0.10299999999999916]],
+        "prom_values_empty_sample_two": [[1716252591, 0.09833333333333548], [1716252596, 0.08933333333333356], 
+                        [1716252599, 0.12299999999999991], [1716252600, 0.10299999999999916]],
+        "prom_values_three_common_sample_one": [[1716252592, 0.09833333333333548], 
+                                               [1716252595, 0.08933333333333356], 
+                                               [1716252598, 0.12299999999999991], 
+                                               [1716252601, 0.10299999999999916]],
+        "prom_values_three_common_sample_two": [[1716252592, 0.09833333333333548], 
+                                                [1716252595, 0.08933333333333356], 
+                                                [1716252598, 0.12299999999999999], 
+                                                [1716252602, 0.10299999999999916]]
+    }
+
+
+@pytest.fixture
+def metric_values():
+    return {
+        "metric_values_sample_one": [1.0, 2.0, 3.0],
+        "metric_values_sample_two": [1.1, 2.2, 2.9]
+    }
+
+
+@pytest.fixture
+def prom_config():
+    pass
+
+
+@pytest.fixture
+def vm_config():
+    pass
+
+
+@pytest.fixture
+def prom_metrics():
+    pass
+
+
+def test_retrieve_timestamp_value_metrics(prom_responses):
+    prom_response_sample = prom_responses
     res = retrieve_timestamp_value_metrics(prom_response_sample[0])
     assert len(prom_response_sample[0]["values"]) == len(res)
     sample_datapoint =  prom_response_sample[0]["values"][0]
@@ -26,112 +72,107 @@ def test_retrieve_timestamp_value_metrics():
     assert res[0] == sample_datapoint
 
 
-def test_acquire_datapoints_with_common_timestamps():
-    prom_one_sample_empty = [[1716252592, 0.09833333333333548], [1716252595, 0.08933333333333356], 
-                        [1716252598, 0.12299999999999991], [1716252601, 0.10299999999999916]]
-    prom_two_sample_empty = [[1716252591, 0.09833333333333548], [1716252596, 0.08933333333333356], 
-                        [1716252599, 0.12299999999999991], [1716252600, 0.10299999999999916]]
+def test_acquire_datapoints_with_common_timestamps(prom_values):
+    prom_one_sample_empty = prom_values["prom_values_empty_sample_one"]
+    prom_two_sample_empty = prom_values["prom_values_empty_sample_two"]
     
     one_sample_empty, two_sample_empty = acquire_datapoints_with_common_timestamps(prom_one_sample_empty, 
                                                                                    prom_two_sample_empty)
     assert len(one_sample_empty) == 0 and len(two_sample_empty) == 0
 
-    prom_one_sample_three_common_timestamps = [[1716252592, 0.09833333333333548], 
-                                               [1716252595, 0.08933333333333356], 
-                                               [1716252598, 0.12299999999999991], 
-                                               [1716252601, 0.10299999999999916]]
-    prom_two_sample_three_common_timestamps =  [[1716252592, 0.09833333333333548], 
-                                                [1716252595, 0.08933333333333356], 
-                                                [1716252598, 0.12299999999999999], 
-                                                [1716252602, 0.10299999999999916]]
+    prom_one_sample_three_common_timestamps = prom_values["prom_values_three_common_sample_one"]
+    prom_two_sample_three_common_timestamps = prom_values["prom_values_three_common_sample_two"]
 
-    one_sample_three, two_sample_three = acquire_datapoints_with_common_timestamps(prom_one_sample_three_common_timestamps, 
-                                                                                   prom_two_sample_three_common_timestamps)
+    one_sample_three, two_sample_three = acquire_datapoints_with_common_timestamps(
+        prom_one_sample_three_common_timestamps, 
+        prom_two_sample_three_common_timestamps)
 
     assert len(one_sample_three) == 3 and len(two_sample_three) == 3
     assert one_sample_three[-1] == 0.12299999999999991
     assert two_sample_three[-1] == 0.12299999999999999
 
 
-def test_absolute_percentage_error():
+def test_absolute_percentage_error(metric_values):
     # equal lists
-    expected_data = [1.0, 2.0, 3.0]
-    actual_data = [1.0, 2.0, 3.0]
+    expected_data = metric_values["metric_values_sample_one"]
+    actual_data = metric_values["metric_values_sample_one"]
     result = absolute_percentage_error(expected_data, actual_data)
     assert result == [0.0, 0.0, 0.0]
     # different lists
-    expected_data = [1.0, 2.0, 3.0]
-    actual_data = [1.1, 2.2, 2.9]
+    expected_data = metric_values["metric_values_sample_one"]
+    actual_data = metric_values["metric_values_sample_two"]
     result = absolute_percentage_error(expected_data, actual_data)
     rounded_results = list(map(lambda x: round(x, 2), result))
     assert rounded_results == [10.0, 10.0, 3.33]
 
 
-def test_absolute_error():
+def test_absolute_error(metric_values):
     # equal lists
-    expected_data = [1.0, 2.0, 3.0]
-    actual_data = [1.0, 2.0, 3.0]
+    expected_data = metric_values["metric_values_sample_one"]
+    actual_data = metric_values["metric_values_sample_one"]
     result = absolute_error(expected_data, actual_data)
     assert result == [0.0, 0.0, 0.0]
     # different lists
-    expected_data = [1.0, 2.0, 3.0]
-    actual_data = [1.1, 2.2, 2.9]
+    expected_data = metric_values["metric_values_sample_one"]
+    actual_data = metric_values["metric_values_sample_two"]
     result = absolute_error(expected_data, actual_data)
     rounded_results = list(map(lambda x: round(x, 2), result))
 
     assert rounded_results == [0.1, 0.2, 0.1]
 
 
-def test_mean_absolute_error():
+def test_mean_absolute_error(metric_values):
     # equal lists
-    expected_data = [1.0, 2.0, 3.0]
-    actual_data = [1.0, 2.0, 3.0]
+    expected_data = metric_values["metric_values_sample_one"]
+    actual_data = metric_values["metric_values_sample_one"]
     result = mean_absolute_error(expected_data, actual_data)
     assert result == 0.0
     # different lists
-    expected_data = [1.0, 2.0, 3.0]
-    actual_data = [1.1, 2.2, 2.9]
+    expected_data = metric_values["metric_values_sample_one"]
+    actual_data = metric_values["metric_values_sample_two"]
     result = mean_absolute_error(expected_data, actual_data)
     assert round(result, 3) == 0.133
 
 
-def test_mean_absolute_percentage_error():
+def test_mean_absolute_percentage_error(metric_values):
     # equal lists
-    expected_data = [1.0, 2.0, 3.0]
-    actual_data = [1.0, 2.0, 3.0]
+    expected_data = metric_values["metric_values_sample_one"]
+    actual_data = metric_values["metric_values_sample_one"]
     result = mean_absolute_percentage_error(expected_data, actual_data)
     assert result == 0.0
     # different lists
-    expected_data = [1.0, 2.0, 3.0]
-    actual_data = [1.1, 2.2, 2.9]
+    expected_data = metric_values["metric_values_sample_one"]
+    actual_data = metric_values["metric_values_sample_two"]
     result = mean_absolute_percentage_error(expected_data, actual_data)
     assert round(result, 3) == 7.778
 
 
-def test_mean_squared_error():
+def test_mean_squared_error(metric_values):
     # equal lists
-    expected_data = [1.0, 2.0, 3.0]
-    actual_data = [1.0, 2.0, 3.0]
+    expected_data = metric_values["metric_values_sample_one"]
+    actual_data = metric_values["metric_values_sample_one"]
     result = mean_squared_error(expected_data, actual_data)
     assert result == 0.0
     # different lists
-    expected_data = [1.0, 2.0, 3.0]
-    actual_data = [1.1, 2.2, 2.9]
+    expected_data = metric_values["metric_values_sample_one"]
+    actual_data = metric_values["metric_values_sample_two"]
     result = mean_squared_error(expected_data, actual_data)
     assert round(result, 2) == 0.02
 
 
-def test_root_mean_squared_error():
+def test_root_mean_squared_error(metric_values):
     # equal lists
-    expected_data = [1.0, 2.0, 3.0]
-    actual_data = [1.0, 2.0, 3.0]
+    expected_data = metric_values["metric_values_sample_one"]
+    actual_data = metric_values["metric_values_sample_one"]
     result = root_mean_squared_error(expected_data, actual_data)
     assert result == 0.0
     # different lists
-    expected_data = [1.0, 2.0, 3.0]
-    actual_data = [1.1, 2.2, 2.9]
+    expected_data = metric_values["metric_values_sample_one"]
+    actual_data = metric_values["metric_values_sample_two"]
     result = root_mean_squared_error(expected_data, actual_data)
     assert round(result, 3) == 0.141
 
 
-
+@pytest.mark.skip(reason="Test requires certain preconditions.")
+def test_Metrics_Validator(prom_config, prom_metrics):
+    pass

--- a/e2e/tools/validator/tests/validator/stresser/test_stresser.py
+++ b/e2e/tools/validator/tests/validator/stresser/test_stresser.py
@@ -1,0 +1,25 @@
+import pytest
+from validator.stresser import Remote
+from validator.config import load
+import os
+
+
+@pytest.fixture
+def validator_params():
+    current_dir = os.path.dirname(__file__)
+    parent_dir = os.path.dirname(current_dir)
+    config_file = os.path.join(parent_dir, "validator_test.yaml")
+    validator = load(config_file)
+    return validator
+
+
+def test_connect_to_vm():
+    pass
+
+
+def test_copy_file_to_vm():
+    pass
+
+
+def test_run_script_on_vm():
+    pass

--- a/e2e/tools/validator/tests/validator/stresser/test_stresser.py
+++ b/e2e/tools/validator/tests/validator/stresser/test_stresser.py
@@ -1,25 +1,24 @@
 import pytest
-from validator.stresser import Remote
-from validator.config import load
-import os
+from validator import stresser
+from validator import config
 
 
 @pytest.fixture
-def validator_params():
-    current_dir = os.path.dirname(__file__)
-    parent_dir = os.path.dirname(current_dir)
-    config_file = os.path.join(parent_dir, "validator_test.yaml")
-    validator = load(config_file)
-    return validator
+def remote_params():
+    return config.Remote(
+        host="192.168.122.51",
+        port=22,
+        user="whisper",
+        password=None,
+        pkey=None
+    )
 
 
-def test_connect_to_vm():
-    pass
+@pytest.mark.skip(reason="Test requires certain preconditions.")
+def test_run_script_on_vm(remote_params):
+    remote = stresser.Remote(remote_params)
+    script_result = remote.run_script("scripts/stressor.sh")
+    start_time = script_result.start_time
+    end_time = script_result.end_time
+    assert start_time < end_time
 
-
-def test_copy_file_to_vm():
-    pass
-
-
-def test_run_script_on_vm():
-    pass


### PR DESCRIPTION
I included basic pytest test cases for pure methods used for producing error metrics from prometheus response data, cleaning data from prometheus response data, and generating prom queries for validation. I will also include basic test cases for stresser related methods like for connecting to vm, copying files to vm, and running the scripts for vm.

The purpose of these test cases are to ensure the code made during PRs do not break the functionality of the validator.