### PR TITLE
fix: Makefile for running on macOS

### DIFF
--- a/.github/workflows/developer_local.yml
+++ b/.github/workflows/developer_local.yml
@@ -9,6 +9,8 @@ jobs:
     strategy:
       matrix:
         kube_provider: [kind]
+    env:
+      CTR_CMD: docker
     steps:
       - uses: actions/checkout@v4.1.1
       - name: local cluster set up

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -11,6 +11,8 @@ env:
 jobs:
   build-kepler:
     runs-on: ubuntu-latest
+    env:
+      CTR_CMD: docker
     steps:
       # checkout source code
       - name: checkout source
@@ -29,7 +31,6 @@ jobs:
           IMAGE_REPO: localhost:5001
           IMAGE_NAME: kepler
           IMAGE_TAG: devel
-          CTR_CMD: docker
           IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}${{env.FILE_NAME}}
       # save kepler image
       - name: save Kepler image as artifact
@@ -48,6 +49,8 @@ jobs:
       fail-fast: false
       matrix:
         cluster_provider: [kind]
+    env:
+      CTR_CMD: docker
     steps:
       - name: checkout source
         uses: actions/checkout@v4.1.1
@@ -66,7 +69,6 @@ jobs:
           CLUSTER_PROVIDER: ${{matrix.cluster_provider}}
           IMAGE_REPO: localhost:5001
           IMAGE_TAG: devel
-          CTR_CMD: docker
 
       - name: import Kepler image
         run: make load-image
@@ -74,7 +76,6 @@ jobs:
           IMAGE_REPO: localhost:5001
           IMAGE_NAME: kepler
           IMAGE_TAG: devel
-          CTR_CMD: docker
           INPUT_PATH: ${{env.FILE_NAME}}
       # set up k8s cluster with ebpf
       - name: use Kepler action to deploy cluster
@@ -92,7 +93,6 @@ jobs:
           IMAGE_REPO: localhost:5001
           IMAGE_NAME: kepler
           IMAGE_TAG: devel
-          CTR_CMD: docker
 
       - name: deploy Kepler on cluster
         run: make cluster-deploy

--- a/.github/workflows/platform-validation.yml
+++ b/.github/workflows/platform-validation.yml
@@ -12,6 +12,8 @@ env:
 jobs:
   build-artifacts:
     runs-on: [self-hosted, linux, x64]
+    env:
+      CTR_CMD: docker
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
@@ -39,7 +41,6 @@ jobs:
           IMAGE_REPO: localhost:5001
           IMAGE_NAME: kepler
           IMAGE_TAG: platform-validation
-          CTR_CMD: docker
           IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}${{env.KEPLER_FILE_NAME}}
 
       - name: Save Kepler image as artifact
@@ -67,7 +68,6 @@ jobs:
           IMAGE_REPO: localhost:5001
           IMAGE_NAME: kepler-validator
           IMAGE_TAG: x86-rapl
-          CTR_CMD: docker
           IMAGE_OUTPUT_PATH: ${{env.OUTPUT_DIR}}${{env.VALIDATOR_FILE_NAME}}
 
       - name: Save kepler-validator test image as artifact
@@ -83,6 +83,8 @@ jobs:
     strategy:
       matrix:
         cluster_provider: [kind]
+    env:
+      CTR_CMD: docker
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
@@ -103,7 +105,6 @@ jobs:
           CLUSTER_PROVIDER: ${{matrix.cluster_provider}}
           IMAGE_REPO: localhost:5001
           IMAGE_TAG: platform-validation
-          CTR_CMD: docker
 
       - name: Import Kepler test image
         run: make load-image
@@ -111,7 +112,6 @@ jobs:
           IMAGE_REPO: localhost:5001
           IMAGE_NAME: kepler
           IMAGE_TAG: platform-validation
-          CTR_CMD: docker
           INPUT_PATH: ${{env.KEPLER_FILE_NAME}}
 
       - name: Import kepler-validator test image
@@ -120,7 +120,6 @@ jobs:
           IMAGE_REPO: localhost:5001
           IMAGE_NAME: kepler-validator
           IMAGE_TAG: x86-rapl
-          CTR_CMD: docker
           INPUT_PATH: ${{env.VALIDATOR_FILE_NAME}}
 
       - name: Get Node component power before deploy kind cluster
@@ -130,7 +129,6 @@ jobs:
           IMAGE_REPO: localhost:5001
           IMAGE_NAME: kepler-validator
           IMAGE_TAG: x86-rapl
-          CTR_CMD: docker
 
       - name: Use Kepler action to deploy cluster
         uses: sustainable-computing-io/kepler-action@v0.0.7
@@ -148,7 +146,6 @@ jobs:
           IMAGE_REPO: localhost:5001
           IMAGE_NAME: kepler
           IMAGE_TAG: platform-validation
-          CTR_CMD: docker
 
       - name: Push kepler-validator test image to local registry
         run: |
@@ -158,7 +155,6 @@ jobs:
           IMAGE_REPO: localhost:5001
           IMAGE_NAME: kepler-validator
           IMAGE_TAG: x86-rapl
-          CTR_CMD: docker
 
       - name: Get Node component power before deploy kepler
         run: |
@@ -167,7 +163,6 @@ jobs:
           IMAGE_REPO: localhost:5001
           IMAGE_NAME: kepler-validator
           IMAGE_TAG: x86-rapl
-          CTR_CMD: docker
 
       - name: Deploy Kepler on cluster
         run: make cluster-deploy
@@ -190,7 +185,6 @@ jobs:
           IMAGE_REPO: localhost:5001
           IMAGE_NAME: kepler-validator
           IMAGE_TAG: x86-rapl
-          CTR_CMD: docker
           kepler_address: localhost:9103
           prometheus_address: localhost:9091
 


### PR DESCRIPTION
A few fixes to more easily run Kepler in a KIND cluster when running make on a macOS system:

- Consistently indent using tabs
- Check for the presence of ldconfig to avoid errors
- export variables required by the cluster-* scripts
- deploy the serivcemonitors for prometheus by default