### PR TITLE
chore(ci): update equinix metal actions to point to org fork

### DIFF
--- a/.github/workflows/mock_acpi.yml
+++ b/.github/workflows/mock_acpi.yml
@@ -36,8 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: metal-runner-action
-        # TODO: use the forked version of metal-runner-action inside sustainable-computing-io organization
-        uses: vprashar2929/metal-runner-action@custom-action
+        uses: sustainable-computing-io/metal-runner-action@main
         with:
           github_token: ${{ secrets.GH_SELF_HOSTED_RUNNER_TOKEN }}
           metal_auth_token: ${{ secrets.EQUINIX_API_TOKEN }}
@@ -95,7 +94,7 @@ jobs:
     steps:
       - name: delete runner
         if: ${{ always() }}
-        uses: rootfs/metal-delete-action@main
+        uses: sustainable-computing-io/metal-sweeper-action@main
         with:
           authToken: ${{ secrets.EQUINIX_API_TOKEN }}
           projectID: ${{ secrets.EQUINIX_PROJECT_ID }}


### PR DESCRIPTION
This commit updates the equinix metal actions used in the workflow to point to use the forked version maintained under `sustainable-computing-io` organization.

Addresses #1739