### PR TITLE
feat: Add mock-acpi validation to validator

### DIFF
--- a/e2e/tools/validator/acpi_validations.yaml
+++ b/e2e/tools/validator/acpi_validations.yaml
@@ -1,0 +1,12 @@
+validations:
+  - name: mock - node
+    actual: |
+      sum(
+        rate(
+          kepler_node_platform_joules_total{{
+            job="{metal_job_name}"
+          }}[{rate_interval}]
+        )
+      )
+    expected: |
+      mock_acpi_power1_average/10^6

--- a/e2e/tools/validator/src/validator/cli/options.py
+++ b/e2e/tools/validator/src/validator/cli/options.py
@@ -1,7 +1,7 @@
 import datetime
 
 import click
-from prometheus_api_client.utils import parse_datetime
+from prometheus_api_client.utils import parse_datetime, parse_timedelta
 
 
 class DateTime(click.ParamType):
@@ -24,3 +24,17 @@ class DateTime(click.ParamType):
             )
 
         return dt
+
+
+class Duration(click.ParamType):
+    name = "duration"
+
+    def convert(self, value, param, ctx):
+        td = parse_timedelta("now", value)
+        if not td:
+            self.self.fail(
+                "Expected duration format got " f"{value:r}",
+                param,
+                ctx,
+            )
+        return td

--- a/e2e/tools/validator/src/validator/specs/__init__.py
+++ b/e2e/tools/validator/src/validator/specs/__init__.py
@@ -77,6 +77,29 @@ def get_vm_dram_size(vm: Remote):
     return vm_dram_size
 
 
+class HostReporter:
+    def __init__(self, host: config.Metal) -> None:
+        self.host = host
+
+    def write(self, report: typing.TextIO) -> None:
+        host_cpu_spec = get_host_cpu_spec()
+        host_dram_size = get_host_dram_size()
+
+        # create section header for specs
+        report.write("## Specs\n")
+        report.write("### Host CPU Specs\n")
+        report.write("| Model | Cores | Threads | Sockets | Flags |\n")
+        report.write("|-----------|-----------|-------------|-------------|-----------|\n")
+        report.write(
+            f"| {host_cpu_spec['cpu']['model']} | {host_cpu_spec['cpu']['cores']} | {host_cpu_spec['cpu']['threads']} | {host_cpu_spec['cpu']['sockets']} | ```{host_cpu_spec['cpu']['flags']}``` |\n"
+        )
+        report.write("### Host DRAM Size\n")
+        report.write("| Size |\n")
+        report.write("|------|\n")
+        report.write(f"| {host_dram_size} |\n")
+        report.flush()
+
+
 class Reporter:
     def __init__(self, host: config.Metal, vm: config.Remote) -> None:
         self.host = host

--- a/e2e/tools/validator/validator.mock-acpi.yaml
+++ b/e2e/tools/validator/validator.mock-acpi.yaml
@@ -1,0 +1,23 @@
+log_level: warn # Logging level, defaults is warn
+
+# The below section is unused in mock-acpi validation, and is present only for config object to parse correctly
+remote:
+  host: 192.168.1.1 # IP address or hostname of the VM
+  port: 22 # SSH port, default is 22
+  username: user # SSH username
+  password: yourpassword # SSH password
+  pkey: ~/.ssh/id_rsa # Path to SSH private key
+
+metal:
+  vm:
+    pid: 123456 # Process ID for the KVM process running on metal
+
+prometheus:
+  job:
+    metal: dev
+
+  url: http://localhost:9090 # Prometheus server URL
+  rate_interval: 20s  # Rate interval for Promql, default is 20s, typically 4 x $scrape_interval
+  steps: 3s  # Step duration for Prometheus range queries
+
+validations_file: ./acpi_validations.yaml # Path to the validations file, default is ./validations.yaml

--- a/manifests/compose/mock-acpi/grafana/dashboards/mock-acpi/dashboard.json
+++ b/manifests/compose/mock-acpi/grafana/dashboards/mock-acpi/dashboard.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 7,
+  "id": 11,
   "links": [],
   "panels": [
     {
@@ -80,7 +80,32 @@
           },
           "unit": "MHz"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "{__name__=\"turbostat_cpu_freq\", core=\"-\", cpu=\"-\", instance=\"turbostat:8001\", job=\"turbostat\"}"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 13,
@@ -554,6 +579,79 @@
       "fieldConfig": {
         "defaults": {
           "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 5
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PDE6745920139CE56"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time( (\nabs((\nsum(mock_acpi_power1_average/10^6)\n - \nsum(rate(kepler_node_platform_joules_total{job=\"dev\"}[$__rate_interval]))\n)/sum(mock_acpi_power1_average/10^6)) * 100\n)[$__range:])",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "MAPE mock acpi vs node power",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PDE6745920139CE56"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
             "mode": "palette-classic"
           },
           "custom": {
@@ -609,8 +707,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
-        "x": 0,
+        "w": 12,
+        "x": 12,
         "y": 30
       },
       "id": 10,
@@ -703,7 +801,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -798,7 +897,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -852,13 +952,13 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "BM validation with mocked ACPI source",
-  "uid": "cdivvuyp5nqpsa",
-  "version": 5,
+  "uid": "bdr7pgiw7xblsf",
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
Updated validator to validate mock-acpi
Added MSE/MAPE for mock-acpi dashboard

Sample report:
```
  * Generating validate acpi report file and dir
	report: /tmp/report-v0.7.10-192-ge30ed57c.md
	results dir: /tmp/validator-v0.7.10-192-ge30ed57c

  * Build Info
    - kepler_exporter_build_info{goarch="amd64", goos="linux", goversion="go1.20.12", instance="kepler-latest:8888", job="latest", revision="unknown", tags="include_gcs,include_oss,containers_image_openpgp,gssapi,providerless,netgo,osusergo,libbpf,linux,gpu"}
    - kepler_exporter_build_info{arch="amd64", branch="validate-mock-acpi", instance="kepler-dev:8888", job="dev", os="linux", revision="4b426d675ecb300c2e5cd1d220c419d22532e34f", version="v0.7.10-191-g4b426d67-dirty"}

  * Generating spec report ...
  * Generating validation report
   - started at: 2024-07-22 11:11:12.276316
   - ended   at: 2024-07-22 11:41:12.274034
   - duration  : 0:29:59.997718

Run validations
	 * mock - node
	    MSE : 0.0003076234805329509
	    MAPE: 0.019475969657114952

Report Generated 
  time range: 2024-07-22 11:11:12.276316 - 2024-07-22 11:41:12.274034: (0:29:59.997718) 
  report: /tmp/report-v0.7.10-192-ge30ed57c.md 
  dir   : /tmp/validator-v0.7.10-192-ge30ed57c 

```