### PR TITLE
fix: pre-commit auto update permissions

### DIFF
--- a/.github/workflows/pre-commit-auto-update.yml
+++ b/.github/workflows/pre-commit-auto-update.yml
@@ -4,7 +4,9 @@ on: # yamllint disable-line rule:truthy
   schedule:
     - cron: 0 0 1 * *
 
-permissions: read-all
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   auto-update:
@@ -26,8 +28,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: update/pre-commit-autoupdate
+          delete-branch: true
           title: Auto-update pre-commit hooks
           commit-message: Auto-update pre-commit hooks
           body: |
             Update pre-commit hooks to latest version
           labels: dependencies
+          draft: false


### PR DESCRIPTION
Enable write permissions for auto update
workflow.


Refs: [#1869](https://github.com/sustainable-computing-io/kepler/issues/1869)