### PR TITLE
feat: update static models to use 0.7.11 models

### DIFF
--- a/data/model_weight/acpi_AbsPowerModel.json
+++ b/data/model_weight/acpi_AbsPowerModel.json
@@ -2,14 +2,16 @@
   "model_name": "SGDRegressorTrainer_0",
   "platform": {
     "All_Weights": {
-      "Bias_Weight": 220.9079278650894,
+      "Bias_Weight": 63.732101547596734,
       "Categorical_Variables": {},
       "Numerical_Variables": {
         "bpf_cpu_time_ms": {
-          "scale": 5911.969193263386,
-          "mean": 0,
-          "variance": 0,
-          "weight": 29.028228361462897
+          "scale": 3991.690709751875,
+          "weight": 60.735455390707436
+        },
+        "bpf_page_cache_hit": {
+          "scale": 1.0,
+          "weight": 0.0
         }
       }
     }

--- a/data/model_weight/acpi_AbsPowerModel.json
+++ b/data/model_weight/acpi_AbsPowerModel.json
@@ -1,1 +1,17 @@
-{"model_name": "SGDRegressorTrainer_0", "platform": {"All_Weights": {"Bias_Weight": 220.9079278650894, "Categorical_Variables": {}, "Numerical_Variables": {"bpf_cpu_time_ms": {"scale": 5911.969193263386, "mean": 0, "variance": 0, "weight": 29.028228361462897}}}}}
+{
+  "model_name": "SGDRegressorTrainer_0",
+  "platform": {
+    "All_Weights": {
+      "Bias_Weight": 220.9079278650894,
+      "Categorical_Variables": {},
+      "Numerical_Variables": {
+        "bpf_cpu_time_ms": {
+          "scale": 5911.969193263386,
+          "mean": 0,
+          "variance": 0,
+          "weight": 29.028228361462897
+        }
+      }
+    }
+  }
+}

--- a/data/model_weight/acpi_DynPowerModel.json
+++ b/data/model_weight/acpi_DynPowerModel.json
@@ -1,1 +1,17 @@
-{"model_name": "SGDRegressorTrainer_0", "platform": {"All_Weights": {"Bias_Weight": 49.56491877218095, "Categorical_Variables": {}, "Numerical_Variables": {"bpf_cpu_time_ms": {"scale": 5911.969193263386, "mean": 0, "variance": 0, "weight": 28.501356366108837}}}}}
+{
+  "model_name": "SGDRegressorTrainer_0",
+  "platform": {
+    "All_Weights": {
+      "Bias_Weight": 49.56491877218095,
+      "Categorical_Variables": {},
+      "Numerical_Variables": {
+        "bpf_cpu_time_ms": {
+          "scale": 5911.969193263386,
+          "mean": 0,
+          "variance": 0,
+          "weight": 28.501356366108837
+        }
+      }
+    }
+  }
+}

--- a/data/model_weight/acpi_DynPowerModel.json
+++ b/data/model_weight/acpi_DynPowerModel.json
@@ -2,14 +2,16 @@
   "model_name": "SGDRegressorTrainer_0",
   "platform": {
     "All_Weights": {
-      "Bias_Weight": 49.56491877218095,
+      "Bias_Weight": 2.2983085534792616,
       "Categorical_Variables": {},
       "Numerical_Variables": {
         "bpf_cpu_time_ms": {
-          "scale": 5911.969193263386,
-          "mean": 0,
-          "variance": 0,
-          "weight": 28.501356366108837
+          "scale": 3991.690709751875,
+          "weight": 59.30618884592585
+        },
+        "bpf_page_cache_hit": {
+          "scale": 1.0,
+          "weight": 0.0
         }
       }
     }

--- a/data/model_weight/intel_rapl_AbsPowerModel.json
+++ b/data/model_weight/intel_rapl_AbsPowerModel.json
@@ -2,14 +2,16 @@
   "model_name": "SGDRegressorTrainer_0",
   "package": {
     "All_Weights": {
-      "Bias_Weight": 69.91739430907396,
+      "Bias_Weight": 143.81206324506658,
       "Categorical_Variables": {},
       "Numerical_Variables": {
         "bpf_cpu_time_ms": {
-          "scale": 5911.969193263386,
-          "mean": 0,
-          "variance": 0,
-          "weight": 22.16772409328642
+          "scale": 95877.00000000001,
+          "weight": 305.148172889668
+        },
+        "bpf_page_cache_hit": {
+          "scale": 1.0,
+          "weight": 0.0
         }
       }
     }
@@ -20,9 +22,11 @@
       "Categorical_Variables": {},
       "Numerical_Variables": {
         "bpf_cpu_time_ms": {
-          "scale": 5911.969193263386,
-          "mean": 0,
-          "variance": 0,
+          "scale": 95877.00000000001,
+          "weight": 0.0
+        },
+        "bpf_page_cache_hit": {
+          "scale": 1.0,
           "weight": 0.0
         }
       }
@@ -34,9 +38,11 @@
       "Categorical_Variables": {},
       "Numerical_Variables": {
         "bpf_cpu_time_ms": {
-          "scale": 5911.969193263386,
-          "mean": 0,
-          "variance": 0,
+          "scale": 95877.00000000001,
+          "weight": 0.0
+        },
+        "bpf_page_cache_hit": {
+          "scale": 1.0,
           "weight": 0.0
         }
       }
@@ -44,14 +50,16 @@
   },
   "dram": {
     "All_Weights": {
-      "Bias_Weight": 47.142633336743344,
+      "Bias_Weight": 18.616285480502686,
       "Categorical_Variables": {},
       "Numerical_Variables": {
         "bpf_cpu_time_ms": {
-          "scale": 5911.969193263386,
-          "mean": 0,
-          "variance": 0,
-          "weight": 3.57348245077466
+          "scale": 95877.00000000001,
+          "weight": 8.434209551249596
+        },
+        "bpf_page_cache_hit": {
+          "scale": 1.0,
+          "weight": 0.0
         }
       }
     }

--- a/data/model_weight/intel_rapl_AbsPowerModel.json
+++ b/data/model_weight/intel_rapl_AbsPowerModel.json
@@ -1,1 +1,59 @@
-{"model_name": "SGDRegressorTrainer_0", "package": {"All_Weights": {"Bias_Weight": 69.91739430907396, "Categorical_Variables": {}, "Numerical_Variables": {"bpf_cpu_time_ms": {"scale": 5911.969193263386, "mean": 0, "variance": 0, "weight": 22.16772409328642}}}}, "core": {"All_Weights": {"Bias_Weight": 0.0, "Categorical_Variables": {}, "Numerical_Variables": {"bpf_cpu_time_ms": {"scale": 5911.969193263386, "mean": 0, "variance": 0, "weight": 0.0}}}}, "uncore": {"All_Weights": {"Bias_Weight": 0.0, "Categorical_Variables": {}, "Numerical_Variables": {"bpf_cpu_time_ms": {"scale": 5911.969193263386, "mean": 0, "variance": 0, "weight": 0.0}}}}, "dram": {"All_Weights": {"Bias_Weight": 47.142633336743344, "Categorical_Variables": {}, "Numerical_Variables": {"bpf_cpu_time_ms": {"scale": 5911.969193263386, "mean": 0, "variance": 0, "weight": 3.57348245077466}}}}}
+{
+  "model_name": "SGDRegressorTrainer_0",
+  "package": {
+    "All_Weights": {
+      "Bias_Weight": 69.91739430907396,
+      "Categorical_Variables": {},
+      "Numerical_Variables": {
+        "bpf_cpu_time_ms": {
+          "scale": 5911.969193263386,
+          "mean": 0,
+          "variance": 0,
+          "weight": 22.16772409328642
+        }
+      }
+    }
+  },
+  "core": {
+    "All_Weights": {
+      "Bias_Weight": 0.0,
+      "Categorical_Variables": {},
+      "Numerical_Variables": {
+        "bpf_cpu_time_ms": {
+          "scale": 5911.969193263386,
+          "mean": 0,
+          "variance": 0,
+          "weight": 0.0
+        }
+      }
+    }
+  },
+  "uncore": {
+    "All_Weights": {
+      "Bias_Weight": 0.0,
+      "Categorical_Variables": {},
+      "Numerical_Variables": {
+        "bpf_cpu_time_ms": {
+          "scale": 5911.969193263386,
+          "mean": 0,
+          "variance": 0,
+          "weight": 0.0
+        }
+      }
+    }
+  },
+  "dram": {
+    "All_Weights": {
+      "Bias_Weight": 47.142633336743344,
+      "Categorical_Variables": {},
+      "Numerical_Variables": {
+        "bpf_cpu_time_ms": {
+          "scale": 5911.969193263386,
+          "mean": 0,
+          "variance": 0,
+          "weight": 3.57348245077466
+        }
+      }
+    }
+  }
+}

--- a/data/model_weight/intel_rapl_DynPowerModel.json
+++ b/data/model_weight/intel_rapl_DynPowerModel.json
@@ -1,1 +1,59 @@
-{"model_name": "SGDRegressorTrainer_0", "package": {"All_Weights": {"Bias_Weight": 38.856412561925055, "Categorical_Variables": {}, "Numerical_Variables": {"bpf_cpu_time_ms": {"scale": 5911.969193263386, "mean": 0, "variance": 0, "weight": 22.258830113477515}}}}, "core": {"All_Weights": {"Bias_Weight": 0.0, "Categorical_Variables": {}, "Numerical_Variables": {"bpf_cpu_time_ms": {"scale": 5911.969193263386, "mean": 0, "variance": 0, "weight": 0.0}}}}, "uncore": {"All_Weights": {"Bias_Weight": 0.0, "Categorical_Variables": {}, "Numerical_Variables": {"bpf_cpu_time_ms": {"scale": 5911.969193263386, "mean": 0, "variance": 0, "weight": 0.0}}}}, "dram": {"All_Weights": {"Bias_Weight": 9.080889901856153, "Categorical_Variables": {}, "Numerical_Variables": {"bpf_cpu_time_ms": {"scale": 5911.969193263386, "mean": 0, "variance": 0, "weight": 3.0358946796490924}}}}}
+{
+  "model_name": "SGDRegressorTrainer_0",
+  "package": {
+    "All_Weights": {
+      "Bias_Weight": 38.856412561925055,
+      "Categorical_Variables": {},
+      "Numerical_Variables": {
+        "bpf_cpu_time_ms": {
+          "scale": 5911.969193263386,
+          "mean": 0,
+          "variance": 0,
+          "weight": 22.258830113477515
+        }
+      }
+    }
+  },
+  "core": {
+    "All_Weights": {
+      "Bias_Weight": 0.0,
+      "Categorical_Variables": {},
+      "Numerical_Variables": {
+        "bpf_cpu_time_ms": {
+          "scale": 5911.969193263386,
+          "mean": 0,
+          "variance": 0,
+          "weight": 0.0
+        }
+      }
+    }
+  },
+  "uncore": {
+    "All_Weights": {
+      "Bias_Weight": 0.0,
+      "Categorical_Variables": {},
+      "Numerical_Variables": {
+        "bpf_cpu_time_ms": {
+          "scale": 5911.969193263386,
+          "mean": 0,
+          "variance": 0,
+          "weight": 0.0
+        }
+      }
+    }
+  },
+  "dram": {
+    "All_Weights": {
+      "Bias_Weight": 9.080889901856153,
+      "Categorical_Variables": {},
+      "Numerical_Variables": {
+        "bpf_cpu_time_ms": {
+          "scale": 5911.969193263386,
+          "mean": 0,
+          "variance": 0,
+          "weight": 3.0358946796490924
+        }
+      }
+    }
+  }
+}

--- a/pkg/model/node_component_energy.go
+++ b/pkg/model/node_component_energy.go
@@ -55,11 +55,14 @@ func CreateNodeComponentPowerEstimatorModel(nodeFeatureNames, systemMetaDataFeat
 	var err error
 	nodeComponentPowerModel, err = createPowerModelEstimator(modelConfig)
 	if err != nil {
-		klog.Errorf("Failed to create %s/%s Model to estimate Node Component Power: %v", modelConfig.ModelType, modelConfig.ModelOutputType, err)
+		klog.Errorf("Failed to create %s/%s Model from %s to estimate Node Component Power: %v",
+			modelConfig.ModelType, modelConfig.ModelOutputType,
+			modelConfig.SourceURL(), err)
 		return
 	}
 
-	klog.V(1).Infof("Using the %s/%s Model to estimate Node Component Power", modelConfig.ModelType, modelConfig.ModelOutputType)
+	klog.V(1).Infof("Using the %s/%s Model from %s to estimate Node Component Power",
+		modelConfig.ModelType, modelConfig.ModelOutputType, modelConfig.SourceURL())
 }
 
 // IsNodeComponentPowerModelEnabled returns if the estimator has been enabled or not

--- a/pkg/model/node_platform_energy.go
+++ b/pkg/model/node_platform_energy.go
@@ -51,10 +51,13 @@ func CreateNodePlatformPowerEstimatorModel(nodeFeatureNames, systemMetaDataFeatu
 	var err error
 	nodePlatformPowerModel, err = createPowerModelEstimator(modelConfig)
 	if err != nil {
-		klog.Errorf("Failed to create %s/%s Model to estimate Node Platform Power: %v", modelConfig.ModelType, modelConfig.ModelOutputType, err)
+		klog.Errorf("Failed to create %s/%s Model from %s to estimate Node Platform Power: %v",
+			modelConfig.ModelType, modelConfig.ModelOutputType,
+			modelConfig.SourceURL(), err)
 		return
 	}
-	klog.V(1).Infof("Using the %s/%s Model to estimate Node Platform Power", modelConfig.ModelType, modelConfig.ModelOutputType)
+	klog.V(1).Infof("Using the %s/%s Model from %s to estimate Node Platform Power",
+		modelConfig.ModelType, modelConfig.ModelOutputType, modelConfig.SourceURL())
 }
 
 // IsNodePlatformPowerModelEnabled returns if the estimator has been enabled or not

--- a/pkg/model/types/types.go
+++ b/pkg/model/types/types.go
@@ -16,8 +16,10 @@ limitations under the License.
 
 package types
 
-type ModelType int
-type ModelOutputType int
+type (
+	ModelType       int
+	ModelOutputType int
+)
 
 const (
 	// Power Model types
@@ -25,6 +27,7 @@ const (
 	Regressor                             // estimation happens within kepler, but pre-trained model parameters are downloaded externally
 	EstimatorSidecar                      // estimation happens in the sidecar with a loaded pre-trained power model
 )
+
 const (
 	// Power Model Output types
 	// Absolute Power Model (AbsPower): is the power model trained by measured power (including the idle power)
@@ -33,6 +36,7 @@ const (
 	DynPower
 	Unsupported
 )
+
 const (
 	// Define energy source
 	PlatformEnergySource    = "acpi"
@@ -98,4 +102,12 @@ type ModelConfig struct {
 	NodeFeatureNames            []string
 	SystemMetaDataFeatureNames  []string
 	SystemMetaDataFeatureValues []string
+}
+
+func (c *ModelConfig) SourceURL() string {
+	if c.InitModelURL != "" {
+		return c.InitModelURL
+	}
+
+	return c.InitModelFilepath
 }

--- a/pkg/sensors/components/power.go
+++ b/pkg/sensors/components/power.go
@@ -48,6 +48,12 @@ var (
 )
 
 func InitPowerImpl() {
+	if !enabled {
+		klog.V(1).Infoln("System power collection is disabled, using estimate method")
+		powerImpl = &source.PowerEstimate{}
+		return
+	}
+
 	sysfsImpl := &source.PowerSysfs{}
 	if sysfsImpl.IsSystemCollectionSupported() /*&& false*/ {
 		klog.V(1).Infoln("use sysfs to obtain power")

--- a/pkg/sensors/platform/power.go
+++ b/pkg/sensors/platform/power.go
@@ -37,8 +37,7 @@ type powerInterface interface {
 }
 
 // dummy satisfies the powerInterface and can be used as the default NOP source
-type dummy struct {
-}
+type dummy struct{}
 
 func (dummy) GetName() string {
 	return "none"
@@ -47,6 +46,7 @@ func (dummy) GetName() string {
 func (dummy) IsSystemCollectionSupported() bool {
 	return false
 }
+
 func (dummy) StopPower() {
 }
 
@@ -60,6 +60,12 @@ var (
 )
 
 func InitPowerImpl() {
+	if !enabled {
+		klog.V(1).Infoln("System power collection is disabled, using dummy method")
+		powerImpl = &dummy{}
+		return
+	}
+
 	// switch the platform power collector source to hmc if the system architecture is s390x
 	// TODO: add redfish or ipmi as well.
 	if runtime.GOARCH == "s390x" {


### PR DESCRIPTION
NOTE: `intel_rapl_DynPower` has not been updated since 
SGDRegressor for Dynamic Power Node Type 0 is missing  https://github.com/sustainable-computing-io/kepler-model-db/tree/main/models/v0.7/ec2-0.7.11/rapl-sysfs/DynPower/BPFOnly 

After updating the models to the latest, here are the changes on **my** machine 
```

kepler_node_info{components_power_source="rapl-sysfs", cpu_architecture="Skylake", instance="kepler-latest:8888", job="latest", platform_power_source="none", source="os"} | 1
-- | --
kepler_node_info{components_power_source="estimator", cpu_architecture="Skylake", instance="kepler-dev:8888", job="dev", platform_power_source="none", source="os"}

```
NOTE: `kepler-latest` reports power_sources incorrectly (fixed in this pr; see "dev") 


### Platform / Idle
* seems like an improvement 


<img width="950" alt="image" src="https://github.com/user-attachments/assets/8fc4e5ed-d2c4-4d10-b16e-c460fd9a3fc5">


### Platform / Dynamic 
<img width="950" alt="image" src="https://github.com/user-attachments/assets/7b85654c-39d7-4f1e-89bc-fe16432b87d6">


### Package / Idle
* Idle power is much higher than the old 
<img width="950" alt="image" src="https://github.com/user-attachments/assets/2df5d60e-f116-45d3-9b0d-01dad194bd5a">

### Package / dynamic 
* higher but closer to real usage

<img width="950" alt="image" src="https://github.com/user-attachments/assets/86ee05ac-d89e-4c52-9917-b46b7fb4c1c9">


