### PR TITLE
chore: fix wrong stressor init in validator

### DIFF
--- a/e2e/tools/validator/src/validator/cli/__init__.py
+++ b/e2e/tools/validator/src/validator/cli/__init__.py
@@ -431,7 +431,11 @@ def stress(cfg: config.Validator, script_path: str, report_dir: str):
 
     click.secho("  * Running stress test ...", fg="green")
     remote = Remote(cfg.remote)
-    stress_test = remote.run_script(script_path)
+    total_runtime_seconds = cfg.stressor.total_runtime_seconds
+    curve_type = cfg.stressor.curve_type
+    stress_test = remote.run_script(
+        script_path=script_path, target_script="/tmp/stress.sh", t=total_runtime_seconds, c=curve_type
+    )
     res.start_time = stress_test.start_time
     res.end_time = stress_test.end_time
 

--- a/e2e/tools/validator/validations.yaml
+++ b/e2e/tools/validator/validations.yaml
@@ -2,9 +2,6 @@ config:
   mapping:
     actual: metal
     predicted: vm
-  stressor:
-    total_runtime_seconds: 1200
-    curve_type: default
 
 validations:
   - name: node-rapl - kepler-package

--- a/e2e/tools/validator/validator.yaml.sample
+++ b/e2e/tools/validator/validator.yaml.sample
@@ -20,4 +20,8 @@ prometheus:
   rate_interval: 20s  # Rate interval for Promql, default is 20s, typically 4 x $scrape_interval
   steps: 3s  # Step duration for Prometheus range queries
 
+stressor:
+    total_runtime_seconds: 1200
+    curve_type: default
+
 validations_file: ./validations.yaml  # Path to the validations file, default is ./validations.yaml


### PR DESCRIPTION
this is to fix the previous PR that didn't get full tested. This change is verified with the following config:
```yaml
log_level: warn # Logging level, defaults is warn

remote:
  host: my-vm
  username: root
  pkey: /tmp/vm_ssh_key

metal:
  vm:
    pid: 123456 # Process ID for the KVM process running on metal

prometheus:
  job:
    vm: vm  # Job name for virtual machine metrics, default is vm
    metal: metal  # Job name for metal metrics, default is metal

  url: http://localhost:9090 # Prometheus server URL
  rate_interval: 20s  # Rate interval for Promql, default is 20s, typically 4 x $scrape_interval
  steps: 3s  # Step duration for Prometheus range queries

stressor:
  total_runtime_seconds: 600  # Total runtime in seconds for the stress test
  curve_type: default  # Curve type for the stress test, default is linear

validations_file: ./validations.yaml  # Path to the validations file, default is ./validations.yaml

```