### PR TITLE
feat(ci): add workflow to pr checks

### DIFF
--- a/.github/publish-image/action.yaml
+++ b/.github/publish-image/action.yaml
@@ -29,11 +29,16 @@ runs:
         cache: true
 
     - name: Login to Image Registry
+      if: "!startsWith(inputs.registry, 'localhost')"
       uses: docker/login-action@v2
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
+
+    - name: make deps
+      shell: bash
+      run: make deps
 
     - name: Build Image
       shell: bash
@@ -44,6 +49,7 @@ runs:
 
     - name: Push Image
       shell: bash
+      if: "!startsWith(inputs.registry, 'localhost')"
       run: |
         make push
       env:

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,0 +1,81 @@
+name: pr-checks
+
+on:
+  pull_request:
+    branches: [ reboot ]
+
+jobs:
+  # docs:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@main
+  #     - uses: actions/setup-go@main
+  #       with:
+  #         go-version-file: go.mod
+  #
+  #     - name: make docs
+  #       shell: bash
+  #       run: |
+  #         make docs && git diff --exit-code
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: actions/setup-go@main
+        with:
+          go-version-file: go.mod
+
+      - name: make fmt
+        shell: bash
+        run:  make fmt && git diff --exit-code
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: actions/setup-go@main
+        with:
+          go-version-file: go.mod
+
+      - name: make test
+        shell: bash
+        run: make test
+
+  golangci:
+    permissions:
+      contents: read
+      pull-requests: read
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: code checkout
+        uses: actions/checkout@v3
+      - uses: actions/setup-go@main
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.56
+          args: --timeout=3m --issues-exit-code=0 ./...
+          only-new-issues: true
+
+  build-images:
+    needs: [fmt, test, golangci ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-go@main
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: build images for PR checks
+        uses: ./.github/publish-image
+        with:
+          registry: "localhost:5001"

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ deps:
 	$(GOMOD) verify
 
 # Build Docker image
-image: test deps
+image:
 	docker build -t \
 		$(KEPLER_IMAGE) \
 		--platform=linux/$(GOARCH) .


### PR DESCRIPTION
This commit adds basic workflow to run PR checks on kepler reboot Currently it performs the following checks:
* Runs `make fmt` to check if the code is formatted correctly
* Runs `make test` to check if the code is unit tested
* Runs `golangci-lint` to check if the code is linted correctly
* Runs `build-image` to check if the image can be built successfully