### PR TITLE
fix(bpf): use prev_tgid to register process

### DIFF
--- a/bpf/kepler.bpf.h
+++ b/bpf/kepler.bpf.h
@@ -351,7 +351,7 @@ static inline int do_kepler_sched_switch_trace(
 	bpf_map_update_elem(&pid_time_map, &next_pid, &curr_ts, BPF_ANY);
 
 	// create new process metrics
-	register_new_process_if_not_exist(next_tgid);
+	register_new_process_if_not_exist(prev_tgid);
 
 	return 0;
 }


### PR DESCRIPTION
In release 7.11 `bpf_get_current_pid_tgid()` was used to get the `tgid` to register new process, which refers to the task being switched out. reverting it back to same behavior using `prev_tgid`.
