### PR TITLE
fix(openshift): patch deployment issue

### DIFF
--- a/manifests/k8s/config/exporter/patch/patch-estimator-sidecar.yaml
+++ b/manifests/k8s/config/exporter/patch/patch-estimator-sidecar.yaml
@@ -33,15 +33,15 @@ spec:
             - /bin/sh
             - -c
           args:
-            - until [ -e /tmp/estimator.sock ]; do sleep 1; done && /usr/bin/kepler -v=$(KEPLER_LOG_LEVEL) -kernel-source-dir=/usr/share/kepler/kernel_sources -redfish-cred-file-path=/etc/redfish/redfish.csv
+            - until [ -e /tmp/estimator.sock ]; do sleep 1; done && /usr/bin/kepler -v=$(KEPLER_LOG_LEVEL) -redfish-cred-file-path=/etc/redfish/redfish.csv
           volumeMounts:
             - mountPath: /tmp
               name: tmp
           name: kepler-exporter
         - image: kepler_model_server
           imagePullPolicy: IfNotPresent
-          command: [python3.8]
-          args: [-u, src/estimate/estimator.py]
+          command: [python3]
+          args: [-u, src/kepler_model/estimate/estimator.py]
           name: estimator
           volumeMounts:
             - name: cfm

--- a/manifests/k8s/config/model-server/patch/patch-openshift.yaml
+++ b/manifests/k8s/config/model-server/patch/patch-openshift.yaml
@@ -11,3 +11,10 @@ spec:
         - name: server-api
           securityContext:
             privileged: true
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp-volume
+              readOnly: false
+      volumes:
+        - name: tmp-volume
+          emptyDir: {}


### PR DESCRIPTION
### Description
For performance testing we need all the 4 deployment models of kepler to work: https://sustainable-computing.io/kepler_model_server/power_estimation/
So inorder for all of them to work, we need the patches in this PR to go in.

### Testing
Tested and verified them in local openshift cluster
1. Kepler minimal deployment
```
GOFLAGS="" make build-manifest OPTS="OPENSHIFT_DEPLOY PROMETHEUS_DEPLOY"
```
2. Deployment with estimator sidecar
```
GOFLAGS="" make build-manifest OPTS="OPENSHIFT_DEPLOY PROMETHEUS_DEPLOY ESTIMATOR_SIDECAR_DEPLOY"
```
3. Deployment with model server
```
GOFLAGS="" make build-manifest OPTS="OPENSHIFT_DEPLOY PROMETHEUS_DEPLOY MODEL_SERVER_DEPLOY"
```
4. Full kepler deployment with estimator and model server
```
GOFLAGS="" make build-manifest OPTS="OPENSHIFT_DEPLOY PROMETHEUS_DEPLOY ESTIMATOR_SIDECAR_DEPLOY MODEL_SERVER_DEPLOY"
```
All the generator output manifests worked as expected.
Pre-requisite for this PR: https://github.com/openshift/release/pull/62512