### PR TITLE
chore: fix and update precommit hooks

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -36,9 +36,9 @@ jobs:
         with:
           go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.58
+          version: v2.1.1
 
   govet_test:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,51 +1,15 @@
-linters-settings:
-  dupl:
-    threshold: 150
-  goconst:
-    min-len: 2
-    min-occurrences: 3
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-  goimports:
-    local-prefixes: github.com/golangci/golangci-lint
-
-  govet:
-    enable:
-      - shadow
-    settings:
-      printf:
-        funcs:
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-  lll:
-    line-length: 140
-  misspell:
-    locale: US
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
+    - asciicheck
     - bodyclose
     - dupl
     - errcheck
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
     - goprintffuncname
-    - gosimple
     - govet
     - ineffassign
     - misspell
@@ -53,41 +17,70 @@ linters:
     - noctx
     - nolintlint
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unparam
-    - whitespace
     - unused
-    - asciicheck
-    # don't enable:
-    # - lll
-    # - dogsled
-    # - gochecknoinits
-    # - gomnd
-    # - unused
-    # TODO: try to enable
-    # - scopelint
-    # - gochecknoglobals
-    # - gocognit
-    # - godot
-    # - godox
-    # - goerr113
-    # - interfacer
-    # - maligned
-    # - nestif
-    # - prealloc
-    # - testpackage
-    # - revive
-    # - wsl
-    # - funlen
-
-run:
-  timeout: 5m
-
-issues:
-  exclude-rules:
-    - linters: [dupl]
-      text: .*pkg/collector/stats/types/types_test.go.* # false positive, https://github.com/mibk/dupl/issues/20
-    - text: 'shadow: declaration of "(err|ctx)" shadows declaration at' # yamllint disable-line rule:quoted-strings
-      linters: [govet]
+    - whitespace
+  settings:
+    dupl:
+      threshold: 150
+    goconst:
+      min-len: 2
+      min-occurrences: 3
+    gocritic:
+      disabled-checks:
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    govet:
+      enable:
+        - shadow
+      settings:
+        printf:
+          funcs:
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+        text: .*pkg/collector/stats/types/types_test.go.*
+      - linters:
+          - govet
+        text: 'shadow: declaration of "(err|ctx)" shadows declaration at' # yamllint disable-line rule:quoted-strings
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/golangci/golangci-lint
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v20.1.0
+    rev: v19.1.7 # NOTE: The current config is not compatible with clang-format 20.x
     hooks:
       - id: clang-format
         types_or: [c]
@@ -28,7 +28,7 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.0.2
+    rev: v2.1.1
     hooks:
       - id: golangci-lint
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook

--- a/pkg/model/estimator/local/regressor/exponential.go
+++ b/pkg/model/estimator/local/regressor/exponential.go
@@ -26,7 +26,7 @@ type ExponentialPredictor struct {
 }
 
 func NewExponentialPredictor(weight ModelWeights) (predictor Predictor, err error) {
-	if len(weight.AllWeights.CurveFitWeights) != 3 {
+	if len(weight.CurveFitWeights) != 3 {
 		return nil, fmt.Errorf("exponential predictor: %w", errModelWeightsInvalid)
 	}
 	return &ExponentialPredictor{ModelWeights: weight}, nil
@@ -37,16 +37,16 @@ func (p *ExponentialPredictor) name() string {
 }
 
 func (p *ExponentialPredictor) predict(usageMetricNames []string, usageMetricValues [][]float64, systemMetaDataFeatureNames, systemMetaDataFeatureValues []string) []float64 {
-	categoricalX, numericalX, _ := p.ModelWeights.getX(usageMetricNames, usageMetricValues, systemMetaDataFeatureNames, systemMetaDataFeatureValues)
+	categoricalX, numericalX, _ := p.getX(usageMetricNames, usageMetricValues, systemMetaDataFeatureNames, systemMetaDataFeatureValues)
 	var basePower float64
 	// TODO: update categoricalX transform (current no categorical value trained)
 	for _, val := range categoricalX {
 		basePower += val
 	}
 	var powers []float64
-	a := p.ModelWeights.CurveFitWeights[0]
-	b := p.ModelWeights.CurveFitWeights[1]
-	c := p.ModelWeights.CurveFitWeights[2]
+	a := p.CurveFitWeights[0]
+	b := p.CurveFitWeights[1]
+	c := p.CurveFitWeights[2]
 	for _, x := range numericalX {
 		// note: curvefit use only index 0 feature
 		power := basePower + a*math.Exp(b*x[0]) + c

--- a/pkg/model/estimator/local/regressor/linear.go
+++ b/pkg/model/estimator/local/regressor/linear.go
@@ -32,7 +32,7 @@ type LinearPredictor struct {
 
 // NewLinearPredictor creates a new LinearPredictor instance with the provided ModelWeights
 func NewLinearPredictor(weight ModelWeights) (predictor Predictor, err error) {
-	if len(weight.AllWeights.CurveFitWeights) != 0 {
+	if len(weight.CurveFitWeights) != 0 {
 		return nil, fmt.Errorf("linear predictor: %w", errModelWeightsInvalid)
 	}
 
@@ -44,8 +44,8 @@ func (p *LinearPredictor) name() string {
 }
 
 func (p *LinearPredictor) predict(usageMetricNames []string, usageMetricValues [][]float64, systemMetaDataFeatureNames, systemMetaDataFeatureValues []string) []float64 {
-	categoricalX, numericalX, numericalWeights := p.ModelWeights.getX(usageMetricNames, usageMetricValues, systemMetaDataFeatureNames, systemMetaDataFeatureValues)
-	basePower := p.ModelWeights.AllWeights.BiasWeight
+	categoricalX, numericalX, numericalWeights := p.getX(usageMetricNames, usageMetricValues, systemMetaDataFeatureNames, systemMetaDataFeatureValues)
+	basePower := p.BiasWeight
 	for _, val := range categoricalX {
 		basePower += val
 	}

--- a/pkg/model/estimator/local/regressor/logarithm.go
+++ b/pkg/model/estimator/local/regressor/logarithm.go
@@ -26,7 +26,7 @@ type LogarithmicPredictor struct {
 }
 
 func NewLogarithmicPredictor(weight ModelWeights) (predictor Predictor, err error) {
-	if len(weight.AllWeights.CurveFitWeights) != 3 {
+	if len(weight.CurveFitWeights) != 3 {
 		return nil, fmt.Errorf("logarithmic predictor: %w", errModelWeightsInvalid)
 	}
 
@@ -38,16 +38,16 @@ func (LogarithmicPredictor) name() string {
 }
 
 func (p *LogarithmicPredictor) predict(usageMetricNames []string, usageMetricValues [][]float64, systemMetaDataFeatureNames, systemMetaDataFeatureValues []string) []float64 {
-	categoricalX, numericalX, _ := p.ModelWeights.getX(usageMetricNames, usageMetricValues, systemMetaDataFeatureNames, systemMetaDataFeatureValues)
+	categoricalX, numericalX, _ := p.getX(usageMetricNames, usageMetricValues, systemMetaDataFeatureNames, systemMetaDataFeatureValues)
 	var basePower float64
 	// TODO: update categoricalX transform (current no categorical value trained)
 	for _, val := range categoricalX {
 		basePower += val
 	}
 	var powers []float64
-	a := p.ModelWeights.CurveFitWeights[0]
-	b := p.ModelWeights.CurveFitWeights[1]
-	c := p.ModelWeights.CurveFitWeights[2]
+	a := p.CurveFitWeights[0]
+	b := p.CurveFitWeights[1]
+	c := p.CurveFitWeights[2]
 	for _, x := range numericalX {
 		// note: curvefit use only index 0 feature
 		power := basePower + a*math.Log(b*x[0]+1) + c

--- a/pkg/model/estimator/local/regressor/logistic.go
+++ b/pkg/model/estimator/local/regressor/logistic.go
@@ -26,7 +26,7 @@ type LogisticPredictor struct {
 }
 
 func NewLogisticPredictor(weight ModelWeights) (predictor Predictor, err error) {
-	if len(weight.AllWeights.CurveFitWeights) != 4 {
+	if len(weight.CurveFitWeights) != 4 {
 		return nil, fmt.Errorf("logistic predictor: %w", errModelWeightsInvalid)
 	}
 
@@ -38,17 +38,17 @@ func (LogisticPredictor) name() string {
 }
 
 func (p *LogisticPredictor) predict(usageMetricNames []string, usageMetricValues [][]float64, systemMetaDataFeatureNames, systemMetaDataFeatureValues []string) []float64 {
-	categoricalX, numericalX, _ := p.ModelWeights.getX(usageMetricNames, usageMetricValues, systemMetaDataFeatureNames, systemMetaDataFeatureValues)
+	categoricalX, numericalX, _ := p.getX(usageMetricNames, usageMetricValues, systemMetaDataFeatureNames, systemMetaDataFeatureValues)
 	var basePower float64
 	// TODO: update categoricalX transform (current no categorical value trained)
 	for _, val := range categoricalX {
 		basePower += val
 	}
 	var powers []float64
-	A := p.ModelWeights.CurveFitWeights[0]
-	x0 := p.ModelWeights.CurveFitWeights[1]
-	k := p.ModelWeights.CurveFitWeights[2]
-	off := p.ModelWeights.CurveFitWeights[3]
+	A := p.CurveFitWeights[0]
+	x0 := p.CurveFitWeights[1]
+	k := p.CurveFitWeights[2]
+	off := p.CurveFitWeights[3]
 	for _, x := range numericalX {
 		// note: curvefit use only index 0 feature
 		power := basePower + A/(1+math.Exp(-k*(x[0]-x0))) + off

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -285,11 +285,12 @@ func getCPUArchitecture() (string, error) {
 		myCPUArch string
 		err       error
 	)
-	if runtime.GOARCH == "amd64" {
+	switch runtime.GOARCH {
+	case "amd64":
 		myCPUArch, err = x86Architecture()
-	} else if runtime.GOARCH == "s390x" {
+	case "s390x":
 		return s390xArchitecture()
-	} else {
+	default:
 		myCPUArch, err = cpuPmuName()
 	}
 

--- a/pkg/sensors/accelerator/devices/device.go
+++ b/pkg/sensors/accelerator/devices/device.go
@@ -152,10 +152,11 @@ func addDeviceInterface(registry *Registry, dtype DeviceType, accType string, de
 			return errors.New("multiple Devices attempting to register with name")
 		}
 
-		if dtype == DCGM {
+		switch dtype {
+		case DCGM:
 			// Remove "nvml" if "dcgm" is being registered
 			registry.Unregister(NVML)
-		} else if dtype == NVML {
+		case NVML:
 			// Do not register "nvml" if "dcgm" is already registered
 			if _, ok := registry.Registry[config.GPU][DCGM]; ok {
 				return errors.New("DCGM already registered. Skipping NVML")

--- a/pkg/sensors/platform/source/redfish_test.go
+++ b/pkg/sensors/platform/source/redfish_test.go
@@ -33,7 +33,8 @@ func TestRedFishClient_IsPowerSupported(t *testing.T) {
 
 	// Create a mock HTTP server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/redfish/v1/Chassis" {
+		switch r.URL.Path {
+		case "/redfish/v1/Chassis":
 			system := RedfishChassisModel{
 				Name: "Test Chassis",
 				Members: []struct {
@@ -50,7 +51,7 @@ func TestRedFishClient_IsPowerSupported(t *testing.T) {
 			if err := json.NewEncoder(w).Encode(system); err != nil {
 				fmt.Println(err)
 			}
-		} else if r.URL.Path == "/redfish/v1/Chassis/1/Power" || r.URL.Path == "/redfish/v1/Chassis/2/Power" {
+		case "/redfish/v1/Chassis/1/Power", "/redfish/v1/Chassis/2/Power":
 			power := RedfishPowerModel{
 				Name: "Test Power",
 				PowerControl: []PowerControl{
@@ -62,7 +63,8 @@ func TestRedFishClient_IsPowerSupported(t *testing.T) {
 			if err := json.NewEncoder(w).Encode(power); err != nil {
 				fmt.Println(err)
 			}
-		} else {
+
+		default:
 			fmt.Printf("Path not found: %s\n", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
 		}


### PR DESCRIPTION
- Downgrade the clang-format version to 19.1.7 for config compatibility.
- Migrate golangci-lint config to latest
- Fix linting issues inside `pkg`
- Updates the golang workflow to now use v7 action and golangci-lint v2.1.1