### PR TITLE
ci: sign all image builds

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
       id-token: write
     strategy:
       fail-fast: false

--- a/.github/workflows/image_base.yml
+++ b/.github/workflows/image_base.yml
@@ -15,6 +15,9 @@ on: # yamllint disable-line rule:truthy
 jobs:
   baseimagebuild:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,6 +27,8 @@ jobs:
           image: tonistiigi/binfmt:qemu-v8.1.5
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Set up cosign
+        uses: sigstore/cosign-installer@main
       - name: Login to Quay
         if: ${{ inputs.pushImage }}
         uses: docker/login-action@v3
@@ -32,6 +37,7 @@ jobs:
           username: ${{ secrets.username }}
           password: ${{ secrets.password }}
       - name: Build and push a base image for building Kepler with libbpf
+        id: build-push-image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -39,3 +45,6 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/s390x
           push: ${{ inputs.pushImage }}
           tags: quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.3.0
+      - name: Sign images with GitHub OIDC token
+        run: |
+          cosign sign -y quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.3.0@${{ steps.build-push-image.outputs.digest }}

--- a/.github/workflows/image_pr.yml
+++ b/.github/workflows/image_pr.yml
@@ -11,6 +11,9 @@ on: # yamllint disable-line rule:truthy
 jobs:
   image_build_for_specific_commit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,6 +23,8 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Set up cosign
+        uses: sigstore/cosign-installer@main
       - name: Login to Quay
         uses: docker/login-action@v3
         with:
@@ -28,6 +33,7 @@ jobs:
           password: ${{ secrets.BOT_TOKEN }}
 
       - name: Build and push
+        id: build-push-image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -36,3 +42,7 @@ jobs:
           tags: quay.io/sustainable_computing_io/kepler
           labels: ${{ github.event.inputs.commitSHA }}
           file: build/Dockerfile.libbpf.kepler
+
+      - name: Sign images with GitHub OIDC token
+        run: |
+          cosign sign -y quay.io/sustainable_computing_io/kepler@${{ steps.build-push-image.outputs.digest }}


### PR DESCRIPTION
This builds on previous commit `9d567e5` to add cryptographic signing to two additional workflows: `image_pr.yml` and `image_base.yml`.  This resolves the issue with images only being intermittently signed.  It also reduces the scope of privileges on `image.yml` to only what is necessary for the OIDC token to be used.