### PR TITLE
fix(ci): switch to custom metal-runner-action in mock-acpi workflow

### DIFF
--- a/.github/workflows/mock_acpi.yml
+++ b/.github/workflows/mock_acpi.yml
@@ -34,7 +34,8 @@ jobs:
           ref: ${{ steps.pr_branch.outputs.head_sha }}
 
       - name: metal-runner-action
-        uses: equinix-labs/metal-runner-action@v0.3.0
+        uses: vprashar2929/metal-runner-action@custom-action
+        # uses: equinix-labs/metal-runner-action@v0.3.0
         with:
           github_token: ${{ secrets.GH_SELF_HOSTED_RUNNER_TOKEN }}
           metal_auth_token: ${{ secrets.EQUINIX_API_TOKEN }}
@@ -42,6 +43,7 @@ jobs:
           metro: da
           plan: c3.small.x86
           os: ubuntu_20_04
+          organization: sustainable-computing-io
 
       - name: Configure SSH
         if: ${{ success() }}


### PR DESCRIPTION
This commit updates the mock-acpi workflow to use the custom `metal-runner-action` instead of the `equinix-labs`. This change is necessary because the workflow does not expose the `github.organization` value when triggered by the `issue_comment` event

Ref: https://github.com/sustainable-computing-io/kepler/actions/runs/10572316346/job/29289799353#step:6:14