### PR TITLE
fix(metrics): Remove resource usage check for skipping bpf metrics

### DIFF
--- a/pkg/collector/resourceutilization/bpf/process_bpf_collector.go
+++ b/pkg/collector/resourceutilization/bpf/process_bpf_collector.go
@@ -90,12 +90,8 @@ func UpdateProcessBPFMetrics(bpfExporter bpf.Exporter, processStats map[uint64]*
 		comm := C.GoString((*C.char)(unsafe.Pointer(&ct.Comm)))
 
 		if ct.Pid != 0 {
-			klog.V(6).Infof("process %s (pid=%d, cgroup=%d) has %d CPU cycles, %d instructions, %d cache misses, %d page cache hits",
-				comm, ct.Pid, ct.CgroupId, ct.CpuCycles, ct.CpuInstr, ct.CacheMiss, ct.PageCacheHit)
-		}
-		// skip process without resource utilization
-		if ct.CacheMiss == 0 && ct.PageCacheHit == 0 {
-			continue
+			klog.V(6).Infof("process %s (pid=%d, cgroup=%d) has %d process run time, %d CPU cycles, %d instructions, %d cache misses, %d page cache hits",
+				comm, ct.Pid, ct.CgroupId, ct.ProcessRunTime, ct.CpuCycles, ct.CpuInstr, ct.CacheMiss, ct.PageCacheHit)
 		}
 
 		// if the pid is within a container, it will have a container ID


### PR DESCRIPTION
- Removed check for mandatory `CacheMiss` and `PageCacheHit` before creating bpf metric
- Added `ProcessRunTime` in the bpf collector log



In a VM where `hostPassThrough` is disabled, we will not get `cpu_cycles`, `cpu_instructions`, `cache_miss`, these values are always 0.
So as per the resource usage check, only when there is a page cache hit, bpf metrics will be created.

we can see the same in the logs.

I executed stress-ng in the VM, and checked for `docker compose logs kepler | grep process_bpf_ | grep -i stress`

we can see that every so often there is a page cache hit n stress-ng, perhaps it tries to read something, and we get a bpf cpu time metric.



```sh
kepler-1  | I0919 23:35:46.597731    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4023, cgroup=8982) has 873929 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:35:46.597979    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4024, cgroup=8982) has 875693 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:35:46.598140    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4044, cgroup=8982) has 322709 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:35:46.598194    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4045, cgroup=8982) has 319412 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:35:49.596107    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4044, cgroup=8982) has 766100 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:35:49.596121    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4045, cgroup=8982) has 752919 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:35:52.598567    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4044, cgroup=8982) has 756619 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:35:52.598679    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4045, cgroup=8982) has 737898 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:35:55.596915    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4044, cgroup=8982) has 708001 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:35:55.596958    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4045, cgroup=8982) has 729921 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:35:58.595775    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4044, cgroup=8982) has 721737 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:35:58.595791    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4045, cgroup=8982) has 729014 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:01.595610    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4044, cgroup=8982) has 735494 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:01.595622    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4045, cgroup=8982) has 727664 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:04.595586    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4044, cgroup=8982) has 728856 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:04.595600    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4045, cgroup=8982) has 746230 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:07.596938    2844 process_bpf_collector.go:93] process stress-ng (pid=4043, cgroup=8982) has 4608 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:07.596991    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4047, cgroup=8982) has 232008 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:07.596999    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4048, cgroup=8982) has 242001 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:07.597047    2844 process_bpf_collector.go:93] process stress-ng (pid=4046, cgroup=8982) has 16472 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 4128 page cache hits
kepler-1  | I0919 23:36:07.597061    2844 process_bpf_collector.go:104] failed to resolve container for PID 4046 (command=stress-ng): path too short to determine container ID, set containerID=system_processes
kepler-1  | I0919 23:36:07.597149    2844 process_bpf_collector.go:112] failed to resolve VM ID for PID 4046 (command=stress-ng): pid 4046 does not have vm ID
kepler-1  | I0919 23:36:07.597214    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4044, cgroup=8982) has 180895 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:07.597230    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4045, cgroup=8982) has 196752 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:10.596454    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4047, cgroup=8982) has 254642 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:10.596475    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4048, cgroup=8982) has 277132 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:13.596268    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4047, cgroup=8982) has 311130 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:13.596277    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4048, cgroup=8982) has 270934 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:16.599369    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4047, cgroup=8982) has 244911 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:16.600637    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4048, cgroup=8982) has 312058 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:19.596383    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4047, cgroup=8982) has 300926 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:19.596398    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4048, cgroup=8982) has 268868 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:22.597873    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4047, cgroup=8982) has 272888 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:22.597880    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4048, cgroup=8982) has 307087 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:25.595994    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4051, cgroup=8982) has 48 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:25.596125    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4047, cgroup=8982) has 275891 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:25.596135    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4048, cgroup=8982) has 286592 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:25.596218    2844 process_bpf_collector.go:93] process stress-ng (pid=4049, cgroup=8982) has 14065 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 4100 page cache hits
kepler-1  | I0919 23:36:25.596230    2844 process_bpf_collector.go:104] failed to resolve container for PID 4049 (command=stress-ng): path too short to determine container ID, set containerID=system_processes
kepler-1  | I0919 23:36:25.596365    2844 process_bpf_collector.go:112] failed to resolve VM ID for PID 4049 (command=stress-ng): pid 4049 does not have vm ID
kepler-1  | I0919 23:36:25.596468    2844 process_bpf_collector.go:93] process stress-ng (pid=4046, cgroup=8982) has 0 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:25.596504    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4050, cgroup=8982) has 73 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:31.596289    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4051, cgroup=8982) has 0 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:31.596320    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4054, cgroup=8982) has 43 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:31.596501    2844 process_bpf_collector.go:93] process stress-ng (pid=4052, cgroup=8982) has 0 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:31.596622    2844 process_bpf_collector.go:93] process stress-ng (pid=4049, cgroup=8982) has 5450 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:31.596721    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4050, cgroup=8982) has 0 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:31.597261    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4053, cgroup=8982) has 41 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:37.595650    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4054, cgroup=8982) has 0 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:37.595688    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4074, cgroup=8982) has 220105 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:37.595691    2844 process_bpf_collector.go:93] process stress-ng (pid=4052, cgroup=8982) has 2415 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:37.595699    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4075, cgroup=8982) has 227891 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:37.595702    2844 process_bpf_collector.go:93] process stress-ng (pid=4073, cgroup=8982) has 5299 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 4108 page cache hits
kepler-1  | I0919 23:36:37.595706    2844 process_bpf_collector.go:104] failed to resolve container for PID 4073 (command=stress-ng): path too short to determine container ID, set containerID=system_processes
kepler-1  | I0919 23:36:37.595757    2844 process_bpf_collector.go:112] failed to resolve VM ID for PID 4073 (command=stress-ng): pid 4073 does not have vm ID
kepler-1  | I0919 23:36:37.595819    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4053, cgroup=8982) has 0 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:40.596470    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4074, cgroup=8982) has 277270 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:40.596503    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4075, cgroup=8982) has 277083 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:43.596580    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4074, cgroup=8982) has 284550 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:43.596604    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4075, cgroup=8982) has 299430 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:46.596384    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4074, cgroup=8982) has 281211 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:46.596417    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4075, cgroup=8982) has 266786 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:49.596958    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4074, cgroup=8982) has 303720 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:49.597000    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4075, cgroup=8982) has 270772 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:52.596983    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4074, cgroup=8982) has 314179 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:52.597315    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4075, cgroup=8982) has 280186 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:55.598996    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4074, cgroup=8982) has 242235 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:55.599101    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4075, cgroup=8982) has 300338 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:58.598953    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4074, cgroup=8982) has 0 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:58.598974    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4075, cgroup=8982) has 339 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:58.598985    2844 process_bpf_collector.go:93] process stress-ng (pid=4093, cgroup=8982) has 10562 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 4128 page cache hits
kepler-1  | I0919 23:36:58.598999    2844 process_bpf_collector.go:104] failed to resolve container for PID 4093 (command=stress-ng): path too short to determine container ID, set containerID=system_processes
kepler-1  | I0919 23:36:58.599618    2844 process_bpf_collector.go:112] failed to resolve VM ID for PID 4093 (command=stress-ng): pid 4093 does not have vm ID
kepler-1  | I0919 23:36:58.599669    2844 process_bpf_collector.go:93] process stress-ng (pid=4073, cgroup=8982) has 2497 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:58.600134    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4094, cgroup=8982) has 755692 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:36:58.600181    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4095, cgroup=8982) has 748800 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:01.597711    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4094, cgroup=8982) has 732118 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:01.597717    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4095, cgroup=8982) has 730734 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:04.595923    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4094, cgroup=8982) has 764155 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:04.595933    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4095, cgroup=8982) has 769786 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:07.595970    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4094, cgroup=8982) has 726078 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:07.595973    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4095, cgroup=8982) has 706500 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:10.596307    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4094, cgroup=8982) has 722564 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:10.596323    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4095, cgroup=8982) has 715613 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:13.596314    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4094, cgroup=8982) has 777998 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:13.596320    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4095, cgroup=8982) has 752430 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:16.597100    2844 process_bpf_collector.go:93] process stress-ng (pid=4093, cgroup=8982) has 4667 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:16.597413    2844 process_bpf_collector.go:93] process stress-ng (pid=4098, cgroup=8982) has 16569 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 4128 page cache hits
kepler-1  | I0919 23:37:16.597494    2844 process_bpf_collector.go:104] failed to resolve container for PID 4098 (command=stress-ng): path too short to determine container ID, set containerID=system_processes
kepler-1  | I0919 23:37:16.597688    2844 process_bpf_collector.go:112] failed to resolve VM ID for PID 4098 (command=stress-ng): pid 4098 does not have vm ID
kepler-1  | I0919 23:37:16.597874    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4100, cgroup=8982) has 421423 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:16.597882    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4094, cgroup=8982) has 489584 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:16.597891    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4099, cgroup=8982) has 421459 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:16.597998    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4095, cgroup=8982) has 507076 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:19.595501    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4100, cgroup=8982) has 1509613 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:19.595504    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4099, cgroup=8982) has 1512375 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:22.597754    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4100, cgroup=8982) has 1504543 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:22.597758    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4099, cgroup=8982) has 1499970 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:25.597589    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4100, cgroup=8982) has 1513342 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:25.597592    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4099, cgroup=8982) has 1511096 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:28.607874    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4100, cgroup=8982) has 1498027 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:28.608356    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4099, cgroup=8982) has 1499674 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:31.595835    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4100, cgroup=8982) has 1490740 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:31.595837    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4099, cgroup=8982) has 1514924 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:34.596333    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4100, cgroup=8982) has 1497107 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:34.596345    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4099, cgroup=8982) has 1494698 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:37.595791    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4121, cgroup=8982) has 1369604 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:37.595795    2844 process_bpf_collector.go:93] process stress-ng (pid=4120, cgroup=8982) has 4940 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 4108 page cache hits
kepler-1  | I0919 23:37:37.595802    2844 process_bpf_collector.go:104] failed to resolve container for PID 4120 (command=stress-ng): path too short to determine container ID, set containerID=system_processes
kepler-1  | I0919 23:37:37.595867    2844 process_bpf_collector.go:112] failed to resolve VM ID for PID 4120 (command=stress-ng): pid 4120 does not have vm ID
kepler-1  | I0919 23:37:37.595909    2844 process_bpf_collector.go:93] process stress-ng (pid=4098, cgroup=8982) has 1467 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:37.595929    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4100, cgroup=8982) has 589732 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:37.595933    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4099, cgroup=8982) has 591743 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:37.595943    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4122, cgroup=8982) has 1365536 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:40.595812    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4121, cgroup=8982) has 2227061 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:40.596025    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4122, cgroup=8982) has 2231181 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:43.595987    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4121, cgroup=8982) has 2254867 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:43.596020    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4122, cgroup=8982) has 2251881 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:46.596977    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4121, cgroup=8982) has 2247893 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:46.596998    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4122, cgroup=8982) has 2252432 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:49.596364    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4121, cgroup=8982) has 2254879 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:49.596407    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4122, cgroup=8982) has 2262484 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:52.598217    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4121, cgroup=8982) has 2260952 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:52.598269    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4122, cgroup=8982) has 2259432 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:55.595922    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4121, cgroup=8982) has 2245513 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:55.595970    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4122, cgroup=8982) has 2244366 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:58.598475    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4124, cgroup=8982) has 2646335 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:58.598487    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4121, cgroup=8982) has 121574 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:58.598499    2844 process_bpf_collector.go:93] process stress-ng (pid=4120, cgroup=8982) has 1607 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:58.598522    2844 process_bpf_collector.go:93] process stress-ng (pid=4123, cgroup=8982) has 5397 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 3951 page cache hits
kepler-1  | I0919 23:37:58.598530    2844 process_bpf_collector.go:104] failed to resolve container for PID 4123 (command=stress-ng): path too short to determine container ID, set containerID=system_processes
kepler-1  | I0919 23:37:58.598594    2844 process_bpf_collector.go:112] failed to resolve VM ID for PID 4123 (command=stress-ng): pid 4123 does not have vm ID
kepler-1  | I0919 23:37:58.598794    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4122, cgroup=8982) has 144148 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:37:58.598832    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4125, cgroup=8982) has 2640236 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:38:01.596977    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4124, cgroup=8982) has 2996973 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
kepler-1  | I0919 23:38:01.597029    2844 process_bpf_collector.go:93] process stress-ng-cpu (pid=4125, cgroup=8982) has 2992479 process run time, 0 CPU cycles, 0 instructions, 0 cache misses, 0 page cache hits
```

plot for `sum(rate(kepler_process_bpf_cpu_time_ms_total{job="vm",command=~".*stress.*"}[20s]))` is mostly zero

![image](https://github.com/user-attachments/assets/f9291899-fab9-455f-afdf-f7220e537313)


With this check removed, the bpf cpu time metric from vm gets updated nicely.

same query as above gives

![image](https://github.com/user-attachments/assets/28d67b14-4e39-462f-a63b-4ec96e665136)


hopefully this helps to fix the model usage in VMs also. we get less power values from models in VM because the bpf cpu time input to models is less.




Cc: @rootfs @sthaha @dave-tucker 




