### PR TITLE
chore(compose): disable cgroup in compose

### DIFF
--- a/manifests/compose/compose.yaml
+++ b/manifests/compose/compose.yaml
@@ -42,7 +42,7 @@ services:
         /usr/bin/kepler \
           -address "0.0.0.0:8888" \
           -v "8" \
-          -enable-cgroup-id=true \
+          -enable-cgroup-id=false \
           -enable-gpu=false
 
 networks:

--- a/manifests/compose/dev/compose.yaml
+++ b/manifests/compose/dev/compose.yaml
@@ -56,7 +56,7 @@ services:
         /usr/bin/kepler \
           -address "0.0.0.0:8888" \
           -v "8" \
-          -enable-cgroup-id=true \
+          -enable-cgroup-id=false \
           -enable-gpu=false
     networks:
       - kepler-network

--- a/manifests/compose/mock-acpi/compose.yaml
+++ b/manifests/compose/mock-acpi/compose.yaml
@@ -59,7 +59,7 @@ services:
         /usr/bin/kepler \
           -address "0.0.0.0:8888" \
           -v "5" \
-          -enable-cgroup-id=true \
+          -enable-cgroup-id=false \
           -enable-gpu=false
     networks:
       - kepler-network

--- a/manifests/compose/validation/metal/compose.yaml
+++ b/manifests/compose/validation/metal/compose.yaml
@@ -49,7 +49,7 @@ services:
         /usr/bin/kepler \
           -address "0.0.0.0:8888" \
           -v "8" \
-          -enable-cgroup-id=true \
+          -enable-cgroup-id=false \
           -enable-gpu=false
     networks:
       - kepler-network

--- a/manifests/compose/validation/vm/compose.yaml
+++ b/manifests/compose/validation/vm/compose.yaml
@@ -47,6 +47,7 @@ services:
         set -x;
         /usr/bin/kepler
           -address="0.0.0.0:9100"
+          -enable-cgroup-id=false
           -v="8"
 
   estimator:


### PR DESCRIPTION
This disables usage of cgroups while running Kepler using compose