### PR TITLE
ci: Don't override binary version in image builds

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -28,7 +28,6 @@ jobs:
             BUILD_ARGS: |
               INSTALL_DCGM=false
               INSTALL_HABANA=false
-              VERSION=${{ inputs.imageTag }}
             LABEL: ${{ inputs.imageTag }}
           - IMAGE_NAME: kepler
             IMAGE_FILE: build/Dockerfile
@@ -36,7 +35,6 @@ jobs:
             BUILD_ARGS: |
               INSTALL_DCGM=true
               INSTALL_HABANA=false
-              VERSION=${{ inputs.imageTag }}-dcgm
             LABEL: ${{ inputs.imageTag }}-dcgm
           - IMAGE_NAME: kepler
             IMAGE_FILE: build/Dockerfile
@@ -44,7 +42,6 @@ jobs:
             BUILD_ARGS: |
               INSTALL_DCGM=false
               INSTALL_HABANA=true
-              VERSION=${{ inputs.imageTag }}-habana
             LABEL: ${{ inputs.imageTag }}-habana
           - IMAGE_NAME: kepler-validator
             IMAGE_FILE: build/Dockerfile.kepler-validator


### PR DESCRIPTION
Before this change, the `kepler_exporter_build_info` metric would report that the current version is `latest`. This makes it difficult to understand precisely which version of Kepler is running.

If we don't override this at image build time, then the version will be reported as something like v0.7.10-91-g95dce23a

This more accurately identifies which version of kepler is in use.