### PR TITLE
chore(git): remove e2e from dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 ./_output/
 ./ansible/
-./e2e/
 ./enhancements/
 ./manifests/


### PR DESCRIPTION
This commit removes e2e from dockerignore file as it is required while building the test image for running the e2e tests downstream Ref: https://github.com/openshift-power-monitoring/kepler/blob/main/e2e/Dockerfile