### PR TITLE
chore(validator)update validator usage; remove job from prom query

### DIFF
--- a/e2e/tools/validator/.gitignore
+++ b/e2e/tools/validator/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+validator.yaml

--- a/e2e/tools/validator/README.md
+++ b/e2e/tools/validator/README.md
@@ -10,10 +10,24 @@
 - [Installation](#installation)
 - [License](#license)
 
+## Requirements
+
+- Python 3.11 and above.
+- stress-ng on both the remote and local machines.
+
 ## Installation
 
+Inside of the `validator` directory:
 ```console
-pip install validator
+pip install .
+```
+
+## Usage
+
+Generate the validator.yaml file based on [validator.yaml.sample](validator.yaml.sample) and run the following command:
+```console
+
+python -m validator stress -s ./scripts/stressor.sh 
 ```
 
 ## License

--- a/e2e/tools/validator/pyproject.toml
+++ b/e2e/tools/validator/pyproject.toml
@@ -7,7 +7,7 @@ name = "validator"
 dynamic = ["version"]
 description = ''
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 license = "Apache-2.0"
 keywords = ["kepler", "kepler-model-server", "validator"]
 authors = [
@@ -18,7 +18,7 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -57,7 +57,7 @@ cov = [
 ]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.12"]
+python = ["3.11"]
 
 [tool.hatch.envs.types]
 dependencies = [

--- a/e2e/tools/validator/src/validator/cases/__init__.py
+++ b/e2e/tools/validator/src/validator/cases/__init__.py
@@ -6,20 +6,20 @@ from validator import config
 
 RAW_PROM_QUERIES = [
     {
-        "expected_query": "rate(kepler_process_package_joules_total{{job='metal', pid='{vm_pid}', mode='dynamic'}}[{interval}])",
-        "actual_query": "rate(kepler_node_platform_joules_total{{job='vm'}}[{interval}])",
+        "expected_query": "rate(kepler_process_package_joules_total{{pid='{vm_pid}', mode='dynamic'}}[{interval}])",
+        "actual_query": "rate(kepler_node_platform_joules_total[{interval}])",
     },
     {
-        "expected_query": "rate(kepler_process_platform_joules_total{{job='metal', pid='{vm_pid}', mode='dynamic'}}[{interval}])",
-        "actual_query": "rate(kepler_node_platform_joules_total{{job='vm'}}[{interval}])",
+        "expected_query": "rate(kepler_process_platform_joules_total{{pid='{vm_pid}', mode='dynamic'}}[{interval}])",
+        "actual_query": "rate(kepler_node_platform_joules_total[{interval}])",
     },
     {
-        "expected_query": "rate(kepler_process_bpf_cpu_time_ms_total{{job='metal', pid='{vm_pid}'}}[{interval}])",
-        "actual_query": "sum by(__name__, job) (rate(kepler_process_bpf_cpu_time_ms_total{{job='vm'}}[{interval}]))",
+        "expected_query": "rate(kepler_process_bpf_cpu_time_ms_total{{pid='{vm_pid}'}}[{interval}])",
+        "actual_query": "sum by(__name__, job) (rate(kepler_process_bpf_cpu_time_ms_total[{interval}]))",
     },
     {
-        "expected_query": "rate(kepler_process_bpf_page_cache_hit_total{{job='metal', pid='{vm_pid}'}}[{interval}])",
-        "actual_query": "sum by(__name__, job) (rate(kepler_process_bpf_page_cache_hit_total{{job='vm'}}[{interval}]))",
+        "expected_query": "rate(kepler_process_bpf_page_cache_hit_total{{pid='{vm_pid}'}}[{interval}])",
+        "actual_query": "sum by(__name__, job) (rate(kepler_process_bpf_page_cache_hit_total[{interval}]))",
     },
 
 

--- a/e2e/tools/validator/src/validator/cli/__init__.py
+++ b/e2e/tools/validator/src/validator/cli/__init__.py
@@ -83,6 +83,9 @@ def stress(cfg: Validator, script_path: str):
     for test_case in test_case_result.test_cases:
         expected_query = test_case.expected_query
         actual_query = test_case.actual_query
+        print(f"expected_query: {expected_query}")
+        print(f"actual_query: {actual_query}")
+        print(f"start_time: {result.start_time}, end_time: {result.end_time}")
         metrics_res = metrics_validator.compare_metrics(result.start_time, 
                                                         result.end_time, 
                                                         expected_query, 

--- a/e2e/tools/validator/validator.yaml.sample
+++ b/e2e/tools/validator/validator.yaml.sample
@@ -1,0 +1,16 @@
+remote:
+  host: 192.168.124.28
+  # ### defaults ###
+  # port: 22
+  # username: fedora
+  # password: supersecret
+  # pkey: ~/.ssh/id_rsa
+
+metal:
+  vm:
+    pid: 2093543
+
+prometheus:
+  url: http://localhost:9090
+  interval: 30s
+  steps: 10s


### PR DESCRIPTION
RHEL 9 doesn't have python 3.12. So we need to use the latest i.e. 3.11