### PR TITLE
feat: compute core ratio for local regressor

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Test Configuration", func() {
 	It("Test machine spec generation and read", func() {
 		tmpPath := "./test_spec"
 		// generate spec
-		spec := generateSpec()
+		spec := GenerateSpec()
 		Expect(spec).NotTo(BeNil())
 		err := spec.saveToFile(tmpPath)
 		Expect(err).To(BeNil())

--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -90,7 +90,7 @@ func roundToNearestHundred(value float64) int {
 	return int(math.Round(value/100) * 100)
 }
 
-func generateSpec() *MachineSpec {
+func GenerateSpec() *MachineSpec {
 	spec := &MachineSpec{}
 
 	cpus, err := cpu.Info()
@@ -134,7 +134,7 @@ func getDefaultMachineSpec() *MachineSpec {
 			klog.Errorf("failed to read default spec from %s: %v", DefaultMachineSpecFilePath, err)
 		}
 	}
-	return generateSpec()
+	return GenerateSpec()
 }
 
 func readMachineSpec(path string) (*MachineSpec, error) {

--- a/pkg/model/estimator/local/regressor/model_weights.go
+++ b/pkg/model/estimator/local/regressor/model_weights.go
@@ -19,6 +19,8 @@ package regressor
 import (
 	"errors"
 	"fmt"
+
+	"github.com/sustainable-computing-io/kepler/pkg/config"
 )
 
 var (
@@ -95,25 +97,14 @@ type NormalizedNumericalFeature struct {
 	Weight float64 `json:"weight,omitempty"`
 }
 
-// TODO: remove when PR #1684 merge
-type MachineSpec struct {
-	Vendor         string `json:"vendor"`
-	Processor      string `json:"processor"`
-	Cores          int    `json:"cores"`
-	Chips          int    `json:"chips"`
-	Memory         int    `json:"memory"`
-	Frequency      int    `json:"frequency"`
-	ThreadsPerCore int    `json:"threads_per_core"`
-}
-
 type ComponentModelWeights struct {
-	ModelName        string        `json:"model_name,omitempty"`
-	ModelMachineSpec *MachineSpec  `json:"machine_spec,omitempty"`
-	Platform         *ModelWeights `json:"platform,omitempty"`
-	Core             *ModelWeights `json:"core,omitempty"`
-	Uncore           *ModelWeights `json:"uncore,omitempty"`
-	Package          *ModelWeights `json:"package,omitempty"`
-	DRAM             *ModelWeights `json:"dram,omitempty"`
+	ModelName        string              `json:"model_name,omitempty"`
+	ModelMachineSpec *config.MachineSpec `json:"machine_spec,omitempty"`
+	Platform         *ModelWeights       `json:"platform,omitempty"`
+	Core             *ModelWeights       `json:"core,omitempty"`
+	Uncore           *ModelWeights       `json:"uncore,omitempty"`
+	Package          *ModelWeights       `json:"package,omitempty"`
+	DRAM             *ModelWeights       `json:"dram,omitempty"`
 }
 
 func (w ComponentModelWeights) String() string {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -114,14 +114,15 @@ func createPowerModelEstimator(modelConfig *types.ModelConfig) (PowerModelInterf
 			FloatFeatureNames:           featuresNames,
 			SystemMetaDataFeatureNames:  modelConfig.SystemMetaDataFeatureNames,
 			SystemMetaDataFeatureValues: modelConfig.SystemMetaDataFeatureValues,
-			MachineSpec:                 config.GetMachineSpec(),
+			RequestMachineSpec:          config.GetMachineSpec(),
+			DiscoveredMachineSpec:       config.GenerateSpec(),
 		}
 		err := model.Start()
 		if err != nil {
 			return nil, err
 		}
 		klog.V(3).Infof("Using Power Model %s", modelConfig.ModelOutputType.String())
-		klog.Infof("Machine Spec: %v", model.MachineSpec)
+		klog.Infof("Requesting for Machine Spec: %v", model.RequestMachineSpec)
 		return model, nil
 
 	case types.EstimatorSidecar:


### PR DESCRIPTION
This PR implement TODO addressed in https://github.com/sustainable-computing-io/kepler/pull/1732 by computing core ratio based on model machine spec and discovered spec (e.g., VM cores).

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>