### PR TITLE
fix(bpf): Fix overhead when sampling

### DIFF
--- a/bpf/kepler.bpf.h
+++ b/bpf/kepler.bpf.h
@@ -317,21 +317,27 @@ static inline int do_kepler_sched_switch_trace(
 
 	cpu_id = bpf_get_smp_processor_id();
 
-	// Collect metrics
-	// Regardless of skipping the collection, we need to update the hardware
-	// counter events to keep the metrics map current.
-	collect_metrics_and_reset_counters(&buf, prev_pid, curr_ts, cpu_id);
-
 	// Skip some samples to minimize overhead
-	// Note that we can only skip samples after updating the metric maps to
-	// collect the right values
 	if (SAMPLE_RATE > 0) {
 		if (counter_sched_switch > 0) {
+			// update hardware counters to be used when sample is taken
+			if (counter_sched_switch == 1) {
+				collect_metrics_and_reset_counters(
+					&buf, prev_pid, curr_ts, cpu_id);
+				// Add task on-cpu running start time
+				bpf_map_update_elem(
+					&pid_time_map, &next_pid, &curr_ts,
+					BPF_ANY);
+				// create new process metrics
+				register_new_process_if_not_exist(next_tgid);
+			}
 			counter_sched_switch--;
 			return 0;
 		}
 		counter_sched_switch = SAMPLE_RATE;
 	}
+
+	collect_metrics_and_reset_counters(&buf, prev_pid, curr_ts, cpu_id);
 
 	// The process_run_time is 0 if we do not have the previous timestamp of
 	// the task or due to a clock issue. In either case, we skip collecting


### PR DESCRIPTION
  Update the register counters one step before metrics sample is taken
  instead of updating registers every time which is increasing overhead

- with `EXPERIMENTAL_BPF_SAMPLE_RATE = 0`
```
[root@vimalkum-thinkpadp1gen4i ~]# bpftool prog show name kepler_sched_switch_trace | head -n 1 | awk '{print "rt_ns:", $(NF-2), "count: ", $NF, "avg: ", $(NF-2)/$NF } '
rt_ns: 301913885 count:  95144 avg:  3173.23

[root@vimalkum-thinkpadp1gen4i ~]# bpftool prog show name kepler_sched_switch_trace | head -n 1 | awk '{print "rt_ns:", $(NF-2), "count: ", $NF, "avg: ", $(NF-2)/$NF } '
rt_ns: 212656178 count:  68417 avg:  3108.24
```

- with `EXPERIMENTAL_BPF_SAMPLE_RATE = 1000`
```
[root@vimalkum-thinkpadp1gen4i ~]# bpftool prog show name kepler_sched_switch_trace | head -n 1 | awk '{print "rt_ns:", $(NF-2), "count: ", $NF, "avg: ", $(NF-2)/$NF } '
rt_ns: 33681094 count:  76518 avg:  440.172

[root@vimalkum-thinkpadp1gen4i ~]# bpftool prog show name kepler_sched_switch_trace | head -n 1 | awk '{print "rt_ns:", $(NF-2), "count: ", $NF, "avg: ", $(NF-2)/$NF } '
rt_ns: 45678100 count:  105344 avg:  433.609

```

Fixes: #1607 

Can you please try it @rootfs @dave-tucker 