### PR TITLE
fix: format ComponentModelWeights

### DIFF
--- a/pkg/model/estimator/local/regressor/model_weights.go
+++ b/pkg/model/estimator/local/regressor/model_weights.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package regressor
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	errModelWeightsInvalid = errors.New("ModelWeights is invalid")
@@ -99,4 +102,11 @@ type ComponentModelWeights struct {
 	Uncore    *ModelWeights `json:"uncore,omitempty"`
 	Package   *ModelWeights `json:"package,omitempty"`
 	DRAM      *ModelWeights `json:"dram,omitempty"`
+}
+
+func (w ComponentModelWeights) String() string {
+	if w.Platform != nil {
+		return fmt.Sprintf("%s (platform: %v)", w.ModelName, w.Platform)
+	}
+	return fmt.Sprintf("%s (package: %v (core: %v, uncore: %v), dram: %v)", w.ModelName, w.Package, w.Core, w.Uncore, w.DRAM)
 }


### PR DESCRIPTION
Fix formatting for previous PR.

Due to the change in https://github.com/sustainable-computing-io/kepler/pull/1699, the print format is replaced with object reference. 

```
I0819 06:05:57.796020    2574 regressor.go:91] Regression Model (AbsPower): getWeightFromServer: &{ <nil> 0xc0021fe060 0xc0021fe210 0xc0021fe180 0xc0021fe0f0} (error: <nil>)
```

This also affects the CI in kepler-model-server that checks for `core` word inside the weight log.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>