### PR TITLE
fix(models): log name of regressor

### DIFF
--- a/pkg/model/estimator/local/regressor/exponential.go
+++ b/pkg/model/estimator/local/regressor/exponential.go
@@ -32,6 +32,10 @@ func NewExponentialPredictor(weight ModelWeights) (predictor Predictor, err erro
 	return &ExponentialPredictor{ModelWeights: weight}, nil
 }
 
+func (p *ExponentialPredictor) name() string {
+	return "exponential"
+}
+
 func (p *ExponentialPredictor) predict(usageMetricNames []string, usageMetricValues [][]float64, systemMetaDataFeatureNames, systemMetaDataFeatureValues []string) []float64 {
 	categoricalX, numericalX, _ := p.ModelWeights.getX(usageMetricNames, usageMetricValues, systemMetaDataFeatureNames, systemMetaDataFeatureValues)
 	var basePower float64

--- a/pkg/model/estimator/local/regressor/exponential.go
+++ b/pkg/model/estimator/local/regressor/exponential.go
@@ -17,6 +17,7 @@ limitations under the License.
 package regressor
 
 import (
+	"fmt"
 	"math"
 )
 
@@ -26,7 +27,7 @@ type ExponentialPredictor struct {
 
 func NewExponentialPredictor(weight ModelWeights) (predictor Predictor, err error) {
 	if len(weight.AllWeights.CurveFitWeights) != 3 {
-		return nil, errModelWeightsInvalid
+		return nil, fmt.Errorf("exponential predictor: %w", errModelWeightsInvalid)
 	}
 	return &ExponentialPredictor{ModelWeights: weight}, nil
 }

--- a/pkg/model/estimator/local/regressor/linear.go
+++ b/pkg/model/estimator/local/regressor/linear.go
@@ -22,16 +22,19 @@ The model weights can be obtained by Kepler Model Server or configured initial m
 
 package regressor
 
+import "fmt"
+
 type LinearPredictor struct {
 	ModelWeights
 }
 
 // NewLinearPredictor creates a new LinearPredictor instance with the provided ModelWeights
 func NewLinearPredictor(weight ModelWeights) (predictor Predictor, err error) {
-	if len(weight.AllWeights.CurveFitWeights) == 0 {
-		return &LinearPredictor{ModelWeights: weight}, nil
+	if len(weight.AllWeights.CurveFitWeights) != 0 {
+		return nil, fmt.Errorf("linear predictor: %w", errModelWeightsInvalid)
 	}
-	return nil, errModelWeightsInvalid
+
+	return &LinearPredictor{ModelWeights: weight}, nil
 }
 
 func (p *LinearPredictor) predict(usageMetricNames []string, usageMetricValues [][]float64, systemMetaDataFeatureNames, systemMetaDataFeatureValues []string) []float64 {

--- a/pkg/model/estimator/local/regressor/linear.go
+++ b/pkg/model/estimator/local/regressor/linear.go
@@ -22,7 +22,9 @@ The model weights can be obtained by Kepler Model Server or configured initial m
 
 package regressor
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type LinearPredictor struct {
 	ModelWeights
@@ -35,6 +37,10 @@ func NewLinearPredictor(weight ModelWeights) (predictor Predictor, err error) {
 	}
 
 	return &LinearPredictor{ModelWeights: weight}, nil
+}
+
+func (p *LinearPredictor) name() string {
+	return "linear"
 }
 
 func (p *LinearPredictor) predict(usageMetricNames []string, usageMetricValues [][]float64, systemMetaDataFeatureNames, systemMetaDataFeatureValues []string) []float64 {

--- a/pkg/model/estimator/local/regressor/logarithm.go
+++ b/pkg/model/estimator/local/regressor/logarithm.go
@@ -29,7 +29,12 @@ func NewLogarithmicPredictor(weight ModelWeights) (predictor Predictor, err erro
 	if len(weight.AllWeights.CurveFitWeights) != 3 {
 		return nil, fmt.Errorf("logarithmic predictor: %w", errModelWeightsInvalid)
 	}
+
 	return &LogarithmicPredictor{ModelWeights: weight}, nil
+}
+
+func (LogarithmicPredictor) name() string {
+	return "logarithmic"
 }
 
 func (p *LogarithmicPredictor) predict(usageMetricNames []string, usageMetricValues [][]float64, systemMetaDataFeatureNames, systemMetaDataFeatureValues []string) []float64 {

--- a/pkg/model/estimator/local/regressor/logarithm.go
+++ b/pkg/model/estimator/local/regressor/logarithm.go
@@ -17,6 +17,7 @@ limitations under the License.
 package regressor
 
 import (
+	"fmt"
 	"math"
 )
 
@@ -26,7 +27,7 @@ type LogarithmicPredictor struct {
 
 func NewLogarithmicPredictor(weight ModelWeights) (predictor Predictor, err error) {
 	if len(weight.AllWeights.CurveFitWeights) != 3 {
-		return nil, errModelWeightsInvalid
+		return nil, fmt.Errorf("logarithmic predictor: %w", errModelWeightsInvalid)
 	}
 	return &LogarithmicPredictor{ModelWeights: weight}, nil
 }

--- a/pkg/model/estimator/local/regressor/logistic.go
+++ b/pkg/model/estimator/local/regressor/logistic.go
@@ -33,6 +33,10 @@ func NewLogisticPredictor(weight ModelWeights) (predictor Predictor, err error) 
 	return &LogisticPredictor{ModelWeights: weight}, nil
 }
 
+func (LogisticPredictor) name() string {
+	return "logistic"
+}
+
 func (p *LogisticPredictor) predict(usageMetricNames []string, usageMetricValues [][]float64, systemMetaDataFeatureNames, systemMetaDataFeatureValues []string) []float64 {
 	categoricalX, numericalX, _ := p.ModelWeights.getX(usageMetricNames, usageMetricValues, systemMetaDataFeatureNames, systemMetaDataFeatureValues)
 	var basePower float64

--- a/pkg/model/estimator/local/regressor/logistic.go
+++ b/pkg/model/estimator/local/regressor/logistic.go
@@ -17,6 +17,7 @@ limitations under the License.
 package regressor
 
 import (
+	"fmt"
 	"math"
 )
 
@@ -26,8 +27,9 @@ type LogisticPredictor struct {
 
 func NewLogisticPredictor(weight ModelWeights) (predictor Predictor, err error) {
 	if len(weight.AllWeights.CurveFitWeights) != 4 {
-		return nil, errModelWeightsInvalid
+		return nil, fmt.Errorf("logistic predictor: %w", errModelWeightsInvalid)
 	}
+
 	return &LogisticPredictor{ModelWeights: weight}, nil
 }
 

--- a/pkg/model/estimator/local/regressor/regressor.go
+++ b/pkg/model/estimator/local/regressor/regressor.go
@@ -46,6 +46,7 @@ type ModelRequest struct {
 
 // Predictor defines required implementation for power prediction
 type Predictor interface {
+	name() string
 	predict(usageMetricNames []string, usageMetricValues [][]float64, systemMetaDataFeatureNames, systemMetaDataFeatureValues []string) []float64
 }
 
@@ -261,6 +262,7 @@ func (r *Regressor) createPredictor(weight ModelWeights) (predictor Predictor, e
 	default:
 		predictor, err = NewLinearPredictor(weight)
 	}
+	klog.Infof("Created predictor %s for trainer: %q", predictor.name(), r.TrainerName)
 	return
 }
 


### PR DESCRIPTION
The PR modifies the models/regressor 
* to add a `name` method to predictor so the name of of the predictor can be used in logs or elsewhere
* adds predictor name to the error returned
