### PR TITLE
feat(compose): add node-exporter for rapl metrics

### DIFF
--- a/manifests/compose/default/override.yaml
+++ b/manifests/compose/default/override.yaml
@@ -2,8 +2,6 @@ services:
   prometheus:
     networks:
       - kepler-network
-    depends_on:
-      - kepler-latest
     volumes:
       - type: bind
         source: ../default/prometheus/scrape-configs/latest.yaml

--- a/manifests/compose/dev/compose.yaml
+++ b/manifests/compose/dev/compose.yaml
@@ -74,6 +74,34 @@ services:
     networks:
       - scaph-network
 
+  node-exporter:
+    image: quay.io/prometheus/node-exporter:latest
+    pid: host
+    ports:
+      - 9100:9100
+    volumes:
+      - type: bind
+        source: /proc
+        target: /host/proc
+      - type: bind
+        source: /sys
+        target: /host/sys
+      - type: bind
+        source: /
+        target: /rootfs
+    command:
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --path.rootfs=/rootfs
+      - --collector.rapl  # Enable RAPL collector
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+    privileged: true
+    user: root
+    cap_add:
+      - ALL
+    networks:
+      - kepler-network
+
 networks:
   scaph-network:
   kepler-network:

--- a/manifests/compose/dev/prometheus/scrape-configs/dev.yaml
+++ b/manifests/compose/dev/prometheus/scrape-configs/dev.yaml
@@ -6,3 +6,7 @@ scrape_configs:
   - job_name: scaphandre
     static_configs:
       - targets: [scaphandre:8080]
+
+  - job_name: node-exporter
+    static_configs:
+      - targets: [node-exporter:9100]


### PR DESCRIPTION
 
 node-exporter provides rapl power metrics
    - node_rapl_core_joules_total
    - node_rapl_uncore_joules_total
    - node_rapl_package_joules_total
    - node_rapl_psys_joules_total

removed unwanted dependency on kepler-latest in default override.yaml