### PR TITLE
fix(compose): Enable measuring ContextSwitches in node-exporter

### DIFF
--- a/manifests/compose/dev/compose.yaml
+++ b/manifests/compose/dev/compose.yaml
@@ -103,10 +103,15 @@ services:
       - --collector.cpu
       - --collector.cpufreq
       - --collector.perf
+      - --collector.perf.cpus=0-19 # specify range of all cpus
+      - --collector.perf.software-profilers=ContextSwitch
       - --collector.meminfo
       - --collector.rapl
       - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
     user: root
+    cap_add: # Add capabilities for perf collection.
+      - SYS_ADMIN
+      - SYS_PTRACE
     networks:
       - node-exporter-network
 

--- a/manifests/compose/validation/metal/compose.yaml
+++ b/manifests/compose/validation/metal/compose.yaml
@@ -110,10 +110,15 @@ services:
       - --collector.cpu
       - --collector.cpufreq
       - --collector.perf
+      - --collector.perf.cpus=0-19 # specify range of all cpus
+      - --collector.perf.software-profilers=ContextSwitch
       - --collector.meminfo
       - --collector.rapl
       - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
     user: root
+    cap_add: # Add capabilities for perf collection.
+      - SYS_ADMIN
+      - SYS_PTRACE
     networks:
       - node-exporter-network
 


### PR DESCRIPTION
Enables measuring per cpu context switches.

example:
![image](https://github.com/user-attachments/assets/b666f5b5-a8d8-4e12-b7ce-e12b5c8704ac)


Note: In case of isolated CPUs, if we dont specify `--collector.perf.cpus` config parameter, node-exporter will use the range from `0` to `runtime.NumCPU()` which does not include isolated CPUs. if this range includes isolated cpus those cpus will be considered, whereas the last few CPUs will be dropped.

e,.g. if there are 20 CPUs, and cpus 2,3,12,13 are isolated, not configuring `--collector.perf.cpus` means 0-15 will be shown, which includes the isolated cpus. which is counter intuitive.

sp pls mention the complete cpu range  `--collector.perf.cpus=0-19`