### PR TITLE
feat(ci): add workflow to build, push image to quay

### DIFF
--- a/.github/publish-image/action.yaml
+++ b/.github/publish-image/action.yaml
@@ -1,0 +1,51 @@
+name: Build and Publish Images
+description: "Publishes Kepler image to an Image Registry"
+inputs:
+  registry:
+    description: "image registry"
+    required: true
+  username:
+    description: "registry username"
+    required: true
+  password:
+    description: "registry password"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout source
+      uses: actions/checkout@v4
+      with:
+        # NOTE: setting fetch-depth to 0 to retrieve the entire history
+        # intead of a shallow -clone so that all tags are fetched as well.
+        # This is necessary for computing the VERSION using `git describe`
+        fetch-depth: 0
+
+    - uses: actions/setup-go@main
+      with:
+        go-version-file: go.mod
+        check-latest: true
+        cache: true
+
+    - name: Login to Image Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
+    - name: Build Image
+      shell: bash
+      run: |
+        make image
+      env:
+        IMG_BASE: ${{ inputs.registry }}
+
+    - name: Push Image
+      shell: bash
+      run: |
+        make push
+      env:
+        IMG_BASE: ${{ inputs.registry }}
+

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -1,0 +1,26 @@
+name: Publish image
+
+on:
+  push:
+    branches: [ reboot ]
+
+jobs:
+  publish:
+    name: Publish Kepler image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-go@main
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build and Publish image to external registry
+        uses: ./.github/publish-image
+        with:
+          registry: quay.io/sustainable_computing_io
+          username: ${{ secrets.BOT_NAME }}
+          password: ${{ secrets.BOT_TOKEN }}
+


### PR DESCRIPTION
This commit adds a basic workflow which builds and pushes Kepler image to quay.io registry on push to `reboot` branch

It will push the image to `kepler-reboot` repo under sustainable_computing_io org. The tag will be pointing to current commit SHA


**Note: BOT_NAME and BOT_TOKEN secrets must be defined under repo's settings**

Ref: https://github.com/sustainable-computing-io/kepler/blob/85d017bc23bb6be33adf471414870d874357f532/.github/workflows/push.yml#L16


Signed-off-by: vprashar2929 <vibhu.sharma2929@gmail.com>