### PR TITLE
chore(dashboard): use cpu info metric

### DIFF
--- a/compose/dev/grafana/dashboards/dev/dashboard.json
+++ b/compose/dev/grafana/dashboards/dev/dashboard.json
@@ -132,7 +132,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count by (instance, model_name, vendor_id) (kepler_node_cpu_info)",
+          "expr": "count by (instance, model_name, vendor_id) (kepler_cpu_info)",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",


### PR DESCRIPTION
This commit updates the dashboard to use the `kepler_cpu_info` metric to show the CPU related information