### PR TITLE
fix(bpf): Fix kepler_write_page_cache attach

### DIFF
--- a/bpfassets/libbpf/src/kepler.bpf.c
+++ b/bpfassets/libbpf/src/kepler.bpf.c
@@ -313,8 +313,8 @@ int kepler_read_page_trace(void *ctx)
 }
 
 // count write page cache
-SEC("tp_btf/writeback_dirty_folio")
-int kepler_write_page_trace(u64 *ctx)
+SEC("tp/writeback_dirty_folio")
+int kepler_write_page_trace(void *ctx)
 {
 	u32 curr_tgid;
 	struct process_metrics_t *process_metrics;

--- a/pkg/bpf/exporter.go
+++ b/pkg/bpf/exporter.go
@@ -195,9 +195,13 @@ func (e *exporter) attach() error {
 	if err != nil {
 		return fmt.Errorf("failed to get kepler_write_page_trace: %w", err)
 	} else {
-		_, err = page_write.AttachTracepoint("writeback", "writeback_dirty_folio")
-		if err != nil {
-			klog.Warningf("failed to attach tp/writeback/writeback_dirty_folio: %v. Kepler will not collect page cache write events. This will affect the DRAM power model estimation on VMs.", err)
+		category := "writeback"
+		name := "writeback_dirty_page"
+		if _, err := os.Stat("/sys/kernel/debug/tracing/events/writeback/writeback_dirty_folio"); err == nil {
+			name = "writeback_dirty_folio"
+		}
+		if _, err = page_write.AttachTracepoint(category, name); err != nil {
+			klog.Warningf("failed to attach tp/%s/%s: %v. Kepler will not collect page cache write events. This will affect the DRAM power model estimation on VMs.", category, name, err)
 		} else {
 			e.enabledSoftwareCounters[config.PageCacheHit] = struct{}{}
 		}


### PR DESCRIPTION
We need to use a standard tracepoint for kepler_write_page_cache to
avoid BTF relocation errors on systems where the writeback_dirty_folio
tracepoint doesn't exist.

This is due to the rename of writeback_dirty_page to
writeback_dirty_folio that happened in Kernel 5.16.

This patch adjust the attach logic to fall back to the old name if the
writeback_dirty_folio tracepoint does not exist.
