### PR TITLE
fix: Bash functions should exit on error

### DIFF
--- a/hack/utils.bash
+++ b/hack/utils.bash
@@ -64,7 +64,7 @@ info_run() {
 
 run() {
 	echo -e " ❯ $*\n" >&2
-	"$@"
+	"$@" || die "Failed to run: $*"
 }
 
 die() {


### PR DESCRIPTION
The run command wrapper was silently ignoring errors. This commit ensures that a failed command will exit, ensuring that we don't accidentally ignore errors anymore.