### PR TITLE
feat: compute idle power with core ratio

### DIFF
--- a/pkg/model/estimator/local/regressor/model_weights.go
+++ b/pkg/model/estimator/local/regressor/model_weights.go
@@ -95,13 +95,25 @@ type NormalizedNumericalFeature struct {
 	Weight float64 `json:"weight,omitempty"`
 }
 
+// TODO: remove when PR #1684 merge
+type MachineSpec struct {
+	Vendor         string `json:"vendor"`
+	Processor      string `json:"processor"`
+	Cores          int    `json:"cores"`
+	Chips          int    `json:"chips"`
+	Memory         int    `json:"memory"`
+	Frequency      int    `json:"frequency"`
+	ThreadsPerCore int    `json:"threads_per_core"`
+}
+
 type ComponentModelWeights struct {
-	ModelName string        `json:"model_name,omitempty"`
-	Platform  *ModelWeights `json:"platform,omitempty"`
-	Core      *ModelWeights `json:"core,omitempty"`
-	Uncore    *ModelWeights `json:"uncore,omitempty"`
-	Package   *ModelWeights `json:"package,omitempty"`
-	DRAM      *ModelWeights `json:"dram,omitempty"`
+	ModelName        string        `json:"model_name,omitempty"`
+	ModelMachineSpec *MachineSpec  `json:"machine_spec,omitempty"`
+	Platform         *ModelWeights `json:"platform,omitempty"`
+	Core             *ModelWeights `json:"core,omitempty"`
+	Uncore           *ModelWeights `json:"uncore,omitempty"`
+	Package          *ModelWeights `json:"package,omitempty"`
+	DRAM             *ModelWeights `json:"dram,omitempty"`
 }
 
 func (w ComponentModelWeights) String() string {

--- a/pkg/model/utils/utils.go
+++ b/pkg/model/utils/utils.go
@@ -25,20 +25,20 @@ const (
 )
 
 // GetComponentPower called by getPodComponentPowers to check if component key is present in powers response and fills with single 0
-func GetComponentPower(powers map[string][]float64, componentKey string, index int) uint64 {
+func GetComponentPower(powers map[string][]float64, componentKey string, index int, coreRatio float64) uint64 {
 	values := powers[componentKey]
 	if index >= len(values) {
 		return 0
 	} else {
-		return uint64(values[index] * JouleMillijouleConversionFactor)
+		return uint64(values[index] * JouleMillijouleConversionFactor * coreRatio)
 	}
 }
 
 // GetPlatformPower returns powerInMilliJoule
-func GetPlatformPower(powers []float64) []uint64 {
+func GetPlatformPower(powers []float64, coreRatio float64) []uint64 {
 	powerInMilliJoule := make([]uint64, len(powers))
 	for index := range powers {
-		powerInMilliJoule[index] = uint64(powers[index] * JouleMillijouleConversionFactor)
+		powerInMilliJoule[index] = uint64(powers[index] * JouleMillijouleConversionFactor * coreRatio)
 	}
 	return powerInMilliJoule
 }
@@ -57,4 +57,13 @@ func FillNodeComponentsPower(pkgPower, corePower, uncorePower, dramPower uint64)
 		DRAM:   dramPower,
 		Pkg:    pkgPower,
 	}
+}
+
+// GetCoreRatio returns core ratio to apply only with idle power
+func GetCoreRatio(isIdlePower bool, inCoreRatio float64) float64 {
+	var coreRatio float64 = 1
+	if isIdlePower && inCoreRatio > 0 {
+		coreRatio = inCoreRatio
+	}
+	return coreRatio
 }


### PR DESCRIPTION
This patch is for adding an idle power based on ratio of the machine cores over the cores of the machine that is used for training the power model. 

Need the following Kepler PR to solve the TODO.
- [ ] https://github.com/sustainable-computing-io/kepler/pull/1684

Need the following PR in kepler-model-server to have estimator provides machine spec and server API to put machine spec to weight response.
- [ ] https://github.com/sustainable-computing-io/kepler-model-server/pull/405

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>