### PR TITLE
Revert "bpf: fix the process parameter order to match the c and go code"

### DIFF
--- a/pkg/bpf/types.go
+++ b/pkg/bpf/types.go
@@ -46,8 +46,8 @@ type SupportedMetrics struct {
 // must be in sync with bpf program
 type ProcessBPFMetrics struct {
 	CGroupID       uint64
-	PID            uint64 /* TGID of the threads, i.e. user space pid */
 	ThreadPID      uint64 /* thread id */
+	PID            uint64 /* TGID of the threads, i.e. user space pid */
 	ProcessRunTime uint64 /* in ms */
 	TaskClockTime  uint64 /* in ms */
 	CPUCycles      uint64


### PR DESCRIPTION
See:
https://github.com/sustainable-computing-io/kepler/blob/main/bpfassets/libbpf/src/kepler.bpf.c#L217-L219

Struct Definition:
https://github.com/sustainable-computing-io/kepler/blob/main/bpfassets/libbpf/src/kepler.bpf.h#L90-L102

And the man page:
```
     u64 bpf_get_current_pid_tgid(void)

              Description
                     Get the current pid and tgid.

              Return A 64-bit integer containing the current tgid and
                     pid, and created as such: current_task->tgid << 32
                     | current_task->pid.
```

Therefore we can conclude that in our `process_metrics_t` struct, that pid/tgid are as the kernel sees them.
In userland however these values are the opposite - e.g when you issue `ps` - Kepler accounted for this difference (deliberately or accidentally) by switching the name of those fields around in the Go struct.

Therefore I believe we should revert sustainable-computing-io/kepler#1479
I've not verified it, but to the best of my understanding metrics will now be being reported on a per-kernel-pid basis which is not correct.