### PR TITLE
chore(validator): fix graphs rendered incorrectly

### DIFF
--- a/e2e/tools/validator/src/validator/cli/__init__.py
+++ b/e2e/tools/validator/src/validator/cli/__init__.py
@@ -533,8 +533,8 @@ def run_validation(
         if not result.mape_passed:
             click.secho(f"MAPE exceeded threshold. mape: {cmp.mape}, max_mape: {v.max_mape}", fg="red")
 
-        result.actual_filepath = dump_query_result(results_dir, v.expected, cmp.expected_series)
-        result.expected_filepath = dump_query_result(results_dir, v.actual, cmp.actual_series)
+        result.actual_filepath = dump_query_result(results_dir, v.expected, cmp.actual_series)
+        result.expected_filepath = dump_query_result(results_dir, v.actual, cmp.expected_series)
 
     # ruff: noqa: BLE001 (Suppressed as we want to catch all exceptions here)
     except Exception as e:


### PR DESCRIPTION
This fixes the graphs that were flipped leading to confusion in how MAPE is calculated!
See: https://github.com/sustainable-computing-io/kepler-metal-ci/blob/main/docs/train-validate-e2e/2024-09-05_02-22-45/AbsPower/BPFOnly/SGDRegressorTrainer/report-v0.7.11-196-g6a76bc35.md#platform---dynamic 

The graph should have caused MAPE to be 100% where as the MAPE is `inf`  as the [dynamic data](https://github.com/sustainable-computing-io/kepler-metal-ci/blob/main/docs/train-validate-e2e/2024-09-05_02-22-45/AbsPower/BPFOnly/SGDRegressorTrainer/artifacts/kepler_vm_platform_joules_total--dynamic.json) is all 0