### PR TITLE
ci: add pr-labeler config

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,12 @@
+include-title: false
+include-commits: true
+label-mapping:
+  fix: [fix, bugfix]
+  feat: [feat, feature]
+  chore: [chore]
+  docs: [docs, documentation]
+  test: [test]
+  refactor: [refactor]
+  ci: [ci]
+  perf: [perf]
+  revert: [revert]


### PR DESCRIPTION
This commit adds a PR labeler config to the default branch of the repo i.e `main`. Since `grafana/pr-labeler-action` expects the config to be available in the default branch, adding this to reboot branch will not work