### PR TITLE
chore: pre-commit updates

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on: # yamllint disable-line rule:truthy
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,7 @@ linters:
     - dupl
     - errcheck
     - goconst
+    - gochecknoglobals
     - gocritic
     - gocyclo
     - gofmt
@@ -60,27 +61,25 @@ linters:
     - whitespace
     - unused
     - asciicheck
+    - gocognit
+    - godot
+    - godox
+    - goerr113
+    - nestif
+    - prealloc
+    - testpackage
+    - revive
+    - wsl
+    - funlen
     # don't enable:
     # - lll
     # - dogsled
     # - gochecknoinits
     # - gomnd
-    # - unused
     # TODO: try to enable
     # - scopelint
-    # - gochecknoglobals
-    # - gocognit
-    # - godot
-    # - godox
-    # - goerr113
     # - interfacer
     # - maligned
-    # - nestif
-    # - prealloc
-    # - testpackage
-    # - revive
-    # - wsl
-    # - funlen
 
 run:
   timeout: 5m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,4 +31,10 @@ repos:
     rev: v1.59.1
     hooks:
       - id: golangci-lint
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.16.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ['@commitlint/config-conventional']
 exclude: ^vendor/.*|^_output/.*|^bpf/include/.*|^local-dev-cluster/.*

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -14,3 +14,4 @@ rules:
 ignore:
   - _output/*
   - vendor/*
+  - .pre-commit-config.yaml

--- a/e2e/tools/validator/README.md
+++ b/e2e/tools/validator/README.md
@@ -30,7 +30,8 @@ pip install .
 
 - Configure and Generate `validator.yaml` file
 
-  - Create the `validator.yaml` file based on the [validator.yaml.sample](validator.yaml.sample) template provided.
+  - Create the `validator.yaml` file based on the
+  [validator.yaml.sample](validator.yaml.sample) template provided.
   - Adjust the configuration according to your environment and requirements.
 
 - Run the validator

--- a/manifests/compose/validation/README.md
+++ b/manifests/compose/validation/README.md
@@ -32,7 +32,8 @@ target deploys the following
 
 ### Usage
 
-To allow access to the VM from the Prometheus container running on the host, `virt-net` must be created using the following command:
+To allow access to the VM from the Prometheus container running on the host,
+`virt-net` must be created using the following command:
 
 - Check the Virtual Bridge Interface:
 
@@ -44,7 +45,8 @@ To allow access to the VM from the Prometheus container running on the host, `vi
 
 - Create the Docker Network:
 
-Use the `inet` address from the previous step to create the Docker Network with `macvlan` driver. Replace `<subnet>` with appropriate value.
+Use the `inet` address from the previous step to create the Docker Network with
+`macvlan` driver. Replace `<subnet>` with appropriate value.
 
 ```sh
 docker network create --driver=macvlan --subnet=<subnet>/24 -o parent=virbr0 virt-net
@@ -52,7 +54,8 @@ docker network create --driver=macvlan --subnet=<subnet>/24 -o parent=virbr0 vir
 
 - Start the Services:
 
-Navigate to appropriate directory, set the `VM_IP` environment variable, and bring up the services:
+Navigate to appropriate directory, set the `VM_IP` environment variable, and bring
+up the services:
 
 ```sh
 cd manifests/compose/validation/metal

--- a/manifests/compose/validation/dockerfiles/Dockerfile.scaphandre
+++ b/manifests/compose/validation/dockerfiles/Dockerfile.scaphandre
@@ -3,4 +3,3 @@ FROM hubblo/scaphandre:latest
 
 # Install only curl
 RUN apt-get update && apt-get install -y curl
-


### PR DESCRIPTION
Add a workflow that runs the pre-commit jobs to
cover the case where a developer hasn't opted into pre-commit. Also add the conventional commit message hook and enable more golang linters. The commits also tidies up the markdown files that had line length
issues.