### PR TITLE
chore: pre-commit auto update enable manual trigger

### DIFF
--- a/.github/workflows/pre-commit-auto-update.yml
+++ b/.github/workflows/pre-commit-auto-update.yml
@@ -1,6 +1,7 @@
 name: Pre-commit auto-update
 
 on: # yamllint disable-line rule:truthy
+  workflow_dispatch:
   schedule:
     - cron: 0 0 1 * *
 


### PR DESCRIPTION
Allow the pre-commit auto update job to also be triggered manually