### PR TITLE
chore(compose): switch to stable Prometheus version

### DIFF
--- a/manifests/compose/monitoring/prometheus/Dockerfile
+++ b/manifests/compose/monitoring/prometheus/Dockerfile
@@ -1,3 +1,3 @@
-FROM quay.io/prometheus/prometheus:main
+FROM quay.io/prometheus/prometheus:latest
 
 COPY /prometheus.yml /etc/prometheus/prometheus.yml


### PR DESCRIPTION
This commit updates the compose config to use a stable Prometheus version instead of the main development version.
Additionally, it resolves an issue where Prometheus could not scrape metrics from Scaphandre, which was failing due to an invalid `Content-Type` header in Scaphandre's response.