### PR TITLE
feat(compose): add fallback scrape protocol for Scaphandre service

### DIFF
--- a/manifests/compose/dev/prometheus/scrape-configs/dev.yaml
+++ b/manifests/compose/dev/prometheus/scrape-configs/dev.yaml
@@ -6,6 +6,8 @@ scrape_configs:
   - job_name: scaphandre
     static_configs:
       - targets: [scaphandre:8080]
+    scheme: http
+    fallback_scrape_protocol: PrometheusText1.0.0
 
   - job_name: node-exporter
     static_configs:

--- a/manifests/compose/monitoring/prometheus/Dockerfile
+++ b/manifests/compose/monitoring/prometheus/Dockerfile
@@ -1,3 +1,3 @@
-FROM quay.io/prometheus/prometheus:v2.55.0
+FROM quay.io/prometheus/prometheus:latest
 
 COPY /prometheus.yml /etc/prometheus/prometheus.yml

--- a/manifests/compose/validation/metal/prometheus/scrape-configs/metal.yaml
+++ b/manifests/compose/validation/metal/prometheus/scrape-configs/metal.yaml
@@ -6,6 +6,8 @@ scrape_configs:
   - job_name: scaphandre
     static_configs:
       - targets: [scaphandre:8080]
+    scheme: http
+    fallback_scrape_protocol: PrometheusText1.0.0
 
   - job_name: metal
     static_configs:


### PR DESCRIPTION
This update modifies the Prometheus scrape config for the Scaphandre service to use the fallback scrape protocol

* Resolving an issue where Prometheus `latest` was unable to scrape Scaphandre service due to invalid `Content-Type` header in response
* Switch Prometheus to use `latest`