### PR TITLE
fix(bpf): exclude swapper process bpf_cpu_time

### DIFF
--- a/pkg/collector/resourceutilization/bpf/process_bpf_collector.go
+++ b/pkg/collector/resourceutilization/bpf/process_bpf_collector.go
@@ -89,6 +89,11 @@ func UpdateProcessBPFMetrics(bpfExporter bpf.Exporter, processStats map[uint64]*
 	for _, ct := range processesData {
 		comm := C.GoString((*C.char)(unsafe.Pointer(&ct.Comm)))
 
+		if ct.Pid == 0 && config.ExcludeSwapperProcess() {
+			// exclude swapper process
+			continue
+		}
+
 		if ct.Pid != 0 {
 			klog.V(6).Infof("process %s (pid=%d, cgroup=%d) has %d process run time, %d CPU cycles, %d instructions, %d cache misses, %d page cache hits",
 				comm, ct.Pid, ct.CgroupId, ct.ProcessRunTime, ct.CpuCycles, ct.CpuInstr, ct.CacheMiss, ct.PageCacheHit)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,6 +64,7 @@ type KeplerConfig struct {
 	EstimatorSelectFilter        string
 	CPUArchOverride              string
 	MachineSpecFilePath          string
+	ExcludeSwapperProcess        bool
 }
 type MetricsConfig struct {
 	CoreUsageMetric    string
@@ -158,6 +159,7 @@ func getKeplerConfig() KeplerConfig {
 		EstimatorModel:               getConfig("ESTIMATOR_MODEL", defaultMetricValue),
 		EstimatorSelectFilter:        getConfig("ESTIMATOR_SELECT_FILTER", defaultMetricValue), // no filter
 		CPUArchOverride:              getConfig("CPU_ARCH_OVERRIDE", defaultCPUArchOverride),
+		ExcludeSwapperProcess:        getBoolConfig("EXCLUDE_SWAPPER_PROCESS", defaultExcludeSwapperProcess),
 	}
 }
 
@@ -262,6 +264,7 @@ func logBoolConfigs() {
 		klog.V(5).Infof("EXPOSE_COMPONENT_POWER: %t", instance.Kepler.ExposeComponentPower)
 		klog.V(5).Infof("EXPOSE_ESTIMATED_IDLE_POWER_METRICS: %t. This only impacts when the power is estimated using pre-prained models. Estimated idle power is meaningful only when Kepler is running on bare-metal or with a single virtual machine (VM) on the node.", instance.Kepler.ExposeIdlePowerMetrics)
 		klog.V(5).Infof("EXPERIMENTAL_BPF_SAMPLE_RATE: %d", instance.Kepler.BPFSampleRate)
+		klog.V(5).Infof("EXCLUDE_SWAPPER_PROCESS: %t", instance.Kepler.ExcludeSwapperProcess)
 	}
 }
 
@@ -680,4 +683,9 @@ func BPFSwCounters() []string {
 func DCGMHostEngineEndpoint() string {
 	ensureConfigInitialized()
 	return instance.DCGMHostEngineEndpoint
+}
+
+func ExcludeSwapperProcess() bool {
+	ensureConfigInitialized()
+	return instance.Kepler.ExcludeSwapperProcess
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -90,11 +90,12 @@ const (
 	// MaxIRQ is the maximum number of IRQs to be monitored
 	MaxIRQ = 10
 	// defaultSamplePeriodSec is the time in seconds that the reader will wait before reading the metrics again
-	defaultSamplePeriodSec = 3
-	configDir              = "/etc/kepler/kepler.config"
-	defaultKubeConfig      = ""
-	defaultBPFSampleRate   = 0
-	defaultCPUArchOverride = ""
+	defaultSamplePeriodSec       = 3
+	configDir                    = "/etc/kepler/kepler.config"
+	defaultKubeConfig            = ""
+	defaultBPFSampleRate         = 0
+	defaultCPUArchOverride       = ""
+	defaultExcludeSwapperProcess = false
 	// model_parameter_prefix
 	defaultNodePlatformPowerKey        = "NODE_TOTAL"
 	defaultNodeComponentsPowerKey      = "NODE_COMPONENTS"


### PR DESCRIPTION
when cpu is idle, swapper process is scheduled, and kepler adds its bpf_cpu_time to kernel processes

adding a configuration to exclude swapper process


with-swapper
![with-swapper](https://github.com/user-attachments/assets/b0c8143a-e13c-4ad2-8b04-66048c089630)

without-swapper
![without-swapper](https://github.com/user-attachments/assets/cd17269a-aae5-4c35-9ea9-aa2cd1636314)
