### PR TITLE
fix: Fix uncomment of YAML in hack/build-manifests.sh

### DIFF
--- a/hack/build-manifest.sh
+++ b/hack/build-manifest.sh
@@ -79,7 +79,7 @@ uncomment_path() {
 uncomment() {
 	regex="${1:?}"
 	file="${2:?}"
-	sed <"$file" "/^# .*${regex}.*/s/^# //" >"${file}.tmp"
+	sed <"$file" "/^# .*${regex}.*/s/^# / /" >"${file}.tmp"
 	mv "${file}.tmp" "${file}"
 }
 

--- a/manifests/k8s/config/base/kustomization.yaml
+++ b/manifests/k8s/config/base/kustomization.yaml
@@ -7,7 +7,7 @@ bases:
   - ../rbac
   - ../exporter
 # add this line to enable model-server
-# - ../model-server
+#  - ../model-server
 
 # TO-DO: patch namespace=openshift-monitoring for OPENSHIFT_DEPLOY
 patchesJson6902:
@@ -23,8 +23,8 @@ patchesJson6902:
 
 patchesStrategicMerge: []
 # add this line to set model-server endpoint to kepler
-# - ./patch/patch-model-server-kepler-config.yaml
+#  - ./patch/patch-model-server-kepler-config.yaml
 # add this line to change log level for debugging
-# - ./patch/patch-debug.yaml
+#  - ./patch/patch-debug.yaml
 # add this line to get high metric granularity (3s interval)
-# - ./patch/patch-high-granularity.yaml
+#  - ./patch/patch-high-granularity.yaml

--- a/manifests/k8s/config/exporter/kustomization.yaml
+++ b/manifests/k8s/config/exporter/kustomization.yaml
@@ -2,30 +2,30 @@ resources:
   # uncomment this line for openshift
   # - openshift_scc.yaml
   - exporter.yaml
-# uncomment this line if prometheus deployed
-# - prometheus_common_service_monitor.yaml
-# - prometheus_common_rules.yaml
-# - prometheus_high_granularity_rules.yaml
+#  uncomment this line if prometheus deployed
+#  - prometheus_common_service_monitor.yaml
+#  - prometheus_common_rules.yaml
+#  - prometheus_high_granularity_rules.yaml
 
 patchesStrategicMerge: []
 # add this line to allow ci
-# - ./patch/patch-ci.yaml
+#  - ./patch/patch-ci.yaml
 # add this for kind provider ci
-# - ./patch/patch-kind.yaml
+#  - ./patch/patch-kind.yaml
 # add this line for bm case
-# - ./patch/patch-bm.yaml
+#  - ./patch/patch-bm.yaml
 # add this line to enable estimator sidecar
-# - ./patch/patch-estimator-sidecar.yaml
+#  - ./patch/patch-estimator-sidecar.yaml
 # add this line for openshift patch
-# - ./patch/patch-openshift.yaml
+#  - ./patch/patch-openshift.yaml
 # add this line for rootless patch
-# - ./patch/patch-rootless.yaml
+#  - ./patch/patch-rootless.yaml
 # add this line for qat patch
-# - ./patch/patch-qat.yaml
+#  - ./patch/patch-qat.yaml
 # add this line for dcgmi patch
-# - ./patch/patch-dcgmi.yaml
+#  - ./patch/patch-dcgmi.yaml
 # add this line for habana patch
-# - ./patch/patch-habana.yaml
+#  - ./patch/patch-habana.yaml
 
 secretGenerator:
   - name: redfish

--- a/manifests/k8s/config/model-server/kustomization.yaml
+++ b/manifests/k8s/config/model-server/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 
 patchesStrategicMerge: []
 # add this line for openshift patch
-# - ./patch/patch-openshift.yaml
+#  - ./patch/patch-openshift.yaml

--- a/manifests/k8s/config/rbac/kustomization.yaml
+++ b/manifests/k8s/config/rbac/kustomization.yaml
@@ -3,5 +3,5 @@ resources:
   - k8s_clusterrole.yaml
   - k8s_clusterrole_binding.yaml
 # uncomment these two lines if prometheus deployed
-# - prometheus_role.yaml
-# - prometheus_role_binding.yaml
+#  - prometheus_role.yaml
+#  - prometheus_role_binding.yaml


### PR DESCRIPTION
When we formatted the code with yamllint it was not immediately clear that we had a shell script that was performing uncommenting of lines.

When done by a human, their IDE (or eyes) would see that the indentation didn't align and would adjust. This is not clear to machines, for example when performing `make build-manifests`

This commit adds spaces to commented YAML lines in any kustomization.yaml to ensure that once the leading '#` has been removed that they are correctly indented.

In addition the uncomment() function in hack/build-manifests.sh has been adjusted to preserve any spaces that occur after the leading `#`