### PR TITLE
ci: Fix codecov secret propagation

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
   unit_test:
     uses: ./.github/workflows/unit_test.yml
     secrets:
-      GH_BOT_SECRET: ${{ secrets.GH_BOT_SECRET }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   # for each PR merge, openSSF scan
   scorecard:
     uses: ./.github/workflows/scorecard.yml

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -3,7 +3,7 @@ name: Unit test
 on: # yamllint disable-line rule:truthy
   workflow_call:
     secrets:
-      GH_BOT_SECRET:
+      CODECOV_TOKEN:
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
It looks like secrets don't propagate automatically when using workflow_call so we have to explicitly set them.

Hopefully this should fix codecov uploads from main.