### PR TITLE
ci: label PR based on commit messages

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,12 @@
+include-title: false
+include-commits: true
+label-mapping:
+  fix: [fix, bugfix]
+  feat: [feat, feature]
+  chore: [chore]
+  docs: [docs, documentation]
+  test: [test]
+  refactor: [refactor]
+  ci: [ci]
+  perf: [perf]
+  revert: [revert]

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -5,6 +5,19 @@ on: # yamllint disable-line rule:truthy
     branches: [reboot]
 
 jobs:
+  # label-pr:
+  #   permissions:
+  #     contents: read
+  #     issues: read
+  #     pull-requests: write
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: checkout source
+  #       uses: actions/checkout@v4
+  #
+  #     - uses: grafana/pr-labeler-action@v0.1.0
+  #       with:
+  #         token: ${{ secrets.GITHUB_TOKEN }}
   # docs:
   #   runs-on: ubuntu-latest
   #   steps:


### PR DESCRIPTION
This commit adds a labeler job to PR workflow to label PRs based on commit messages. Following labels are added:
- feat
- fix
- chore
- docs
- ci
- refactor
- perf
- test
- revert

Partially addresses #1989 

Ref: https://github.com/grafana/pr-labeler-action?tab=readme-ov-file#default-config
Relevant labels are already added to project: https://github.com/sustainable-computing-io/kepler/labels