### PR TITLE
ci: add attestation to container images and SBOMs

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -21,6 +21,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      attestations: write
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -96,6 +98,14 @@ jobs:
         run: |
           cosign sign -y quay.io/sustainable_computing_io/${{matrix.IMAGE_NAME}}:${{matrix.LABEL}}@${{ steps.build-push-image.outputs.digest }}
 
+      - name: Generate image attestation
+        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch')}}
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: quay.io/sustainable_computing_io/${{matrix.IMAGE_NAME}}
+          subject-digest: ${{ steps.build-push-image.outputs.digest }}
+          push-to-registry: ${{ inputs.pushImage }}
+
       - name: Generate SBOM
         uses: anchore/sbom-action@v0.17.2
         with:
@@ -110,3 +120,12 @@ jobs:
           name: sbom-${{matrix.IMAGE_NAME}}-${{matrix.LABEL}}.spdx.json
           path: ./sbom-${{matrix.IMAGE_NAME}}-${{matrix.LABEL}}.spdx.json
           retention-days: 1
+
+      - name: Generate SBOM attestation
+        uses: actions/attest-sbom@v1
+        if: ${{ inputs.pushImage }}
+        with:
+          subject-name: quay.io/sustainable_computing_io/${{matrix.IMAGE_NAME}}
+          subject-digest: ${{ steps.build-push-image.outputs.digest }}
+          sbom-path: ./sbom-${{matrix.IMAGE_NAME}}-${{matrix.LABEL}}.spdx.json
+          push-to-registry: ${{ inputs.pushImage }}


### PR DESCRIPTION
Add in-toto attestation to all image-building ci workflows, for both SBOMs (image.yml) and images themselves (all 3 workflows). Allow necessary permissions to attest (attestations, packages).