### PR TITLE
fix(ci): consolidate mock-acpi workflow into single job

### DIFF
--- a/.github/workflows/mock_acpi.yml
+++ b/.github/workflows/mock_acpi.yml
@@ -6,47 +6,27 @@ on: # yamllint disable-line rule:truthy
     types: [created]
 
 jobs:
-  # Since `issue_comment` event runs on the default branch,
-  # we need to get the branch of the pull request
-  fetch-branch-name:
+  test-mock-acpi:
     if: github.event.issue.pull_request && github.event.comment.body == '/test-acpi'
-    name: Fetch branch name
+    name: Test Mock ACPI
     runs-on: ubuntu-latest
-    outputs:
-      head_ref: ${{ steps.pr_branch.outputs.head_ref }}
-      head_sha: ${{ steps.pr_branch.outputs.head_sha }}
     steps:
+      # Since `issue_comment` event runs on the default branch,
+      # we need to get the branch of the pull request
       - name: Get PR branch
         id: pr_branch
         uses: xt0rted/pull-request-comment-branch@v2
-
-      - name: Set ref and sha as outputs
-        run: |
-          echo "head_ref=${{ steps.pr_branch.outputs.head_ref }}" >> $GITHUB_ENV
-          echo "head_sha=${{ steps.pr_branch.outputs.head_sha }}" >> $GITHUB_ENV
-
-  # Since `issue_comment` event workflow will not appear on the
-  # pull request page, we need to set the status of the job
-  # in order to attach it to the pull request itself
-  set-status-pending:
-    if: github.event.issue.pull_request && github.event.comment.body == '/test-acpi'
-    name: Set job status as pending
-    runs-on: ubuntu-latest
-    needs: fetch-branch-name
-    steps:
+      # Since `issue_comment` event workflow will not appear on the
+      # pull request page, we need to set the status of the job
+      # in order to attach it to the pull request itself
       - name: Set job status as pending
+        if: ${{ success() }}
         uses: myrotvorets/set-commit-status-action@master
         with:
-          sha: ${{ needs.fetch-branch-name.outputs.head_sha }}
+          sha: ${{ steps.pr_branch.outputs.head_sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           status: pending
 
-  create-runner:
-    if: github.event.issue.pull_request && github.event.comment.body == '/test-acpi'
-    name: Create Runner
-    runs-on: ubuntu-latest
-
-    steps:
       - name: metal-runner-action
         uses: equinix-labs/metal-runner-action@v0.2.0
         with:
@@ -57,18 +37,8 @@ jobs:
           plan: c3.small.x86
           os: ubuntu_20_04
 
-  setup-runner:
-    if: github.event.issue.pull_request && github.event.comment.body == '/test-acpi'
-    name: Setup Runner
-    needs: [fetch-branch-name, create-runner]
-    runs-on: self-hosted
-    continue-on-error: true # This is done to release equinix runners irrespective of failure
-    outputs:
-      runner-name: ${{ runner.name }}
-      playbook-status: ${{ steps.run-playbook.outcome }}
-
-    steps:
       - name: Configure SSH
+        if: ${{ success() }}
         run: |
           echo "Configuring SSH for runner"
           sudo ssh-keygen -t rsa -b 4096 -f /root/.ssh/ansible_rsa -N ''
@@ -76,6 +46,7 @@ jobs:
           sudo echo "StrictHostKeyChecking no" >> ~/.ssh/config
 
       - name: Install Dependencies
+        if: ${{ success() }}
         run: |
           echo "Installing Ansible and Docker module"
           sudo apt install software-properties-common -y
@@ -84,12 +55,15 @@ jobs:
           sudo ansible-galaxy collection install community.docker
 
       - name: Checkout code
+        if: ${{ success() }}
         uses: actions/checkout@v3
         with:
-          ref: ${{ needs.fetch-branch-name.outputs.head_ref }}
+          ref: ${{ steps.pr_branch.outputs.head_ref }}
 
       - name: Run playbook
         id: run-playbook
+        if: ${{ success() }}
+        continue-on-error: true # This is done to release equinix runners irrespective of failure
         run: |
           echo "Setting up the infra"
           cd ${GITHUB_WORKSPACE}/ansible
@@ -97,41 +71,24 @@ jobs:
           echo "Launching Mock ACPI compose and running validator"
           ansible-playbook -vv -i inventory.yaml mock_acpi_playbook.yaml -e "pr_number=${{ github.event.issue.number }}"
 
-  cleanup:
-    if: github.event.issue.pull_request && github.event.comment.body == '/test-acpi'
-    name: Cleanup
-    runs-on: ubuntu-latest
-    needs: setup-runner
-    steps:
       - name: delete runner
         uses: rootfs/metal-delete-action@main
         with:
           authToken: ${{ secrets.EQUINIX_API_TOKEN }}
           projectID: ${{ secrets.EQUINIX_PROJECT_ID }}
-          runnerName: ${{ needs.setup-runner.outputs.runner-name }}
+          runnerName: ${{ runner.name }}
 
-  # Marking the workflow as failed if the playbook fails
-  mark-workflow-failed:
-    if: github.event.issue.pull_request && github.event.comment.body == '/test-acpi'
-    name: Mark workflow as failed
-    runs-on: ubuntu-latest
-    needs: setup-runner
-    steps:
+      # Marking the workflow as failed if the playbook fails
       - name: Mark workflow as failed if playbook failed
-        if: needs.setup-runner.outputs.playbook-status == 'failure'
+        if: ${{ steps.run-playbook.outcome == 'failure' }}
         run: |
           echo "Playbook failed, marking workflow as failed"
           exit 1
 
-  set-final-status:
-    if: github.event.issue.pull_request && github.event.comment.body == '/test-acpi'
-    name: Set final status
-    runs-on: ubuntu-latest
-    steps:
       - name: Set job status as ${{ job.status }}
         uses: myrotvorets/set-commit-status-action@master
         if: always()
         with:
-          sha: ${{ env.head_sha }}
+          sha: ${{ steps.pr_branch.outputs.head_sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}


### PR DESCRIPTION
This commit addresses the issue of multiple jobs defined in the `mock-acpi` workflow, which were unintentionally executing in parallel due to sequence constraints. By consolidating the workflow into a single job, we ensure that the tasks are executed sequentially