### PR TITLE
fix(compose): remove fallback scrape protocol config

### DIFF
--- a/manifests/compose/dev/prometheus/scrape-configs/dev.yaml
+++ b/manifests/compose/dev/prometheus/scrape-configs/dev.yaml
@@ -11,7 +11,6 @@ scrape_configs:
     static_configs:
       - targets: [scaphandre:8080]
     scheme: http
-    fallback_scrape_protocol: PrometheusText1.0.0
 
   - job_name: node-exporter
     static_configs:

--- a/manifests/compose/validation/metal/prometheus/scrape-configs/metal.yaml
+++ b/manifests/compose/validation/metal/prometheus/scrape-configs/metal.yaml
@@ -7,7 +7,6 @@ scrape_configs:
     static_configs:
       - targets: [scaphandre:8080]
     scheme: http
-    fallback_scrape_protocol: PrometheusText1.0.0
 
   - job_name: metal
     static_configs:


### PR DESCRIPTION
This PR removes the fallback scrape protocol config from the Scaphandre scrape config as the latest prometheus doesn't recoganize the field as part of Scrape config structure