### PR TITLE
chore: improve test coverage of config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,10 +172,12 @@ func (c *Config) String() string {
 	if err == nil {
 		return string(bytes)
 	}
-
 	// NOTE:  this code path should not happen but if it does (i.e if yaml marshal) fails
 	// for some reason, manually build the string
+	return c.manualString()
+}
 
+func (c *Config) manualString() string {
 	cfgs := []struct {
 		Name  string
 		Value string


### PR DESCRIPTION
This commit adds missing tests for config.String and config.Load functions.