### PR TITLE
ci: Fix go lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,8 @@ linters-settings:
     local-prefixes: github.com/golangci/golangci-lint
 
   govet:
-    shadow: true
+    enable:
+      - shadow
     settings:
       printf:
         funcs:
@@ -86,9 +87,7 @@ run:
 
 issues:
   exclude-rules:
-    - linters:
-        - typecheck
-      text: could not import C
-    - linters:
-        - dupl
+    - linters: [dupl]
       text: .*pkg/collector/stats/types/types_test.go.* # false positive, https://github.com/mibk/dupl/issues/20
+    - text: 'shadow: declaration of "(err|ctx)" shadows declaration at' # yamllint disable-line rule:quoted-strings
+      linters: [govet]


### PR DESCRIPTION
This fixes the configuration to enable the go vet shadowing checks. It deliberately ignores the shadowing of err or ctx variables given this is a pattern that is widely used in Go code.