### PR TITLE
chore(logger): move logger to internal

### DIFF
--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/oklog/run"
 	"github.com/sustainable-computing-io/kepler/internal/config"
+	"github.com/sustainable-computing-io/kepler/internal/logger"
 	"github.com/sustainable-computing-io/kepler/internal/version"
 )
 
@@ -22,7 +23,7 @@ func main() {
 	if err != nil {
 		os.Exit(1)
 	}
-	logger := setupLogger(cfg.Log.Level, cfg.Log.Format)
+	logger := logger.New(cfg.Log.Level, cfg.Log.Format)
 	logVersionInfo(logger)
 	printConfigInfo(logger, cfg)
 
@@ -110,7 +111,7 @@ func parseArgsAndConfig() (*config.Config, error) {
 	updateConfig := config.RegisterFlags(app)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
-	logger := setupLogger("info", "text")
+	logger := logger.New("info", "text")
 	cfg := config.DefaultConfig()
 	if *configFile != "" {
 		logger.Info("Loading configuration file", "path", *configFile)

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 The Kepler Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package main
+package logger
 
 import (
 	"fmt"
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-func setupLogger(level, format string) *slog.Logger {
+func New(level, format string) *slog.Logger {
 	logLevel := parseLogLevel(level)
 	return slog.New(handlerForFormat(format, logLevel))
 }


### PR DESCRIPTION
This commit moves logger to internal package.

Follow up to #1977