### PR TITLE
[fix]: unset permissions to avoid CI issue

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -6,9 +6,6 @@ on: # yamllint disable-line rule:truthy
   schedule:
     - cron: 12 9 * * *
 
-permissions:
-  security-events: write
-
 jobs:
   # daily go security
   gosec:


### PR DESCRIPTION
ref to https://github.com/sustainable-computing-io/kepler/actions/runs/12116247835
I am not get the point for know, but it seems
- the upper pipeline as daily, should not have any permissions setting.
- when a pipeline been invoked, it will inherit from upper pipeline as permissions setting.

so, by this PR, set daily job's permission same as push pipeline, as push pipeline works.
https://github.com/sustainable-computing-io/kepler/actions?query=event%3Apush

The workflow is not valid. .github/workflows/daily.yml (Line: 14, Col: 3): Error calling workflow 'sustainable-computing-io/kepler/.github/workflows/gosec.yml@a447077ffd2e40f633f2aa200b1b8d61063573c4'. The workflow is requesting 'contents: read', but is only allowed 'contents: none'.
