### PR TITLE
fix: limit max core ratio to 1

### DIFF
--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sustainable-computing-io/kepler/pkg/collector/stats"
 	"github.com/sustainable-computing-io/kepler/pkg/config"
+	"github.com/sustainable-computing-io/kepler/pkg/model/utils"
 	"github.com/sustainable-computing-io/kepler/pkg/sensors/components"
 	"github.com/sustainable-computing-io/kepler/pkg/sensors/components/source"
 	"github.com/sustainable-computing-io/kepler/pkg/sensors/platform"
@@ -53,4 +54,19 @@ var _ = Describe("Test Model Unit", func() {
 		initModelURL := configValues[getModelConfigKey(modelItem, config.InitModelURLKey)]
 		Expect(initModelURL).NotTo(Equal(""))
 	})
+
+	Context("utils", func() {
+		DescribeTable("Test GetCoreRatio()", func(isIdlePower bool, inCoreRatio float64, expectedCoreRatio float64) {
+			coreRatio := utils.GetCoreRatio(isIdlePower, inCoreRatio)
+			Expect(coreRatio).To(Equal(expectedCoreRatio))
+		},
+			Entry("DynPower with valid coreRatio < 1", false, 0.5, 1.0),
+			Entry("IdlePower with valid coreRatio < 1", true, 0.5, 0.5),
+			Entry("IdlePower with valid coreRatio = 1", true, 1.0, 1.0),
+			Entry("IdlePower with invalid coreRatio = 0", true, 0.0, 1.0),
+			Entry("IdlePower with invalid coreRatio = -1", true, -1.0, 1.0),
+			Entry("IdlePower with invalid coreRatio > 1", true, 1.2, 1.0),
+		)
+	})
+
 })

--- a/pkg/model/utils/utils.go
+++ b/pkg/model/utils/utils.go
@@ -17,6 +17,8 @@ limitations under the License.
 package utils
 
 import (
+	"math"
+
 	"github.com/sustainable-computing-io/kepler/pkg/sensors/components/source"
 )
 
@@ -63,7 +65,7 @@ func FillNodeComponentsPower(pkgPower, corePower, uncorePower, dramPower uint64)
 func GetCoreRatio(isIdlePower bool, inCoreRatio float64) float64 {
 	var coreRatio float64 = 1
 	if isIdlePower && inCoreRatio > 0 {
-		coreRatio = inCoreRatio
+		coreRatio = math.Min(inCoreRatio, 1)
 	}
 	return coreRatio
 }


### PR DESCRIPTION
This is a fix to avoid core ratio > 1 (trained machine is smaller than the target machine itself). 
Idle power should not affect DynEnergy.

https://github.com/sustainable-computing-io/kepler/blob/777c733dfc4a696c17d06494fa7d783e4b3af6e5/pkg/collector/stats/stats.go#L140

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>