### PR TITLE
bpf: fix the process parameter order to match the c and go code

### DIFF
--- a/pkg/bpf/types.go
+++ b/pkg/bpf/types.go
@@ -46,8 +46,8 @@ type SupportedMetrics struct {
 // must be in sync with bpf program
 type ProcessBPFMetrics struct {
 	CGroupID       uint64
-	ThreadPID      uint64 /* thread id */
 	PID            uint64 /* TGID of the threads, i.e. user space pid */
+	ThreadPID      uint64 /* thread id */
 	ProcessRunTime uint64 /* in ms */
 	TaskClockTime  uint64 /* in ms */
 	CPUCycles      uint64


### PR DESCRIPTION
fix the process parameter order to match the c and go code