### PR TITLE
[nit]: update ginkgo version in CI process keep same with go mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ ginkgo-set:
 	mkdir -p $(GOBIN)
 	mkdir -p $(ENVTEST_ASSETS_DIR)
 	@test -f $(ENVTEST_ASSETS_DIR)/ginkgo || \
-		(go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.19.0  && \
+		(go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.20.1  && \
 		cp $(GOBIN)/ginkgo $(ENVTEST_ASSETS_DIR)/ginkgo)
 
 .PHONY: container_test

--- a/pkg/collector/stats/vm_stats_test.go
+++ b/pkg/collector/stats/vm_stats_test.go
@@ -8,6 +8,11 @@ import (
 
 var _ = Describe("VMMetric", func() {
 
+	BeforeEach(func() {
+		_, err := config.Initialize(".")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("Test ResetDeltaValues", func() {
 		SetMockedCollectorMetrics()
 		vm := NewVMStats(0, "name")


### PR DESCRIPTION
try to fix warning as https://github.com/sustainable-computing-io/kepler/actions/runs/11903667506/job/33171074065#step:7:451

and a nil pointer in test code.