### PR TITLE
fix(dockerfile): remove redundant habanalabs installation steps

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,11 +5,6 @@ WORKDIR /workspace
 COPY . .
 
 RUN make tidy-vendor format
-RUN if [[ "$INSTALL_HABANA" == "true" ]]; then \
-		rpm -Uvh https://vault.habana.ai/artifactory/rhel/9/9.2/habanalabs-firmware-tools-1.15.1-15.el9.x86_64.rpm --nodeps; \
-		echo /usr/lib/habanalabs > /etc/ld.so.conf.d/habanalabs.conf; \
-		ldconfig; \
-	fi
 
 RUN make build
 


### PR DESCRIPTION
This commit resolves an issue where the habanalabs installation step was unnecessary repeated multiple times in the Dockerfile.