### PR TITLE
feat(ci): update workflow to enforce conventional commit message

### DIFF
--- a/.github/workflows/commitMsg.yml
+++ b/.github/workflows/commitMsg.yml
@@ -1,41 +1,16 @@
 name: Commit Message Check
 on: # yamllint disable-line rule:truthy
   pull_request:
-    types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
 
 jobs:
   check-commit-message:
     name: Check Commit Message
     runs-on: ubuntu-latest
     steps:
-      - name: Try to keep the subject line to 50 characters or less; do not exceed 72 characters
-        uses: gsactions/commit-message-checker@v2
+      - name: Check out source
+        uses: actions/checkout@v4.1.1
+
+      - name: Check commit message
+        uses: webiny/action-conventional-commits@v1.3.0
         with:
-          pattern: ^[^#].{72}
-          error: The maximum line length of 72 characters is exceeded.
-          excludeDescription: "true" # optional: this excludes the description body of a pull request
-          excludeTitle: "true" # optional: this excludes the title of a pull request
-      - name: Providing additional context if I am right means formatting in topic":" something
-        uses: gsactions/commit-message-checker@v2
-        with:
-          pattern: ^.*:\s.*
-          error: "topic: someting for example commit msg as [CI: enhancement xxx]"
-          excludeDescription: "true" # optional: this excludes the description body of a pull request
-          excludeTitle: "true" # optional: this excludes the title of a pull request
-      - name: The first word in the commit message subject should be capitalized unless it starts with a lowercase symbol or other identifier
-        uses: gsactions/commit-message-checker@v2
-        with:
-          pattern: ^[^].*
-          error: "topic: someting for example commit msg as [CI: enhancement xxx]"
-          excludeDescription: "true" # optional: this excludes the description body of a pull request
-          excludeTitle: "true" # optional: this excludes the title of a pull request
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit updates the existing `commitMsg.yml` workflow to enforce the use of conventional commit messages. It makes use of the [webiny/action-conventional-commits](https://github.com/webiny/action-conventional-commits) action to check the commit message and fail the workflow if it does not adhere to the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0-beta.2/) message format.

Address #1502