### PR TITLE
feat(stubs) stubs for all services

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,6 @@ require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DV
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=

--- a/internal/device/cpu_power_meter.go
+++ b/internal/device/cpu_power_meter.go
@@ -3,6 +3,8 @@
 
 package device
 
+import "context"
+
 // EnergyZone represents a measurable energy or power zone/domain exposed by a power meter.
 // An EnergyZone typically represents a logical zone of the hardware unit, e.g. cpu core, cpu package
 // dram, uncore etc.
@@ -32,4 +34,31 @@ type CPUPowerMeter interface {
 
 	// Zones() returns a slice of the energy measurement zones
 	Zones() ([]EnergyZone, error)
+}
+
+var _ CPUPowerMeter = (*cpuPowerMeter)(nil)
+
+type cpuPowerMeter struct{}
+
+func (c *cpuPowerMeter) Zones() ([]EnergyZone, error) {
+	return nil, nil
+}
+
+func (c *cpuPowerMeter) Name() string {
+	// TODO: set a proper name when rapl is implemented
+	return "cpu"
+}
+
+func (c *cpuPowerMeter) Start(ctx context.Context) error {
+	// TODO: Implement power monitoring logic
+	return nil
+}
+
+func (c *cpuPowerMeter) Stop() error {
+	// TODO: Implement stop logic
+	return nil
+}
+
+func NewCPUPowerMeter() *cpuPowerMeter {
+	return &cpuPowerMeter{}
 }

--- a/internal/device/cpu_power_meter_test.go
+++ b/internal/device/cpu_power_meter_test.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package device
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCPUPowerMeterInterface ensures that cpuPowerMeter properly implements the CPUPowerMeter interface
+func TestCPUPowerMeterInterface(t *testing.T) {
+	var _ CPUPowerMeter = (*cpuPowerMeter)(nil)
+}
+
+func TestNewCPUPowerMeter(t *testing.T) {
+	meter := NewCPUPowerMeter()
+	assert.NotNil(t, meter, "NewCPUPowerMeter should not return nil")
+	assert.IsType(t, &cpuPowerMeter{}, meter, "NewCPUPowerMeter should return a *cpuPowerMeter")
+}
+
+func TestCPUPowerMeter_Name(t *testing.T) {
+	meter := &cpuPowerMeter{}
+	name := meter.Name()
+	assert.Equal(t, "cpu", name, "Name() should return 'cpu'")
+}
+
+func TestCPUPowerMeter_Start(t *testing.T) {
+	meter := &cpuPowerMeter{}
+	ctx := context.Background()
+	err := meter.Start(ctx)
+	assert.NoError(t, err, "Start() should not return an error")
+}
+
+func TestCPUPowerMeter_Stop(t *testing.T) {
+	meter := &cpuPowerMeter{}
+	err := meter.Stop()
+	assert.NoError(t, err, "Stop() should not return an error")
+}
+
+func TestCPUPowerMeter_Zones(t *testing.T) {
+	meter := &cpuPowerMeter{}
+	zones, err := meter.Zones()
+	assert.NoError(t, err, "Zones() should not return an error")
+	assert.Nil(t, zones, "Zones() should return nil for the current implementation")
+}

--- a/internal/device/energy.go
+++ b/internal/device/energy.go
@@ -3,7 +3,9 @@
 
 package device
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Energy represents energy usage as an uint64 MicroJoule count.
 // The maximum energy that can be captured is
@@ -22,4 +24,31 @@ func (e Energy) MicroJoules() uint64 {
 
 func (e Energy) String() string {
 	return fmt.Sprintf("%fJ", e.Joules())
+}
+
+// Power represents power usage as an float64 MicroWatts.
+// Use functions Watts and MicroWatts to get the power value as
+// Watts or MicroWatts
+type Power float64
+
+const (
+	MicroWatt Power = 1.0
+	MilliWatt       = 1000 * MicroWatt
+	Watt            = 1000 * MilliWatt
+)
+
+func (p Power) MicroWatts() float64 {
+	return float64(p)
+}
+
+func (p Power) MilliWatts() float64 {
+	return float64(p / MilliWatt)
+}
+
+func (p Power) Watts() float64 {
+	return float64(p / Watt)
+}
+
+func (p Power) String() string {
+	return fmt.Sprintf("%fW", p.Watts())
 }

--- a/internal/device/energy_test.go
+++ b/internal/device/energy_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"math"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEnergy_Joules(t *testing.T) {
@@ -66,6 +68,109 @@ func TestEnergy_String(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("String() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestPower_MicroWatts(t *testing.T) {
+	tests := []struct {
+		name  string
+		power Power
+		want  float64
+	}{
+		{"Zero", 0, 0.0},
+		{"2 Million", 2_000_000, 2_000_000},
+		{"Maximum value", math.MaxFloat64, math.MaxFloat64},
+
+		{"Zero MicoWatt	", 0 * MicroWatt, 0.0},
+		{"1 MicroWatt", 1 * MicroWatt, 1.0},
+		{"Five MicroWatts", 5 * MicroWatt, 5.0},
+		{"1.5 Watts", 1.5 * MicroWatt, 1.5},
+		{"Maximum MicroWatts", math.MaxFloat64 * MicroWatt, math.MaxFloat64},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.power.MicroWatts()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPower_MilliWatts(t *testing.T) {
+	tests := []struct {
+		name  string
+		power Power
+		want  float64
+	}{
+		{"Zero", 0, 0.0},
+		{"Regular One", 1, 0.001},
+		{"Regular 5", 5, 0.005},
+		{"Regular 1000", 1000, 1.0},
+		{"MaxFloat64", math.MaxFloat64, math.MaxFloat64 / 1000},
+
+		{"MilliWatt", MilliWatt, 1.0},
+		{"Zero MilliWatt", 0 * MilliWatt, 0.0},
+		{"Five MilliWatt", 5 * MilliWatt, 5.0},
+		{"1.5 MilliWatt", 1.5 * MilliWatt, 1.5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.power.MilliWatts()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	// NOTE: cannot compare Max Milli watt directly as above due to float64 precision
+	// {"Max MilliWatts", math.MaxFloat64 / 1000 * MilliWatt, math.MaxFloat64},
+	// compute max milli watts
+	maxMilliWatts := Power(math.MaxFloat64 * MicroWatt).MilliWatts()
+	assert.InDelta(t, math.MaxFloat64/1_000, maxMilliWatts, 0.0001)
+}
+
+func TestPower_Watts(t *testing.T) {
+	tests := []struct {
+		name  string
+		power Power
+		want  float64
+	}{
+		{"Zero", 0, 0.0},
+		{"Regular One", 1, 0.000_001},
+		{"Regular 5", 5, 0.000_005},
+		{"Regular 1000", 1000, 0.001},
+		{"MaxFloat64", math.MaxFloat64, math.MaxFloat64 / 1000_000},
+
+		{"Zero Watt", 0, 0.0},
+		{"One Watt", Watt, 1.0},
+		{"Five Watt", 5 * Watt, 5.0},
+		{"1.5 Watts", 1.5 * Watt, 1.5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.power.Watts()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	// compute max watts
+	maxWatts := Power(math.MaxFloat64 * MicroWatt).Watts()
+	assert.InDelta(t, math.MaxFloat64/1_000_000, maxWatts, 0.0001)
+}
+
+func TestPower_String(t *testing.T) {
+	tests := []struct {
+		name  string
+		power Power
+		want  string
+	}{
+		{"Zero", 0, "0.000000W"},
+		{"Regular", 1_250_000, "1.250000W"},
+		{"Watt", 1.25 * Watt, "1.250000W"},
+		{"MaxFloat64", Power(math.MaxFloat64), fmt.Sprintf("%fW", float64(math.MaxFloat64)/1_000_000)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.power.String()
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/device/power_meter.go
+++ b/internal/device/power_meter.go
@@ -3,6 +3,8 @@
 
 package device
 
+import "context"
+
 // powerMeter is a generic interface for power meters which reads energy
 // or power readings from hardware devices like CPU/GPU/DRAM etc
 type powerMeter interface {
@@ -10,7 +12,7 @@ type powerMeter interface {
 	Name() string
 
 	// Start() initialuzes and starts the power meter for reading energy or power
-	Start() error
+	Start(ctx context.Context) error
 
 	// Stop() stops the power meter and releases any resources held
 	Stop() error

--- a/internal/monitor/mock_cpu_meter_test.go
+++ b/internal/monitor/mock_cpu_meter_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitor
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/sustainable-computing-io/kepler/internal/device"
+)
+
+// MockCPUPowerMeter is a mock implementation of device.CPUPowerMeter
+type MockCPUPowerMeter struct {
+	mock.Mock
+}
+
+func (m *MockCPUPowerMeter) Zones() ([]device.EnergyZone, error) {
+	args := m.Called()
+	return args.Get(0).([]device.EnergyZone), args.Error(1)
+}
+
+func (m *MockCPUPowerMeter) Name() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockCPUPowerMeter) Start(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockCPUPowerMeter) Stop() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+type MockEnergyZone struct {
+	mock.Mock
+}
+
+func (m *MockEnergyZone) Name() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockEnergyZone) Index() int {
+	args := m.Called()
+	return args.Int(0)
+}
+
+func (m *MockEnergyZone) Path() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockEnergyZone) Energy() device.Energy {
+	args := m.Called()
+	return args.Get(0).(device.Energy)
+}
+
+func (m *MockEnergyZone) MaxEnergy() device.Energy {
+	args := m.Called()
+	return args.Get(0).(device.Energy)
+}

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package monitor
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/sustainable-computing-io/kepler/internal/device"
+	"github.com/sustainable-computing-io/kepler/internal/service"
+)
+
+// Service defines the interface for the power monitoring service
+type Service interface {
+	service.Service
+	// Snapshot returns the current power data
+	Snapshot() (*Snapshot, error)
+
+	// DataChannel returns a channel that signals when new data is available
+	DataChannel() <-chan struct{}
+
+	// ZoneNames returns the names of the available RAPL zones
+	ZoneNames() []string
+}
+
+// PowerMonitor is the default implementation of the monitoring service
+type PowerMonitor struct {
+	// passed externally
+	logger        *slog.Logger
+	cpuPowerMeter device.CPUPowerMeter
+
+	// signals when a snapshot has been updated
+	dataCh   chan struct{}
+	snapshot *Snapshot
+}
+
+var _ Service = (*PowerMonitor)(nil)
+
+type Opts struct {
+	logger        *slog.Logger
+	cpuPowerMeter device.CPUPowerMeter
+}
+
+// NewConfig returns a new Config with defaults set
+func DefaultOpts() Opts {
+	return Opts{
+		logger:        slog.Default(),
+		cpuPowerMeter: device.NewCPUPowerMeter(),
+	}
+}
+
+// OptionFn is a function sets one more more options in Opts struct
+type OptionFn func(*Opts)
+
+// WithLogger sets the logger for the PowerMonitor
+func WithLogger(logger *slog.Logger) OptionFn {
+	return func(o *Opts) {
+		o.logger = logger
+	}
+}
+
+// WithCPUPowerMeter sets the logger for the PowerMonitor
+func WithCPUPowerMeter(m device.CPUPowerMeter) OptionFn {
+	return func(o *Opts) {
+		o.cpuPowerMeter = m
+	}
+}
+
+// NewPowerMonitor creates a new PowerMonitor instance
+func NewPowerMonitor(applyOpts ...OptionFn) *PowerMonitor {
+	opts := DefaultOpts()
+	for _, apply := range applyOpts {
+		apply(&opts)
+	}
+
+	monitor := &PowerMonitor{
+		logger:        opts.logger.With("service", "monitor"),
+		cpuPowerMeter: opts.cpuPowerMeter,
+		dataCh:        make(chan struct{}, 1),
+		snapshot:      NewSnapshot(),
+	}
+
+	return monitor
+}
+
+func (pm *PowerMonitor) Name() string {
+	return "monitor"
+}
+
+func (pm *PowerMonitor) Start(ctx context.Context) error {
+	// TODO: Implement power monitoring logic
+
+	pm.logger.Info("Monitor is running...")
+	<-ctx.Done()
+	pm.logger.Info("Monitor has terminated.")
+
+	return nil
+}
+
+func (pm *PowerMonitor) Stop() error {
+	// TODO: Implement stop logic
+	err := pm.cpuPowerMeter.Stop()
+	return err
+}
+
+func (pm *PowerMonitor) Snapshot() (*Snapshot, error) {
+	// TODO: Implement snapshot logic
+	return nil, nil
+}
+
+func (pm *PowerMonitor) DataChannel() <-chan struct{} {
+	return pm.dataCh
+}
+
+func (pm *PowerMonitor) ZoneNames() []string {
+	// TODO: Implement zone names logic
+	return []string{}
+}

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitor
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPowerMonitor(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []OptionFn
+		want string
+	}{
+		{
+			name: "default options",
+			opts: []OptionFn{},
+			want: "monitor",
+		},
+		{
+			name: "with logger",
+			opts: []OptionFn{
+				WithLogger(slog.Default().With("test", "custom")),
+			},
+			want: "monitor",
+		},
+		{
+			name: "with custom power meter",
+			opts: []OptionFn{
+				func() OptionFn {
+					mockPowerMeter := new(MockCPUPowerMeter)
+					mockPowerMeter.On("Name").Return("mock-cpu")
+					return WithCPUPowerMeter(mockPowerMeter)
+				}(),
+			},
+			want: "monitor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			monitor := NewPowerMonitor(tt.opts...)
+
+			// Check if monitor is correctly initialized
+			assert.NotNil(t, monitor)
+			assert.Equal(t, tt.want, monitor.Name())
+			assert.NotNil(t, monitor.dataCh)
+			assert.NotNil(t, monitor.snapshot)
+			assert.NotNil(t, monitor.logger)
+			assert.NotNil(t, monitor.cpuPowerMeter)
+		})
+	}
+}
+
+func TestPowerMonitor_Start(t *testing.T) {
+	mockPowerMeter := &MockCPUPowerMeter{}
+
+	// TODO: Since the current monitor doesn't actually call these methods,
+	// we don't set any expectations on mock
+	// FIX: Implement a mock implementation that actually calls the methods
+	// call: assert.Expectations(t)
+
+	monitor := NewPowerMonitor(
+		WithCPUPowerMeter(mockPowerMeter),
+		WithLogger(slog.Default()),
+	)
+
+	// Create a context with a short timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// Start the monitor and verify it blocks until context cancellation
+	startTime := time.Now()
+	err := monitor.Start(ctx)
+	duration := time.Since(startTime)
+
+	// Verify the method returns when context is done and there's no error
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, duration, 50*time.Millisecond, "Start should block until context is done")
+}
+
+func TestPowerMonitor_Stop(t *testing.T) {
+	mockPowerMeter := &MockCPUPowerMeter{}
+	mockPowerMeter.On("Stop").Return(nil)
+
+	monitor := NewPowerMonitor(
+		WithCPUPowerMeter(mockPowerMeter),
+	)
+
+	err := monitor.Stop()
+	assert.NoError(t, err)
+	mockPowerMeter.AssertExpectations(t)
+}
+
+func TestPowerMonitor_DataChannel(t *testing.T) {
+	monitor := NewPowerMonitor()
+
+	dataCh := monitor.DataChannel()
+	assert.NotNil(t, dataCh)
+}
+
+func TestPowerMonitor_ZoneNames(t *testing.T) {
+	mockPowerMeter := &MockCPUPowerMeter{}
+	monitor := NewPowerMonitor(
+		WithCPUPowerMeter(mockPowerMeter),
+	)
+	// TODO: Implement zone names validation
+
+	names := monitor.ZoneNames()
+	assert.Empty(t, names)
+}
+
+func TestPowerMonitor_Snapshot(t *testing.T) {
+	mockPowerMeter := new(MockCPUPowerMeter)
+
+	monitor := NewPowerMonitor(
+		WithCPUPowerMeter(mockPowerMeter),
+	)
+
+	// TODO: Implement snapshot validation
+	snapshot, err := monitor.Snapshot()
+	assert.Nil(t, snapshot)
+	assert.Nil(t, err)
+}

--- a/internal/monitor/types.go
+++ b/internal/monitor/types.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitor
+
+import (
+	"maps"
+	"time"
+
+	"github.com/sustainable-computing-io/kepler/internal/device"
+)
+
+type (
+	Energy     = device.Energy
+	Power      = device.Power
+	EnergyZone = device.EnergyZone
+)
+
+// Usage contains energy consumption data
+type Usage struct {
+	Absolute Energy // Cumulative joules counter
+	Delta    Energy // Difference since last measurement
+	Watts    Power  // Current power in watts
+}
+
+// ZoneUsageMap maps zones to energy data
+type ZoneUsageMap map[EnergyZone]Usage
+
+type Node struct {
+	Timestamp time.Time    // Timestamp of the last measurement
+	Zones     ZoneUsageMap // Map of zones to usage
+}
+
+func (n *Node) Clone() *Node {
+	ret := &Node{
+		Timestamp: n.Timestamp,
+		Zones:     make(ZoneUsageMap, len(n.Zones)),
+	}
+	maps.Copy(ret.Zones, n.Zones)
+	return ret
+}
+
+// Snapshot encapsulates power monitoring data
+type Snapshot struct {
+	Timestamp time.Time // Timestamp of the snapshot
+	Node      *Node
+}
+
+// NewSnapshot creates a new Snapshot instance
+func NewSnapshot() *Snapshot {
+	return &Snapshot{
+		Timestamp: time.Now(),
+		Node: &Node{
+			Zones: make(ZoneUsageMap),
+		},
+	}
+}
+
+func (s *Snapshot) Clone() *Snapshot {
+	return &Snapshot{
+		Timestamp: s.Timestamp,
+		Node:      s.Node.Clone(),
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import "context"
+
+// Service is the interface that all services must implement
+type Service interface {
+	// Name returns the name of the service
+	Name() string
+	// Start starts the service
+	Start(ctx context.Context) error
+	// Stop stops the service
+	Stop() error
+}


### PR DESCRIPTION
This commit introduces the following changes:
* Adds a service interfaces that all services (currently monitor)
  implements
* Refactors application startup to use services and starts them up,
  terminating if any of the service fails to start.
* Adds monitor service (with unit-tests)
* Modifies Device startup to accept a context so that the startup can be
  aborted if context is canceled.

Signed-off-by: Sunil Thaha <sthaha@redhat.com>