### PR TITLE
chore: enable selected collectors in node-exporter

### DIFF
--- a/manifests/compose/dev/compose.yaml
+++ b/manifests/compose/dev/compose.yaml
@@ -95,10 +95,16 @@ services:
         source: /
         target: /rootfs
     command:
+      # - --log.level=debug
       - --path.procfs=/host/proc
       - --path.sysfs=/host/sys
       - --path.rootfs=/rootfs
-      - --collector.rapl  # Enable RAPL collector
+      - --collector.disable-defaults
+      - --collector.cpu
+      - --collector.cpufreq
+      - --collector.perf
+      - --collector.meminfo
+      - --collector.rapl
       - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
     user: root
     networks:

--- a/manifests/compose/validation/metal/compose.yaml
+++ b/manifests/compose/validation/metal/compose.yaml
@@ -102,10 +102,16 @@ services:
         source: /
         target: /rootfs
     command:
+      # - --log.level=debug
       - --path.procfs=/host/proc
       - --path.sysfs=/host/sys
       - --path.rootfs=/rootfs
-      - --collector.rapl  # Enable RAPL collector
+      - --collector.disable-defaults
+      - --collector.cpu
+      - --collector.cpufreq
+      - --collector.perf
+      - --collector.meminfo
+      - --collector.rapl
       - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
     user: root
     networks:


### PR DESCRIPTION
With all default collectors enabled, node-exporter produces a lot of metrics, and prometheus can timeout scraping node-exporter.

This PR :

Disable default collectors
Only enable collectors `cpu, cpufreq, perf, rapl, meminfo`