### PR TITLE
fix: resolve pid 0 to system_processes

### DIFF
--- a/pkg/comm/resolve_comm.go
+++ b/pkg/comm/resolve_comm.go
@@ -7,10 +7,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/sustainable-computing-io/kepler/pkg/utils"
 	"golang.org/x/sys/unix"
 )
 
-const unknownComm = "unknown"
+const unknownComm = `unknown`
 
 type CommResolver struct {
 	cacheExist     map[int]string
@@ -35,6 +36,10 @@ func NewTestCommResolver(procFsResolver func(pid int) (string, error)) *CommReso
 }
 
 func (r *CommResolver) ResolveComm(pid int) (string, error) {
+	if pid == 0 {
+		return utils.SystemProcessName, nil
+	}
+
 	if comm, ok := r.cacheExist[pid]; ok {
 		return comm, nil
 	}


### PR DESCRIPTION
The resolves pid 0 to system_processes without (throwing) any error since there is no command associated with it. This commit fixes the following log

```
I0802 03:24:03.647656  733341 process_bpf_collector.go:100] failed to resolve comm for PID 0: process not running: stat /proc/0: no such file or directory, set comm=system_processes
I0802 03:24:03.648079  733341 process_bpf_collector.go:100] failed to resolve comm for PID 0: process not running, set comm=system_processes
I0802 03:24:03.648108  733341 process_bpf_collector.go:100] failed to resolve comm for PID 0: process not running, set comm=system_processes

```