### PR TITLE
feat(disable-power-models): Add DisablePowerModels flag

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,6 +65,7 @@ type KeplerConfig struct {
 	CPUArchOverride              string
 	MachineSpecFilePath          string
 	ExcludeSwapperProcess        bool
+	DisablePowerModels           bool
 }
 type MetricsConfig struct {
 	CoreUsageMetric    string
@@ -182,6 +183,7 @@ func getKeplerConfig() KeplerConfig {
 		EstimatorSelectFilter:        getConfig("ESTIMATOR_SELECT_FILTER", defaultMetricValue), // no filter
 		CPUArchOverride:              getConfig("CPU_ARCH_OVERRIDE", defaultCPUArchOverride),
 		ExcludeSwapperProcess:        getBoolConfig("EXCLUDE_SWAPPER_PROCESS", defaultExcludeSwapperProcess),
+		DisablePowerModels:           getBoolConfig("DISABLE_POWER_MODELS", false),
 	}
 }
 
@@ -287,6 +289,7 @@ func logBoolConfigs() {
 		klog.V(5).Infof("EXPOSE_ESTIMATED_IDLE_POWER_METRICS: %t. This only impacts when the power is estimated using pre-prained models. Estimated idle power is meaningful only when Kepler is running on bare-metal or with a single virtual machine (VM) on the node.", instance.Kepler.ExposeIdlePowerMetrics)
 		klog.V(5).Infof("EXPERIMENTAL_BPF_SAMPLE_RATE: %d", instance.Kepler.BPFSampleRate)
 		klog.V(5).Infof("EXCLUDE_SWAPPER_PROCESS: %t", instance.Kepler.ExcludeSwapperProcess)
+		klog.V(5).Infof("DISABLE_POWER_MODELS: %t", instance.Kepler.DisablePowerModels)
 	}
 }
 
@@ -644,4 +647,8 @@ func DCGMHostEngineEndpoint() string {
 
 func ExcludeSwapperProcess() bool {
 	return instance.Kepler.ExcludeSwapperProcess
+}
+
+func DisablePowerModels() bool {
+	return instance.Kepler.DisablePowerModels
 }

--- a/pkg/model/estimator/local/ratio.go
+++ b/pkg/model/estimator/local/ratio.go
@@ -70,7 +70,8 @@ type RatioPowerModel struct {
 	processFeatureValues [][]float64 // metrics per process/process/pod
 	nodeFeatureValues    []float64   // node metrics
 	// xidx represents the features slide window position
-	xidx int
+	xidx    int
+	enabled bool
 }
 
 func (r *RatioPowerModel) getPowerByRatio(processIdx, resUsageFeature, nodePowerFeature int, numProcesses float64) uint64 {
@@ -235,9 +236,14 @@ func (r *RatioPowerModel) Train() error {
 	return nil
 }
 
-// IsEnabled returns true as Ratio Power model is always active
+// IsEnabled returns if ratio power model is active or not
 func (r *RatioPowerModel) IsEnabled() bool {
-	return true
+	return r.enabled
+}
+
+// SetEnabled modifies the enabled flag to activate or deactivate the ratio power model
+func (r *RatioPowerModel) SetEnabled(enable bool) {
+	r.enabled = enable
 }
 
 // GetModelType returns the model type

--- a/pkg/model/estimator/local/regressor/regressor.go
+++ b/pkg/model/estimator/local/regressor/regressor.go
@@ -406,6 +406,11 @@ func (r *Regressor) IsEnabled() bool {
 	return r.enabled
 }
 
+// SetEnabled modifies the enabled flag to activate or deactivate the regressor power model
+func (r *Regressor) SetEnabled(enable bool) {
+	r.enabled = enable
+}
+
 // GetModelType returns the model type
 func (r *Regressor) GetModelType() types.ModelType {
 	return types.Regressor

--- a/pkg/model/estimator/sidecar/estimate.go
+++ b/pkg/model/estimator/sidecar/estimate.go
@@ -262,6 +262,11 @@ func (c *EstimatorSidecar) IsEnabled() bool {
 	return c.enabled
 }
 
+// SetEnabled modifies the enabled flag to activate or deactivate the power model
+func (c *EstimatorSidecar) SetEnabled(enable bool) {
+	c.enabled = enable
+}
+
 // GetModelType returns the model type
 func (c *EstimatorSidecar) GetModelType() types.ModelType {
 	return types.EstimatorSidecar

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -52,6 +52,8 @@ type PowerModelInterface interface {
 	Train() error
 	// IsEnabled returns true if the power model was trained and is active
 	IsEnabled() bool
+	// SetEnabled modifies the enabled flag to activate or deactivate the power model
+	SetEnabled(enable bool)
 	// GetModelType returns if the model is Ratio, Regressor or EstimatorSidecar
 	GetModelType() types.ModelType
 	// GetProcessFeatureNamesList returns the list of process features that the model was configured to use
@@ -88,6 +90,7 @@ func createPowerModelEstimator(modelConfig *types.ModelConfig) (PowerModelInterf
 			ProcessFeatureNames: modelConfig.ProcessFeatureNames,
 			NodeFeatureNames:    modelConfig.NodeFeatureNames,
 		}
+		model.SetEnabled(true)
 		klog.V(3).Infof("Using Power Model Ratio")
 		return model, nil
 
@@ -189,15 +192,17 @@ func getModelConfigKey(modelItem, attribute string) string {
 // getPowerModelType return the model type for a given power source, such as platform or components power sources
 // The default power model type is Ratio
 func getPowerModelType(powerSourceTarget string) (modelType types.ModelType) {
-	useEstimatorSidecarStr := config.ModelConfigValues(getModelConfigKey(powerSourceTarget, config.EstimatorEnabledKey))
-	if strings.EqualFold(useEstimatorSidecarStr, "true") {
-		modelType = types.EstimatorSidecar
-		return
-	}
-	useLocalRegressor := config.ModelConfigValues(getModelConfigKey(powerSourceTarget, config.LocalRegressorEnabledKey))
-	if strings.EqualFold(useLocalRegressor, "true") {
-		modelType = types.Regressor
-		return
+	if !config.DisablePowerModels() {
+		useEstimatorSidecarStr := config.ModelConfigValues(getModelConfigKey(powerSourceTarget, config.EstimatorEnabledKey))
+		if strings.EqualFold(useEstimatorSidecarStr, "true") {
+			modelType = types.EstimatorSidecar
+			return
+		}
+		useLocalRegressor := config.ModelConfigValues(getModelConfigKey(powerSourceTarget, config.LocalRegressorEnabledKey))
+		if strings.EqualFold(useLocalRegressor, "true") {
+			modelType = types.Regressor
+			return
+		}
 	}
 	// set the default node power model as Regressor
 	if powerSourceTarget == config.NodePlatformPowerKey() || powerSourceTarget == config.NodeComponentsPowerKey() {

--- a/pkg/model/node_component_energy.go
+++ b/pkg/model/node_component_energy.go
@@ -49,7 +49,7 @@ func createNodeComponentPowerModelConfig(nodeFeatureNames []string) *types.Model
 // CreateNodeComponentPowerEstimatorModel only create a new power model estimator if node components power metrics are not available
 func CreateNodeComponentPowerEstimatorModel(nodeFeatureNames []string) {
 	var err error
-	if !components.IsSystemCollectionSupported() {
+	if !components.IsSystemCollectionSupported() && !config.DisablePowerModels() {
 		modelConfig := createNodeComponentPowerModelConfig(nodeFeatureNames)
 		// init func for NodeComponentPower
 		nodeComponentPowerModel, err = createPowerModelEstimator(modelConfig)
@@ -59,7 +59,7 @@ func CreateNodeComponentPowerEstimatorModel(nodeFeatureNames []string) {
 			klog.Infof("Failed to create %s Power Model to estimate Node Component Power: %v\n", modelConfig.ModelType.String()+"/"+modelConfig.ModelOutputType.String(), err)
 		}
 	} else {
-		klog.Infof("Skipping creation of Node Component Power Model since the system collection is supported")
+		klog.Infof("Skipping creation of Node Component Power Model since the system collection is supported or models are disabled")
 		return
 	}
 }

--- a/pkg/model/node_platform_energy.go
+++ b/pkg/model/node_platform_energy.go
@@ -37,7 +37,7 @@ var nodePlatformPowerModel PowerModelInterface
 func CreateNodePlatformPoweEstimatorModel(nodeFeatureNames []string) {
 	systemMetaDataFeatureNames := node.MetadataFeatureNames()
 	systemMetaDataFeatureValues := node.MetadataFeatureValues()
-	if !platform.IsSystemCollectionSupported() {
+	if !platform.IsSystemCollectionSupported() && !config.DisablePowerModels() {
 		modelConfig := CreatePowerModelConfig(config.NodePlatformPowerKey())
 		if modelConfig.InitModelURL == "" {
 			modelConfig.InitModelFilepath = config.GetDefaultPowerModelURL(modelConfig.ModelOutputType.String(), types.PlatformEnergySource)
@@ -54,6 +54,8 @@ func CreateNodePlatformPoweEstimatorModel(nodeFeatureNames []string) {
 		} else {
 			klog.Infof("Failed to create %s Power Model to estimate Node Platform Power: %v\n", modelConfig.ModelType.String()+"/"+modelConfig.ModelOutputType.String(), err)
 		}
+	} else {
+		klog.Infof("Skipping creation of Node Platform Power Model since the system collection is supported or models are disabled")
 	}
 }
 

--- a/pkg/model/process_energy.go
+++ b/pkg/model/process_energy.go
@@ -25,7 +25,9 @@ import (
 	"github.com/sustainable-computing-io/kepler/pkg/model/types"
 	"github.com/sustainable-computing-io/kepler/pkg/node"
 	acc "github.com/sustainable-computing-io/kepler/pkg/sensors/accelerator"
+	"github.com/sustainable-computing-io/kepler/pkg/sensors/components"
 	"github.com/sustainable-computing-io/kepler/pkg/sensors/components/source"
+	"github.com/sustainable-computing-io/kepler/pkg/sensors/platform"
 	"github.com/sustainable-computing-io/kepler/pkg/utils"
 	"k8s.io/klog/v2"
 )
@@ -118,11 +120,18 @@ func CreateProcessPowerEstimatorModel(processFeatureNames []string) {
 		modelConfig := createProcessPowerModelConfig(k, processFeatureNames, v)
 		modelConfig.IsNodePowerModel = false
 		m, err := createPowerModelEstimator(modelConfig)
+		klog.V(5).Infof("Generating Process models now")
 		switch k {
 		case config.ProcessPlatformPowerKey():
 			processPlatformPowerModel = m
+			if !platform.IsSystemCollectionSupported() && config.DisablePowerModels() {
+				processPlatformPowerModel.SetEnabled(false)
+			}
 		case config.ProcessComponentsPowerKey():
 			processComponentPowerModel = m
+			if !components.IsSystemCollectionSupported() && config.DisablePowerModels() {
+				processComponentPowerModel.SetEnabled(false)
+			}
 		}
 		if err != nil {
 			klog.Infof("Failed to create %s Power Model to estimate %s Power: %v\n", modelConfig.ModelType.String()+"/"+modelConfig.ModelOutputType.String(), k, err)


### PR DESCRIPTION
Added a config flag to prevent Kepler from resorting to models when power meters like acpi and rapl are not available.

Issues: While Node level metrics that rely on models are fully removed, due to the current setup of process metrics, process metrics which rely on node metrics that rely on models are not removed and instead output 0 in prometheus.