### PR TITLE
chore(compose): add scaphandre to dev compose

### DIFF
--- a/manifests/compose/dev/compose.yaml
+++ b/manifests/compose/dev/compose.yaml
@@ -60,3 +60,23 @@ services:
       - kepler-network
     cap_add:
       - ALL
+
+  scaphandre:
+    image: hubblo/scaphandre
+    privileged: true
+    ports:
+      - 8880:8080
+    volumes:
+      - type: bind
+        source: /proc
+        target: /proc
+      - type: bind
+        source: /sys/class/powercap
+        target: /sys/class/powercap
+    command: [prometheus]
+    networks:
+      - scaph-network
+
+networks:
+  scaph-network:
+  kepler-network:

--- a/manifests/compose/dev/grafana/dashboards/dev/dashboard.json
+++ b/manifests/compose/dev/grafana/dashboards/dev/dashboard.json
@@ -5225,26 +5225,16 @@
             ]
           },
           {
-            "__systemRef": "hideSeriesFrom",
             "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "dev: dynamic",
-                  "dev: idle"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
+              "id": "byRegexp",
+              "options": "/scaph.*/"
             },
             "properties": [
               {
-                "id": "custom.hideFrom",
+                "id": "color",
                 "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
+                  "fixedColor": "semi-dark-purple",
+                  "mode": "fixed"
                 }
               }
             ]
@@ -5285,6 +5275,19 @@
           "legendFormat": "{{job}}: {{mode}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PDE6745920139CE56"
+          },
+          "editorMode": "code",
+          "expr": "scaph_process_power_consumption_microwatts{pid=\"${process}\"} / 10^6\n",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "scaph - {{pid}}",
+          "range": true,
+          "refId": "B"
         }
       ],
       "type": "timeseries"
@@ -5944,7 +5947,32 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "dynamic"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 5,
@@ -6163,6 +6191,19 @@
           "legendFormat": "{{job}}: {{mode}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PDE6745920139CE56"
+          },
+          "editorMode": "code",
+          "expr": "scaph_process_power_consumption_microwatts{pid=\"${process}\"} / 10^6\n",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "scaph - {{pid}}",
+          "range": true,
+          "refId": "B"
         }
       ],
       "type": "timeseries"
@@ -6473,8 +6514,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -6654,8 +6694,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -6784,8 +6823,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "dark-red",
-                "value": null
+                "color": "dark-red"
               },
               {
                 "color": "semi-dark-red",
@@ -6912,8 +6950,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -6949,30 +6986,6 @@
                 "value": {
                   "fixedColor": "dark-blue",
                   "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "dev - bpf"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
                 }
               }
             ]
@@ -7064,8 +7077,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7178,8 +7190,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "dark-red",
-                "value": null
+                "color": "dark-red"
               },
               {
                 "color": "semi-dark-red",
@@ -7306,8 +7317,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7458,8 +7468,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7572,8 +7581,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "dark-red",
-                "value": null
+                "color": "dark-red"
               },
               {
                 "color": "semi-dark-red",
@@ -7700,8 +7708,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7852,8 +7859,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7966,8 +7972,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "dark-red",
-                "value": null
+                "color": "dark-red"
               },
               {
                 "color": "semi-dark-red",
@@ -8094,8 +8099,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -8246,8 +8250,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -8312,6 +8315,7 @@
       "type": "timeseries"
     }
   ],
+  "refresh": "",
   "schemaVersion": 39,
   "tags": [],
   "templating": {
@@ -8341,13 +8345,13 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "Latest vs Development",
-  "uid": "cdlr930lbpjwge",
-  "version": 9,
+  "uid": "ddr7l8fdlgw74c",
+  "version": 2,
   "weekStart": ""
 }

--- a/manifests/compose/dev/override.yaml
+++ b/manifests/compose/dev/override.yaml
@@ -13,3 +13,6 @@ services:
       - type: bind
         source: ./dev/prometheus/scrape-configs/dev.yaml
         target: /etc/prometheus/scrape-configs/dev.yaml
+
+    networks:
+      - scaph-network

--- a/manifests/compose/dev/prometheus/scrape-configs/dev.yaml
+++ b/manifests/compose/dev/prometheus/scrape-configs/dev.yaml
@@ -2,3 +2,7 @@ scrape_configs:
   - job_name: dev
     static_configs:
       - targets: [kepler-dev:8888]
+
+  - job_name: scaphandre
+    static_configs:
+      - targets: [scaphandre:8080]


### PR DESCRIPTION
This commit adds scaphandre to the dev compose so that power predication can be compared against it. Additionally grafana dashboards is updated to compare `process_package` power against scaphandre's process power consumption.