### PR TITLE
chore: align rpm volume mounts with Kepler requirements

### DIFF
--- a/packaging/rpm/container-kepler.service
+++ b/packaging/rpm/container-kepler.service
@@ -15,7 +15,7 @@ Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon -d --replace --name kepler \
-    --privileged --network=host --pid=host --rm -e ENABLE_PROCESS_METRICS="true" -v /lib/modules:/lib/modules -v /usr/src:/usr/src -v /sys/:/sys/ -v /proc:/proc -v /etc:/etc \
+    --privileged --network=host --pid=host --rm -e ENABLE_PROCESS_METRICS="true" -v /sys/:/sys/ -v /proc:/proc -v /etc:/etc \
     quay.io/sustainable_computing_io/kepler:latest
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id


### PR DESCRIPTION
This commit updates the rpm volume mounts to match to specific requirements of Kepler

Addresses #1885 