### PR TITLE
test: add concurrency test for build info collector

### DIFF
--- a/internal/exporter/prometheus/collectors/build_info_test.go
+++ b/internal/exporter/prometheus/collectors/build_info_test.go
@@ -4,20 +4,21 @@
 package collectors
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDescribe(t *testing.T) {
+func TestBuildInfo_Describe(t *testing.T) {
 	collector := NewBuildInfoCollector()
 	ch := make(chan *prometheus.Desc, 1)
 	collector.Describe(ch)
 	assert.Len(t, ch, 1, "expected one metric description")
 }
 
-func TestCollect(t *testing.T) {
+func TestBuildInfo_Collect(t *testing.T) {
 	// Create collector
 	collector := NewBuildInfoCollector()
 
@@ -41,4 +42,38 @@ func TestCollect(t *testing.T) {
 	assert.Contains(t, desc, "revision")
 	assert.Contains(t, desc, "version")
 	assert.Contains(t, desc, "goversion")
+}
+
+func TestBuildInfo_ParallelCollect(t *testing.T) {
+	// Create collector
+	collector := NewBuildInfoCollector()
+	parallelCalls := 10
+
+	// Create a shared channel for metrics
+	ch := make(chan prometheus.Metric, parallelCalls)
+
+	// WaitGroup to sync goroutines
+	var wg sync.WaitGroup
+	wg.Add(parallelCalls)
+
+	// Run multiple collect calls in parallel to check for race conditions
+	for i := 0; i < parallelCalls; i++ {
+		go func() {
+			defer wg.Done()
+			// Collect metrics
+			collector.Collect(ch)
+		}()
+	}
+
+	// Wait for all goroutines to complete
+	wg.Wait()
+	close(ch)
+
+	var metrics []prometheus.Metric
+	for metric := range ch {
+		assert.NotNil(t, metric, "metric should not be nil")
+		metrics = append(metrics, metric)
+	}
+
+	assert.Len(t, metrics, parallelCalls, "should have received the correct number of metrics")
 }


### PR DESCRIPTION
This commit adds a new test case to verify that the collector behaves correctly under multiple collection requests without race conditions.

