### PR TITLE
fix: remove .dockerignore to ensure clean version computation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,0 @@
-./_output/
-./ansible/
-./enhancements/
-./manifests/


### PR DESCRIPTION
This commit removes the `.dockerignore` file from the repository. The current build process relies on `git describe` to compute the Kepler version. However, the `.dockerignore` file was causing certain Git-tracked files to be excluded from the Docker build context, leading to `dirty` version state. By removing the `.dockerignore` file, we ensure that all files are included, allowing Git to recognize a clean working directory during the image build process

Address: #1808 