### PR TITLE
chore(Dockerfile): fix From instruction casing in Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.3.0 as builder
+FROM quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.3.0 AS builder
 ARG INSTALL_HABANA=false
 WORKDIR /workspace
 

--- a/build/Dockerfile.builder
+++ b/build/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
 
 USER 0
 

--- a/build/Dockerfile.kepler-validator
+++ b/build/Dockerfile.kepler-validator
@@ -1,4 +1,4 @@
-FROM quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.3.0 as builder
+FROM quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.3.0 AS builder
 
 WORKDIR /workspace
 COPY . .


### PR DESCRIPTION
This commit ensures that the FROM instruction in the Dockerfile is correctly formatted with consistent casing.
The casing is now consistent with the standard `FROM AS` syntax