### PR TITLE
chore(compose): Disable idle power metrics in VM

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.59.1
+    rev: v1.61.0
     hooks:
       - id: golangci-lint
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook

--- a/manifests/compose/validation/vm/kepler/etc/kepler/kepler.config/EXPOSE_ESTIMATED_IDLE_POWER_METRICS
+++ b/manifests/compose/validation/vm/kepler/etc/kepler/kepler.config/EXPOSE_ESTIMATED_IDLE_POWER_METRICS
@@ -1,1 +1,1 @@
-true
+false


### PR DESCRIPTION
This patch disables the idle power metrics produced when Kepler is run
on the VM

Additionally this, patch also updates the version of golangci-lint in pre-commit-config.yaml to fix the failing pre-commit check https://github.com/sustainable-computing-io/kepler/actions/runs/11435710050/job/31811844512