### PR TITLE
chore(validator): add cpu method to stress-ng

### DIFF
--- a/e2e/tools/validator/scripts/stressor.sh
+++ b/e2e/tools/validator/scripts/stressor.sh
@@ -38,7 +38,7 @@ main() {
 		for x in "${load_curve[@]}"; do
 			local load="${x%%:*}"
 			local time="${x##*:}s"
-			run stress-ng --cpu "$cpus" --cpu-load "$load" --timeout "$time"
+			run stress-ng --cpu "$cpus" --cpu-method ackermann --cpu-load "$load" --timeout "$time"
 		done
 	done
 }


### PR DESCRIPTION
This commit enhances the stress-ng command by adding the `ackermann` method for CPU stress testing