### PR TITLE
feat(compose): enable admin API for prometheus snapshot

### DIFF
--- a/manifests/compose/monitoring/compose.yaml
+++ b/manifests/compose/monitoring/compose.yaml
@@ -13,6 +13,10 @@ services:
         target: /etc/prometheus/prometheus.yml
     networks:
       - monitoring
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.enable-admin-api
 
     healthcheck:
       test: wget -q --spider http://localhost:9090/ -O /dev/null || exit 1


### PR DESCRIPTION
This commit introduces the `--web.enable-admin-api` flag, allowing the Prometheus admin API to be enabled for capturing snapshots.