### PR TITLE
fix: enhance sed command for uncomment operation in manifest script

### DIFF
--- a/hack/build-manifest.sh
+++ b/hack/build-manifest.sh
@@ -79,7 +79,7 @@ uncomment_path() {
 uncomment() {
 	regex="${1:?}"
 	file="${2:?}"
-	sed <"$file" "/^# .*${regex}.*/s/^# / /" >"${file}.tmp"
+	sed <"$file" "/^ *# .*${regex}.*/s/^ *#*/ /" >"${file}.tmp"
 	mv "${file}.tmp" "${file}"
 }
 


### PR DESCRIPTION
This PR refines the `sed` command in the `hack/build-manifest.sh` script