### PR TITLE
chore(compose): expose config when bringing service up

### DIFF
--- a/compose/dev/compose.yaml
+++ b/compose/dev/compose.yaml
@@ -25,11 +25,10 @@ services:
         source: /sys
         target: /host/sys
         read_only: true
-    # command:
-    #  - --log.level=debug
-    #  - --host.proc=/host/proc
-    #  - --host.sys=/host/sys
-    #  - --monitor.interval=2500ms
+    command:
+      - --log.level=debug
+      - --host.procfs=/host/proc
+      - --host.sysfs=/host/sys
 
     networks:
       - kepler-network

--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -1,3 +1,7 @@
 log:
-  level: debug  # default: info
-  format: text  # default
+  level: debug  # debug, info, warn, error (default: info)
+  format: text  # text or json (default: text)
+
+host:
+  sysfs: /sys   # Path to sysfs filesystem (default: /sys)
+  procfs: /proc # Path to procfs filesystem (default: /proc)


### PR DESCRIPTION
This commit uses desired config when bringing kepler-dev service up. It also updates the sample config file with newly host related config