### PR TITLE
chore: remove version from docker-compose

### DIFF
--- a/manifests/compose/dev/compose.yaml
+++ b/manifests/compose/dev/compose.yaml
@@ -13,7 +13,6 @@ services:
       args:
         INSTALL_DCGM: false
         INSTALL_HABANA: false
-        VERSION: dev
 
     ports:
       # NOTE: use 9888 to keep the host 8888 port free for any local testing

--- a/manifests/compose/mock-acpi/compose.yaml
+++ b/manifests/compose/mock-acpi/compose.yaml
@@ -15,7 +15,6 @@ services:
       args:
         INSTALL_DCGM: false
         INSTALL_HABANA: false
-        VERSION: dev
 
     ports:
       # NOTE: use 9188 to keep the host 8888 port free for any local testing

--- a/manifests/compose/validation/metal/compose.yaml
+++ b/manifests/compose/validation/metal/compose.yaml
@@ -13,7 +13,6 @@ services:
       args:
         INSTALL_DCGM: false
         INSTALL_HABANA: false
-        VERSION: metal
 
     ports:
       # NOTE: use 9888 to keep the host 8888 port free for any local testing


### PR DESCRIPTION
Removes the `VERSION` build-arg from the docker compose files as it was removed in #1552