### PR TITLE
chore(ci): enable Codecov for PRs

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -37,7 +37,6 @@ jobs:
         run: |
           make VERBOSE=1 test
       - name: Upload coverage reports to Codecov
-        if: github.event_name != 'pull_request'
         uses: codecov/codecov-action@v5.1.2
         with:
           fail_ci_if_error: false # because codecov updates occasionally fail


### PR DESCRIPTION
This commit will allow Codecov to run on every PR so that we can get a better code coverage report at the time of PR review.

Ref: 
https://app.codecov.io/gh/sustainable-computing-io/kepler/commit/e9855ddbcbc41c482d033f3573fd2d44637c7936
