### PR TITLE
ci: Set gomod dependabot to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     directory: /
     schedule:
       day: monday
-      interval: daily
+      interval: weekly
     groups:
       go-dependencies:
         patterns:


### PR DESCRIPTION
This is supposed to check for updates weekly on a monday, not every day.