### PR TITLE
feat(ci): add additional tags when pushing image

### DIFF
--- a/.github/publish-image/action.yaml
+++ b/.github/publish-image/action.yaml
@@ -10,6 +10,9 @@ inputs:
   password:
     description: "registry password"
     required: true
+  additional_tags:
+    description: "additional tags for container image"
+    required: false
 
 runs:
   using: composite
@@ -41,6 +44,7 @@ runs:
         make image
       env:
         IMG_BASE: ${{ inputs.registry }}
+        ADDITIONAL_TAGS: ${{ inputs.additional_tags }}
 
     - name: Push Image
       shell: bash
@@ -48,4 +52,4 @@ runs:
         make push
       env:
         IMG_BASE: ${{ inputs.registry }}
-
+        ADDITIONAL_TAGS: ${{ inputs.additional_tags }}

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -17,10 +17,17 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: additional tags
+        id: additional_tags
+        shell: bash
+        run: |
+         echo "result=$(git rev-parse --short HEAD)-$(date +%Y%m%d%H%M%S),latest" >> $GITHUB_OUTPUT
+
       - name: Build and Publish image to external registry
         uses: ./.github/publish-image
         with:
           registry: quay.io/sustainable_computing_io
           username: ${{ secrets.BOT_NAME }}
           password: ${{ secrets.BOT_TOKEN }}
+          additional_tags: ${{ steps.additional_tags.outputs.result }}
 


### PR DESCRIPTION
This commit adds additional tags to the image when pushing to quay.io. Now we will have tags like `latest`, `SHA` and `SHA-timestamp` pushed to quay.io.