### PR TITLE
docs: add new line after host/vm/summary table

### DIFF
--- a/e2e/tools/validator/src/validator/cli/__init__.py
+++ b/e2e/tools/validator/src/validator/cli/__init__.py
@@ -172,6 +172,9 @@ class MarkdownReport:
             ],
         )
 
+    def new_line(self):
+        self.write("\n")
+
 
 def write_md_report(results_dir: str, r: TestResult):
     path = os.path.join(results_dir, f"report-{r.tag}.md")
@@ -193,8 +196,10 @@ def write_md_report(results_dir: str, r: TestResult):
 
     md.h2("Machine Specs")
     md.add_machine_spec("Host", r.host_spec)
+    md.new_line()
     if r.vm_spec is not None:
         md.add_machine_spec("VM", r.vm_spec)
+        md.new_line()
 
     md.h2("Validation Results")
     md.li(f"Started At: `{r.start_time}`")
@@ -217,6 +222,7 @@ def write_md_report(results_dir: str, r: TestResult):
             if not v.unexpected_error
         ],
     )
+    md.new_line()
 
     md.h3("Details")
     for v in r.validations.results:


### PR DESCRIPTION
## Before:
<img width="434" alt="Screenshot 2024-11-06 at 18 12 19" src="https://github.com/user-attachments/assets/b1e38730-2c9c-4032-abbe-847e622da9a0">

## After add a line:
<img width="438" alt="Screenshot 2024-11-06 at 18 11 26" src="https://github.com/user-attachments/assets/5a24f2a6-7944-49dd-a50a-60533c851513">

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>