### PR TITLE
fix(validator): include scikit-learn in dependencies

### DIFF
--- a/e2e/tools/validator/pyproject.toml
+++ b/e2e/tools/validator/pyproject.toml
@@ -26,10 +26,11 @@ dependencies = [
   "click",
   "paramiko",
   "prometheus-api-client",
-	"pyyaml",
-	"numpy",
-	"pandas",
-	"matplotlib",
+  "pyyaml",
+  "numpy",
+  "pandas",
+  "matplotlib",
+  "scikit-learn",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This commit adds the missing scikit-learn dependency to the validator as pip install fails currently due to missing dependency.