### PR TITLE
fix(bpf_collector): fix command for kernel processes

### DIFF
--- a/pkg/collector/resourceutilization/bpf/process_bpf_collector.go
+++ b/pkg/collector/resourceutilization/bpf/process_bpf_collector.go
@@ -110,17 +110,19 @@ func UpdateProcessBPFMetrics(bpfExporter bpf.Exporter, processStats map[uint64]*
 		}
 
 		mapKey := ct.Pid
+		process := comm
 		if ct.CgroupId == 1 && config.EnabledEBPFCgroupID() {
 			// we aggregate all kernel process to minimize overhead
 			// all kernel process has cgroup id as 1 and pid 1 is also a kernel process
 			mapKey = 1
+			process = "kernel_processes"
 		}
 
 		bpfSupportedMetrics := bpfExporter.SupportedMetrics()
 		var ok bool
 		var pStat *stats.ProcessStats
 		if pStat, ok = processStats[mapKey]; !ok {
-			pStat = stats.NewProcessStats(ct.Pid, ct.CgroupId, containerID, vmID, comm, bpfSupportedMetrics)
+			pStat = stats.NewProcessStats(mapKey, ct.CgroupId, containerID, vmID, process, bpfSupportedMetrics)
 			processStats[mapKey] = pStat
 		} else if pStat.Command == "" {
 			pStat.Command = comm


### PR DESCRIPTION
-  fix command name in case of kernel processes

if the cgroupID for the pid is 1, it is considered as kernel process
and bpf cpu time for each such process is aggregated under the same  ProcessStat

But the command which shows up in metric is from the first pid which  created the entry in ProcessStats. It could be a `kworker`, or  `rcu_preempt`, or some other kernel process. Which is misleading because it shows that process consuming most of bpf cpu time.

  This commit:
  - uses "kernel_processes" as the command for pid 1 kernel processes
  - sets the pid as 1 instead of the pid of the process that created the  entry

after change:

![image](https://github.com/user-attachments/assets/df8f4027-5355-4a15-a60e-9dc93c678d58)
