### PR TITLE
feat(version): add version information to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,13 @@ BUILD_TIME=$(shell date -u '+%Y-%m-%d_%H:%M:%S')
 GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null)
 
+LDFLAGS=-ldflags "\
+	-X github.com/sustainable-computing-io/kepler/internal/version.version=$(VERSION) \
+	-X github.com/sustainable-computing-io/kepler/internal/version.buildTime=$(BUILD_TIME) \
+	-X github.com/sustainable-computing-io/kepler/internal/version.gitBranch=$(GIT_BRANCH) \
+	-X github.com/sustainable-computing-io/kepler/internal/version.gitCommit=$(GIT_COMMIT) \
+"
+
 # Docker parameters
 IMG_BASE ?= quay.io/sustainable_computing_io
 

--- a/cmd/kepler/logger.go
+++ b/cmd/kepler/logger.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func setupLogger(level, format string) *slog.Logger {
+	logLevel := parseLogLevel(level)
+	return slog.New(handlerForFormat(format, logLevel))
+}
+
+func handlerForFormat(format string, logLevel slog.Level) slog.Handler {
+	switch format {
+	case "json":
+		return slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level:     logLevel,
+			AddSource: true,
+		})
+
+	case "text":
+		return slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level:     logLevel,
+			AddSource: true,
+			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+				if a.Key == slog.SourceKey {
+					if src, ok := a.Value.Any().(*slog.Source); ok {
+
+						// Split the path into components
+						parts := strings.Split(filepath.ToSlash(src.File), "/")
+
+						// If we have enough components, take the last 3 -> 2 dirs + filename
+						if len(parts) > 2 {
+							src.File = filepath.Join(parts[len(parts)-3], parts[len(parts)-2], parts[len(parts)-1])
+						} else if len(parts) > 0 {
+							// If not, take all the parts
+							src.File = filepath.Join(parts...)
+						}
+					}
+				}
+				return a
+			},
+		})
+
+	default:
+		panic(fmt.Sprintf("invalid format: %s", format))
+	}
+}
+
+func parseLogLevel(level string) slog.Level {
+	switch level {
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/cmd/kepler/logger_test.go
+++ b/cmd/kepler/logger_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetupLogger(t *testing.T) {
+	tests := []struct {
+		name     string
+		format   string
+		logLevel string
+
+		shouldLogInfo bool // indicate if info should be logged or not
+		expectPanic   bool
+	}{{
+		name:          "json format debug level",
+		format:        "json",
+		logLevel:      "debug",
+		shouldLogInfo: true,
+	}, {
+		name:          "json format info level",
+		format:        "json",
+		logLevel:      "info",
+		shouldLogInfo: true,
+	}, {
+		name:          "json format warn level",
+		format:        "json",
+		logLevel:      "warn",
+		shouldLogInfo: false,
+	}, {
+		name:          "text format info level",
+		format:        "text",
+		logLevel:      "info",
+		shouldLogInfo: true,
+	}, {
+		name:          "text format error level",
+		format:        "text",
+		logLevel:      "warn",
+		shouldLogInfo: false,
+	}, {
+		name:          "text format error level",
+		format:        "text",
+		logLevel:      "error",
+		shouldLogInfo: false,
+	}, {
+		name:        "invalid format panics",
+		format:      "invalid",
+		logLevel:    "info",
+		expectPanic: true,
+	}}
+
+	// This test setup up logger in various formats and log levels
+	// and checks if the log message at INFO is logged or not
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.expectPanic {
+				assert.Panics(t, func() {
+					_ = setupLogger(tt.format, tt.logLevel)
+				}, "Expected setupLogger to panic with invalid format")
+				//
+				return
+			}
+
+			// Logger writes to stdout, so, redirect stdout to a buffer and
+			// restore it at the end
+			stdoutOrig := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			logger := setupLogger(tt.logLevel, tt.format)
+			logger.Info("test message", "key", "value")
+
+			// Restore stdout
+			w.Close()
+			os.Stdout = stdoutOrig
+
+			// read stdout to string
+			var outBuffer bytes.Buffer
+			_, err := outBuffer.ReadFrom(r)
+			assert.NoError(t, err, "Failed to read output")
+
+			output := outBuffer.String()
+
+			if tt.shouldLogInfo {
+				assert.Contains(t, output, "test message", "Expected log message not found in output")
+			} else {
+				assert.NotContains(t, output, "test message", "Unexpected log message found in output")
+			}
+
+			// text format -> verify source path is shortened
+			messageLogged := strings.Contains(output, "test message")
+			if tt.format == "text" && messageLogged {
+				// ensure source path was transformed
+				assert.NotContains(t, output, "/home/user/",
+					"Source path was not shortened as expected: %s", output)
+			}
+
+			// JSON format -> verify the structure
+			if tt.format == "json" && messageLogged {
+				logParts := map[string]any{}
+				err := json.Unmarshal(outBuffer.Bytes(), &logParts)
+				assert.NoError(t, err, "Failed to parse JSON log")
+
+				assert.Contains(t, logParts, "time", "JSON log: missing 'time' field")
+				assert.Contains(t, logParts, "msg", "JSON log missing 'msg' field")
+				assert.Equal(t, "test message", logParts["msg"], "JSON log: incorrect 'msg' value")
+				assert.Contains(t, logParts, "key", "JSON log: missing 'key' field")
+				assert.Equal(t, "value", logParts["key"], "JSON log: incorrect 'key' value")
+			}
+		})
+	}
+}

--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -18,14 +18,17 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"os/signal"
 
 	"github.com/oklog/run"
+	"github.com/sustainable-computing-io/kepler/internal/version"
 )
 
 func main() {
 	logger := setupLogger("info", "text")
+	logVersionInfo(logger)
 
 	var g run.Group
 
@@ -72,6 +75,19 @@ func main() {
 		os.Exit(1)
 	}
 	logger.Info("Graceful shutdown completed")
+}
+
+func logVersionInfo(logger *slog.Logger) {
+	v := version.Info()
+	logger.Info("Kepler version information",
+		"version", v.Version,
+		"buildTime", v.BuildTime,
+		"gitBranch", v.GitBranch,
+		"gitCommit", v.GitCommit,
+		"goVersion", v.GoVersion,
+		"goOS", v.GoOS,
+		"goArch", v.GoArch,
+	)
 }
 
 func waitForInterrupt(ctx context.Context, signals ...os.Signal) (func() error, func(error)) {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,13 @@ module github.com/sustainable-computing-io/kepler
 
 go 1.22
 
-require github.com/oklog/run v1.1.0
+require (
+	github.com/oklog/run v1.1.0
+	github.com/stretchr/testify v1.10.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import "runtime"
+
+var (
+	version   string
+	buildTime string
+	gitBranch string
+	gitCommit string
+)
+
+type VersionInfo struct {
+	Version   string
+	BuildTime string
+	GitBranch string
+	GitCommit string
+
+	GoVersion string
+	GoOS      string
+	GoArch    string
+}
+
+// Info returns the version information
+func Info() VersionInfo {
+	return VersionInfo{
+		Version:   version,
+		BuildTime: buildTime,
+		GitBranch: gitBranch,
+		GitCommit: gitCommit,
+
+		GoVersion: runtime.Version(),
+		GoOS:      runtime.GOOS,
+		GoArch:    runtime.GOARCH,
+	}
+}


### PR DESCRIPTION
This commits adds version information to kepler. This infomation get
logged in the startup as follows

```
time=2025-04-01T10:21:52.529-04:00 level=INFO source=cmd/kepler/main.go:82 \
msg="Kepler version information"
version=074c9fe5 \
buildTime=2025-04-01_14:21:52 \
gitBranch=reboot \
gitCommit=074c9fe5 \
goVersion=go1.22.12 \
goOS=linux \
goArch=amd64
```
NOTE: output above is broken into multiple lines for better readability.

Signed-off-by: Sunil Thaha <sthaha@redhat.com>
