### PR TITLE
chore(main): use run.Group to run multiple services

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/sustainable-computing-io/kepler
 
-go 1.23.0
+go 1.22
+
+require github.com/oklog/run v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
+github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=


### PR DESCRIPTION
This commit provide a skeleton to run multiple services in separate go threads and orchestrate clean up if any of these services exit with an error during its startup phase.

NOTE: interrupting (SIGINT) kepler does not result in exit code 0 rather it initiates the shutdown process.