### PR TITLE
chore(validator): fix typings and python version

### DIFF
--- a/e2e/tools/validator/pyproject.toml
+++ b/e2e/tools/validator/pyproject.toml
@@ -28,9 +28,6 @@ dependencies = [
   "prometheus-api-client",
 	"pyyaml",
 	"numpy",
-	# "pydantic",
-	# "requests",
-	# "rich",
 ]
 
 [project.scripts]
@@ -40,10 +37,14 @@ validator = "validator.cli:validator"
 path = "src/validator/__about__.py"
 
 [tool.hatch.envs.default]
+python = "3.11" # latest supported python on RHEL-9
 dependencies = [
   "coverage[toml]>=6.5",
   "pytest",
+  "ipython",
+  "ipdb",
 ]
+
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"
@@ -60,11 +61,14 @@ cov = [
 python = ["3.11"]
 
 [tool.hatch.envs.types]
-dependencies = [
+extra-dependencies = [
   "mypy>=1.0.0",
 ]
 [tool.hatch.envs.types.scripts]
 check = "mypy --install-types --non-interactive {args:src/validator tests}"
+
+[tool.mypy]
+plugins = "numpy.typing.mypy_plugin"
 
 [tool.coverage.run]
 source_pkgs = ["validator", "tests"]

--- a/e2e/tools/validator/src/validator/prometheus/__init__.py
+++ b/e2e/tools/validator/src/validator/prometheus/__init__.py
@@ -85,6 +85,11 @@ class Result(NamedTuple):
 
 def mse(actual: npt.ArrayLike, expected: npt.ArrayLike) -> float:
     actual, expected = np.array(actual), np.array(expected)
+    if len(actual) != len(expected):
+        raise ValueError("actual and expected must have the same length")
+    elif len(actual) == 0 or len(expected) == 0:
+        raise ValueError("actual and expected must have non-zero length")
+
     return np.square(np.subtract(actual, expected)).mean()
 
 

--- a/e2e/tools/validator/src/validator/specs/__init__.py
+++ b/e2e/tools/validator/src/validator/specs/__init__.py
@@ -14,7 +14,7 @@ class SubprocessError(Exception):
 
 
 def parse_lscpu_output(output: str):
-    cpu_spec = {}
+    cpu_spec: dict[str, dict[str, str]] = {}
     cpu_spec["cpu"] = {}
     cpu_spec["cpu"]["model"] = ""
     cpu_spec["cpu"]["cores"] = ""


### PR DESCRIPTION
This pr fixes most of the issue raised by `hatch run types:check` 
It also 
* improves the coverage of both mse and mape functions which are modifies as a result of typings fix.
* sets python version to 3.11




