### PR TITLE
[fix]: fix image libbpf build version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -56,7 +56,7 @@ RUN set -e -x ;\
 		microdnf clean all
 
 COPY --from=builder /workspace/_output/bin/kepler /usr/bin/kepler
-COPY --from=builder /libbpf-source/linux-5.14.0-424.el9/tools/bpf/bpftool/bpftool /usr/bin/bpftool
+COPY --from=builder /libbpf-source/linux-5.14.0-473.el9/tools/bpf/bpftool/bpftool /usr/bin/bpftool
 
 RUN mkdir -p /var/lib/kepler/data
 COPY --from=builder /workspace/data/cpus.yaml /var/lib/kepler/data/cpus.yaml


### PR DESCRIPTION
ref https://github.com/sustainable-computing-io/kepler/actions/runs/11985980953/job/33419265828
fix libbpf build version in container image