### PR TITLE
fix(bpf): exclude bpf overhead in bpf_cpu_time

### DIFF
--- a/bpf/kepler.bpf.h
+++ b/bpf/kepler.bpf.h
@@ -353,11 +353,12 @@ static inline int do_kepler_sched_switch_trace(
 		}
 	}
 
-	// Add task on-cpu running start time
-	bpf_map_update_elem(&pid_time_map, &next_pid, &curr_ts, BPF_ANY);
-
 	// create new process metrics
 	register_new_process_if_not_exist(prev_tgid);
+
+	// Add task on-cpu running start time
+	curr_ts = bpf_ktime_get_ns();
+	bpf_map_update_elem(&pid_time_map, &next_pid, &curr_ts, BPF_ANY);
 
 	return 0;
 }


### PR DESCRIPTION
currently `sched_switch_trace` takes timestamp at entry, and uses the same timestamp as prev timestamp for the next task. this makes process_run_time for next process to include the bpf processing time of prev process also.

to avoid this take another timestamp at the end of `sched_switch_trace` and save that as the starting timestamp for the next process.

