### PR TITLE
chore(compose): add proc and sys dir config for latest

### DIFF
--- a/manifests/compose/compose.yaml
+++ b/manifests/compose/compose.yaml
@@ -20,10 +20,10 @@ services:
     volumes:
       - type: bind
         source: /proc
-        target: /proc
+        target: /host/proc
       - type: bind
         source: /sys
-        target: /sys
+        target: /host/sys
       - type: bind
         source: ./default/kepler/etc/kepler
         target: /etc/kepler

--- a/manifests/compose/default/kepler/etc/kepler/kepler.config/PROC_DIR
+++ b/manifests/compose/default/kepler/etc/kepler/kepler.config/PROC_DIR
@@ -1,0 +1,1 @@
+/host/proc

--- a/manifests/compose/default/kepler/etc/kepler/kepler.config/SYS_DIR
+++ b/manifests/compose/default/kepler/etc/kepler/kepler.config/SYS_DIR
@@ -1,0 +1,1 @@
+/host/sys


### PR DESCRIPTION
This commit adds the `PROC_DIR` and `SYS_DIR` config for the latest and also updates the `compose.yaml` to use the appropriate `target` path when mounting the volumes