### PR TITLE
feat: add model_name attribute to ComponentModelWeights

### DIFF
--- a/pkg/model/estimator/local/regressor/model_weights.go
+++ b/pkg/model/estimator/local/regressor/model_weights.go
@@ -92,4 +92,11 @@ type NormalizedNumericalFeature struct {
 	Weight float64 `json:"weight,omitempty"`
 }
 
-type ComponentModelWeights map[string]ModelWeights
+type ComponentModelWeights struct {
+	ModelName string        `json:"model_name,omitempty"`
+	Platform  *ModelWeights `json:"platform,omitempty"`
+	Core      *ModelWeights `json:"core,omitempty"`
+	Uncore    *ModelWeights `json:"uncore,omitempty"`
+	Package   *ModelWeights `json:"package,omitempty"`
+	DRAM      *ModelWeights `json:"dram,omitempty"`
+}

--- a/pkg/model/estimator/local/regressor/regressor.go
+++ b/pkg/model/estimator/local/regressor/regressor.go
@@ -99,13 +99,41 @@ func (r *Regressor) Start() error {
 		r.enabled = true
 		r.modelWeight = weight
 		r.modelPredictors = map[string]Predictor{}
-		for component, allWeights := range *weight {
-			var predictor Predictor
-			predictor, err = r.createPredictor(allWeights)
-			if err != nil {
+		if weight.Platform != nil {
+			if predictor, err := r.createPredictor(*weight.Platform); err != nil {
 				return err
+			} else {
+				r.modelPredictors[config.PLATFORM] = predictor
 			}
-			r.modelPredictors[component] = predictor
+		} else {
+			if weight.Package != nil {
+				if predictor, err := r.createPredictor(*weight.Package); err != nil {
+					return err
+				} else {
+					r.modelPredictors[config.PKG] = predictor
+				}
+			}
+			if weight.Core != nil {
+				if predictor, err := r.createPredictor(*weight.Core); err != nil {
+					return err
+				} else {
+					r.modelPredictors[config.CORE] = predictor
+				}
+			}
+			if weight.Uncore != nil {
+				if predictor, err := r.createPredictor(*weight.Uncore); err != nil {
+					return err
+				} else {
+					r.modelPredictors[config.UNCORE] = predictor
+				}
+			}
+			if weight.DRAM != nil {
+				if predictor, err := r.createPredictor(*weight.DRAM); err != nil {
+					return err
+				} else {
+					r.modelPredictors[config.DRAM] = predictor
+				}
+			}
 		}
 		return nil
 	} else {
@@ -156,6 +184,9 @@ func (r *Regressor) getWeightFromServer() (*ComponentModelWeights, error) {
 	err = json.Unmarshal(body, &powerResonse)
 	if err != nil {
 		return nil, fmt.Errorf("model unmarshal error: %v (%s)", err, string(body))
+	}
+	if powerResonse.ModelName != "" {
+		klog.V(3).Infof("Using weights trained by %s", powerResonse.ModelName)
 	}
 	return &powerResonse, nil
 }

--- a/pkg/model/estimator/local/regressor/regressor_test.go
+++ b/pkg/model/estimator/local/regressor/regressor_test.go
@@ -70,19 +70,19 @@ var (
 
 func GenPlatformModelWeights(curveFitWeights []float64) ComponentModelWeights {
 	return ComponentModelWeights{
-		config.PLATFORM: genWeights(SampleCoreNumericalVars, curveFitWeights),
+		Platform: genWeights(SampleCoreNumericalVars, curveFitWeights),
 	}
 }
 
 func GenComponentModelWeights(curveFitWeights []float64) ComponentModelWeights {
 	return ComponentModelWeights{
-		config.CORE: genWeights(SampleCoreNumericalVars, curveFitWeights),
-		config.DRAM: genWeights(SampleDramNumbericalVars, curveFitWeights),
+		Core: genWeights(SampleCoreNumericalVars, curveFitWeights),
+		DRAM: genWeights(SampleDramNumbericalVars, curveFitWeights),
 	}
 }
 
-func genWeights(numericalVars map[string]NormalizedNumericalFeature, curveFitWeights []float64) ModelWeights {
-	return ModelWeights{
+func genWeights(numericalVars map[string]NormalizedNumericalFeature, curveFitWeights []float64) *ModelWeights {
+	return &ModelWeights{
 		AllWeights{
 			BiasWeight:           1.0,
 			CategoricalVariables: map[string]map[string]CategoricalFeature{"cpu_architecture": SampleCategoricalFeatures},

--- a/pkg/sensors/platform/source/redfish.go
+++ b/pkg/sensors/platform/source/redfish.go
@@ -270,7 +270,7 @@ func (rf *RedFishClient) IsSystemCollectionSupported() bool {
 			}
 		}
 	}()
-	return rf.systems != nil && len(rf.systems) > 0
+	return len(rf.systems) > 0
 }
 
 // GetAbsEnergyFromPlatform returns the power consumption in Watt


### PR DESCRIPTION
For updating model selection logic, I would like to add more information on the model weight file started with the model_name in PR https://github.com/sustainable-computing-io/kepler-model-server/pull/370. 

This PR update the ComponentModelWeights in Kepler in order to unmarshal the new weight file. 
The new structure is also support the old version of weight file.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>