### PR TITLE
chore(compose): disable idle power in case of dev

### DIFF
--- a/manifests/compose/default/kepler/etc/kepler/kepler.config/EXPOSE_ESTIMATED_IDLE_POWER_METRICS
+++ b/manifests/compose/default/kepler/etc/kepler/kepler.config/EXPOSE_ESTIMATED_IDLE_POWER_METRICS
@@ -1,1 +1,1 @@
-true
+false

--- a/manifests/compose/dev/kepler/etc/kepler/kepler.config/EXPOSE_ESTIMATED_IDLE_POWER_METRICS
+++ b/manifests/compose/dev/kepler/etc/kepler/kepler.config/EXPOSE_ESTIMATED_IDLE_POWER_METRICS
@@ -1,1 +1,1 @@
-true
+false


### PR DESCRIPTION
This commit disables the idle power metrics in case of dev compose.