### PR TITLE
fix: update the VERSION variable assignment method

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -52,7 +52,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
         with:
-          fetch-depth: 0 # Set fetch-depth to 0 to retrieve the entire history for all branches and tags, essential for accurate version computation.
+           # NOTE:  setting fetch-depth to 0 to retrieve the entire history 
+           # instead of a shallow-clone so that all tags are fetched as well. 
+           # This is necessary for computing the VERSION using `git describe`
+          fetch-depth: 0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -51,12 +51,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0 # Set fetch-depth to 0 to retrieve the entire history for all branches and tags, essential for accurate version computation.
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
           image: tonistiigi/binfmt:qemu-v8.1.5
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Login to Quay
         if: ${{ inputs.pushImage }}
         uses: docker/login-action@v3

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -52,9 +52,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
         with:
-           # NOTE:  setting fetch-depth to 0 to retrieve the entire history 
-           # instead of a shallow-clone so that all tags are fetched as well. 
-           # This is necessary for computing the VERSION using `git describe`
+          # NOTE:  setting fetch-depth to 0 to retrieve the entire history
+          # instead of a shallow-clone so that all tags are fetched as well.
+          # This is necessary for computing the VERSION using `git describe`
           fetch-depth: 0
 
       - name: Set up QEMU

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ CROSS_BUILD_BINDIR := $(OUTPUT_DIR)/bin
 GIT_VERSION        := $(shell git describe --dirty --tags --always --match='v*')
 GIT_SHA            := $(shell git rev-parse HEAD)
 GIT_BRANCH         := $(shell git rev-parse --abbrev-ref HEAD)
-VERSION            ?= $(GIT_VERSION)
+VERSION            := $(GIT_VERSION)
 ROOTLESS           ?= false
 IMAGE_REPO         ?= quay.io/sustainable_computing_io
 BUILDER_IMAGE      ?= quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.3.0

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,19 +1,17 @@
 FROM quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.3.0 as builder
-ARG VERSION
 ARG INSTALL_HABANA=false
 WORKDIR /workspace
 
 COPY . .
 
-RUN make tidy-vendor
-RUN make format
+RUN make tidy-vendor format
 RUN if [[ "$INSTALL_HABANA" == "true" ]]; then \
 		rpm -Uvh https://vault.habana.ai/artifactory/rhel/9/9.2/habanalabs-firmware-tools-1.15.1-15.el9.x86_64.rpm --nodeps; \
 		echo /usr/lib/habanalabs > /etc/ld.so.conf.d/habanalabs.conf; \
 		ldconfig; \
 	fi
 
-RUN make build VERSION=${VERSION}
+RUN make build
 
 FROM registry.access.redhat.com/ubi9:latest
 # NOTE: use bash instead of sh
@@ -52,7 +50,6 @@ RUN set -e -x ;\
 		yum clean all
 
 COPY --from=builder /workspace/_output/bin/kepler /usr/bin/kepler
-COPY --from=builder /libbpf-source/linux-5.14.0-424.el9/tools/bpf/bpftool/bpftool /usr/bin/bpftool
 COPY --from=builder /libbpf-source/linux-5.14.0-424.el9/tools/bpf/bpftool/bpftool /usr/bin/bpftool
 
 RUN mkdir -p /var/lib/kepler/data


### PR DESCRIPTION
This PR:
* fixes the issue the VERSION variable assignment
  from `?=` to `:=` to ensure immediate evaluation of `$(GIT_VERSION)`

* Use `fetch_depth` to fetch the tag info for computing the `GIT_VERSION`
  correctly while building Kepler images

* Removes the `VERSION` argument from the Dockerfile

* Removes the redundant bpftool COPY statement in build/Dockerfile

* Addresses issue #1540
