### PR TITLE
chore(compose): allow scraping from kepler on host

### DIFF
--- a/manifests/compose/dev/override.yaml
+++ b/manifests/compose/dev/override.yaml
@@ -19,3 +19,5 @@ services:
       - node-exporter-network
       - libvirt-exporter-network
       - process-exporter-network
+    extra_hosts:
+      - host.docker.internal:host-gateway

--- a/manifests/compose/dev/prometheus/scrape-configs/dev.yaml
+++ b/manifests/compose/dev/prometheus/scrape-configs/dev.yaml
@@ -3,6 +3,10 @@ scrape_configs:
     static_configs:
       - targets: [kepler-dev:8888]
 
+  - job_name: host
+    static_configs:
+      - targets: [host.docker.internal:8888]
+
   - job_name: scaphandre
     static_configs:
       - targets: [scaphandre:8080]


### PR DESCRIPTION
This change allows running kepler on host and scrape it, making it easier during
development to test changes quickly without building an image.