### PR TITLE
fix(bpf): restore command label in process metrics

### DIFF
--- a/bpfassets/libbpf/src/kepler.bpf.h
+++ b/bpfassets/libbpf/src/kepler.bpf.h
@@ -98,7 +98,6 @@ typedef struct process_metrics_t {
 	u64 cache_miss;
 	u64 page_cache_hit;
 	u16 vec_nr[10];
-	u32 pad;
 	char comm[16];
 } process_metrics_t;
 


### PR DESCRIPTION
Process metrics was missing `command` label (command="") because of the `pad` that got added to the bpf process_metrics_t in #1481. The command label was empty because the go `ProcessBPFMetrics` struct is 
missing `Pad` 

Fixes #1519