### PR TITLE
feat(metrics): refactor idle power exposure

### DIFF
--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -79,7 +79,7 @@ func newAppConfig() *AppConfig {
 	flag.StringVar(&_config.Kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file, if empty we use the in-cluster configuration")
 	flag.BoolVar(&_config.ApiserverEnabled, "apiserver", true, "if apiserver is disabled, we collect pod information from kubelet")
 	flag.StringVar(&_config.RedfishCredFilePath, "redfish-cred-file-path", "", "path to the redfish credential file")
-	flag.BoolVar(&_config.ExposeEstimatedIdlePower, "expose-estimated-idle-power", false, "estimated idle power is meaningful only if Kepler is running on bare-metal or when there is only one virtual machine on the node")
+	flag.BoolVar(&_config.ExposeEstimatedIdlePower, "expose-estimated-idle-power", false, "Whether to expose the estimated idle power as a metric")
 	flag.StringVar(&_config.MachineSpecFilePath, "machine-spec", "", "path to the machine spec file in json format")
 	flag.BoolVar(&_config.DisablePowerMeter, "disable-power-meter", false, "whether manually disable power meter read and forcefully apply the estimator for node powers")
 
@@ -125,7 +125,7 @@ func main() {
 	config.SetEnabledHardwareCounterMetrics(appConfig.ExposeHardwareCounterMetrics)
 	config.SetEnabledGPU(appConfig.EnableGPU)
 	config.SetEnabledMSR(appConfig.EnableMSR)
-	config.SetEnabledIdlePower(appConfig.ExposeEstimatedIdlePower || components.IsSystemCollectionSupported())
+	config.SetEnabledIdlePower(appConfig.ExposeEstimatedIdlePower)
 
 	config.SetKubeConfig(appConfig.Kubeconfig)
 	config.SetEnableAPIServer(appConfig.ApiserverEnabled)

--- a/pkg/collector/energy/node_energy_collector.go
+++ b/pkg/collector/energy/node_energy_collector.go
@@ -104,7 +104,9 @@ func UpdateNodeEnergyMetrics(nodeStats *stats.NodeStats) {
 	// update platform power later to avoid race condition when using estimation power model
 	UpdatePlatformEnergy(nodeStats)
 	// after updating the total energy we calculate the idle, dynamic and other components energy
-	UpdateNodeIdleEnergy(nodeStats)
+	if config.IsIdlePowerEnabled() {
+		UpdateNodeIdleEnergy(nodeStats)
+	}
 	nodeStats.UpdateDynEnergy()
 	nodeStats.SetNodeOtherComponentsEnergy()
 }

--- a/pkg/collector/stats/stats.go
+++ b/pkg/collector/stats/stats.go
@@ -174,7 +174,7 @@ func (s *Stats) CalcDynEnergy(absM, idleM, dynM, id string) {
 
 // calcDynEnergy calculates the dynamic energy.
 func calcDynEnergy(totalE, idleE uint64) uint64 {
-	if (totalE == 0) || (idleE == 0) || (totalE < idleE) {
+	if (totalE == 0) || (totalE < idleE) {
 		return 0
 	}
 	return totalE - idleE


### PR DESCRIPTION
As discussed in the Oct 15 meeting, we make the idle power classification optional, until we have an idle power regression model that can predict idle power by system utilization.