### PR TITLE
feat(ci): add pre-commit hooks

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,0 +1,9 @@
+# Common Go terms that might be flagged incorrectly
+errcheck
+funcs
+gofmt
+golint
+govet
+inout
+syscall
+thay

--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,0 +1,12 @@
+extends:
+  - '@commitlint/config-conventional' # yamllint disable-line rule:quoted-strings
+rules:
+  subject-case:
+    - 2
+    - never
+    - - sentence-case
+      - start-case
+      - pascal-case
+      - upper-case
+# Custom URL to show upon failure
+helpUrl: "https://github.com/conventional-changelog/commitlint/#what-is-commitlint" # yamllint disable-line rule:quoted-strings

--- a/.github/publish-image/action.yaml
+++ b/.github/publish-image/action.yaml
@@ -1,17 +1,17 @@
 name: Build and Publish Images
-description: "Publishes Kepler image to an Image Registry"
+description: Publishes Kepler image to an Image Registry
 inputs:
   registry:
-    description: "image registry"
+    description: image registry
     required: true
   username:
-    description: "registry username"
+    description: registry username
     required: true
   password:
-    description: "registry password"
+    description: registry password
     required: true
   additional_tags:
-    description: "additional tags for container image"
+    description: additional tags for container image
     required: false
 
 runs:
@@ -21,7 +21,7 @@ runs:
       uses: actions/checkout@v4
       with:
         # NOTE: setting fetch-depth to 0 to retrieve the entire history
-        # intead of a shallow -clone so that all tags are fetched as well.
+        # instead of a shallow -clone so that all tags are fetched as well.
         # This is necessary for computing the VERSION using `git describe`
         fetch-depth: 0
 

--- a/.github/workflows/codecov-upload.yaml
+++ b/.github/workflows/codecov-upload.yaml
@@ -28,4 +28,3 @@ jobs:
           fail_ci_if_error: true
           files: ./coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}
-

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,8 +1,8 @@
 name: PR Checks
 
-on:
+on: # yamllint disable-line rule:truthy
   pull_request:
-    branches: [ reboot ]
+    branches: [reboot]
 
 jobs:
   # docs:
@@ -29,9 +29,13 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: make deps
+        shell: bash
+        run: make deps
+
       - name: make fmt
         shell: bash
-        run:  make fmt && git diff --exit-code
+        run: make fmt && git diff --exit-code
 
   codecov-upload:
     uses: ./.github/workflows/codecov-upload.yaml
@@ -47,7 +51,7 @@ jobs:
     steps:
       - name: checkout source
         uses: actions/checkout@v4
-      
+
       - name: setup go
         uses: actions/setup-go@v5.4.0
         with:
@@ -60,6 +64,18 @@ jobs:
           version: v1.56
           args: --timeout=3m --issues-exit-code=0 ./...
           only-new-issues: true
+
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v3
+
+      - name: Setup Pre-Commit
+        uses: pre-commit/action@v3.0.1
 
   build-images:
     needs: [fmt, golangci, codecov-upload]
@@ -77,4 +93,4 @@ jobs:
       - name: build images for PR checks
         uses: ./.github/publish-image
         with:
-          registry: "localhost:5001"
+          registry: localhost:5001

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,8 +1,8 @@
 name: Push
 
-on:
+on: # yamllint disable-line rule:truthy
   push:
-    branches: [ reboot ]
+    branches: [reboot]
 
 jobs:
   codecov-upload:
@@ -36,4 +36,3 @@ jobs:
           username: ${{ secrets.BOT_NAME }}
           password: ${{ secrets.BOT_TOKEN }}
           additional_tags: ${{ steps.additional_tags.outputs.result }}
-

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,6 @@
+default: true
+# MD013 - Line length
+MD013: false
+# MD046 - Code block style
+MD046:
+  style: consistent

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,38 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+      - id: check-merge-conflict
+
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.37.0
+    hooks:
+      - id: yamllint
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.44.0
+    hooks:
+      - id: markdownlint
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        args: [--ignore-words=.codespellignore]
+        exclude: go\.(sum|mod)$
+
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.0.2
+    hooks:
+      - id: golangci-lint
+        args: [--timeout=5m]
+
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.22.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ['@commitlint/config-conventional'] # yamllint disable-line rule:quoted-strings

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,12 @@
+extends: default
+rules:
+  line-length: disable
+  document-start: disable
+  comments:
+    min-spaces-from-content: 1
+  quoted-strings:
+    required: only-when-needed
+    extra-required:
+      - ^.*:\s.*$
+      - ^.*:$
+    quote-type: double

--- a/Makefile
+++ b/Makefile
@@ -130,4 +130,3 @@ define docker_push
 	done \
 }
 endef
-

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,2 +1,3 @@
-Kepler follows
+# Kepler follows
+
 [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)

--- a/compose/dev/config/process-exporter.yaml
+++ b/compose/dev/config/process-exporter.yaml
@@ -2,4 +2,3 @@ process_names:
   - name: "{{.PID}}"
     cmdline:
       - ".+" # yamllint disable-line rule:quoted-strings
-

--- a/compose/dev/override.yaml
+++ b/compose/dev/override.yaml
@@ -21,4 +21,3 @@ services:
       - process-exporter-network
     extra_hosts:
       - host.docker.internal:host-gateway
-

--- a/docs/developer/pre-commit.md
+++ b/docs/developer/pre-commit.md
@@ -1,0 +1,99 @@
+# Pre-commit Hooks Guide
+
+## Overview
+
+This project uses [pre-commit](https://pre-commit.com/) to ensure code quality and consistency before commits are made. Pre-commit runs a series of checks and formatters on your code to catch issues early.
+
+## Installation
+
+1. Install pre-commit:
+
+   ```bash
+   # Using pip
+   pip install pre-commit
+   ```
+
+2. Install the git hooks in your local repository:
+
+   ```bash
+   cd /path/to/kepler
+   pre-commit install
+   ```
+
+## Available Hooks
+
+Our pre-commit configuration includes the following hooks:
+
+1. **trailing-whitespace**: Trims trailing whitespace from lines
+2. **end-of-file-fixer**: Ensures files end with a newline
+3. **check-added-large-files**: Prevents large files from being committed
+4. **check-merge-conflict**: Prevents files with merge conflicts from being committed
+5. **yamllint**: Validates YAML files
+6. **markdownlint**: Validates Markdown files
+7. **codespell**: Checks for common misspellings
+8. **golangci-lint**: Runs Go linters
+9. **commitlint**: Validates commit messages against Conventional Commits format
+
+## Running Manually
+
+You can run pre-commit manually on all files:
+
+```bash
+pre-commit run --all-files
+```
+
+Or on specific files:
+
+```bash
+pre-commit run --files path/to/file1 path/to/file2
+```
+
+Or run a specific hook:
+
+```bash
+pre-commit run <hook-id> --all-files
+```
+
+## Commit Message Format
+
+Our project follows the [Conventional Commits](https://www.conventionalcommits.org/) specification:
+
+```text
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Common types include:
+
+- **feat**: A new feature
+- **fix**: A bug fix
+- **docs**: Documentation changes
+- **style**: Changes that don't affect the code's meaning (formatting, etc.)
+- **refactor**: Code changes that neither fix a bug nor add a feature
+- **test**: Adding or correcting tests
+- **chore**: Changes to the build process, tools, etc.
+
+## Updating Hooks
+
+To update the hooks to their latest versions:
+
+```bash
+pre-commit autoupdate
+```
+
+## Configuration Files
+
+The project includes several configuration files:
+
+- `.pre-commit-config.yaml`: Main pre-commit configuration
+- `.yamllint.yaml`: Configuration for YAML linting
+- `.markdownlint.yaml`: Configuration for Markdown linting
+- `.commitlintrc.yaml`: Configuration for commit message linting
+- `.codespellignore`: Words to ignore in spellchecking
+
+## Troubleshooting
+
+For more help, run `pre-commit --help` or refer to the [official documentation](https://pre-commit.com/).

--- a/internal/device/cpu_power_meter.go
+++ b/internal/device/cpu_power_meter.go
@@ -30,7 +30,7 @@ type EnergyZone interface {
 	// Path() returns the path from which the energy usage value ie being read
 	Path() string
 
-	// Energy() retuns energy consumed by the zone.
+	// Energy() returns energy consumed by the zone.
 	Energy() Energy
 
 	// MaxEnergy returns  the maximum value of energy usage that can be read.


### PR DESCRIPTION
This commit adds the pre-commit hooks to the project. The hooks are run automatically when a commit is made to the project. The pre-commit hooks include:
- trailing-whitespace: Trims trailing whitespace from lines
- end-of-file-fixer: Ensures files end with a newline
- check-added-large-files: Prevents large files from being committed
- check-merge-conflict: Prevents files with merge conflicts from being committed
- yamllint: Validates YAML files
- markdownlint: Validates Markdown files
- codespell: Checks for common misspellings
- golangci-lint: Runs Go linters
- commitlint: Validates commit messages against Conventional Commits format

Commit adds the appropriate configuration files for each hook and also adds the necessary steps to pr-checks workflow to run this on every PR.