### PR TITLE
chore(compose): Add libvirt-exporter

### DIFF
--- a/manifests/compose/dev/compose.yaml
+++ b/manifests/compose/dev/compose.yaml
@@ -110,7 +110,29 @@ services:
     networks:
       - node-exporter-network
 
+  libvirt-exporter:
+    image: quay.io/osism/prometheus-libvirt-exporter:2024.1
+    ports:
+      - 9177:9177
+    volumes:
+      - type: bind
+        source: /run
+        target: /host/run
+
+    entrypoint: [/usr/bin/bash, -c]
+
+    command:
+      - |
+        set -x;
+        /prometheus-libvirt-exporter/prometheus-libvirt-exporter \
+        --libvirt.uri="/host/run/libvirt/libvirt-sock" \
+        --log.level=debug
+    privileged: true
+    networks:
+      - libvirt-exporter-network
+
 networks:
   scaph-network:
   kepler-network:
   node-exporter-network:
+  libvirt-exporter-network:

--- a/manifests/compose/dev/override.yaml
+++ b/manifests/compose/dev/override.yaml
@@ -17,3 +17,4 @@ services:
     networks:
       - scaph-network
       - node-exporter-network
+      - libvirt-exporter-network

--- a/manifests/compose/dev/prometheus/scrape-configs/dev.yaml
+++ b/manifests/compose/dev/prometheus/scrape-configs/dev.yaml
@@ -10,3 +10,7 @@ scrape_configs:
   - job_name: node-exporter
     static_configs:
       - targets: [node-exporter:9100]
+
+  - job_name: libvirt-exporter
+    static_configs:
+      - targets: [libvirt-exporter:9177]

--- a/manifests/compose/validation/metal/compose.yaml
+++ b/manifests/compose/validation/metal/compose.yaml
@@ -117,10 +117,32 @@ services:
     networks:
       - node-exporter-network
 
+  libvirt-exporter:
+    image: quay.io/osism/prometheus-libvirt-exporter:2024.1
+    ports:
+      - 9177:9177
+    volumes:
+      - type: bind
+        source: /run
+        target: /host/run
+
+    entrypoint: [/usr/bin/bash, -c]
+
+    command:
+      - |
+        set -x;
+        /prometheus-libvirt-exporter/prometheus-libvirt-exporter \
+        --libvirt.uri="/host/run/libvirt/libvirt-sock" \
+        --log.level=debug
+    privileged: true
+    networks:
+      - libvirt-exporter-network
+
 networks:
   scaph-network:
   kepler-network:
   node-exporter-network:
+  libvirt-exporter-network:
   #
   #
   #  NOTE: To allow access to VM from prometheus container

--- a/manifests/compose/validation/metal/override.yaml
+++ b/manifests/compose/validation/metal/override.yaml
@@ -16,6 +16,7 @@ services:
       - scaph-network
       - kepler-network
       - node-exporter-network
+      - libvirt-exporter-network
       - virt-net # external n/w for accessing VM
     volumes:
       - type: bind

--- a/manifests/compose/validation/metal/prometheus/scrape-configs/metal.yaml
+++ b/manifests/compose/validation/metal/prometheus/scrape-configs/metal.yaml
@@ -14,3 +14,7 @@ scrape_configs:
   - job_name: node-exporter
     static_configs:
       - targets: [node-exporter:9100]
+
+  - job_name: libvirt-exporter
+    static_configs:
+      - targets: [libvirt-exporter:9177]


### PR DESCRIPTION
Added a prometheus exporter for libvirt to `metal` and `dev` compose


```
sum(rate(libvirt_domain_vcpu_time_seconds_total{domain="fedora40"}[20s]))
# HELP libvirt_domain_vcpu_time_seconds_total Time spent by the virtual CPU.
```
![image](https://github.com/user-attachments/assets/2082c685-a119-4264-ba3c-ab98f079e180)

```
rate(libvirt_domain_vcpu_delay_seconds_total{domain="fedora40"}[20s])
# HELP libvirt_domain_vcpu_delay_seconds_total Time the vCPU spent waiting in the queue instead of running. Exposed to the VM as steal time.
```
![image](https://github.com/user-attachments/assets/045cf44f-8950-4226-97cd-1d3ec00cf961)

```
libvirt_domain_vcpu_wait_seconds_total{domain="fedora40"}
# HELP libvirt_domain_vcpu_wait_seconds_total Time the vCPU wants to run, but the host scheduler has something else running ahead of it.
```
![image](https://github.com/user-attachments/assets/e54f6759-6e3a-4931-bb9a-28a6bc70413c)

