### PR TITLE
chore(device): add fake CPU power meter for testing

### DIFF
--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -167,7 +167,8 @@ func createServices(logger *slog.Logger, cfg *config.Config) ([]service.Service,
 
 func createPowerMonitor(logger *slog.Logger, cfg *config.Config) (*monitor.PowerMonitor, error) {
 	logger.Debug("Creating PowerMonitor")
-	cpuPowerMeter, err := device.NewCPUPowerMeter(cfg.Host.SysFS)
+
+	cpuPowerMeter, err := createCPUMeter(logger, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CPU power meter: %w", err)
 	}
@@ -178,4 +179,11 @@ func createPowerMonitor(logger *slog.Logger, cfg *config.Config) (*monitor.Power
 	)
 
 	return pm, nil
+}
+
+func createCPUMeter(logger *slog.Logger, cfg *config.Config) (device.CPUPowerMeter, error) {
+	if fake := cfg.Dev.FakeCpuMeter; fake.Enabled {
+		return device.NewFakeCPUMeter(fake.Zones, device.WithFakeLogger(logger))
+	}
+	return device.NewCPUPowerMeter(cfg.Host.SysFS)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -24,9 +24,18 @@ type (
 		ProcFS string `yaml:"procfs"`
 	}
 
+	// Development mode settings; disabled by default
+	Dev struct {
+		FakeCpuMeter struct {
+			Enabled bool     `yaml:"enabled"`
+			Zones   []string `yaml:"zones"`
+		} `yaml:"fake-cpu-meter"`
+	}
+
 	Config struct {
 		Log  Log  `yaml:"log"`
 		Host Host `yaml:"host"`
+		Dev  Dev  `yaml:"dev"` // WARN: do not expose dev settings as flags
 	}
 )
 
@@ -36,6 +45,8 @@ const (
 	LogFormatFlag  = "log.format"
 	HostSysFSFlag  = "host.sysfs"
 	HostProcFSFlag = "host.procfs"
+
+// WARN:  dev settings shouldn't be exposed as flags as flags are intended for end users
 )
 
 // DefaultConfig returns a Config with default values

--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -1,7 +1,13 @@
 log:
-  level: debug  # debug, info, warn, error (default: info)
-  format: text  # text or json (default: text)
+  level: debug # debug, info, warn, error (default: info)
+  format: text # text or json (default: text)
 
 host:
-  sysfs: /sys   # Path to sysfs filesystem (default: /sys)
+  sysfs: /sys # Path to sysfs filesystem (default: /sys)
   procfs: /proc # Path to procfs filesystem (default: /proc)
+
+# WARN DO NOT ENABLE THIS IN PRODUCTION - for development / testing only
+dev:
+  fake-cpu-meter:
+    enabled: false
+    zones: [] # zones to be enabled, empty enables all default zones

--- a/internal/device/fake_cpu_power_meter.go
+++ b/internal/device/fake_cpu_power_meter.go
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package device
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"path/filepath"
+	"sync"
+)
+
+// NOTE: This fake meter is not intended to be used in production and is for testing only
+
+type Zone = string
+
+const (
+	ZonePackage Zone = "package"
+	ZoneCore    Zone = "core"
+	ZoneDRAM    Zone = "dram"
+	ZoneUncore  Zone = "uncore"
+)
+
+var defaultFakeZones = []Zone{ZonePackage, ZoneCore, ZoneDRAM}
+
+const defaultRaplPath = "/sys/class/powercap/intel-rapl"
+
+// fakeEnergyZone implements the EnergyZone interface
+type fakeEnergyZone struct {
+	name      string
+	index     int
+	path      string
+	energy    Energy
+	maxEnergy Energy
+	mu        sync.Mutex
+
+	// For generating fake values
+	increment    Energy
+	randomFactor float64
+}
+
+var _ EnergyZone = (*fakeEnergyZone)(nil)
+
+// Name returns the zone name
+func (z *fakeEnergyZone) Name() string {
+	return z.name
+}
+
+// Index returns the index of the zone
+func (z *fakeEnergyZone) Index() int {
+	return z.index
+}
+
+// Path returns the path from which the energy usage value ie being read
+func (z *fakeEnergyZone) Path() string {
+	return z.path
+}
+
+// Energy returns energy consumed by the zone.
+func (z *fakeEnergyZone) Energy() (Energy, error) {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+
+	randomComponent := Energy(rand.Float64() * float64(z.increment) * z.randomFactor)
+	z.energy = (z.energy + z.increment + randomComponent) % z.maxEnergy
+
+	return z.energy, nil
+}
+
+// MaxEnergy returns the maximum value of energy usage that can be read.
+func (z *fakeEnergyZone) MaxEnergy() Energy {
+	return z.maxEnergy
+}
+
+// fakeRaplMeter implements the CPUPowerMeter interface
+type fakeRaplMeter struct {
+	logger     *slog.Logger
+	zones      []EnergyZone
+	devicePath string
+}
+
+var _ CPUPowerMeter = (*fakeRaplMeter)(nil)
+
+// FakeOptFn is a functional option for configuring FakeRaplMeter
+type FakeOptFn func(*fakeRaplMeter)
+
+// WithFakePath sets the base device path for the fake meter
+func WithFakePath(path string) FakeOptFn {
+	return func(m *fakeRaplMeter) {
+		m.devicePath = path
+		for _, z := range m.zones {
+			if fz, ok := z.(*fakeEnergyZone); ok {
+				fz.path = filepath.Join(path, fmt.Sprintf("energy_%s", fz.name))
+			}
+		}
+	}
+}
+
+// WithFakeMaxEnergy sets the maximum energy value before wrap-around
+func WithFakeMaxEnergy(e Energy) FakeOptFn {
+	return func(m *fakeRaplMeter) {
+		for _, z := range m.zones {
+			if fz, ok := z.(*fakeEnergyZone); ok {
+				fz.maxEnergy = e
+			}
+		}
+	}
+}
+
+// WithFakeMaxEnergy sets the maximum energy value before wrap-around
+func WithFakeLogger(l *slog.Logger) FakeOptFn {
+	return func(m *fakeRaplMeter) {
+		m.logger = l.With("meter", m.Name())
+	}
+}
+
+// NewFakeCPUMeter creates a new fake CPU power meter
+func NewFakeCPUMeter(zones []string, opts ...FakeOptFn) (CPUPowerMeter, error) {
+	meter := &fakeRaplMeter{
+		devicePath: defaultRaplPath,
+		logger:     slog.Default().With("meter", "fake-cpu-meter"),
+	}
+
+	// nil and empty slices are equivalent
+	if len(zones) == 0 {
+		zones = defaultFakeZones
+	}
+
+	zoneIncrementFactor := map[Zone]int{
+		ZonePackage: 12,
+		ZoneCore:    8,
+		ZoneDRAM:    5,
+		ZoneUncore:  2,
+	}
+
+	meter.zones = make([]EnergyZone, 0, len(zones))
+
+	for i, zoneName := range zones {
+		meter.zones = append(meter.zones, &fakeEnergyZone{
+			name:         zoneName,
+			index:        i,
+			path:         filepath.Join(defaultRaplPath, fmt.Sprintf("energy_%s", zoneName)),
+			maxEnergy:    1000000,
+			increment:    Energy(100 + zoneIncrementFactor[zoneName]),
+			randomFactor: 0.5,
+		})
+	}
+
+	for _, opt := range opts {
+		opt(meter)
+	}
+
+	return meter, nil
+}
+
+func (m *fakeRaplMeter) Name() string {
+	return "fake-cpu-meter"
+}
+
+func (m *fakeRaplMeter) Start(ctx context.Context) error {
+	m.logger.Info("Starting fake CPU power meter")
+	return nil
+}
+
+func (m *fakeRaplMeter) Stop() error {
+	m.logger.Info("Stopping fake CPU power meter")
+	return nil
+}
+
+func (m *fakeRaplMeter) Zones() ([]EnergyZone, error) {
+	return m.zones, nil
+}

--- a/internal/device/fake_cpu_power_meter_test.go
+++ b/internal/device/fake_cpu_power_meter_test.go
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package device
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewFakeCPUMeter(t *testing.T) {
+	meter, err := NewFakeCPUMeter(nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, meter)
+	assert.IsType(t, &fakeRaplMeter{}, meter)
+
+	fakeRapl := meter.(*fakeRaplMeter)
+	assert.Equal(t, defaultRaplPath, fakeRapl.devicePath)
+
+	zones, err := meter.Zones()
+	assert.NoError(t, err)
+	assert.Equal(t, len(defaultFakeZones), len(zones))
+
+	// check zone names match defaults
+	zoneNames := make([]string, len(zones))
+	for i, zone := range zones {
+		zoneNames[i] = zone.Name()
+	}
+	for _, name := range defaultFakeZones {
+		assert.Contains(t, zoneNames, name)
+	}
+}
+
+func TestFakeRaplMeter_Name(t *testing.T) {
+	meter, _ := NewFakeCPUMeter(nil)
+	assert.Equal(t, "fake-cpu-meter", meter.Name())
+}
+
+func TestFakeRaplMeter_StartStop(t *testing.T) {
+	meter, _ := NewFakeCPUMeter(nil)
+
+	ctx := context.Background()
+	err := meter.Start(ctx)
+	assert.NoError(t, err)
+
+	err = meter.Stop()
+	assert.NoError(t, err)
+}
+
+func TestFakeEnergyZone_Basics(t *testing.T) {
+	zone := &fakeEnergyZone{
+		name:         "test-zone",
+		index:        42,
+		path:         "/fake/path/energy_test-zone",
+		maxEnergy:    500000,
+		increment:    100,
+		randomFactor: 0.5,
+	}
+
+	assert.Equal(t, "test-zone", zone.Name())
+	assert.Equal(t, 42, zone.Index())
+	assert.Equal(t, "/fake/path/energy_test-zone", zone.Path())
+	assert.Equal(t, Energy(500000), zone.MaxEnergy())
+}
+
+func TestFakeEnergyZone_Energy(t *testing.T) {
+	zone := &fakeEnergyZone{
+		name:         "test-zone",
+		energy:       0,
+		maxEnergy:    1000,
+		increment:    100,
+		randomFactor: 0, // No randomness
+	}
+
+	// First read should return the increment
+	e1, err := zone.Energy()
+	assert.NoError(t, err)
+	assert.Equal(t, Energy(100), e1)
+
+	// Second read should return double the increment
+	e2, err := zone.Energy()
+	assert.NoError(t, err)
+	assert.Equal(t, Energy(200), e2)
+
+	// Test wrap-around at maxEnergy
+	zone.energy = 950
+	e3, err := zone.Energy()
+	assert.NoError(t, err)
+	assert.Equal(t, Energy(50), e3) // Wrapped around: 950 + 100 = 1050, but 1050 % 1000 = 50
+}
+
+func TestWithFakeZones(t *testing.T) {
+	customZones := []string{"package", "custom-zone"}
+	meter, err := NewFakeCPUMeter(customZones)
+	assert.NoError(t, err)
+
+	zones, err := meter.Zones()
+	assert.NoError(t, err)
+	assert.Equal(t, len(customZones), len(zones))
+
+	zoneNames := make([]string, len(zones))
+	for i, zone := range zones {
+		zoneNames[i] = zone.Name()
+	}
+	for _, name := range customZones {
+		assert.Contains(t, zoneNames, name)
+	}
+
+	// empty zones should fallback to defaults
+	meter, err = NewFakeCPUMeter(nil)
+	assert.NoError(t, err)
+
+	zones, err = meter.Zones()
+	assert.NoError(t, err)
+	assert.Equal(t, len(defaultFakeZones), len(zones))
+}
+
+func TestWithFakePath(t *testing.T) {
+	customPath := "/custom/rapl/path"
+	meter, err := NewFakeCPUMeter(nil, WithFakePath(customPath))
+	assert.NoError(t, err)
+
+	fakeRapl := meter.(*fakeRaplMeter)
+	assert.Equal(t, customPath, fakeRapl.devicePath)
+
+	zones, err := meter.Zones()
+	assert.NoError(t, err)
+
+	for _, zone := range zones {
+		assert.Contains(t, zone.Path(), customPath)
+		assert.Equal(t, filepath.Join(customPath, "energy_"+zone.Name()), zone.Path())
+	}
+}
+
+func TestWithFakeMaxEnergy(t *testing.T) {
+	customMax := Energy(999999)
+	meter, err := NewFakeCPUMeter(nil, WithFakeMaxEnergy(customMax))
+	assert.NoError(t, err)
+
+	zones, err := meter.Zones()
+	assert.NoError(t, err)
+	assert.Len(t, zones, len(defaultFakeZones))
+
+	for _, zone := range zones {
+		fakeZone, ok := zone.(*fakeEnergyZone)
+		assert.True(t, ok)
+		assert.Equal(t, customMax, fakeZone.maxEnergy)
+	}
+}
+
+func TestWithFakeLogger(t *testing.T) {
+	logger := slog.Default().With("test", "logger")
+	meter, err := NewFakeCPUMeter(nil, WithFakeLogger(logger))
+	assert.NoError(t, err)
+
+	fakeRapl := meter.(*fakeRaplMeter)
+	assert.NotNil(t, fakeRapl.logger)
+}
+
+func TestMultipleOptions(t *testing.T) {
+	customPath := "/custom/rapl/path"
+	customMax := Energy(888888)
+	customZones := []string{"custom1", "custom2"}
+	logger := slog.Default().With("test", "logger")
+
+	meter, err := NewFakeCPUMeter(
+		customZones,
+		WithFakePath(customPath),
+		WithFakeMaxEnergy(customMax),
+		WithFakeLogger(logger),
+	)
+	assert.NoError(t, err)
+
+	fakeRapl := meter.(*fakeRaplMeter)
+	assert.Equal(t, customPath, fakeRapl.devicePath)
+	assert.NotNil(t, fakeRapl.logger)
+
+	zones, err := meter.Zones()
+	assert.NoError(t, err)
+	assert.Equal(t, len(customZones), len(zones))
+
+	for _, zone := range zones {
+		assert.Contains(t, zone.Path(), customPath)
+		fakeZone, ok := zone.(*fakeEnergyZone)
+		assert.True(t, ok)
+		assert.Equal(t, customMax, fakeZone.maxEnergy)
+	}
+}
+
+// TestEnergyRandomness tests that the energy value changes with random component
+func TestEnergyRandomness(t *testing.T) {
+	zone := &fakeEnergyZone{
+		name:         "test-zone",
+		energy:       0,
+		maxEnergy:    10000,
+		increment:    100,
+		randomFactor: 1.0, // Full randomness
+	}
+
+	// Read energy multiple times
+	var readings []Energy
+	for range 10 {
+		e, err := zone.Energy()
+		assert.NoError(t, err)
+		readings = append(readings, e)
+	}
+
+	// with randomness, it's unlikely all readings follow exact increment
+	exactIncrement := true
+	for i := 1; i < len(readings); i++ {
+		if readings[i]-readings[i-1] != zone.increment {
+			exactIncrement = false
+			break
+		}
+	}
+
+	assert.False(t, exactIncrement, "Expected randomness in energy readings")
+}


### PR DESCRIPTION
Adds a new `FakeCPUMeter` implementation in the `device` package to simulate CPU power metrics for testing purposes. The fake meter is not intended for production use and is for development / testing use only

Changes include:

- New with `fakeEnergyZone` and `fakeRaplMeter` types  that implement the `EnergyZone` and `CPUPowerMeter` interfaces.
- Configuration support for enabling the fake meter via `dev.fake-cpu-meter.enabled` in `config.yaml` ONLY and not through flags
- Refactored `main.go` to use a new `createCPUMeter` function that conditionally creates either a real or fake CPU power meter based on the configuration.
- Updated `config.go` to include `Dev` struct for development settings
- Added default configuration in `hack/config.yaml` with `fake-cpu-meter` disabled.