### PR TITLE
ci: Ignore K8s major/minor dep updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
       - dependency-name: github.com/NVIDIA/go-nvml
       # Ignore libbpfgo updates as this requires changing the base image
       - dependency-name: github.com/aquasecurity/libbpfgo
+      - dependency-name: k8s.io/*
+        update-types: [version-update:semver-major, version-update:semver-minor]
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
K8s client-go, apimachinery and api updates to 1.30 require a Go bump to version 1.22. We can't do this yet since we're blocked on needing a Go 1.22 toolset in UBI. Ignore major/minor semver bumps to these packages for now. We can revert this when we're on Go 1.22