### PR TITLE
chore(bpf): account all running state processes

### DIFF
--- a/bpfassets/libbpf/src/kepler.bpf.h
+++ b/bpfassets/libbpf/src/kepler.bpf.h
@@ -33,8 +33,6 @@ typedef struct pid_time_t {
 # define MAP_SIZE 32768
 #endif
 
-#define TASK_RUNNING 0
-
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
 


### PR DESCRIPTION
The process state can have multiple states, running state is one of them, yet most of the user space processes are spending CPU on interruptible state. 

The process can voluntarily changes its state fro running to interruptible, so by the time the sched_switch tracepoint enters, the state may not be in running.