### PR TITLE
chore(compose): remove process-exporter

### DIFF
--- a/compose/dev/compose.yaml
+++ b/compose/dev/compose.yaml
@@ -129,23 +129,7 @@ services:
     networks:
       - node-exporter-network
 
-  process-exporter:
-    image: ncabatoff/process-exporter
-    privileged: true
-    ports:
-      - 29256:9256
-    command:
-      - --procfs=/host/proc
-      - --config.path=/config/process-exporter.yaml
-    volumes:
-      - ./config/process-exporter.yaml:/config/process-exporter.yaml
-      - /proc:/host/proc
-
-    networks:
-      - process-exporter-network
-
 networks:
   kepler-network:
   scaph-network:
   node-exporter-network:
-  process-exporter-network:

--- a/compose/dev/config/process-exporter.yaml
+++ b/compose/dev/config/process-exporter.yaml
@@ -1,4 +1,0 @@
-process_names:
-  - name: "{{.PID}}"
-    cmdline:
-      - ".+" # yamllint disable-line rule:quoted-strings

--- a/compose/dev/override.yaml
+++ b/compose/dev/override.yaml
@@ -18,6 +18,5 @@ services:
       - scaph-network
       - kepler-network
       - node-exporter-network
-      - process-exporter-network
     extra_hosts:
       - host.docker.internal:host-gateway

--- a/compose/dev/prometheus/scrape-configs/dev.yaml
+++ b/compose/dev/prometheus/scrape-configs/dev.yaml
@@ -20,7 +20,3 @@ scrape_configs:
   - job_name: node-exporter
     static_configs:
       - targets: [node-exporter:9100]
-
-  - job_name: process-exporter
-    static_configs:
-      - targets: [process-exporter:9256]


### PR DESCRIPTION
This commit removes the process-exporter from the compose manifests.