### PR TITLE
feat: add --disable-power-meter option

### DIFF
--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -64,6 +64,7 @@ type AppConfig struct {
 	ApiserverEnabled             bool
 	RedfishCredFilePath          string
 	ExposeEstimatedIdlePower     bool
+	DisablePowerMeter            bool
 }
 
 func newAppConfig() *AppConfig {
@@ -79,6 +80,7 @@ func newAppConfig() *AppConfig {
 	flag.BoolVar(&_config.ApiserverEnabled, "apiserver", true, "if apiserver is disabled, we collect pod information from kubelet")
 	flag.StringVar(&_config.RedfishCredFilePath, "redfish-cred-file-path", "", "path to the redfish credential file")
 	flag.BoolVar(&_config.ExposeEstimatedIdlePower, "expose-estimated-idle-power", false, "estimated idle power is meaningful only if Kepler is running on bare-metal or when there is only one virtual machine on the node")
+	flag.BoolVar(&_config.DisablePowerMeter, "disable-power-meter", false, "whether manually disable power meter read and forcefully apply the estimator for node powers")
 
 	return _config
 }
@@ -114,6 +116,9 @@ func main() {
 		},
 		func() float64 { return 1 },
 	))
+
+	platform.SetIsSystemCollectionSupported(!appConfig.DisablePowerMeter)
+	components.SetIsSystemCollectionSupported(!appConfig.DisablePowerMeter)
 
 	config.SetEnabledEBPFCgroupID(appConfig.EnableEBPFCgroupID)
 	config.SetEnabledHardwareCounterMetrics(appConfig.ExposeHardwareCounterMetrics)


### PR DESCRIPTION
This PR adds an option to set power support to false to forcefully use estimator to estimate the node power regardless of power meter installation.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>