### PR TITLE
fix(ci): use SHA for checkout

### DIFF
--- a/.github/workflows/mock_acpi.yml
+++ b/.github/workflows/mock_acpi.yml
@@ -31,7 +31,7 @@ jobs:
         if: ${{ success() }}
         uses: actions/checkout@v3
         with:
-          ref: ${{ steps.pr_branch.outputs.head_ref }}
+          ref: ${{ steps.pr_branch.outputs.head_sha }}
 
       - name: metal-runner-action
         uses: equinix-labs/metal-runner-action@v0.3.0


### PR DESCRIPTION
This commit addresses a checkout action failure occurring in the pull request from forked repos. The issue stemmed from the use of `ref`. Switching to `sha` resolves this

Ref: https://github.com/sustainable-computing-io/kepler/actions/runs/10558274696/job/29247409471#step:5:59