### PR TITLE
feat(config): Make /proc and /sys paths configurable

### DIFF
--- a/manifests/compose/dev/compose.yaml
+++ b/manifests/compose/dev/compose.yaml
@@ -24,10 +24,11 @@ services:
     volumes:
       - type: bind
         source: /proc
-        target: /proc
+        target: /host/proc
       - type: bind
         source: /sys
-        target: /sys
+        target: /host/sys
+
       - type: bind
         source: ./kepler/etc/kepler
         target: /etc/kepler

--- a/manifests/compose/dev/kepler/etc/kepler/kepler.config/PROC_DIR
+++ b/manifests/compose/dev/kepler/etc/kepler/kepler.config/PROC_DIR
@@ -1,0 +1,1 @@
+/host/proc

--- a/manifests/compose/dev/kepler/etc/kepler/kepler.config/SYS_DIR
+++ b/manifests/compose/dev/kepler/etc/kepler/kepler.config/SYS_DIR
@@ -1,0 +1,1 @@
+/host/sys

--- a/pkg/bpf/exporter.go
+++ b/pkg/bpf/exporter.go
@@ -126,7 +126,7 @@ func (e *exporter) attach() error {
 
 	group := "writeback"
 	name := "writeback_dirty_page"
-	if _, err := os.Stat("/sys/kernel/debug/tracing/events/writeback/writeback_dirty_folio"); err == nil {
+	if _, err := os.Stat(config.SysDir() + "/kernel/debug/tracing/events/writeback/writeback_dirty_folio"); err == nil {
 		name = "writeback_dirty_folio"
 	}
 	e.pageWriteLink, err = link.Tracepoint(group, name, e.bpfObjects.KeplerWritePageTrace, nil)

--- a/pkg/bpf/fake_mac.go
+++ b/pkg/bpf/fake_mac.go
@@ -125,7 +125,7 @@ func (e *exporter) attach() error {
 
 	group := "writeback"
 	name := "writeback_dirty_page"
-	if _, err := os.Stat("/sys/kernel/debug/tracing/events/writeback/writeback_dirty_folio"); err == nil {
+	if _, err := os.Stat(config.SysDir() + "/kernel/debug/tracing/events/writeback/writeback_dirty_folio"); err == nil {
 		name = "writeback_dirty_folio"
 	}
 	e.pageWriteLink, err = link.Tracepoint(group, name, e.bpfObjects.KeplerWritePageTrace, nil)

--- a/pkg/collector/metric_collector.go
+++ b/pkg/collector/metric_collector.go
@@ -37,9 +37,8 @@ import (
 )
 
 const (
-	maxInactiveContainers        = 10
-	maxInactiveVM                = 3
-	procPath              string = "/proc/%d/cgroup"
+	maxInactiveContainers = 10
+	maxInactiveVM         = 3
 )
 
 type Collector struct {

--- a/pkg/collector/resourceutilization/accelerator/process_gpu_collector.go
+++ b/pkg/collector/resourceutilization/accelerator/process_gpu_collector.go
@@ -32,14 +32,8 @@ import (
 	"github.com/sustainable-computing-io/kepler/pkg/utils"
 )
 
-const (
-	procPath string = "/proc/%d/cgroup"
-)
-
-var (
-	// lastUtilizationTimestamp represents the CPU timestamp in microseconds at which utilization samples were last read
-	lastUtilizationTimestamp time.Time = time.Now()
-)
+// lastUtilizationTimestamp represents the CPU timestamp in microseconds at which utilization samples were last read
+var lastUtilizationTimestamp time.Time = time.Now()
 
 // UpdateProcessGPUUtilizationMetrics reads the GPU metrics of each process using the GPU
 func UpdateProcessGPUUtilizationMetrics(processStats map[uint64]*stats.ProcessStats) {
@@ -105,7 +99,8 @@ func addGPUUtilizationToProcessStats(ai dev.Device, processStats map[uint64]*sta
 }
 
 func getProcessCommand(pid uint64) string {
-	fileName := fmt.Sprintf(procPath, pid)
+	procPath := "%s/proc/%d/cgroup"
+	fileName := fmt.Sprintf(procPath, config.ProcDir(), pid)
 	// Read the file
 	comm, err := os.ReadFile(fileName)
 	if err != nil {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -71,7 +71,7 @@ const (
 
 	cGroupIDMinKernelVersion = 4.18
 	// If this file is present, cgroups v2 is enabled on that node.
-	cGroupV2Path   = "/sys/fs/cgroup/cgroup.controllers"
+	cGroupV2Path   = "%s/fs/cgroup/cgroup.controllers"
 	metricPathKey  = "METRIC_PATH"
 	bindAddressKey = "BIND_ADDRESS"
 	// model_parameter_attributes

--- a/pkg/libvirt/resolve_vm.go
+++ b/pkg/libvirt/resolve_vm.go
@@ -31,9 +31,8 @@ import (
 )
 
 const (
-	procPath            string = "/proc/%d/cgroup"
-	maxCacheSize        int    = 1000
-	cacheRemoveElements int    = 100
+	maxCacheSize        int = 1000
+	cacheRemoveElements int = 100
 )
 
 var (
@@ -43,8 +42,8 @@ var (
 )
 
 func GetVMID(pid uint64) (string, error) {
-	fileName := fmt.Sprintf(procPath, pid)
-	return getVMID(pid, fileName)
+	filePath := fmt.Sprintf("%s/%d/cgroup", config.ProcDir(), pid)
+	return getVMID(pid, filePath)
 }
 
 func getVMID(pid uint64, fileName string) (string, error) {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -33,7 +33,6 @@ import (
 
 const (
 	cpuModelDataPath = "/var/lib/kepler/data/cpus.yaml"
-	cpuPmuNamePath   = "/sys/devices/cpu/caps/pmu_name"
 	unknownCPUArch   = "unknown"
 )
 
@@ -266,6 +265,7 @@ func cpuMicroArchitecture(family, model, stepping string) (string, error) {
 }
 
 func cpuPmuName() (string, error) {
+	cpuPmuNamePath := config.SysDir() + "/devices/cpu/caps/pmu_name"
 	data, err := os.ReadFile(cpuPmuNamePath)
 	if err != nil {
 		klog.V(3).Infoln(err)

--- a/pkg/sensors/accelerator/devices/grace_acpi.go
+++ b/pkg/sensors/accelerator/devices/grace_acpi.go
@@ -30,11 +30,10 @@ import (
 
 const (
 	// Grace ACPI power paths and identifiers
-	graceHwmonPathTemplate = "/sys/class/hwmon/hwmon*"
-	graceDevicePath        = "device/"
-	gracePowerPrefix       = "power1"
-	graceOemInfoFile       = "_oem_info"
-	graceAverageFile       = "_average"
+	graceDevicePath  = "device/"
+	gracePowerPrefix = "power1"
+	graceOemInfoFile = "_oem_info"
+	graceAverageFile = "_average"
 
 	// Grace Hopper module power identifier
 	graceModuleLabel = "Module Power Socket" // Total CG1 module power (GPU+HBM)
@@ -78,6 +77,7 @@ func graceDeviceStartup() Device {
 
 func (g *gpuGraceACPI) findModulePowerPaths() error {
 	g.modulePowerPaths = make(map[int]string)
+	graceHwmonPathTemplate := config.SysDir() + "/class/hwmon/hwmon*"
 
 	hwmonDirs, err := filepath.Glob(graceHwmonPathTemplate)
 	if err != nil {

--- a/pkg/sensors/components/source/apm_xgene_sysfs.go
+++ b/pkg/sensors/components/source/apm_xgene_sysfs.go
@@ -23,19 +23,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sustainable-computing-io/kepler/pkg/config"
 	"k8s.io/klog/v2"
 )
 
 const (
-	// sysfs path templates for Ampere Xgene hwmon
-	powerLabelPathTemplate = "/sys/class/hwmon/hwmon*/power*_label"
-	cpuPowerLabel          = "CPU power"
-	uJTomJ                 = 1000
+	cpuPowerLabel = "CPU power"
+	uJTomJ        = 1000
 )
 
-var (
-	powerInputPath = ""
-)
+var powerInputPath = ""
 
 type ApmXgeneSysfs struct {
 	currTime time.Time
@@ -46,6 +43,8 @@ func (ApmXgeneSysfs) GetName() string {
 }
 
 func (r *ApmXgeneSysfs) IsSystemCollectionSupported() bool {
+	// sysfs path templates for Ampere Xgene hwmon
+	powerLabelPathTemplate := config.SysDir() + "/class/hwmon/hwmon*/power*_label"
 	labelFiles, err := filepath.Glob(powerLabelPathTemplate)
 	if err != nil {
 		return false

--- a/pkg/sensors/components/source/grace_acpi.go
+++ b/pkg/sensors/components/source/grace_acpi.go
@@ -24,17 +24,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sustainable-computing-io/kepler/pkg/config"
 	"k8s.io/klog/v2"
 )
 
 // Per https://docs.nvidia.com/grace-perf-tuning-guide/index.html#power-and-thermal-management
 const (
 	// Grace ACPI power paths and identifiers
-	graceHwmonPathTemplate = "/sys/class/hwmon/hwmon*"
-	graceDevicePath        = "device/"
-	gracePowerPrefix       = "power1"
-	graceOemInfoFile       = "_oem_info"
-	graceAverageFile       = "_average"
+	graceDevicePath  = "device/"
+	gracePowerPrefix = "power1"
+	graceOemInfoFile = "_oem_info"
+	graceAverageFile = "_average"
 
 	// Conversion factors
 	microWattToMilliJoule = 1000 // Convert microwatts to mJ assuming 1 second sampling
@@ -59,6 +59,7 @@ func (GraceACPI) GetName() string {
 func (g *GraceACPI) findPowerPathsByLabel() error {
 	g.sockets = make(map[int]*socketPowerPaths)
 
+	graceHwmonPathTemplate := config.SysDir() + "/class/hwmon/hwmon*"
 	hwmonDirs, err := filepath.Glob(graceHwmonPathTemplate)
 	if err != nil {
 		return fmt.Errorf("failed to find hwmon directories: %v", err)

--- a/pkg/sensors/components/source/rapl_sysfs_util.go
+++ b/pkg/sensors/components/source/rapl_sysfs_util.go
@@ -22,7 +22,12 @@ import (
 	"strings"
 )
 
-func detectEventPaths() {
+func detectEventPaths(sysDir string) map[string]map[string]string {
+	paths := map[string]map[string]string{}
+
+	packageNamePathTemplate := sysDir + "/class/powercap/intel-rapl/intel-rapl:%d/"
+	eventNamePathTemplate := sysDir + "/class/powercap/intel-rapl/intel-rapl:%d/intel-rapl:%d:%d/"
+
 	for i := 0; i < numPackages; i++ {
 		packagePath := fmt.Sprintf(packageNamePathTemplate, i)
 		data, err := os.ReadFile(packagePath + "name")
@@ -30,8 +35,8 @@ func detectEventPaths() {
 		if err != nil {
 			continue
 		}
-		eventPaths[packageName] = map[string]string{}
-		eventPaths[packageName][packageName] = packagePath
+		paths[packageName] = map[string]string{}
+		paths[packageName][packageName] = packagePath
 		for j := 0; j < numRAPLEvents; j++ {
 			eventNamePath := fmt.Sprintf(eventNamePathTemplate, i, i, j)
 			data, err := os.ReadFile(eventNamePath + "name")
@@ -39,9 +44,10 @@ func detectEventPaths() {
 			if err != nil {
 				continue
 			}
-			eventPaths[packageName][eventName] = eventNamePath
+			paths[packageName][eventName] = eventNamePath
 		}
 	}
+	return paths
 }
 
 func hasEvent(event string) bool {


### PR DESCRIPTION
This patch replaces hardcoded /proc and /sys paths just like in other exporters like node-exporter with configurable ones using the config package. E.g., config.ProcDir() and config.SysDir().
These paths can now be set via SYS_DIR and PROC_DIR config variables, defaulting to "/proc" and "/sys" if unspecified.

Mounting host /proc and /sys into containers is discouraged because it compromises security and isolation.