### PR TITLE
fix(pkg/bpf): Use channel to process events

### DIFF
--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -79,6 +79,7 @@ var (
 	apiserverEnabled             = flag.Bool("apiserver", true, "if apiserver is disabled, we collect pod information from kubelet")
 	redfishCredFilePath          = flag.String("redfish-cred-file-path", "", "path to the redfish credential file")
 	exposeEstimatedIdlePower     = flag.Bool("expose-estimated-idle-power", false, "estimated idle power is meaningful only if Kepler is running on bare-metal or when there is only one virtual machine on the node")
+	bpfDebugMetricsEnabled       = flag.Bool("bpf-debug-metrics", false, "whether to enable debug metrics for eBPF")
 )
 
 func healthProbe(w http.ResponseWriter, req *http.Request) {
@@ -150,6 +151,10 @@ func main() {
 		klog.Fatalf("failed to create eBPF exporter: %v", err)
 	}
 	defer bpfExporter.Detach()
+	if *bpfDebugMetricsEnabled {
+		bpfExporter.RegisterMetrics(registry)
+	}
+
 	stopCh := make(chan struct{})
 	bpfErrCh := make(chan error)
 	go func() {

--- a/pkg/bpf/test_utils.go
+++ b/pkg/bpf/test_utils.go
@@ -1,6 +1,7 @@
 package bpf
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sustainable-computing-io/kepler/pkg/config"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -68,3 +69,5 @@ func (m *mockExporter) CollectProcesses() (ProcessMetricsCollection, error) {
 		FreedPIDs: []int{0},
 	}, nil
 }
+
+func (m *mockExporter) RegisterMetrics(registry *prometheus.Registry) {}

--- a/pkg/bpf/types.go
+++ b/pkg/bpf/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package bpf
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -25,6 +26,7 @@ type Exporter interface {
 	Detach()
 	CollectProcesses() (ProcessMetricsCollection, error)
 	Start(<-chan struct{}) error
+	RegisterMetrics(registry *prometheus.Registry)
 }
 
 type ProcessMetrics struct {


### PR DESCRIPTION
Processing events in the same goroutine as the ring buffer reader requires acquiring a mutex, which blocks ringbuf event processing causing a backlog. To avoid this, send events via a buffered channel to a dedicated event processing goroutine to ensure that the ringbuf remains unblocked. This has decreased CPU load from 1-3% on my machine to 0-1% CPU load.

Additionally adds some metrics to track events read, events processed and the current depth of the events channel.

Updates: #1670, #1660 