### PR TITLE
Revert "build(deps): bump securego/gosec from 2.20.0 to 2.21.3 in the github-actions group across 1 directory"

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@be8bd6e40be105333f2bc783ba8d688154441559 # v2.21.3
+        uses: securego/gosec@6fbd381238e97e1d1f3358f0d6d65de78dcf9245 # v2.20.0
         with:
           # Arguments for gosec, -no-fail to not fail the workflow based on findings
           args: -no-fail -fmt sarif -out gosec-results.sarif ./...


### PR DESCRIPTION
Reverts sustainable-computing-io/kepler#1794

Submitted issue to: https://github.com/securego/gosec/issues/1234