### PR TITLE
chore: Use Codecov

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -49,28 +49,11 @@ jobs:
           cd ../../../
           make VERBOSE=1 test
           go tool cover -func=coverage.out -o=coverage.out
-      - name: Go Coverage Badge # Pass the `coverage.out` output to this action
-        uses: tj-actions/coverage-badge-go@v2
-        with:
-          filename: coverage.out
 
-      - name: Verify Changed files
-        uses: tj-actions/verify-changed-files@v20
-        id: verify-changed-files
+      - name: Upload coverage reports to Codecov
+        if: github.event_name != 'pull_request'
+        uses: codecov/codecov-action@v4.0.1
         with:
-          files: README.md
-
-      - name: Commit changes
-        if: github.event_name != 'pull_request' && steps.verify-changed-files.outputs.files_changed == 'true'
-        run: |
-          git config --local user.email "bot@sustainable-computing.io"
-          git config --local user.name "sustainable-computing-bot"
-          git add README.md
-          git commit -m "bot: Updated coverage badge." -s
-
-      - name: Push changes
-        if: github.event_name != 'pull_request' && steps.verify-changed-files.outputs.files_changed == 'true'
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GH_BOT_SECRET }}
-          branch: ${{ github.head_ref }}
+          fail_ci_if_error: false # because codecov updates occasionally fail
+          files: coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![GitHub Workflow Status (event)](https://img.shields.io/github/actions/workflow/status/sustainable-computing-io/kepler/unit_test.yml?branch=main&label=CI)
 
-![Coverage](https://img.shields.io/badge/Coverage-47.8%25-yellow)
+[![codecov](https://codecov.io/gh/sustainable-computing-io/kepler/graph/badge.svg?token=K9BDX9M86E)](https://codecov.io/gh/sustainable-computing-io/kepler)
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/7391/badge)](https://bestpractices.coreinfrastructure.org/projects/7391)[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/sustainable-computing-io/kepler/badge)](https://securityscorecards.dev/viewer/?uri=github.com/sustainable-computing-io/kepler)
 <!--
 [![GoDoc](https://godoc.org/github.com/kubernetes/kube-state-metrics?status.svg)](https://godoc.org/github.com/kubernetes/kube-state-metrics)


### PR DESCRIPTION
This removes the current infra for updating the code coverage badge which calculates a percentage and checks in a commit to update the README.

It's replaced with CodeCov, a web service that will provide an always-up-to-date link to a coverage badge, as well as allowing users to dig into coverage reports through a web UI.

This avoids flooding the git history with commits that update the coverage badge. For example, the SHA of the latest git commit and the SHA used to build the `latest` container image aren't the same because of the coverage commit.
Similary, we miss seeing information about the last merge commit (and a CI status indicator) on the front page on GitHub.