### PR TITLE
fix: gosec failures

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@6fbd381238e97e1d1f3358f0d6d65de78dcf9245 #v2.20.0
         with:
           # Arguments for gosec, -no-fail to not fail the workflow based on findings
           args: -no-fail -fmt sarif -out gosec-results.sarif ./...


### PR DESCRIPTION
it looks like there's a bit of flux on the [gosec repo](https://github.com/securego/gosec) ATM... with multiple releases happening last week - so I propose we fix the version we are using till that settles...

