### PR TITLE
[fix]: fix CI permissions according to failed CI jobs

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -7,7 +7,6 @@ on: # yamllint disable-line rule:truthy
 
 permissions:
   security-events: write
-  contents: read
 
 jobs:
   tests:

--- a/.github/workflows/pre-commit-auto-update.yml
+++ b/.github/workflows/pre-commit-auto-update.yml
@@ -4,8 +4,6 @@ on: # yamllint disable-line rule:truthy
   schedule:
     - cron: 0 0 1 * *
 
-permissions: read-all
-
 jobs:
   auto-update:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit-auto-update.yml
+++ b/.github/workflows/pre-commit-auto-update.yml
@@ -4,6 +4,10 @@ on: # yamllint disable-line rule:truthy
   schedule:
     - cron: 0 0 1 * *
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   auto-update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
fix CI permissions according to failed CI jobs

ref 
https://github.com/sustainable-computing-io/kepler/actions/runs/12104149942
https://github.com/sustainable-computing-io/kepler/actions/runs/12100596870