### PR TITLE
chore: rename collectors to collector

### DIFF
--- a/internal/exporter/prometheus/collector/build_info.go
+++ b/internal/exporter/prometheus/collector/build_info.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 The Kepler Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package collectors
+package collector
 
 import (
 	prom "github.com/prometheus/client_golang/prometheus"
@@ -17,8 +17,8 @@ type BuildInfoCollector struct {
 	buildInfo *prom.GaugeVec
 }
 
-// NewBuildInfoCollector creates a new collector for build information
-func NewBuildInfoCollector() *BuildInfoCollector {
+// NewKeplerBuildInfoCollector creates a new collector for build information
+func NewKeplerBuildInfoCollector() *BuildInfoCollector {
 	buildInfo := prom.NewGaugeVec(
 		prom.GaugeOpts{
 			Namespace: namespace,

--- a/internal/exporter/prometheus/collector/build_info_test.go
+++ b/internal/exporter/prometheus/collector/build_info_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 The Kepler Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package collectors
+package collector
 
 import (
 	"sync"
@@ -12,7 +12,7 @@ import (
 )
 
 func TestBuildInfo_Describe(t *testing.T) {
-	collector := NewBuildInfoCollector()
+	collector := NewKeplerBuildInfoCollector()
 	ch := make(chan *prometheus.Desc, 1)
 	collector.Describe(ch)
 	assert.Len(t, ch, 1, "expected one metric description")
@@ -20,7 +20,7 @@ func TestBuildInfo_Describe(t *testing.T) {
 
 func TestBuildInfo_Collect(t *testing.T) {
 	// Create collector
-	collector := NewBuildInfoCollector()
+	collector := NewKeplerBuildInfoCollector()
 
 	// Create a channel for metrics
 	ch := make(chan prometheus.Metric, 1)
@@ -46,7 +46,7 @@ func TestBuildInfo_Collect(t *testing.T) {
 
 func TestBuildInfo_ParallelCollect(t *testing.T) {
 	// Create collector
-	collector := NewBuildInfoCollector()
+	collector := NewKeplerBuildInfoCollector()
 	parallelCalls := 10
 
 	// Create a shared channel for metrics

--- a/internal/exporter/prometheus/collector/cpuinfo.go
+++ b/internal/exporter/prometheus/collector/cpuinfo.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 The Kepler Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package collectors
+package collector
 
 import (
 	"fmt"

--- a/internal/exporter/prometheus/collector/cpuinfo_test.go
+++ b/internal/exporter/prometheus/collector/cpuinfo_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 The Kepler Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package collectors
+package collector
 
 import (
 	"errors"

--- a/internal/exporter/prometheus/collector/power_collector.go
+++ b/internal/exporter/prometheus/collector/power_collector.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 The Kepler Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package collectors
+package collector
 
 import (
 	"log/slog"

--- a/internal/exporter/prometheus/collector/power_collector_test.go
+++ b/internal/exporter/prometheus/collector/power_collector_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 The Kepler Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package collectors
+package collector
 
 import (
 	"context"

--- a/internal/exporter/prometheus/collector/utils.go
+++ b/internal/exporter/prometheus/collector/utils.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 The Kepler Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package collectors
+package collector
 
 import (
 	"regexp"

--- a/internal/exporter/prometheus/prometheus.go
+++ b/internal/exporter/prometheus/prometheus.go
@@ -12,7 +12,7 @@ import (
 	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	collector "github.com/sustainable-computing-io/kepler/internal/exporter/prometheus/collectors"
+	collector "github.com/sustainable-computing-io/kepler/internal/exporter/prometheus/collector"
 	"github.com/sustainable-computing-io/kepler/internal/monitor"
 	"github.com/sustainable-computing-io/kepler/internal/service"
 )
@@ -126,7 +126,7 @@ func CreateCollectors(pm Monitor, applyOpts ...OptionFn) (map[string]prom.Collec
 		apply(&opts)
 	}
 	collectors := map[string]prom.Collector{
-		"build_info": collectors.NewBuildInfoCollector(),
+		"build_info": collector.NewKeplerBuildInfoCollector(),
 		"power":      collector.NewPowerCollector(pm, opts.logger),
 	}
 	cpuInfoCollector, err := collector.NewCPUInfoCollector(opts.procfs)


### PR DESCRIPTION
This commit renames the collectors with collector for singular naming consistency. It also updates `BuildInfoCollector` to `KeplerBuildInfoCollector` to avoid conflicts with Prometheus `BuildInfoCollector`.
