### PR TITLE
Fix use of goroutines and implement graceful shutdown

### DIFF
--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -17,11 +17,16 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
-	"runtime/debug"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
 	"time"
 
 	"github.com/sustainable-computing-io/kepler/pkg/bpf"
@@ -68,17 +73,8 @@ func healthProbe(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func finalizing() {
-	stack := "exit stack: \n" + string(debug.Stack())
-	klog.Infof(stack)
-	exitCode := 10
-	klog.Infoln(finishingMsg)
-	klog.FlushAndExit(klog.ExitFlushTimeout, exitCode)
-}
-
 func main() {
 	start := time.Now()
-	defer finalizing()
 	klog.InitFlags(nil)
 	flag.Parse()
 
@@ -152,34 +148,67 @@ func main() {
 	metricPathConfig := config.GetMetricPath(*metricsPath)
 	bindAddressConfig := config.GetBindAddress(*address)
 
-	http.Handle(metricPathConfig, promhttp.HandlerFor(
+	handler := http.ServeMux{}
+	handler.Handle(metricPathConfig, promhttp.HandlerFor(
 		reg,
 		promhttp.HandlerOpts{
 			Registry: reg,
 		},
 	))
-	http.HandleFunc("/healthz", healthProbe)
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		_, httpErr := w.Write([]byte(`<html>
-                        <head><title>Energy Stats Exporter</title></head>
-                        <body>
-                        <h1>Energy Stats Exporter</h1>
-                        <p><a href="` + metricPathConfig + `">Metrics</a></p>
-                        </body>
-                        </html>`))
-		if err != nil {
-			klog.Fatalf("%s", fmt.Sprintf("failed to write response: %v", httpErr))
-		}
-	})
+	handler.HandleFunc("/healthz", healthProbe)
+	handler.HandleFunc("/", rootHandler(metricPathConfig))
+	handler.HandleFunc("/debug/pprof/", http.DefaultServeMux.ServeHTTP)
+	srv := &http.Server{
+		Addr:    bindAddressConfig,
+		Handler: &handler,
+	}
 
 	klog.Infof("starting to listen on %s", bindAddressConfig)
-	ch := make(chan error)
-	go func() {
-		ch <- http.ListenAndServe(bindAddressConfig, nil)
-	}()
+	errChan := make(chan error)
 
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errChan <- err
+		}
+	}()
 	klog.Infof(startedMsg, time.Since(start))
 	klog.Flush() // force flush to parse the start msg in the e2e test
-	err = <-ch
-	klog.Fatalf("%s", fmt.Sprintf("failed to bind on %s: %v", bindAddressConfig, err))
+
+	// Wait for an exit signal
+
+	ctx := context.Background()
+	select {
+	case err := <-errChan:
+		klog.Fatalf("%s", fmt.Sprintf("failed to listen and serve: %v", err))
+	case <-signalChan:
+		klog.Infof("Received shutdown signal")
+		ctx, cancel := context.WithDeadline(ctx, time.Now().Add(5*time.Second))
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			klog.Fatalf("%s", fmt.Sprintf("failed to shutdown gracefully: %v", err))
+		}
+	}
+	wg.Wait()
+	klog.Infoln(finishingMsg)
+	klog.FlushAndExit(klog.ExitFlushTimeout, 0)
+}
+
+func rootHandler(metricPathConfig string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(`<html>
+					<head><title>Energy Stats Exporter</title></head>
+					<body>
+					<h1>Energy Stats Exporter</h1>
+					<p><a href="` + metricPathConfig + `">Metrics</a></p>
+					</body>
+					</html>`)); err != nil {
+			klog.Errorf("%s", fmt.Sprintf("failed to write http response: %v", err))
+		}
+	}
 }

--- a/cmd/validator/validator.go
+++ b/cmd/validator/validator.go
@@ -100,29 +100,26 @@ func calculateNodeComponentsPower(index int, pre, cur map[int]source.NodeCompone
 }
 
 func updateNodePower(wg *sync.WaitGroup) {
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	defer wg.Done()
 
-		for i := 0; i < *sampleCount; i++ {
-			pre := components.GetAbsEnergyFromNodeComponents()
-			time.Sleep(time.Duration(*sampleDuration) * time.Second)
-			cur := components.GetAbsEnergyFromNodeComponents()
-			fmt.Printf("Sample %d:\n", i+1)
-			fmt.Printf("pre: %v\ncur: %v\n", pre, cur)
-			calculateNodeComponentsPower(i, pre, cur)
-			meanPower.pkgPower += samplePowers[i].pkgPower
-			meanPower.corePower += samplePowers[i].corePower
-			meanPower.uncorePower += samplePowers[i].uncorePower
-			meanPower.dramPower += samplePowers[i].dramPower
-		}
-		meanPower.pkgPower /= float64(*sampleCount)
-		meanPower.corePower /= float64(*sampleCount)
-		meanPower.uncorePower /= float64(*sampleCount)
-		meanPower.dramPower /= float64(*sampleCount)
-		fmt.Printf("Dump mean power:\n")
-		fmt.Printf("pkg:%f\ncore:%f\nuncore:%f\ndram:%f\n", meanPower.pkgPower, meanPower.corePower, meanPower.uncorePower, meanPower.dramPower)
-	}()
+	for i := 0; i < *sampleCount; i++ {
+		pre := components.GetAbsEnergyFromNodeComponents()
+		time.Sleep(time.Duration(*sampleDuration) * time.Second)
+		cur := components.GetAbsEnergyFromNodeComponents()
+		fmt.Printf("Sample %d:\n", i+1)
+		fmt.Printf("pre: %v\ncur: %v\n", pre, cur)
+		calculateNodeComponentsPower(i, pre, cur)
+		meanPower.pkgPower += samplePowers[i].pkgPower
+		meanPower.corePower += samplePowers[i].corePower
+		meanPower.uncorePower += samplePowers[i].uncorePower
+		meanPower.dramPower += samplePowers[i].dramPower
+	}
+	meanPower.pkgPower /= float64(*sampleCount)
+	meanPower.corePower /= float64(*sampleCount)
+	meanPower.uncorePower /= float64(*sampleCount)
+	meanPower.dramPower /= float64(*sampleCount)
+	fmt.Printf("Dump mean power:\n")
+	fmt.Printf("pkg:%f\ncore:%f\nuncore:%f\ndram:%f\n", meanPower.pkgPower, meanPower.corePower, meanPower.uncorePower, meanPower.dramPower)
 }
 
 func getX86Architecture() (string, error) {
@@ -286,7 +283,8 @@ func main() {
 
 	if *genPower {
 		wg := sync.WaitGroup{}
-		updateNodePower(&wg)
+		wg.Add(1)
+		go updateNodePower(&wg)
 		wg.Wait()
 
 		pkg := strconv.FormatFloat(meanPower.pkgPower, 'f', 3, 64)

--- a/pkg/collector/energy/node_energy_collector.go
+++ b/pkg/collector/energy/node_energy_collector.go
@@ -94,11 +94,11 @@ func UpdateNodeIdleEnergy(nodeStats *stats.NodeStats) {
 
 // UpdateNodeEnergyMetrics updates the node energy consumption of each component
 func UpdateNodeEnergyMetrics(nodeStats *stats.NodeStats) {
-	var wgNode sync.WaitGroup
-	wgNode.Add(2)
-	go UpdateNodeComponentsEnergy(nodeStats, &wgNode)
-	go UpdateNodeGPUEnergy(nodeStats, &wgNode)
-	wgNode.Wait()
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go UpdateNodeComponentsEnergy(nodeStats, wg)
+	go UpdateNodeGPUEnergy(nodeStats, wg)
+	wg.Wait()
 	// update platform power later to avoid race condition when using estimation power model
 	UpdatePlatformEnergy(nodeStats)
 	// after updating the total energy we calculate the idle, dynamic and other components energy

--- a/pkg/collector/metric_collector.go
+++ b/pkg/collector/metric_collector.go
@@ -153,10 +153,10 @@ func (c *Collector) UpdateProcessEnergyUtilizationMetrics() {
 }
 
 func (c *Collector) updateResourceUtilizationMetrics() {
-	var wg sync.WaitGroup
+	wg := &sync.WaitGroup{}
 	wg.Add(2)
-	c.updateNodeResourceUtilizationMetrics(&wg)
-	c.updateProcessResourceUtilizationMetrics(&wg)
+	go c.updateNodeResourceUtilizationMetrics(wg)
+	go c.updateProcessResourceUtilizationMetrics(wg)
 	wg.Wait()
 	// aggregate processes' resource utilization metrics to containers, virtual machines and nodes
 	c.AggregateProcessResourceUtilizationMetrics()


### PR DESCRIPTION
Some small fixes while investigating #1467:

- In `cmd/validator` adds to the `wg` before it's passed into another function. `updateNodePower` is then run as `go updateNodePower`
- Consistently initilize wg's as `wg := &sync.WaitGroup{}`
- Call `go c.updateNodeResourceUtilizationMetrics(wg)` and `go c.updateProcessResourceUtilizationMetrics(wg)` in their own goroutines. Otherwise the use of a wg is pointless since they would be run sequentially
- Allows for Kepler to gracefully shutdown when a SIGINT or SIGTERM is received