### PR TITLE
fix: Redfish: Use Chassis instead of Systems to obtain chassis ID

### DIFF
--- a/pkg/nodecred/csv_cred.go
+++ b/pkg/nodecred/csv_cred.go
@@ -46,7 +46,7 @@ func (c csvNodeCred) GetNodeCredByNodeName(nodeName, target string) (map[string]
 		cred["redfish_username"] = credMap["redfish_username"]
 		cred["redfish_password"] = credMap["redfish_password"]
 		cred["redfish_host"] = credMap["redfish_host"]
-		if cred["redfish_username"] == "" || cred["redfish_password"] == "" || cred["redfish_host"] == "" {
+		if cred["redfish_host"] == "" {
 			return nil, fmt.Errorf("no credential found")
 		}
 		return cred, nil

--- a/pkg/sensors/platform/source/redfish_test.go
+++ b/pkg/sensors/platform/source/redfish_test.go
@@ -33,9 +33,9 @@ func TestRedFishClient_IsPowerSupported(t *testing.T) {
 
 	// Create a mock HTTP server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/redfish/v1/Systems" {
-			system := RedfishSystemModel{
-				Name: "Test System",
+		if r.URL.Path == "/redfish/v1/Chassis" {
+			system := RedfishChassisModel{
+				Name: "Test Chassis",
 				Members: []struct {
 					OdataID string `json:"@odata.id"`
 				}{

--- a/pkg/sensors/platform/source/redfish_util.go
+++ b/pkg/sensors/platform/source/redfish_util.go
@@ -102,20 +102,20 @@ func getRedfishModel(access RedfishAccessInfo, endpoint string, model interface{
 	return returnErr
 }
 
-func getRedfishSystem(access RedfishAccessInfo) (*RedfishSystemModel, error) {
-	var system RedfishSystemModel
-	err := getRedfishModel(access, "/redfish/v1/Systems", &system)
+func getRedfishChassis(access RedfishAccessInfo) (*RedfishChassisModel, error) {
+	var chassis RedfishChassisModel
+	err := getRedfishModel(access, "/redfish/v1/Chassis", &chassis)
 	if err != nil {
-		klog.V(1).Infof("Failed to get system: %v", err)
+		klog.V(1).Infof("Failed to get chassis: %v", err)
 		return nil, err
 	}
 
-	return &system, nil
+	return &chassis, nil
 }
 
-func getRedfishPower(access RedfishAccessInfo, system string) (*RedfishPowerModel, error) {
+func getRedfishPower(access RedfishAccessInfo, chassis string) (*RedfishPowerModel, error) {
 	var power RedfishPowerModel
-	err := getRedfishModel(access, "/redfish/v1/Chassis/"+system+"/Power#/PowerControl", &power)
+	err := getRedfishModel(access, "/redfish/v1/Chassis/"+chassis+"/Power#/PowerControl", &power)
 	if err != nil {
 		klog.V(1).Infof("Failed to get power: %v", err)
 		return nil, err


### PR DESCRIPTION
I'm trying to evaluate Kepler with [dmtf/redfish-interface-emulator](https://hub.docker.com/r/dmtf/redfish-interface-emulator) on my laptop, but it does not seem to work because `/redfish/v1/Systems` endpoint returns system ID, not chassis ID which we  expect.

Redfish client in Kepler attempts to get system ID from `/redfish/v1/Systems`, and it is used in the request to `/redfish/v1/Chassis` to get `PowerControl`. However, according to [Redfish Resource and Schema Guide](https://www.dmtf.org/sites/default/files/standards/documents/DSP2046_2023.1.pdf), system ID is different from chassis ID. `PowerControl` is under `Chassis`, so we need to get chassis ID.

**System ID (6.24 ComputerSystem)**
> The ComputerSystem schema represents a computer or system instance and the software-visible resources, or items within the data plane, such as memory, CPU, and other devices that it can access.

**Chassis ID (6.19 Chassis)**
> The Chassis schema represents the physical components of a system. This resource represents the sheet-metal confined spaces and logical zones such as racks, enclosures, chassis and all other containers. Subsystems, such as sensors, that operate outside of a system's data plane are linked either directly or indirectly through this resource.


And also
 Redfish spec does not require to authentication, so this PR allows Redfish configuration without credentials (user/passphrase).