### PR TITLE
feat: add build info collector

### DIFF
--- a/internal/exporter/prometheus/collectors/build_info.go
+++ b/internal/exporter/prometheus/collectors/build_info.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package collectors
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sustainable-computing-io/kepler/internal/version"
+)
+
+const (
+	namespace      = "kepler"
+	buildSubsystem = "build"
+)
+
+type BuildInfoCollector struct {
+	buildInfo *prometheus.GaugeVec
+}
+
+// NewBuildInfoCollector creates a new collector for build information
+func NewBuildInfoCollector() *BuildInfoCollector {
+	buildInfo := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: buildSubsystem,
+			Name:      "info",
+			Help:      "A metric with a constant '1' value labeled with version information",
+		},
+		[]string{"arch", "branch", "revision", "version", "goversion"},
+	)
+
+	return &BuildInfoCollector{
+		buildInfo: buildInfo,
+	}
+}
+
+func (c *BuildInfoCollector) Describe(ch chan<- *prometheus.Desc) {
+	c.buildInfo.Describe(ch)
+}
+
+func (c *BuildInfoCollector) Collect(ch chan<- prometheus.Metric) {
+	info := version.Info()
+
+	c.buildInfo.WithLabelValues(
+		info.GoArch,
+		info.GitBranch,
+		info.GitCommit,
+		info.Version,
+		info.GoVersion,
+	).Set(1)
+
+	c.buildInfo.Collect(ch)
+}

--- a/internal/exporter/prometheus/collectors/build_info_test.go
+++ b/internal/exporter/prometheus/collectors/build_info_test.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package collectors
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDescribe(t *testing.T) {
+	collector := NewBuildInfoCollector()
+	ch := make(chan *prometheus.Desc, 1)
+	collector.Describe(ch)
+	assert.Len(t, ch, 1, "expected one metric description")
+}
+
+func TestCollect(t *testing.T) {
+	// Create collector
+	collector := NewBuildInfoCollector()
+
+	// Create a channel for metrics
+	ch := make(chan prometheus.Metric, 1)
+
+	// Collect metrics
+	collector.Collect(ch)
+
+	// Verify we got one metric
+	assert.Len(t, ch, 1, "should have received exactly one metric")
+
+	// Get the metric
+	metric := <-ch
+
+	// Verify metric description
+	desc := metric.Desc().String()
+	assert.Contains(t, desc, "kepler_build_info")
+	assert.Contains(t, desc, "arch")
+	assert.Contains(t, desc, "branch")
+	assert.Contains(t, desc, "revision")
+	assert.Contains(t, desc, "version")
+	assert.Contains(t, desc, "goversion")
+}

--- a/internal/exporter/prometheus/prometheus.go
+++ b/internal/exporter/prometheus/prometheus.go
@@ -12,6 +12,7 @@ import (
 	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	collector "github.com/sustainable-computing-io/kepler/internal/exporter/prometheus/collectors"
 	"github.com/sustainable-computing-io/kepler/internal/monitor"
 	"github.com/sustainable-computing-io/kepler/internal/service"
 )
@@ -112,6 +113,10 @@ func (e *Exporter) Start(ctx context.Context) error {
 		e.logger.Info("Enabling debug collector", "collector", c)
 		e.registry.MustRegister(collector)
 	}
+
+	// Register build info collector
+	buildInfoCollector := collector.NewBuildInfoCollector()
+	e.registry.MustRegister(buildInfoCollector)
 
 	err := e.server.Register("/metrics", "Metrics", "Prometheus metrics",
 		promhttp.HandlerFor(


### PR DESCRIPTION
This commit adds the build info collector that exposes build related information(architecture,branch, commit, version, goversion) as a `kepler_build_info` metric.