### PR TITLE
chore(dockerfile): remove the arg from the builder stage

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,4 @@
 FROM quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.3.0 AS builder
-ARG INSTALL_HABANA=false
 WORKDIR /workspace
 
 COPY . .


### PR DESCRIPTION
This commit removes the ARG `INSTALL_HABANA` from the builder stage of the Dockerfile as it is already defined in the final image stage