### PR TITLE
feat(idle-power): Update Idle Energy Estimation Calculation

### DIFF
--- a/pkg/collector/energy/node_energy_collector.go
+++ b/pkg/collector/energy/node_energy_collector.go
@@ -80,6 +80,7 @@ func UpdateNodeGPUEnergy(nodeStats *stats.NodeStats, wg *sync.WaitGroup) {
 // When the node power model estimator is utilized, the idle power is updated with the estimated power considering minimal resource utilization.
 func UpdateNodeIdleEnergy(nodeStats *stats.NodeStats) {
 	isComponentsSystemCollectionSupported := components.IsSystemCollectionSupported()
+	nodeStats.UpdateIdleEnergyWithLinearRegresion(isComponentsSystemCollectionSupported)
 	// the idle energy is only updated if we find the node using less resources than previously observed
 	// TODO: Use regression to estimate the idle power when real-time system power metrics are available, instead of relying on the minimum power consumption.
 	nodeStats.UpdateIdleEnergyWithMinValue(isComponentsSystemCollectionSupported)

--- a/pkg/collector/energy/node_energy_collector.go
+++ b/pkg/collector/energy/node_energy_collector.go
@@ -83,7 +83,7 @@ func UpdateNodeIdleEnergy(nodeStats *stats.NodeStats) {
 	nodeStats.UpdateIdleEnergyWithLinearRegresion(isComponentsSystemCollectionSupported)
 	// the idle energy is only updated if we find the node using less resources than previously observed
 	// TODO: Use regression to estimate the idle power when real-time system power metrics are available, instead of relying on the minimum power consumption.
-	nodeStats.UpdateIdleEnergyWithMinValue(isComponentsSystemCollectionSupported)
+	//nodeStats.UpdateIdleEnergyWithMinValue(isComponentsSystemCollectionSupported)
 	if !isComponentsSystemCollectionSupported {
 		// if power collection on components is not supported, try using estimator to update idle energy
 		if model.IsNodeComponentPowerModelEnabled() {

--- a/pkg/collector/stats/node_stats.go
+++ b/pkg/collector/stats/node_stats.go
@@ -117,8 +117,7 @@ type NodeStats struct {
 	IdleResUtilization map[string]uint64
 
 	// Pkg idle energy
-	IdleEnergyPkg     *IdleEnergyCalculator
-	IdleEnergyPkgAggr *IdleEnergyCalculator
+	IdleEnergyPkg *IdleEnergyCalculator
 
 	currentIdleEnergy uint64
 
@@ -177,31 +176,7 @@ func (ne *NodeStats) CalcIdleEnergyLR(absM, idleM, resouceUtil string) {
 	} else {
 		idleEnergy := ne.IdleEnergyPkg.UpdateIdleEnergy(float64(totalResUtilization), float64(totalEnergy))
 		klog.V(5).Infof("Idle Energy: %f", idleEnergy)
-		klog.V(5).Infof("Idle Energy: %f", ne.IdleEnergyPkg.calculatedIdleEnergy)
-	}
-	klog.V(5).Infof("Test Aggr Values Instead")
-	totalResUtilization = ne.ResourceUsage[resouceUtil].SumAllAggrValues()
-	totalEnergy = ne.EnergyUsage[absM].SumAllAggrValues()
-	if totalEnergy == 0 {
-		klog.V(5).Infof("Skipping Idle Energy: Set to 0")
-		return
-	}
-
-	if ne.IdleEnergyPkgAggr == nil {
-		initialMinUtilization := NewCoordinate(
-			float64(totalResUtilization),
-			float64(totalEnergy),
-		)
-		initialMaxUtilization := NewCoordinate(
-			float64(totalResUtilization),
-			float64(totalEnergy),
-		)
-		ne.IdleEnergyPkgAggr = NewIdleEnergyCalculator(initialMinUtilization, initialMaxUtilization)
-		klog.V(5).Infof("Initialize Idle Energy: %f", ne.IdleEnergyPkgAggr.calculatedIdleEnergy)
-	} else {
-		idleEnergy := ne.IdleEnergyPkgAggr.UpdateIdleEnergy(float64(totalResUtilization), float64(totalEnergy))
-		klog.V(5).Infof("Idle Energy: %f", idleEnergy)
-		klog.V(5).Infof("Idle Energy: %f", ne.IdleEnergyPkgAggr.calculatedIdleEnergy)
+		klog.V(5).Infof("Stored Idle Energy: %f", ne.IdleEnergyPkg.calculatedIdleEnergy)
 	}
 }
 

--- a/pkg/collector/stats/stats.go
+++ b/pkg/collector/stats/stats.go
@@ -156,23 +156,23 @@ func (s *Stats) CalcDynEnergy(absM, idleM, dynM, id string) {
 	}
 	totalPower := s.EnergyUsage[absM][id].GetDelta()
 	klog.V(6).Infof("Absolute Energy stat: %v (%s)", s.EnergyUsage[absM], id)
-	idlePower := uint64(0)
+	//idlePower := uint64(0)
 	if idleStat, found := s.EnergyUsage[idleM][id]; found {
-		idlePower = idleStat.GetDelta()
-		klog.V(6).Infof("Idle Energy stat: %v (%s)", s.EnergyUsage[idleM], id)
+		//idlePower = idleStat.GetDelta()
+		klog.V(6).Infof("Idle Energy stat: %v (%s)", idleStat, id)
 	}
-	dynPower := calcDynEnergy(totalPower, idlePower)
-	s.EnergyUsage[dynM].SetDeltaStat(id, dynPower)
+	//dynPower := calcDynEnergy(totalPower, idlePower)
+	s.EnergyUsage[dynM].SetDeltaStat(id, totalPower)
 	klog.V(6).Infof("Dynamic Energy stat: %v (%s)", s.EnergyUsage[dynM], id)
 }
 
-// calcDynEnergy calculates the dynamic energy.
-func calcDynEnergy(totalE, idleE uint64) uint64 {
-	if (totalE == 0) || (totalE < idleE) {
-		return 0
-	}
-	return totalE - idleE
-}
+// // calcDynEnergy calculates the dynamic energy.
+// func calcDynEnergy(totalE, idleE uint64) uint64 {
+// 	if (totalE == 0) || (totalE < idleE) {
+// 		return 0
+// 	}
+// 	return totalE - idleE
+// }
 
 // normalize normalizes the value if required.
 func normalize(val float64, shouldNormalize bool) float64 {

--- a/pkg/collector/stats/utils.go
+++ b/pkg/collector/stats/utils.go
@@ -29,6 +29,10 @@ type Coordinate struct {
 	X, Y float64
 }
 
+type LinearModel struct {
+	intercept, slope float64
+}
+
 func percentDiff(a, b float64) float64 {
 	if a == 0 || b == 0 {
 		return 1.0

--- a/pkg/collector/stats/utils.go
+++ b/pkg/collector/stats/utils.go
@@ -19,9 +19,57 @@ package stats
 import (
 	"k8s.io/klog/v2"
 
+	"math"
+
 	"github.com/sustainable-computing-io/kepler/pkg/config"
 	acc "github.com/sustainable-computing-io/kepler/pkg/sensors/accelerator"
 )
+
+type Coordinate struct {
+	X, Y float64
+}
+
+func percentDiff(a, b float64) float64 {
+	if a == 0 || b == 0 {
+		return 1.0
+	}
+	return (math.Abs(a-b) / math.Min(a, b))
+}
+
+func appendToSliceWithSizeRestriction(slice *[]float64, length int, value float64) {
+	if len(*slice) >= length {
+		//ic.result.history = append(ic.result.history[1:], ic.result.calculatedIdleEnergy)
+		copy(*slice, (*slice)[1:])
+		// After copying, the 0th element is removed and the 4th element is a duplicate.
+		// Now we can replace the 4th element with new idleEnergy
+		// pointers required to modify array
+		(*slice)[length-1] = value
+	} else {
+		*slice = append(*slice, value)
+	}
+
+}
+
+func getAverage(slice []float64) float64 {
+	var sum float64 = 0
+	for _, value := range slice {
+		sum += value
+	}
+	return sum / float64(len(slice))
+}
+
+func checkSliceAllSame(slice []float64) bool {
+	if len(slice) == 0 {
+		return true
+	}
+	firstElem := slice[0]
+	for _, value := range slice {
+		if value != firstElem {
+			return false
+		}
+	}
+	return true
+}
 
 func GetProcessFeatureNames() []string {
 	var metrics []string

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -40,6 +40,7 @@ const (
 type nodeInfo struct {
 	name                  string
 	cpuArchitecture       string
+	cpuCount              uint64
 	metadataFeatureNames  []string
 	metadataFeatureValues []string
 }
@@ -47,6 +48,7 @@ type nodeInfo struct {
 type Node interface {
 	Name() string
 	CPUArchitecture() string
+	CPUCount() uint64
 	MetadataFeatureNames() []string
 	MetadataFeatureValues() []string
 }
@@ -70,6 +72,10 @@ func CPUArchitecture() string {
 	return cpuArch()
 }
 
+func CPUCount() uint64 {
+	return cpuCount()
+}
+
 func MetadataFeatureNames() []string {
 	return []string{"cpu_architecture"}
 }
@@ -84,6 +90,7 @@ func NewNodeInfo() Node {
 	return &nodeInfo{
 		name:                  nodeName(),
 		cpuArchitecture:       cpuArchitecture,
+		cpuCount:              cpuCount(),
 		metadataFeatureNames:  []string{"cpu_architecture"},
 		metadataFeatureValues: []string{cpuArchitecture},
 	}
@@ -95,6 +102,10 @@ func (ni *nodeInfo) Name() string {
 
 func (ni *nodeInfo) CPUArchitecture() string {
 	return ni.cpuArchitecture
+}
+
+func (ni *nodeInfo) CPUCount() uint64 {
+	return ni.cpuCount
 }
 
 func (ni *nodeInfo) MetadataFeatureNames() []string {
@@ -114,6 +125,20 @@ func nodeName() string {
 		klog.Fatalf("could not get the node name: %s", err)
 	}
 	return nodeName
+}
+
+func cpuCount() uint64 {
+	cpu := exec.Command("nproc")
+	output, err := cpu.Output()
+	if err != nil {
+		klog.Fatalf("cpuCount command failure: %s", err)
+		return 0
+	}
+	cpuNum, err := strconv.ParseUint(strings.TrimSpace(string(output)), 10, 64)
+	if err != nil {
+		klog.Fatalf("cpuCount string conversion failure: %s", err)
+	}
+	return cpuNum
 }
 
 func cpuArch() string {


### PR DESCRIPTION
Changes:

- Idle Energy Calculation has been changed to track the minimum known cpu time and absolute energy and maximum known cpu time and absolute energy. Using these two points, kepler calculates the slope and y intercept (idle estimated energy or energy when cpu time == 0). 
- Idle Energy is only exposed when kepler has a sufficiently wide difference between the minimum and maximum known cpu times, the calculated idle energy converge, and negative idle energy estimations are ignored.

Pending Issue (must address):
- CPU Time is provided per node, but idle power and absolute power is provided in per socket. 

Before this PR is ready to merge, the above Pending Issue needs to be addressed.