### PR TITLE
chore: move model_weights to its own directory

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -56,8 +56,5 @@ RUN mkdir -p /var/lib/kepler/data
 COPY --from=builder /workspace/data/cpus.yaml /var/lib/kepler/data/cpus.yaml
 
 # copy model weight
-COPY --from=builder /workspace/data/model_weight/acpi_AbsPowerModel.json /var/lib/kepler/data/acpi_AbsPowerModel.json
-COPY --from=builder /workspace/data/model_weight/acpi_DynPowerModel.json /var/lib/kepler/data/acpi_DynPowerModel.json
-COPY --from=builder /workspace/data/model_weight/intel_rapl_AbsPowerModel.json /var/lib/kepler/data/intel_rapl_AbsPowerModel.json
-COPY --from=builder /workspace/data/model_weight/intel_rapl_DynPowerModel.json /var/lib/kepler/data/intel_rapl_DynPowerModel.json
+COPY --from=builder /workspace/data/model_weight /var/lib/kepler/data/model_weight
 ENTRYPOINT ["/usr/bin/kepler"]

--- a/doc/dev/prepare_dev_env.sh
+++ b/doc/dev/prepare_dev_env.sh
@@ -7,8 +7,8 @@ mkdir -p ${DATAPATH}
 
 cp ../data/cpus.yaml ${DATAPATH}
 
-mkdir -p /var/lib/kepler/data/
-cp ../data/model_weight/acpi_AbsPowerModel.json ${DATAPATH}/acpi_AbsPowerModel.json
-cp ../data/model_weight/acpi_DynPowerModel.json ${DATAPATH}/acpi_DynPowerModel.json
-cp ../data/model_weight/intel_rapl_AbsPowerModel.json ${DATAPATH}/intel_rapl_AbsPowerModel.json
-cp ../data/model_weight/intel_rapl_DynPowerModel.json ${DATAPATH}/intel_rapl_DynPowerModel.json
+mkdir -p /var/lib/kepler/data/model_weight
+cp ../data/model_weight/acpi_AbsPowerModel.json ${DATAPATH}/model_weight/acpi_AbsPowerModel.json
+cp ../data/model_weight/acpi_DynPowerModel.json ${DATAPATH}/model_weight/acpi_DynPowerModel.json
+cp ../data/model_weight/intel_rapl_AbsPowerModel.json ${DATAPATH}/model_weight/intel_rapl_AbsPowerModel.json
+cp ../data/model_weight/intel_rapl_DynPowerModel.json ${DATAPATH}/model_weight/intel_rapl_DynPowerModel.json

--- a/manifests/compose/dev/compose.yaml
+++ b/manifests/compose/dev/compose.yaml
@@ -34,11 +34,8 @@ services:
 
       # NOTE: use the weights from the local repo
       - type: bind
-        source: ../../../data/model_weight/
+        source: ../../../data
         target: /var/lib/kepler/data
-      - type: bind
-        source: ../../../data/cpus.yaml
-        target: /var/lib/kepler/data/cpus.yaml
 
     entrypoint: [/usr/bin/bash, -c]
 

--- a/manifests/compose/mock-acpi/compose.yaml
+++ b/manifests/compose/mock-acpi/compose.yaml
@@ -36,11 +36,9 @@ services:
 
       # NOTE: use the weights from the local repo
       - type: bind
-        source: ../../../data/model_weight/
+        source: ../../../data
         target: /var/lib/kepler/data
-      - type: bind
-        source: ../../../data/cpus.yaml
-        target: /var/lib/kepler/data/cpus.yaml
+
       - mock-acpi:/var/mock-acpi:z
 
     entrypoint: [/usr/bin/bash, -c]

--- a/manifests/compose/validation/metal/compose.yaml
+++ b/manifests/compose/validation/metal/compose.yaml
@@ -34,11 +34,8 @@ services:
 
       # NOTE: use the weights from the local repo
       - type: bind
-        source: ../../../../data/model_weight/
+        source: ../../../../data
         target: /var/lib/kepler/data
-      - type: bind
-        source: ../../../../data/cpus.yaml
-        target: /var/lib/kepler/data/cpus.yaml
 
     entrypoint: [/usr/bin/bash, -c]
 

--- a/manifests/compose/validation/vm/compose.yaml
+++ b/manifests/compose/validation/vm/compose.yaml
@@ -22,11 +22,8 @@ services:
 
       # NOTE: use the models from the local repo
       - type: bind
-        source: ../../../../data/model_weight/
+        source: ../../../../data
         target: /var/lib/kepler/data
-      - type: bind
-        source: ../../../../data/cpus.yaml
-        target: /var/lib/kepler/data/cpus.yaml
 
         # NOTE: for estimator - kepler communication
       - kepler-tmp:/tmp

--- a/packaging/rpm/kepler.spec
+++ b/packaging/rpm/kepler.spec
@@ -60,10 +60,10 @@ install -p -m755 ./_output/kepler  %{buildroot}%{_bindir}/kepler
 install -p -m644 ./packaging/rpm/kepler.service %{buildroot}%{_unitdir}/kepler.service
 install -p -m644 ./_output/ENABLE_PROCESS_METRICS %{buildroot}/etc/kepler/kepler.config/ENABLE_PROCESS_METRICS
 install -p -m644 ./data/cpus.yaml %{buildroot}/var/lib/kepler/data/cpus.yaml
-install -p -m644 ./data/model_weight/acpi_AbsPowerModel.json %{buildroot}/var/lib/kepler/data/acpi_AbsPowerModel.json
-install -p -m644 ./data/model_weight/acpi_DynPowerModel.json %{buildroot}/var/lib/kepler/data/acpi_DynPowerModel.json
-install -p -m644 ./data/model_weight/intel_rapl_AbsPowerModel.json %{buildroot}/var/lib/kepler/data/intel_rapl_AbsPowerModel.json
-install -p -m644 ./data/model_weight/intel_rapl_DynPowerModel.json %{buildroot}/var/lib/kepler/data/intel_rapl_DynPowerModel.json
+install -p -m644 ./data/model_weight/acpi_AbsPowerModel.json %{buildroot}/var/lib/kepler/data/model_weight/acpi_AbsPowerModel.json
+install -p -m644 ./data/model_weight/acpi_DynPowerModel.json %{buildroot}/var/lib/kepler/data/model_weight/acpi_DynPowerModel.json
+install -p -m644 ./data/model_weight/intel_rapl_AbsPowerModel.json %{buildroot}/var/lib/kepler/data/model_weight/intel_rapl_AbsPowerModel.json
+install -p -m644 ./data/model_weight/intel_rapl_DynPowerModel.json %{buildroot}/var/lib/kepler/data/model_weight/intel_rapl_DynPowerModel.json
 
 %post
 
@@ -74,10 +74,10 @@ install -p -m644 ./data/model_weight/intel_rapl_DynPowerModel.json %{buildroot}/
 %{_bindir}/kepler
 %{_unitdir}/kepler.service
 /var/lib/kepler/data/cpus.yaml
-/var/lib/kepler/data/acpi_AbsPowerModel.json
-/var/lib/kepler/data/acpi_DynPowerModel.json
-/var/lib/kepler/data/intel_rapl_AbsPowerModel.json
-/var/lib/kepler/data/intel_rapl_DynPowerModel.json
+/var/lib/kepler/data/model_weight/acpi_AbsPowerModel.json
+/var/lib/kepler/data/model_weight/acpi_DynPowerModel.json
+/var/lib/kepler/data/model_weight/intel_rapl_AbsPowerModel.json
+/var/lib/kepler/data/model_weight/intel_rapl_DynPowerModel.json
 /etc/kepler/kepler.config/ENABLE_PROCESS_METRICS
 
 %changelog

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -142,9 +142,9 @@ var (
 )
 
 // return local path to power model weight
-// e.g., /var/lib/kepler/data/acpi_AbsPowerModel.json
+// e.g., /var/lib/kepler/data/model_weight/acpi_AbsPowerModel.json
 func GetDefaultPowerModelURL(modelOutputType, energySource string) string {
-	return fmt.Sprintf("/var/lib/kepler/data/%s_%sModel.json", energySource, modelOutputType)
+	return fmt.Sprintf(`/var/lib/kepler/data/model_weight/%s_%sModel.json`, energySource, modelOutputType)
 }
 
 func logBoolConfigs() {


### PR DESCRIPTION
This commit moves model_weights from/var/lib/kepler/data/ to its own directory - var/lib/kepler/data/model_weights/ this allows additional data like machine-spec to be stored its own directory.

Additionally this change fixes the blank cpu.yaml that gets created when running compose files. Previously the VM compose  used to blank `cpu.yaml` file instead of the one in `data/`