### PR TITLE
chore(compose): use fixed version of prometheus

### DIFF
--- a/manifests/compose/monitoring/prometheus/Dockerfile
+++ b/manifests/compose/monitoring/prometheus/Dockerfile
@@ -1,3 +1,3 @@
-FROM quay.io/prometheus/prometheus:latest
+FROM quay.io/prometheus/prometheus:v2.55.0
 
 COPY /prometheus.yml /etc/prometheus/prometheus.yml


### PR DESCRIPTION
This commit fixes the issue where prometheus using `latest` is unable to scrape scaphandre metrics due to issue in scaphandre of having an invalid `Content-Type` header in Scaphandre's response.