### PR TITLE
feat(metrics): selectively expose prom metrics to reduce overhead

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,6 +75,8 @@ var (
 	ExposeVMStats                = getBoolConfig("EXPOSE_VM_METRICS", true)
 	ExposeHardwareCounterMetrics = getBoolConfig("EXPOSE_HW_COUNTER_METRICS", true)
 	ExposeIRQCounterMetrics      = getBoolConfig("EXPOSE_IRQ_COUNTER_METRICS", true)
+	ExposeBPFMetrics             = getBoolConfig("EXPOSE_BPF_METRICS", true)
+	ExposeComponentPower         = getBoolConfig("EXPOSE_COMPONENT_POWER", true)
 	ExposeIdlePowerMetrics       = getBoolConfig("EXPOSE_ESTIMATED_IDLE_POWER_METRICS", false)
 	MockACPIPowerPath            = getConfig("MOCK_ACPI_POWER_PATH", "")
 
@@ -152,6 +154,8 @@ func logBoolConfigs() {
 		klog.V(5).Infof("ENABLE_PROCESS_METRICS: %t", EnableProcessStats)
 		klog.V(5).Infof("EXPOSE_HW_COUNTER_METRICS: %t", ExposeHardwareCounterMetrics)
 		klog.V(5).Infof("EXPOSE_IRQ_COUNTER_METRICS: %t", ExposeIRQCounterMetrics)
+		klog.V(5).Infof("EXPOSE_BPF_METRICS: %t", ExposeBPFMetrics)
+		klog.V(5).Infof("EXPOSE_COMPONENT_POWER: %t", ExposeComponentPower)
 		klog.V(5).Infof("EXPOSE_ESTIMATED_IDLE_POWER_METRICS: %t. This only impacts when the power is estimated using pre-prained models. Estimated idle power is meaningful only when Kepler is running on bare-metal or with a single virtual machine (VM) on the node.", ExposeIdlePowerMetrics)
 		klog.V(5).Infof("EXPERIMENTAL_BPF_SAMPLE_RATE: %d", BPFSampleRate)
 	}
@@ -332,6 +336,16 @@ func IsExposeVMStatsEnabled() bool {
 // IsExposeQATMetricsEnabled returns false if QATMetrics metrics are disabled to minimize overhead.
 func IsExposeQATMetricsEnabled() bool {
 	return EnabledQAT
+}
+
+// IsExposeBPFMetricsEnabled returns false if BPF Metrics metrics are disabled to minimize overhead.
+func IsExposeBPFMetricsEnabled() bool {
+	return ExposeBPFMetrics
+}
+
+// IsExposeComponentPowerEnabled returns false if component power metrics are disabled to minimize overhead.
+func IsExposeComponentPowerEnabled() bool {
+	return ExposeComponentPower
 }
 
 // SetEnabledGPU enables the exposure of gpu metrics

--- a/pkg/metrics/container/metrics.go
+++ b/pkg/metrics/container/metrics.go
@@ -97,26 +97,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 		utils.CollectEnergyMetrics(ch, container, c.collectors)
 		utils.CollectResUtilizationMetrics(ch, container, c.collectors, c.bpfSupportedMetrics)
 		// update container total joules
-		c.collectTotalEnergyMetrics(ch, container)
+		utils.CollectTotalEnergyMetrics(ch, container, c.collectors)
 	}
 	c.Mx.Unlock()
-}
-
-// We currently export a metric kepler_container_total_joules but this metric is the same as kepler_container_platform_joules. We might remote it in the future.
-func (c *collector) collectTotalEnergyMetrics(ch chan<- prometheus.Metric, container *stats.ContainerStats) {
-	energy := container.EnergyUsage[config.DynEnergyInPkg].SumAllAggrValues()
-	energy += container.EnergyUsage[config.DynEnergyInDRAM].SumAllAggrValues()
-	energy += container.EnergyUsage[config.DynEnergyInOther].SumAllAggrValues()
-	energy += container.EnergyUsage[config.DynEnergyInGPU].SumAllAggrValues()
-	energyInJoules := float64(energy) / utils.JouleMillijouleConversionFactor
-	labelValues := []string{container.ContainerID, container.PodName, container.ContainerName, container.Namespace, "dynamic"}
-	ch <- c.collectors["total"].MustMetric(energyInJoules, labelValues...)
-
-	energy = container.EnergyUsage[config.IdleEnergyInPkg].SumAllAggrValues()
-	energy += container.EnergyUsage[config.IdleEnergyInDRAM].SumAllAggrValues()
-	energy += container.EnergyUsage[config.IdleEnergyInOther].SumAllAggrValues()
-	energy += container.EnergyUsage[config.IdleEnergyInGPU].SumAllAggrValues()
-	energyInJoules = float64(energy) / utils.JouleMillijouleConversionFactor
-	labelValues = []string{container.ContainerID, container.PodName, container.ContainerName, container.Namespace, "idle"}
-	ch <- c.collectors["total"].MustMetric(energyInJoules, labelValues...)
 }

--- a/pkg/metrics/process/metrics.go
+++ b/pkg/metrics/process/metrics.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sustainable-computing-io/kepler/pkg/bpf"
 	"github.com/sustainable-computing-io/kepler/pkg/collector/stats"
 	"github.com/sustainable-computing-io/kepler/pkg/config"
+	"github.com/sustainable-computing-io/kepler/pkg/metrics/consts"
 	"github.com/sustainable-computing-io/kepler/pkg/metrics/metricfactory"
 	"github.com/sustainable-computing-io/kepler/pkg/metrics/utils"
 )
@@ -78,6 +79,9 @@ func (c *collector) initMetrics() {
 		c.descriptions[name] = desc
 		c.collectors[name] = metricfactory.NewPromCounter(desc)
 	}
+	desc := metricfactory.MetricsPromDesc(context, "joules", "_total", "", consts.ProcessEnergyLabels)
+	c.descriptions["total"] = desc
+	c.collectors["total"] = metricfactory.NewPromCounter(desc)
 }
 
 func (c *collector) Describe(ch chan<- *prometheus.Desc) {
@@ -91,6 +95,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 	for _, process := range c.ProcessStats {
 		utils.CollectEnergyMetrics(ch, process, c.collectors)
 		utils.CollectResUtilizationMetrics(ch, process, c.collectors, c.bpfSupportedMetrics)
+		utils.CollectTotalEnergyMetrics(ch, process, c.collectors)
 	}
 	c.Mx.Unlock()
 }

--- a/vendor/github.com/jaypipes/ghw/Dockerfile
+++ b/vendor/github.com/jaypipes/ghw/Dockerfile
@@ -16,7 +16,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 go build -o ghwc ./cmd/ghwc/
 
-FROM alpine:3
+FROM alpine:3.7
 RUN apk add --no-cache ethtool
 
 WORKDIR /bin


### PR DESCRIPTION
fix #1486 

When disabling component power and bpf metrics (i.e. `EXPOSE_COMPONENT_POWER="false" EXPOSE_BPF_METRICS="false" `), the number of metrics is reduced to 5% of what is before.