### PR TITLE
chore(ci): bump metal runner action version

### DIFF
--- a/.github/workflows/mock_acpi.yml
+++ b/.github/workflows/mock_acpi.yml
@@ -28,7 +28,7 @@ jobs:
           status: pending
 
       - name: metal-runner-action
-        uses: equinix-labs/metal-runner-action@v0.2.0
+        uses: equinix-labs/metal-runner-action@v0.3.0
         with:
           github_token: ${{ secrets.GH_SELF_HOSTED_RUNNER_TOKEN }}
           metal_auth_token: ${{ secrets.EQUINIX_API_TOKEN }}


### PR DESCRIPTION
This commit bumps the metal runner action version to v0.3.0 It now supports the [self-hosted runners at organization level](https://github.com/equinix-labs/metal-runner-action/releases/tag/v0.3.0)