### PR TITLE
chore: Flatten Uint64StatCollection

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 linters-settings:
   dupl:
-    threshold: 100
+    threshold: 150
   goconst:
     min-len: 2
     min-occurrences: 3

--- a/pkg/collector/metric_collector.go
+++ b/pkg/collector/metric_collector.go
@@ -180,8 +180,8 @@ func (c *Collector) AggregateProcessResourceUtilizationMetrics() {
 			c.handleIdlingProcess(process)
 		}
 		for metricName, resource := range process.ResourceUsage {
-			for id := range resource.Stat {
-				delta := resource.Stat[id].GetDelta() // currently the process metrics are single socket
+			for id := range resource {
+				delta := resource[id].GetDelta() // currently the process metrics are single socket
 
 				// aggregate metrics per container
 				if config.IsExposeContainerStatsEnabled() {
@@ -266,8 +266,8 @@ func (c *Collector) handleInactiveVM(foundVM map[string]bool) {
 func (c *Collector) AggregateProcessEnergyUtilizationMetrics() {
 	for _, process := range c.ProcessStats {
 		for metricName, stat := range process.EnergyUsage {
-			for id := range stat.Stat {
-				delta := stat.Stat[id].GetDelta() // currently the process metrics are single socket
+			for id := range stat {
+				delta := stat[id].GetDelta() // currently the process metrics are single socket
 
 				// aggregate metrics per container
 				if config.IsExposeContainerStatsEnabled() {

--- a/pkg/collector/stats/node_stats.go
+++ b/pkg/collector/stats/node_stats.go
@@ -74,20 +74,20 @@ func (ne *NodeStats) CalcIdleEnergy(absM, idleM, resouceUtil string) {
 	newTotalResUtilization := ne.ResourceUsage[resouceUtil].SumAllDeltaValues()
 	currIdleTotalResUtilization := ne.IdleResUtilization[resouceUtil]
 
-	for socketID := range ne.EnergyUsage[absM].Stat {
-		newIdleDelta := ne.EnergyUsage[absM].Stat[socketID].Delta
+	for socketID, value := range ne.EnergyUsage[absM] {
+		newIdleDelta := value.GetDelta()
 		if newIdleDelta == 0 {
 			// during the first power collection iterations, the delta values could be 0, so we skip until there are delta values
 			continue
 		}
 
 		// add any value if there is no idle power yet
-		if _, exist := ne.EnergyUsage[idleM].Stat[socketID]; !exist {
+		if _, exist := ne.EnergyUsage[idleM][socketID]; !exist {
 			ne.EnergyUsage[idleM].SetDeltaStat(socketID, newIdleDelta)
 			// store the curret CPU utilization to find a new idle power later
 			ne.IdleResUtilization[resouceUtil] = newTotalResUtilization
 		} else {
-			currIdleDelta := ne.EnergyUsage[idleM].Stat[socketID].Delta
+			currIdleDelta := ne.EnergyUsage[idleM][socketID].GetDelta()
 			// verify if there is a new minimal energy consumption for the given resource
 			// TODO: fix verifying the aggregated resource utilization from all sockets, the update the energy per socket can lead to inconsitency
 			if (newTotalResUtilization <= currIdleTotalResUtilization) || (currIdleDelta == 0) {

--- a/pkg/collector/stats/node_stats_test.go
+++ b/pkg/collector/stats/node_stats_test.go
@@ -35,16 +35,16 @@ var _ = Describe("Test Node Metric", func() {
 		processMetrics = CreateMockedProcessStats(2)
 		nodeMetrics = CreateMockedNodeStats()
 		for _, pMetric := range processMetrics {
-			val := pMetric.ResourceUsage[config.CPUCycle].Stat[MockedSocketID].GetDelta()
+			val := pMetric.ResourceUsage[config.CPUCycle][MockedSocketID].GetDelta()
 			nodeMetrics.ResourceUsage[config.CPUCycle].AddDeltaStat(MockedSocketID, val)
 
-			val = pMetric.ResourceUsage[config.CPUInstruction].Stat[MockedSocketID].GetDelta()
+			val = pMetric.ResourceUsage[config.CPUInstruction][MockedSocketID].GetDelta()
 			nodeMetrics.ResourceUsage[config.CPUInstruction].AddDeltaStat(MockedSocketID, val)
 
-			val = pMetric.ResourceUsage[config.CacheMiss].Stat[MockedSocketID].GetDelta()
+			val = pMetric.ResourceUsage[config.CacheMiss][MockedSocketID].GetDelta()
 			nodeMetrics.ResourceUsage[config.CacheMiss].AddDeltaStat(MockedSocketID, val)
 
-			val = pMetric.ResourceUsage[config.CPUTime].Stat[MockedSocketID].GetDelta()
+			val = pMetric.ResourceUsage[config.CPUTime][MockedSocketID].GetDelta()
 			nodeMetrics.ResourceUsage[config.CPUTime].AddDeltaStat(MockedSocketID, val)
 		}
 	})
@@ -52,7 +52,7 @@ var _ = Describe("Test Node Metric", func() {
 	It("Test nodeMetrics ResourceUsage", func() {
 		v, ok := nodeMetrics.ResourceUsage[config.CPUCycle]
 		Expect(ok).To(Equal(true))
-		Expect(v.Stat[MockedSocketID].GetDelta()).To(Equal(uint64(60000)))
+		Expect(v[MockedSocketID].GetDelta()).To(Equal(uint64(60000)))
 	})
 
 	It("test SetNodeGPUEnergy", func() {

--- a/pkg/collector/stats/types/benchmark_test.go
+++ b/pkg/collector/stats/types/benchmark_test.go
@@ -28,9 +28,7 @@ var seededRand *rand.Rand = rand.New(
 
 // SetAggrStat
 func BenchmarkUInt64StatCollectionSetAggrStatMissed(b *testing.B) {
-	instance := types.UInt64StatCollection{
-		Stat: make(map[string]*types.UInt64Stat),
-	}
+	instance := make(types.UInt64StatCollection)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -42,9 +40,7 @@ func BenchmarkUInt64StatCollectionSetAggrStatMissed(b *testing.B) {
 }
 
 func BenchmarkUInt64StatCollectionSetAggrStatBothRandom(b *testing.B) {
-	instance := types.UInt64StatCollection{
-		Stat: make(map[string]*types.UInt64Stat),
-	}
+	instance := make(types.UInt64StatCollection)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -56,9 +52,7 @@ func BenchmarkUInt64StatCollectionSetAggrStatBothRandom(b *testing.B) {
 }
 
 func BenchmarkUInt64StatCollectionSetAggrStatCachedRandomNumber(b *testing.B) {
-	instance := types.UInt64StatCollection{
-		Stat: make(map[string]*types.UInt64Stat),
-	}
+	instance := make(types.UInt64StatCollection)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -68,9 +62,7 @@ func BenchmarkUInt64StatCollectionSetAggrStatCachedRandomNumber(b *testing.B) {
 }
 
 func BenchmarkUInt64StatCollectionSetAggrStatCached(b *testing.B) {
-	instance := types.UInt64StatCollection{
-		Stat: make(map[string]*types.UInt64Stat),
-	}
+	instance := make(types.UInt64StatCollection)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -81,9 +73,7 @@ func BenchmarkUInt64StatCollectionSetAggrStatCached(b *testing.B) {
 
 // AddDeltaStat
 func BenchmarkUInt64StatCollectionAddDeltaStatMissed(b *testing.B) {
-	instance := types.UInt64StatCollection{
-		Stat: make(map[string]*types.UInt64Stat),
-	}
+	instance := make(types.UInt64StatCollection)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -95,9 +85,7 @@ func BenchmarkUInt64StatCollectionAddDeltaStatMissed(b *testing.B) {
 }
 
 func BenchmarkUInt64StatCollectionAddDeltaStatBothRandom(b *testing.B) {
-	instance := types.UInt64StatCollection{
-		Stat: make(map[string]*types.UInt64Stat),
-	}
+	instance := make(types.UInt64StatCollection)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -109,9 +97,7 @@ func BenchmarkUInt64StatCollectionAddDeltaStatBothRandom(b *testing.B) {
 }
 
 func BenchmarkUInt64StatCollectionAddDeltaStatCachedRandomNumber(b *testing.B) {
-	instance := types.UInt64StatCollection{
-		Stat: make(map[string]*types.UInt64Stat),
-	}
+	instance := make(types.UInt64StatCollection)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,9 +107,7 @@ func BenchmarkUInt64StatCollectionAddDeltaStatCachedRandomNumber(b *testing.B) {
 }
 
 func BenchmarkUInt64StatCollectionAddDeltaStatCached(b *testing.B) {
-	instance := types.UInt64StatCollection{
-		Stat: make(map[string]*types.UInt64Stat),
-	}
+	instance := make(types.UInt64StatCollection)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -134,9 +118,7 @@ func BenchmarkUInt64StatCollectionAddDeltaStatCached(b *testing.B) {
 
 // SetDeltaStat
 func BenchmarkUInt64StatCollectionSetDeltaStatMissed(b *testing.B) {
-	instance := types.UInt64StatCollection{
-		Stat: make(map[string]*types.UInt64Stat),
-	}
+	instance := make(types.UInt64StatCollection)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -148,9 +130,7 @@ func BenchmarkUInt64StatCollectionSetDeltaStatMissed(b *testing.B) {
 }
 
 func BenchmarkUInt64StatCollectionSetDeltaStatBothRandom(b *testing.B) {
-	instance := types.UInt64StatCollection{
-		Stat: make(map[string]*types.UInt64Stat),
-	}
+	instance := make(types.UInt64StatCollection)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -162,9 +142,7 @@ func BenchmarkUInt64StatCollectionSetDeltaStatBothRandom(b *testing.B) {
 }
 
 func BenchmarkUInt64StatCollectionSetDeltaStatCachedRandomNumber(b *testing.B) {
-	instance := types.UInt64StatCollection{
-		Stat: make(map[string]*types.UInt64Stat),
-	}
+	instance := make(types.UInt64StatCollection)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -174,9 +152,7 @@ func BenchmarkUInt64StatCollectionSetDeltaStatCachedRandomNumber(b *testing.B) {
 }
 
 func BenchmarkUInt64StatCollectionSetDeltaStatCached(b *testing.B) {
-	instance := types.UInt64StatCollection{
-		Stat: make(map[string]*types.UInt64Stat),
-	}
+	instance := make(types.UInt64StatCollection)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -54,7 +54,7 @@ func New(bpfExporter bpf.Exporter) *CollectorManager {
 	// configure the watcher
 	manager.Watcher = kubernetes.NewObjListWatcher(supportedMetrics)
 	manager.Watcher.Mx = &manager.PrometheusCollector.Mx
-	manager.Watcher.ContainerStats = &manager.StatsCollector.ContainerStats
+	manager.Watcher.ContainerStats = manager.StatsCollector.ContainerStats
 	manager.Watcher.Run()
 	return manager
 }

--- a/pkg/metrics/prometheus_collector.go
+++ b/pkg/metrics/prometheus_collector.go
@@ -83,31 +83,31 @@ func GetRegistry() *prometheus.Registry {
 }
 
 func (e *PrometheusExporter) RegisterMetrics() *prometheus.Registry {
-	registry := GetRegistry()
+	r := GetRegistry()
 
 	if config.IsExposeProcessStatsEnabled() {
-		registry.MustRegister(e.ProcessStatsCollector)
+		r.MustRegister(e.ProcessStatsCollector)
 		klog.Infoln("Registered Process Prometheus metrics")
 	}
 
 	if config.IsExposeContainerStatsEnabled() {
-		registry.MustRegister(e.ContainerStatsCollector)
+		r.MustRegister(e.ContainerStatsCollector)
 		klog.Infoln("Registered Container Prometheus metrics")
 	}
 
 	if config.IsExposeVMStatsEnabled() {
-		registry.MustRegister(e.VMStatsCollector)
+		r.MustRegister(e.VMStatsCollector)
 		klog.Infoln("Registered VM Prometheus metrics")
 	}
 
-	registry.MustRegister(e.NodeStatsCollector)
+	r.MustRegister(e.NodeStatsCollector)
 	klog.Infoln("Registered Node Prometheus metrics")
 
 	// log prometheus errors
-	_, err := registry.Gather()
+	_, err := r.Gather()
 	if err != nil {
 		klog.Errorln(err)
 	}
 
-	return registry
+	return r
 }

--- a/pkg/metrics/utils/utils.go
+++ b/pkg/metrics/utils/utils.go
@@ -146,8 +146,8 @@ func collectEnergy(ch chan<- prometheus.Metric, instance interface{}, metricName
 	case *stats.NodeStats:
 		node := instance.(*stats.NodeStats)
 		if _, exist := node.EnergyUsage[metricName]; exist {
-			for deviceID, utilization := range node.EnergyUsage[metricName].Stat {
-				value = float64(utilization.Aggr) / JouleMillijouleConversionFactor
+			for deviceID, utilization := range node.EnergyUsage[metricName] {
+				value = float64(utilization.GetAggr()) / JouleMillijouleConversionFactor
 				labelValues = []string{deviceID, stats.NodeName, mode}
 				collect(ch, collector, value, labelValues)
 			}
@@ -173,8 +173,8 @@ func CollectResUtil(ch chan<- prometheus.Metric, instance interface{}, metricNam
 			}
 		}
 		if isGPUMetric {
-			for deviceID, utilization := range container.ResourceUsage[metricName].Stat {
-				value = float64(utilization.Aggr)
+			for deviceID, utilization := range container.ResourceUsage[metricName] {
+				value = float64(utilization.GetAggr())
 				labelValues = []string{container.ContainerID, container.PodName, container.ContainerName, container.Namespace, deviceID}
 				collect(ch, collector, value, labelValues)
 			}
@@ -204,8 +204,8 @@ func CollectResUtil(ch chan<- prometheus.Metric, instance interface{}, metricNam
 	case *stats.NodeStats:
 		node := instance.(*stats.NodeStats)
 		if _, exist := node.ResourceUsage[metricName]; exist {
-			for deviceID, utilization := range node.ResourceUsage[metricName].Stat {
-				value = float64(utilization.Aggr)
+			for deviceID, utilization := range node.ResourceUsage[metricName] {
+				value = float64(utilization.GetAggr())
 				labelValues = []string{deviceID, stats.NodeName}
 				collect(ch, collector, value, labelValues)
 			}

--- a/pkg/model/estimator/local/ratio_model_test.go
+++ b/pkg/model/estimator/local/ratio_model_test.go
@@ -38,19 +38,19 @@ var _ = Describe("Test Ratio Unit", func() {
 		Expect(nodeStats.EnergyUsage[config.DynEnergyInPlatform].SumAllDeltaValues()).Should(BeEquivalentTo(35000))
 
 		for _, pMetric := range processStats {
-			val := pMetric.ResourceUsage[config.CPUCycle].Stat[stats.MockedSocketID].GetDelta()
+			val := pMetric.ResourceUsage[config.CPUCycle][stats.MockedSocketID].GetDelta()
 			nodeStats.ResourceUsage[config.CPUCycle].AddDeltaStat(stats.MockedSocketID, val)
 
-			val = pMetric.ResourceUsage[config.CPUInstruction].Stat[stats.MockedSocketID].GetDelta()
+			val = pMetric.ResourceUsage[config.CPUInstruction][stats.MockedSocketID].GetDelta()
 			nodeStats.ResourceUsage[config.CPUInstruction].AddDeltaStat(stats.MockedSocketID, val)
 
-			val = pMetric.ResourceUsage[config.CacheMiss].Stat[stats.MockedSocketID].GetDelta()
+			val = pMetric.ResourceUsage[config.CacheMiss][stats.MockedSocketID].GetDelta()
 			nodeStats.ResourceUsage[config.CacheMiss].AddDeltaStat(stats.MockedSocketID, val)
 
-			val = pMetric.ResourceUsage[config.CPUTime].Stat[stats.MockedSocketID].GetDelta()
+			val = pMetric.ResourceUsage[config.CPUTime][stats.MockedSocketID].GetDelta()
 			nodeStats.ResourceUsage[config.CPUTime].AddDeltaStat(stats.MockedSocketID, val)
 		}
-		Expect(nodeStats.ResourceUsage[config.CoreUsageMetric].Stat[utils.GenericSocketID].GetDelta()).Should(BeEquivalentTo(90000))
+		Expect(nodeStats.ResourceUsage[config.CoreUsageMetric][utils.GenericSocketID].GetDelta()).Should(BeEquivalentTo(90000))
 
 		// The default estimator model is the ratio
 		model := RatioPowerModel{

--- a/pkg/model/process_energy_test.go
+++ b/pkg/model/process_energy_test.go
@@ -48,16 +48,16 @@ var _ = Describe("ProcessPower", func() {
 			processStats = stats.CreateMockedProcessStats(2)
 			nodeStats = stats.CreateMockedNodeStats()
 			for _, pMetric := range processStats {
-				val := pMetric.ResourceUsage[config.CPUCycle].Stat[stats.MockedSocketID].GetDelta()
+				val := pMetric.ResourceUsage[config.CPUCycle][stats.MockedSocketID].GetDelta()
 				nodeStats.ResourceUsage[config.CPUCycle].AddDeltaStat(stats.MockedSocketID, val)
 
-				val = pMetric.ResourceUsage[config.CPUInstruction].Stat[stats.MockedSocketID].GetDelta()
+				val = pMetric.ResourceUsage[config.CPUInstruction][stats.MockedSocketID].GetDelta()
 				nodeStats.ResourceUsage[config.CPUInstruction].AddDeltaStat(stats.MockedSocketID, val)
 
-				val = pMetric.ResourceUsage[config.CacheMiss].Stat[stats.MockedSocketID].GetDelta()
+				val = pMetric.ResourceUsage[config.CacheMiss][stats.MockedSocketID].GetDelta()
 				nodeStats.ResourceUsage[config.CacheMiss].AddDeltaStat(stats.MockedSocketID, val)
 
-				val = pMetric.ResourceUsage[config.CPUTime].Stat[stats.MockedSocketID].GetDelta()
+				val = pMetric.ResourceUsage[config.CPUTime][stats.MockedSocketID].GetDelta()
 				nodeStats.ResourceUsage[config.CPUTime].AddDeltaStat(stats.MockedSocketID, val)
 			}
 		})
@@ -96,7 +96,7 @@ var _ = Describe("ProcessPower", func() {
 			// So the node total CPU Instructions is 60000
 			// The process power will be (30000/60000)*11667 = 5834
 			// Then, the process energy will be 5834*3 = 17502 mJ
-			Expect(processStats[uint64(1)].EnergyUsage[config.DynEnergyInPkg].Stat[utils.GenericSocketID].GetDelta()).To(Equal(uint64(17502)))
+			Expect(processStats[uint64(1)].EnergyUsage[config.DynEnergyInPkg][utils.GenericSocketID].GetDelta()).To(Equal(uint64(17502)))
 		})
 
 		It("Get process power with Ratio power model and node platform power ", func() {
@@ -126,7 +126,7 @@ var _ = Describe("ProcessPower", func() {
 			// So the node total CPU Instructions is 60000
 			// The process power will be (30000/60000)*11667 = 5834
 			// Then, the process energy will be 5834*3 = 17502 mJ
-			Expect(processStats[uint64(1)].EnergyUsage[config.DynEnergyInPlatform].Stat[utils.GenericSocketID].GetDelta()).To(Equal(uint64(17502)))
+			Expect(processStats[uint64(1)].EnergyUsage[config.DynEnergyInPlatform][utils.GenericSocketID].GetDelta()).To(Equal(uint64(17502)))
 		})
 
 		// TODO: Get process power with no dependency and no node power.


### PR DESCRIPTION
This commit fixes a couple of small issues.
Firstly, in Go maps are reference types (like pointers) so
using *map[string]any for example isn't required.
Secondly, this removes the structure that backs
Uint64StatCollection and replaces it with a map.
Doing so make the code much easier to read (IMHO).

Finally, operations in Uint64Stat have been made
atomic to ensure correct operation if methods are
called from different threads. A test has been added
to verify this behaviour - this test fails when
run against the main branch.

There are some additional small fixes to address lint issues
that appear to have eluded our CI. Firstly the `dupl` threshold
has been moved to 150 to stop it complaining about Gingko-style
tests (which are very similar). Secondly the YAML for the `shadow`
has been fixed and issues with variable shadowing also fixed.

Below are the benchmark results vs. the implementaton in main.
``` console
$ benchstat ../main.txt ../uintflat.txt
goos: linux
goarch: amd64
pkg: github.com/sustainable-computing-io/kepler/pkg/collector/stats/types
cpu: AMD Ryzen 5 5600G with Radeon Graphics         
                                                      │ ../main.txt  │            ../uintflat.txt            │
                                                      │    sec/op    │    sec/op      vs base                │
UInt64StatCollectionSetAggrStatMissed-12                480.0n ± 20%    472.8n ± 17%        ~ (p=0.739 n=10)
UInt64StatCollectionSetAggrStatBothRandom-12            478.7n ±  2%    458.1n ±  3%   -4.28% (p=0.002 n=10)
UInt64StatCollectionSetAggrStatCachedRandomNumber-12    13.15n ±  1%    13.90n ±  0%   +5.71% (p=0.000 n=10)
UInt64StatCollectionSetAggrStatCached-12                5.301n ±  1%    5.609n ±  3%   +5.81% (p=0.000 n=10)
UInt64StatCollectionAddDeltaStatMissed-12               485.6n ±  3%    467.1n ±  8%        ~ (p=0.197 n=10)
UInt64StatCollectionAddDeltaStatBothRandom-12           478.2n ±  5%    400.8n ± 18%  -16.20% (p=0.009 n=10)
UInt64StatCollectionAddDeltaStatCachedRandomNumber-12   9.995n ±  1%   10.535n ±  1%   +5.40% (p=0.000 n=10)
UInt64StatCollectionAddDeltaStatCached-12               5.540n ±  1%    6.543n ±  1%  +18.09% (p=0.000 n=10)
UInt64StatCollectionSetDeltaStatMissed-12               487.8n ±  4%    473.0n ±  6%        ~ (p=0.165 n=10)
UInt64StatCollectionSetDeltaStatBothRandom-12           475.4n ±  3%    461.5n ±  3%   -2.91% (p=0.035 n=10)
UInt64StatCollectionSetDeltaStatCachedRandomNumber-12   10.26n ±  1%    10.79n ±  0%   +5.11% (p=0.000 n=10)
UInt64StatCollectionSetDeltaStatCached-12               5.785n ±  0%    6.792n ±  1%  +17.41% (p=0.000 n=10)
geomean                                                 61.34n          62.40n         +1.74%

                                                      │  ../main.txt  │           ../uintflat.txt            │
                                                      │     B/op      │    B/op      vs base                 │
UInt64StatCollectionSetAggrStatMissed-12                163.5 ± 33%     164.5 ± 33%       ~ (p=0.381 n=10)
UInt64StatCollectionSetAggrStatBothRandom-12            168.0 ±  1%     172.0 ±  2%  +2.38% (p=0.000 n=10)
UInt64StatCollectionSetAggrStatCachedRandomNumber-12    0.000 ±  0%     0.000 ±  0%       ~ (p=1.000 n=10) ¹
UInt64StatCollectionSetAggrStatCached-12                0.000 ±  0%     0.000 ±  0%       ~ (p=1.000 n=10) ¹
UInt64StatCollectionAddDeltaStatMissed-12               163.0 ±  2%     167.5 ±  4%  +2.76% (p=0.008 n=10)
UInt64StatCollectionAddDeltaStatBothRandom-12           168.0 ±  2%     110.0 ± 56%       ~ (p=0.493 n=10)
UInt64StatCollectionAddDeltaStatCachedRandomNumber-12   0.000 ±  0%     0.000 ±  0%       ~ (p=1.000 n=10) ¹
UInt64StatCollectionAddDeltaStatCached-12               0.000 ±  0%     0.000 ±  0%       ~ (p=1.000 n=10) ¹
UInt64StatCollectionSetDeltaStatMissed-12               164.0 ±  3%     167.0 ±  3%       ~ (p=0.098 n=10)
UInt64StatCollectionSetDeltaStatBothRandom-12           170.0 ±  1%     173.0 ±  1%  +1.76% (p=0.017 n=10)
UInt64StatCollectionSetDeltaStatCachedRandomNumber-12   0.000 ±  0%     0.000 ±  0%       ~ (p=1.000 n=10) ¹
UInt64StatCollectionSetDeltaStatCached-12               0.000 ±  0%     0.000 ±  0%       ~ (p=1.000 n=10) ¹
geomean                                                             ²                -2.72%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                      │ ../main.txt  │           ../uintflat.txt           │
                                                      │  allocs/op   │ allocs/op   vs base                 │
UInt64StatCollectionSetAggrStatMissed-12                2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=10) ¹
UInt64StatCollectionSetAggrStatBothRandom-12            2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=10) ¹
UInt64StatCollectionSetAggrStatCachedRandomNumber-12    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
UInt64StatCollectionSetAggrStatCached-12                0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
UInt64StatCollectionAddDeltaStatMissed-12               2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=10) ¹
UInt64StatCollectionAddDeltaStatBothRandom-12           2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=10) ¹
UInt64StatCollectionAddDeltaStatCachedRandomNumber-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
UInt64StatCollectionAddDeltaStatCached-12               0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
UInt64StatCollectionSetDeltaStatMissed-12               2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=10) ¹
UInt64StatCollectionSetDeltaStatBothRandom-12           2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=10) ¹
UInt64StatCollectionSetDeltaStatCachedRandomNumber-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
UInt64StatCollectionSetDeltaStatCached-12               0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                            ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

Note there is no significant performance difference between these 2 implementations.