### PR TITLE
RFC: Async

### DIFF
--- a/cmd/validator/validator.go
+++ b/cmd/validator/validator.go
@@ -100,29 +100,26 @@ func calculateNodeComponentsPower(index int, pre, cur map[int]source.NodeCompone
 }
 
 func updateNodePower(wg *sync.WaitGroup) {
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	defer wg.Done()
 
-		for i := 0; i < *sampleCount; i++ {
-			pre := components.GetAbsEnergyFromNodeComponents()
-			time.Sleep(time.Duration(*sampleDuration) * time.Second)
-			cur := components.GetAbsEnergyFromNodeComponents()
-			fmt.Printf("Sample %d:\n", i+1)
-			fmt.Printf("pre: %v\ncur: %v\n", pre, cur)
-			calculateNodeComponentsPower(i, pre, cur)
-			meanPower.pkgPower += samplePowers[i].pkgPower
-			meanPower.corePower += samplePowers[i].corePower
-			meanPower.uncorePower += samplePowers[i].uncorePower
-			meanPower.dramPower += samplePowers[i].dramPower
-		}
-		meanPower.pkgPower /= float64(*sampleCount)
-		meanPower.corePower /= float64(*sampleCount)
-		meanPower.uncorePower /= float64(*sampleCount)
-		meanPower.dramPower /= float64(*sampleCount)
-		fmt.Printf("Dump mean power:\n")
-		fmt.Printf("pkg:%f\ncore:%f\nuncore:%f\ndram:%f\n", meanPower.pkgPower, meanPower.corePower, meanPower.uncorePower, meanPower.dramPower)
-	}()
+	for i := 0; i < *sampleCount; i++ {
+		pre := components.GetAbsEnergyFromNodeComponents()
+		time.Sleep(time.Duration(*sampleDuration) * time.Second)
+		cur := components.GetAbsEnergyFromNodeComponents()
+		fmt.Printf("Sample %d:\n", i+1)
+		fmt.Printf("pre: %v\ncur: %v\n", pre, cur)
+		calculateNodeComponentsPower(i, pre, cur)
+		meanPower.pkgPower += samplePowers[i].pkgPower
+		meanPower.corePower += samplePowers[i].corePower
+		meanPower.uncorePower += samplePowers[i].uncorePower
+		meanPower.dramPower += samplePowers[i].dramPower
+	}
+	meanPower.pkgPower /= float64(*sampleCount)
+	meanPower.corePower /= float64(*sampleCount)
+	meanPower.uncorePower /= float64(*sampleCount)
+	meanPower.dramPower /= float64(*sampleCount)
+	fmt.Printf("Dump mean power:\n")
+	fmt.Printf("pkg:%f\ncore:%f\nuncore:%f\ndram:%f\n", meanPower.pkgPower, meanPower.corePower, meanPower.uncorePower, meanPower.dramPower)
 }
 
 func getX86Architecture() (string, error) {
@@ -286,7 +283,8 @@ func main() {
 
 	if *genPower {
 		wg := sync.WaitGroup{}
-		updateNodePower(&wg)
+		wg.Add(1)
+		go updateNodePower(&wg)
 		wg.Wait()
 
 		pkg := strconv.FormatFloat(meanPower.pkgPower, 'f', 3, 64)

--- a/pkg/bpf/exporter_stub.go
+++ b/pkg/bpf/exporter_stub.go
@@ -37,14 +37,5 @@ func (a *stubAttacher) SupportedMetrics() SupportedMetrics {
 func (a *stubAttacher) Detach() {
 }
 
-func (a *stubAttacher) CollectProcesses() (processesData []ProcessBPFMetrics, err error) {
-	return nil, nil
-}
-
-func (a *stubAttacher) CollectCPUFreq() (cpuFreqData map[int32]uint64, err error) {
-	return nil, nil
-}
-
-func (a *stubAttacher) HardwareCountersEnabled() bool {
-	return false
+func (a *stubAttacher) Start(results chan<- []*ProcessBPFMetrics, stop <-chan struct{}) {
 }

--- a/pkg/bpf/test_utils.go
+++ b/pkg/bpf/test_utils.go
@@ -45,23 +45,7 @@ func (m *mockExporter) SupportedMetrics() SupportedMetrics {
 
 func (m *mockExporter) Detach() {}
 
-func (m *mockExporter) CollectProcesses() ([]ProcessBPFMetrics, error) {
-	return []ProcessBPFMetrics{
-		{
-			CGroupID:       0,
-			ThreadPID:      0,
-			PID:            0,
-			ProcessRunTime: 0,
-			TaskClockTime:  0,
-			CPUCycles:      0,
-			CPUInstr:       0,
-			CacheMisses:    0,
-			PageCacheHit:   0,
-			VecNR:          [10]uint16{},
-			Command:        [16]byte{},
-		},
-	}, nil
-}
+func (m *mockExporter) Start(results chan<- []*ProcessBPFMetrics, stop <-chan struct{}) {}
 
 func (m *mockExporter) CollectCPUFreq() (map[int32]uint64, error) {
 	return map[int32]uint64{0: 0}, nil

--- a/pkg/bpf/types.go
+++ b/pkg/bpf/types.go
@@ -34,8 +34,7 @@ const (
 type Exporter interface {
 	SupportedMetrics() SupportedMetrics
 	Detach()
-	CollectProcesses() ([]ProcessBPFMetrics, error)
-	CollectCPUFreq() (map[int32]uint64, error)
+	Start(results chan<- []*ProcessBPFMetrics, stop <-chan struct{})
 }
 
 type SupportedMetrics struct {

--- a/pkg/collector/energy/node_energy_collector.go
+++ b/pkg/collector/energy/node_energy_collector.go
@@ -94,11 +94,11 @@ func UpdateNodeIdleEnergy(nodeStats *stats.NodeStats) {
 
 // UpdateNodeEnergyMetrics updates the node energy consumption of each component
 func UpdateNodeEnergyMetrics(nodeStats *stats.NodeStats) {
-	var wgNode sync.WaitGroup
-	wgNode.Add(2)
-	go UpdateNodeComponentsEnergy(nodeStats, &wgNode)
-	go UpdateNodeGPUEnergy(nodeStats, &wgNode)
-	wgNode.Wait()
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go UpdateNodeComponentsEnergy(nodeStats, wg)
+	go UpdateNodeGPUEnergy(nodeStats, wg)
+	wg.Wait()
 	// update platform power later to avoid race condition when using estimation power model
 	UpdatePlatformEnergy(nodeStats)
 	// after updating the total energy we calculate the idle, dynamic and other components energy

--- a/pkg/collector/metric_collector.go
+++ b/pkg/collector/metric_collector.go
@@ -153,10 +153,10 @@ func (c *Collector) UpdateProcessEnergyUtilizationMetrics() {
 }
 
 func (c *Collector) updateResourceUtilizationMetrics() {
-	var wg sync.WaitGroup
+	wg := &sync.WaitGroup{}
 	wg.Add(2)
-	c.updateNodeResourceUtilizationMetrics(&wg)
-	c.updateProcessResourceUtilizationMetrics(&wg)
+	go c.updateNodeResourceUtilizationMetrics(wg)
+	go c.updateProcessResourceUtilizationMetrics(wg)
 	wg.Wait()
 	// aggregate processes' resource utilization metrics to containers, virtual machines and nodes
 	c.AggregateProcessResourceUtilizationMetrics()

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -4,6 +4,8 @@
 package manager
 
 import (
+	"sync"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sustainable-computing-io/kepler/pkg/bpf"
@@ -14,8 +16,16 @@ var _ = Describe("Manager", func() {
 	It("Should work properly", func() {
 		bpfExporter := bpf.NewMockExporter(bpf.DefaultSupportedMetrics())
 		CollectorManager := New(bpfExporter)
-		err := CollectorManager.Start()
-		Expect(err).NotTo(HaveOccurred())
+		stopChan := make(chan struct{})
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := CollectorManager.Start(stopChan)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+		close(stopChan)
+		wg.Wait()
 	})
 
 })


### PR DESCRIPTION
This PR contains some fixes to the way async/waitgroups were being used previously and allows for Kepler to be gracefully shutdown - this doesn't appear to have any measureable performance impact.

The last commit in this series is an experiment on asynchronously collecting the Process Metrics (from eBPF) instead of doing so synchronously (i.e from the `Update` method of the manager).

You can see the result of this on the collector update here:
https://gist.github.com/dave-tucker/57f944a586e0d4463c5e19a586a585c7

I'll want to get a pprof of this and compare to Kepler on main also before we go further with this.

TL;DR The collector update takes on average 600ms less, and the variance (StdDev) reduces by 500ms.

I opened this PR to get some feedback as I'm quite keen to push forward in adapting the Kepler architecture to be more async. I'll open an issue and provide a diagram with what I'm thinking shortly...



