### PR TITLE
fix(ci): ensure proper status reporting for mock-acpi workflow

### DIFF
--- a/.github/workflows/mock_acpi.yml
+++ b/.github/workflows/mock_acpi.yml
@@ -6,6 +6,35 @@ on: # yamllint disable-line rule:truthy
     types: [created]
 
 jobs:
+  # Since `issue_comment` event runs on the default branch,
+  # we need to get the branch of the pull request
+  fetch-branch-name:
+    if: github.event.issue.pull_request && github.event.comment.body == '/test-acpi'
+    name: Fetch branch name
+    runs-on: ubuntu-latest
+    outputs:
+      head_ref: ${{ steps.pr_branch.outputs.head_ref }}
+      head_sha: ${{ steps.pr_branch.outputs.head_sha }}
+    steps:
+      - name: Get PR branch
+        id: pr_branch
+        uses: xt0rted/pull-request-comment-branch@v2
+  # Since `issue_comment` event workflow will not appear on the
+  # pull request page, we need to set the status of the job
+  # in order to attach it to the pull request itself
+  set-status-pending:
+    if: github.event.issue.pull_request && github.event.comment.body == '/test-acpi'
+    name: Set job status as pending
+    runs-on: ubuntu-latest
+    needs: [fetch-branch-name]
+    steps:
+      - name: Set job status as pending
+        uses: myrotvorets/set-commit-status-action@master
+        with:
+          sha: ${{ needs.fetch-branch-name.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: pending
+
   create-runner:
     if: github.event.issue.pull_request && github.event.comment.body == '/test-acpi'
     name: Create Runner
@@ -25,7 +54,7 @@ jobs:
   setup-runner:
     if: github.event.issue.pull_request && github.event.comment.body == '/test-acpi'
     name: Setup Runner
-    needs: create-runner
+    needs: [fetch-branch-name, create-runner]
     runs-on: self-hosted
     continue-on-error: true # This is done to release equinix runners irrespective of failure
     outputs:
@@ -50,6 +79,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.fetch-branch-name.outputs.head_ref }}
 
       - name: Run playbook
         id: run-playbook
@@ -68,7 +99,7 @@ jobs:
     if: github.event.issue.pull_request && github.event.comment.body == '/test-acpi'
     name: Cleanup
     runs-on: ubuntu-latest
-    needs: [setup-runner]
+    needs: create-runner
     steps:
       - name: delete runner
         uses: rootfs/metal-delete-action@main
@@ -82,10 +113,24 @@ jobs:
     if: github.event.issue.pull_request && github.event.comment.body == '/test-acpi'
     name: Mark workflow as failed
     runs-on: ubuntu-latest
-    needs: [setup-runner]
+    needs: setup-runner
     steps:
       - name: Mark workflow as failed if playbook failed
         if: needs.setup-runner.outputs.playbook-status == 'failure'
         run: |
           echo "Playbook failed, marking workflow as failed"
           exit 1
+
+  set-final-status:
+    if: github.event.issue.pull_request && github.event.comment.body == '/test-acpi'
+    name: Set final status
+    runs-on: ubuntu-latest
+    needs: fetch-branch-name
+    steps:
+      - name: Set job status as ${{ job.status }}
+        uses: myrotvorets/set-commit-status-action@master
+        if: always()
+        with:
+          sha: ${{ needs.fetch-branch-name.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}


### PR DESCRIPTION
This commit resolves two key issues with the mock-acpi workflow:
- Checkout correct branch: The workflow previously checkout out the default branch when triggered by a pull request. This fix ensures that the correct pull request branch is checked out during CI run.
- Attach workflow to pull request checks: The workflow was not being reflected under pull request checks. With this fix, the workflow will be correctly attached, ensuring its status visible and reported under pull request checks.

Also addresses: #1709 