### PR TITLE
fixes: aa66ada adding the needed libraries to the builder stage

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,19 @@
 FROM quay.io/sustainable_computing_io/kepler_builder:ubi-9-libbpf-1.3.0 AS builder
+ARG INSTALL_DCGM=false
+ARG INSTALL_HABANA=false
 WORKDIR /workspace
 
 COPY . .
+
+RUN if [[ "$INSTALL_DCGM" == "true" ]]; then \
+		dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo; \
+		yum install -y datacenter-gpu-manager; \
+	fi; \
+	if [[ "$INSTALL_HABANA" == "true" ]]; then \
+		rpm -Uvh https://vault.habana.ai/artifactory/rhel/9/9.2/habanalabs-firmware-tools-1.15.1-15.el9.x86_64.rpm --nodeps; \
+		echo /usr/lib/habanalabs > /etc/ld.so.conf.d/habanalabs.conf; \
+		ldconfig; \
+	fi;
 
 RUN make tidy-vendor format
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -668,3 +668,8 @@ func APIServerEnabled() bool {
 	ensureConfigInitialized()
 	return instance.Kepler.EnableAPIServer
 }
+
+func DCGMHostEngineEndpoint() string {
+	ensureConfigInitialized()
+	return instance.DCGMHostEngineEndpoint
+}

--- a/pkg/sensors/accelerator/device/sources/dcgm.go
+++ b/pkg/sensors/accelerator/device/sources/dcgm.go
@@ -62,7 +62,7 @@ type GPUDcgm struct {
 }
 
 func init() {
-	if _, err := dcgm.Init(dcgm.Standalone, config.DCGMHostEngineEndpoint, isSocket); err != nil {
+	if _, err := dcgm.Init(dcgm.Standalone, config.DCGMHostEngineEndpoint(), isSocket); err != nil {
 		klog.Errorf("Error initializing dcgm: %v", err)
 		return
 	}
@@ -131,7 +131,7 @@ func (d *GPUDcgm) InitLib() (err error) {
 			err = fmt.Errorf("could not init dcgm: %v", r)
 		}
 	}()
-	cleanup, err := dcgm.Init(dcgm.Standalone, config.DCGMHostEngineEndpoint, isSocket)
+	cleanup, err := dcgm.Init(dcgm.Standalone, config.DCGMHostEngineEndpoint(), isSocket)
 	if err != nil {
 		klog.Infof("There is no DCGM daemon running in the host: %s", err)
 		// embedded mode is not recommended for production per https://github.com/NVIDIA/dcgm-exporter/issues/22#issuecomment-1321521995


### PR DESCRIPTION
https://github.com/sustainable-computing-io/kepler/commit/aa66ada360ba6d8348f231a458040b60a69733a2 broke the habana-latest Kepler image. 

I also noticed that the dcgm-latest wouldn't work from the builder stage: https://github.com/sustainable-computing-io/kepler/actions/runs/10880954177/job/30191354022#step:7:1066

As Kepler relies on build tags for the gpu code the libraries need to be installed at the builder stage as well as the final image stage

This fixes issue https://github.com/sustainable-computing-io/kepler/issues/1783 . However I will remove the dcgm/nvml tag dependency in: https://github.com/sustainable-computing-io/kepler/pull/1704 as I added building in all the dcgm/nvml gpu code into kepler by default there. Habana is problematic and can't follow the same solution (re building) out of the box. 
