### PR TITLE
chore(collector): convert cpu time in collection time instead of metrics reporting time to avoid inconsistent use of cpu time in models

### DIFF
--- a/pkg/collector/resourceutilization/bpf/process_bpf_collector.go
+++ b/pkg/collector/resourceutilization/bpf/process_bpf_collector.go
@@ -39,7 +39,7 @@ func updateSWCounters(key uint64, ct *ProcessBPFMetrics, processStats map[uint64
 	for counterKey := range bpfSupportedMetrics.SoftwareCounters {
 		switch counterKey {
 		case config.CPUTime:
-			processStats[key].ResourceUsage[config.CPUTime].AddDeltaStat(utils.GenericSocketID, ct.ProcessRunTime)
+			processStats[key].ResourceUsage[config.CPUTime].AddDeltaStat(utils.GenericSocketID, ct.ProcessRunTime/1000 /* convert microseconds to miliseconds */)
 		case config.PageCacheHit:
 			processStats[key].ResourceUsage[config.PageCacheHit].AddDeltaStat(utils.GenericSocketID, ct.PageCacheHit/(1000*1000))
 		case config.IRQNetTXLabel:

--- a/pkg/metrics/utils/utils.go
+++ b/pkg/metrics/utils/utils.go
@@ -103,14 +103,6 @@ func collectEnergy(ch chan<- prometheus.Metric, instance interface{}, metricName
 	}
 }
 
-func convertUnit(metricName string, val uint64) float64 {
-	if metricName == config.CPUTime {
-		// convert microseconds to miliseconds
-		return float64(val) / 1000.0
-	}
-	return float64(val)
-}
-
 func CollectResUtil(ch chan<- prometheus.Metric, instance interface{}, metricName string, collector metricfactory.PromMetric) {
 	var value float64
 	var labelValues []string
@@ -127,7 +119,7 @@ func CollectResUtil(ch chan<- prometheus.Metric, instance interface{}, metricNam
 		}
 		if isGPUMetric {
 			for deviceID, utilization := range container.ResourceUsage[metricName].Stat {
-				value = convertUnit(metricName, utilization.Aggr)
+				value = float64(utilization.Aggr)
 				labelValues = []string{container.ContainerID, container.PodName, container.ContainerName, container.Namespace, deviceID}
 				collect(ch, collector, value, labelValues)
 			}
@@ -136,20 +128,20 @@ func CollectResUtil(ch chan<- prometheus.Metric, instance interface{}, metricNam
 				klog.Errorf("ContainerStats %s does not have metric %s\n", container.ContainerID, metricName)
 				return
 			}
-			value = convertUnit(metricName, container.ResourceUsage[metricName].SumAllAggrValues())
+			value = float64(container.ResourceUsage[metricName].SumAllAggrValues())
 			labelValues = []string{container.ContainerID, container.PodName, container.ContainerName, container.Namespace}
 			collect(ch, collector, value, labelValues)
 		}
 
 	case *stats.ProcessStats:
 		process := instance.(*stats.ProcessStats)
-		value = convertUnit(metricName, process.ResourceUsage[metricName].SumAllAggrValues())
+		value = float64(process.ResourceUsage[metricName].SumAllAggrValues())
 		labelValues = []string{strconv.FormatUint(process.PID, 10), process.ContainerID, process.VMID, process.Command}
 		collect(ch, collector, value, labelValues)
 
 	case *stats.VMStats:
 		vm := instance.(*stats.VMStats)
-		value = convertUnit(metricName, vm.ResourceUsage[metricName].SumAllAggrValues())
+		value = float64(vm.ResourceUsage[metricName].SumAllAggrValues())
 		labelValues = []string{vm.VMID}
 		collect(ch, collector, value, labelValues)
 
@@ -158,7 +150,7 @@ func CollectResUtil(ch chan<- prometheus.Metric, instance interface{}, metricNam
 		node := instance.(*stats.NodeStats)
 		if _, exist := node.ResourceUsage[metricName]; exist {
 			for deviceID, utilization := range node.ResourceUsage[metricName].Stat {
-				value = convertUnit(metricName, utilization.Aggr)
+				value = float64(utilization.Aggr)
 				labelValues = []string{deviceID, stats.NodeName}
 				collect(ch, collector, value, labelValues)
 			}


### PR DESCRIPTION
The bad MAPE results in latest code (as in contrast to 0.7.8) is related to the inconsistent usage of cpu time. The models trained using early 0.7 code uses [microsecond cpu time ](https://github.com/sustainable-computing-io/kepler/blob/release-0.7.8/bpfassets/libbpf/src/kepler.bpf.c#L68). #1481  [changed it](https://github.com/sustainable-computing-io/kepler/pull/1481/files#diff-0916c401e16b7d26ca96720a88f24fe4fa5117113d56e05b85b515c9b23cea73R109) and compensated the delta at metrics reporting time. This causes the model to use wrong CPU time.

I tested the fix on my env:
After the change:
```
kepler_node_core_joules_total{instance="rhel",mode="dynamic",package="0",source="trained_power_model"} 87.354
kepler_node_core_joules_total{instance="rhel",mode="idle",package="0",source="trained_power_model"} 1468.257
```

Before the change (aka main branch)
```
kepler_node_core_joules_total{instance="rhel",mode="dynamic",package="0",source="trained_power_model"} 96386.637
kepler_node_core_joules_total{instance="rhel",mode="idle",package="0",source="trained_power_model"} 1678.008
```