### PR TITLE
fix: set default trainer only for local regressor

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -99,11 +99,15 @@ func createPowerModelEstimator(modelConfig *types.ModelConfig) (PowerModelInterf
 		} else {
 			featuresNames = modelConfig.ProcessFeatureNames
 		}
+		trainerName := modelConfig.TrainerName
+		if trainerName == "" {
+			trainerName = config.DefaultTrainerName
+		}
 		model := &regressor.Regressor{
 			ModelServerEndpoint:         config.ModelServerEndpoint,
 			OutputType:                  modelConfig.ModelOutputType,
 			EnergySource:                modelConfig.EnergySource,
-			TrainerName:                 modelConfig.TrainerName,
+			TrainerName:                 trainerName,
 			SelectFilter:                modelConfig.SelectFilter,
 			ModelWeightsURL:             modelConfig.InitModelURL,
 			ModelWeightsFilepath:        modelConfig.InitModelFilepath,
@@ -206,9 +210,6 @@ func getPowerModelType(powerSourceTarget string) (modelType types.ModelType) {
 // getPowerModelTrainerName return the trainer name for a given power source, such as platform or components power sources
 func getPowerModelTrainerName(powerSourceTarget string) (trainerName string) {
 	trainerName = config.ModelConfigValues[getModelConfigKey(powerSourceTarget, config.FixedTrainerNameKey)]
-	if trainerName == "" {
-		trainerName = config.DefaultTrainerName
-	}
 	return
 }
 


### PR DESCRIPTION
This PR removes the fixed default trainer name unexpectedly applied to also estimator. 
For local regressor, we need the default trainer name pointed to linear function. 

https://github.com/sustainable-computing-io/kepler/blob/d143b6731fad3f0a44e7b4277cf8aa66a9ebeb84/pkg/model/estimator/local/regressor/regressor.go#L249-L263

However, we shouldn't pass this default trainer to sidecar estimator. 
This causes the mismatch issue in https://github.com/sustainable-computing-io/kepler-model-server/pull/383.
This PR moves the logic to set default trainer to the point before creating the local regressor estimator.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>