### PR TITLE
fix(remove_idle): Remove Idle Validations

### DIFF
--- a/e2e/tools/validator/validations.yaml
+++ b/e2e/tools/validator/validations.yaml
@@ -183,74 +183,74 @@ validations:
 
   # idle power comparison
 
-  - name: platform - idle
-    units: Watts
-    metal: |
-      rate(
-        kepler_{level}_platform_joules_total{{
-          job="{metal_job_name}",
-          {vm_selector},
-          mode="idle",
-        }}[{rate_interval}]
-      )
-    vm: |
-      rate(
-        kepler_node_platform_joules_total{{
-          job="{vm_job_name}",
-          mode="idle",
-        }}[{rate_interval}]
-      )
+  # - name: platform - idle
+  #   units: Watts
+  #   metal: |
+  #     rate(
+  #       kepler_{level}_platform_joules_total{{
+  #         job="{metal_job_name}",
+  #         {vm_selector},
+  #         mode="idle",
+  #       }}[{rate_interval}]
+  #     )
+  #   vm: |
+  #     rate(
+  #       kepler_node_platform_joules_total{{
+  #         job="{vm_job_name}",
+  #         mode="idle",
+  #       }}[{rate_interval}]
+  #     )
 
-  - name: package - idle
-    units: Watts
-    metal: |
-      rate(
-        kepler_{level}_package_joules_total{{
-          job="{metal_job_name}",
-          {vm_selector},
-          mode="idle",
-        }}[{rate_interval}]
-      )
-    vm: |
-      rate(
-        kepler_node_package_joules_total{{
-          job="{vm_job_name}",
-          mode="idle",
-        }}[{rate_interval}]
-      )
+  # - name: package - idle
+  #   units: Watts
+  #   metal: |
+  #     rate(
+  #       kepler_{level}_package_joules_total{{
+  #         job="{metal_job_name}",
+  #         {vm_selector},
+  #         mode="idle",
+  #       }}[{rate_interval}]
+  #     )
+  #   vm: |
+  #     rate(
+  #       kepler_node_package_joules_total{{
+  #         job="{vm_job_name}",
+  #         mode="idle",
+  #       }}[{rate_interval}]
+  #     )
 
-  - name: core - idle
-    units: Watts
-    metal: |
-      rate(
-        kepler_{level}_core_joules_total{{
-          job="{metal_job_name}",
-          {vm_selector},
-          mode="idle",
-        }}[{rate_interval}]
-      )
-    vm: |
-      rate(
-        kepler_node_core_joules_total{{
-          job="{vm_job_name}",
-          mode="idle",
-        }}[{rate_interval}]
-      )
+  # - name: core - idle
+  #   units: Watts
+  #   metal: |
+  #     rate(
+  #       kepler_{level}_core_joules_total{{
+  #         job="{metal_job_name}",
+  #         {vm_selector},
+  #         mode="idle",
+  #       }}[{rate_interval}]
+  #     )
+  #   vm: |
+  #     rate(
+  #       kepler_node_core_joules_total{{
+  #         job="{vm_job_name}",
+  #         mode="idle",
+  #       }}[{rate_interval}]
+  #     )
 
-  - name: dram - idle
-    units: Watts
-    metal: |
-      rate(
-        kepler_{level}_dram_joules_total{{
-          job="{metal_job_name}",
-          {vm_selector},
-          mode="idle",
-        }}[{rate_interval}]
-      )
-    vm: |
-      rate(
-        kepler_node_dram_joules_total{{
-          job="{vm_job_name}",
-          mode="idle",
-        }}[{rate_interval}]
-      )
+  # - name: dram - idle
+  #   units: Watts
+  #   metal: |
+  #     rate(
+  #       kepler_{level}_dram_joules_total{{
+  #         job="{metal_job_name}",
+  #         {vm_selector},
+  #         mode="idle",
+  #       }}[{rate_interval}]
+  #     )
+  #   vm: |
+  #     rate(
+  #       kepler_node_dram_joules_total{{
+  #         job="{vm_job_name}",
+  #         mode="idle",
+  #       }}[{rate_interval}]
+  #     )


### PR DESCRIPTION
Given current issues with idle metrics, it should not be validated upon on the metal ci. Current validations should only use absolute power (no dynamic/idle separation).