### PR TITLE
feat: move from ubi to ubi-minimal

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,7 +19,7 @@ RUN make tidy-vendor format
 
 RUN make build
 
-FROM registry.access.redhat.com/ubi9:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 # NOTE: use bash instead of sh
 SHELL ["/bin/bash", "-c"]
 
@@ -32,20 +32,20 @@ ENV NVIDIA_DRIVER_CAPABILITIES=utility
 ENV NVIDIA_MIG_MONITOR_DEVICES=all
 ENV NVIDIA_MIG_CONFIG_DEVICES=all
 
-RUN yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical && yum clean all
+RUN microdnf clean all && microdnf upgrade -y --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 && microdnf clean all
 # NOTE: set -e ensure all fails results in a non-zero exit code (i.e. fail)
 RUN set -e -x ;\
 		INSTALL_PKGS=" \
 			libbpf  \
 		" ;\
-		yum install -y $INSTALL_PKGS ;\
+		microdnf install -y $INSTALL_PKGS ;\
 		\
 		if [[ "$TARGETARCH" == "amd64" ]]; then \
-			yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm; \
-			yum install -y cpuid; \
+			microdnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm; \
+			microdnf install -y cpuid; \
 			if [[ "$INSTALL_DCGM" == "true" ]]; then \
-				dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo; \
-				yum install -y datacenter-gpu-manager libnvidia-ml; \
+				curl https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo -o /etc/yum.repos.d/cuda-rhel9.repo; \
+				microdnf install -y datacenter-gpu-manager libnvidia-ml; \
 			fi; \
 			if [[ "$INSTALL_HABANA" == "true" ]]; then \
 				rpm -Uvh https://vault.habana.ai/artifactory/rhel/9/9.2/habanalabs-firmware-tools-1.15.1-15.el9.x86_64.rpm --nodeps; \
@@ -53,7 +53,7 @@ RUN set -e -x ;\
 				ldconfig; \
 			fi; \
 		fi;\
-		yum clean all
+		microdnf clean all
 
 COPY --from=builder /workspace/_output/bin/kepler /usr/bin/kepler
 COPY --from=builder /libbpf-source/linux-5.14.0-424.el9/tools/bpf/bpftool/bpftool /usr/bin/bpftool

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -41,7 +41,7 @@ RUN set -e -x ;\
 		microdnf install -y $INSTALL_PKGS ;\
 		\
 		if [[ "$TARGETARCH" == "amd64" ]]; then \
-			microdnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm; \
+			rpm -i https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm; \
 			microdnf install -y cpuid; \
 			if [[ "$INSTALL_DCGM" == "true" ]]; then \
 				curl https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo -o /etc/yum.repos.d/cuda-rhel9.repo; \


### PR DESCRIPTION
This PR should close https://github.com/sustainable-computing-io/kepler/issues/1826.
Using a smaller base image has several benefits:
  - Reducing the storage footprint. Quicker deployments (less and/or smaller layers to pull).
  - Reducing the potential attack surface.
  - Reducing the amount of vulnerabilities that will arise between one `kepler` release and another, simply because there are less items installed.

A picture is worth a thousand words:
<img width="1118" alt="image" src="https://github.com/user-attachments/assets/139fbc3e-c021-434a-b454-51f0d00b58af">
<img width="1123" alt="image" src="https://github.com/user-attachments/assets/289d83d9-d0b9-4490-8832-af7c56f34926">
<img width="1262" alt="image" src="https://github.com/user-attachments/assets/49b51f0e-6c6a-4d68-a1bd-632bbf551b9d">

The vulnerabilities we see above (as of 2024/10/24, in `kepler:release-0.7.12`) are inherited from the base image. They are in the python namespace, which is not needed at all in the `kepler` image, and which is why https://github.com/sustainable-computing-io/kepler/pull/1361 cannot get rid of them.

Thank you.