### PR TITLE
chore(ci): update permissions for unit test workflow

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
   contents: read
   repository-projects: write
-  packages: write
+  packages: read
 
 jobs:
   unit_test:


### PR DESCRIPTION
This commit updates the `GITHUB_TOKEN` permission for the unit test workflow.

Addresses #1880 