### PR TITLE
chore(validator) add statistical tests to validate mean and variance of metal and VM series

### DIFF
--- a/e2e/tools/validator/pyproject.toml
+++ b/e2e/tools/validator/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "prometheus-api-client",
 	"pyyaml",
 	"numpy",
+  "scipy",
 ]
 
 [project.scripts]

--- a/e2e/tools/validator/src/validator/cli/__init__.py
+++ b/e2e/tools/validator/src/validator/cli/__init__.py
@@ -263,10 +263,18 @@ def report_validation_results(
         )
         click.secho(f"\t    MSE : {res.mse}", fg="bright_blue")
         click.secho(f"\t    MAPE: {res.mape}\n", fg="bright_blue")
+        click.secho(f"\t    T-test stat: {res.statistical_tests.t_statistic}", fg="bright_blue")
+        click.secho(f"\t    T-test stat p-value: {res.statistical_tests.t_pvalue}", fg="bright_blue")
+        click.secho(f"\t    F-test stat: {res.statistical_tests.f_statistic}", fg="bright_blue")
+        click.secho(f"\t    F-test stat p-value: {res.statistical_tests.f_pvalue}", fg="bright_blue")
 
         report.h4("Errors")
         report.write(f"  * MSE: {res.mse}\n")
         report.write(f"  * MAPE: {res.mape}\n")
+        report.write(f"  * T-test stat: {res.statistical_tests.t_statistic}\n")
+        report.write(f"  * T-test stat p-value: {res.statistical_tests.t_pvalue}\n")
+        report.write(f"  * F-test stat: {res.statistical_tests.f_statistic}\n")
+        report.write(f"  * F-test stat p-value: {res.statistical_tests.f_pvalue}\n")
         report.flush()
 
         if v.max_mse is not None and res.mse.error is None and res.mse.value > v.max_mse:


### PR DESCRIPTION
Fix #1602 

Adding statistical interpretation

```
Run validations
         * platform - dynamic
            MSE : 872.1541182542771
            MAPE: 43.04445869956295

            T-test stat: 0.7041086654834455
            T-test stat p-value: 0.48762407214306247
            F-test stat: 10.38087732374898
            F-test stat p-value: 0.00015716270763959771
         * package - dynamic
            MSE : 781.389927979207
            MAPE: 60.97003704152708

            T-test stat: 0.8285697465466135
            T-test stat p-value: 0.41488969273665466
            F-test stat: 16.94518966753146
            F-test stat p-value: 9.580051883697835e-06
         * core - dynamic
            MSE : 775.9907361568557
            MAPE: 61.70581950350255

            T-test stat: 0.7857395825602487
            T-test stat p-value: 0.4391224734443857
            F-test stat: 16.890266963016636
            F-test stat p-value: 9.764507897096935e-06
         * dram - dynamic
            MSE : 77.46162243709281
            MAPE: 2340.973330677667

            T-test stat: -33.06874946455766
            T-test stat p-value: 8.956542385920854e-23
            F-test stat: 0.006102671427455077
            F-test stat p-value: 6.700890332425574e-12
         * platform - idle
            MSE : 31650.90055505202
            MAPE: 413.7372093023255

            T-test stat: -178491.06858734478
            T-test stat p-value: 1.103832805280083e-119
            F-test stat: 1.7517333714948787e+18
            F-test stat p-value: 4.6502110909734833e-116
         * package - idle
            MSE : 4576.748000672768
            MAPE: 2986.389052383182

            T-test stat: -1288363.1522943443
            T-test stat p-value: 5.2958582450876104e-142
            F-test stat: 7.721921087645168e+16
            F-test stat p-value: 3.018560304922754e-107
         * core - idle
            MSE : 4699.605212151874
            MAPE: 5028.3863080686715

            T-test stat: -2169304.633152514
            T-test stat p-value: 6.927840674286663e-148
            F-test stat: 2.796824648844493e+16
            F-test stat p-value: 2.221726734192115e-104
         * dram - idle
            MSE : 1963.78968008341
            MAPE: 1567.3661872200225

            T-test stat: -676180.0974293959
            T-test stat p-value: 1.0076508016052531e-134
            F-test stat: 1.7134085651308826e+17
            F-test stat p-value: 1.6979254693468652e-109
```

The idle power estimation doesn't show improvement, this is expected, as the idle power estimate is still under development
 