### PR TITLE
refactor: service lifecycle into optional Init Run Shutdown

### DIFF
--- a/internal/device/fake_cpu_power_meter.go
+++ b/internal/device/fake_cpu_power_meter.go
@@ -159,8 +159,14 @@ func (m *fakeRaplMeter) Name() string {
 	return "fake-cpu-meter"
 }
 
-func (m *fakeRaplMeter) Start(ctx context.Context) error {
-	m.logger.Info("Starting fake CPU power meter")
+func (m *fakeRaplMeter) Init(ctx context.Context) error {
+	m.logger.Info("Initializing fake CPU power meter")
+	return nil
+}
+
+func (m *fakeRaplMeter) Run(ctx context.Context) error {
+	m.logger.Info("Running fake CPU power meter")
+	<-ctx.Done()
 	return nil
 }
 

--- a/internal/device/power_meter.go
+++ b/internal/device/power_meter.go
@@ -11,8 +11,12 @@ type powerMeter interface {
 	// Name() returns a string identifying the power meter
 	Name() string
 
-	// Start() initialuzes and starts the power meter for reading energy or power
-	Start(ctx context.Context) error
+	// Init() initializes the power meter and makes it ready for use. This method
+	// is not required to be thread-safe
+	Init(ctx context.Context) error
+
+	// Run() power meter for reading energy or power
+	Run(ctx context.Context) error
 
 	// Stop() stops the power meter and releases any resources held
 	Stop() error

--- a/internal/device/rapl_sysfs_power_meter.go
+++ b/internal/device/rapl_sysfs_power_meter.go
@@ -53,7 +53,7 @@ func (r *raplPowerMeter) Name() string {
 	return "rapl"
 }
 
-func (r *raplPowerMeter) Start(ctx context.Context) error {
+func (r *raplPowerMeter) Init(ctx context.Context) error {
 	// ensure zones can be read but don't cache them
 	zones, err := r.reader.Zones()
 	if err != nil {
@@ -65,6 +65,11 @@ func (r *raplPowerMeter) Start(ctx context.Context) error {
 	// try reading the first zone and return the error
 	_, err = zones[0].Energy()
 	return err
+}
+
+func (r *raplPowerMeter) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
 }
 
 func (r *raplPowerMeter) Stop() error {

--- a/internal/exporter/prometheus/collector/power_collector_concurrency_test.go
+++ b/internal/exporter/prometheus/collector/power_collector_concurrency_test.go
@@ -33,10 +33,15 @@ func musT[T any](t T, err error) T {
 func TestPowerCollectorConcurrency(t *testing.T) {
 	fakeMonitor := monitor.NewPowerMonitor(musT(device.NewFakeCPUMeter(nil)))
 	collector := NewPowerCollector(fakeMonitor, newLogger())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	assert.NoError(t, fakeMonitor.Init(ctx))
+
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
-		err := fakeMonitor.Start(ctx)
+		err := fakeMonitor.Run(ctx)
 		assert.NoError(t, err)
 	}()
 
@@ -283,10 +288,14 @@ func TestConcurrentRegistration(t *testing.T) {
 	fakeMonitor := monitor.NewPowerMonitor(musT(device.NewFakeCPUMeter(nil)))
 	collector := NewPowerCollector(fakeMonitor, newLogger())
 
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	assert.NoError(t, fakeMonitor.Init(ctx))
+
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
-		err := fakeMonitor.Start(ctx)
+		err := fakeMonitor.Run(ctx)
 		assert.NoError(t, err)
 	}()
 
@@ -330,10 +339,14 @@ func TestFastCollectAndDescribe(t *testing.T) {
 	fakeMonitor := monitor.NewPowerMonitor(musT(device.NewFakeCPUMeter(nil)))
 	collector := NewPowerCollector(fakeMonitor, newLogger())
 
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	assert.NoError(t, fakeMonitor.Init(ctx))
+
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
-		err := fakeMonitor.Start(ctx)
+		err := fakeMonitor.Run(ctx)
 		assert.NoError(t, err)
 	}()
 

--- a/internal/exporter/prometheus/prometheus.go
+++ b/internal/exporter/prometheus/prometheus.go
@@ -137,10 +137,8 @@ func CreateCollectors(pm Monitor, applyOpts ...OptionFn) (map[string]prom.Collec
 	return collectors, nil
 }
 
-// Start implements Exporter.Start
-func (e *Exporter) Start(ctx context.Context) error {
-	e.logger.Info("Starting Prometheus exporter")
-
+func (e *Exporter) Init(ctx context.Context) error {
+	e.logger.Info("Initializing Prometheus exporter")
 	for c := range e.debugCollectors {
 		collector, err := collectorForName(c)
 		if err != nil {
@@ -164,22 +162,7 @@ func (e *Exporter) Start(ctx context.Context) error {
 				Registry:          e.registry,
 			},
 		))
-	if err != nil {
-		return err
-	}
-
-	e.logger.Info("Prometheus exporter started running; waiting for context to be cancelled")
-	<-ctx.Done()
-	e.logger.Info("Prometheus exporter stopped running")
-	return nil
-}
-
-// Stop implements Exporter.Stop
-func (e *Exporter) Stop() error {
-	// NOTE: This is a no-op since prometheus exporter makes uses of http server
-	// for exporting metrics
-	e.logger.Info("Stopping Prometheus exporter")
-	return nil
+	return err
 }
 
 // Name implements service.Name

--- a/internal/monitor/mock_cpu_meter_test.go
+++ b/internal/monitor/mock_cpu_meter_test.go
@@ -24,7 +24,12 @@ func (m *MockCPUPowerMeter) Name() string {
 	return args.String(0)
 }
 
-func (m *MockCPUPowerMeter) Start(ctx context.Context) error {
+func (m *MockCPUPowerMeter) Init(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockCPUPowerMeter) Run(ctx context.Context) error {
 	args := m.Called(ctx)
 	return args.Error(0)
 }

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -80,17 +80,8 @@ func (pm *PowerMonitor) Name() string {
 	return "monitor"
 }
 
-func (pm *PowerMonitor) signalNewData() {
-	select {
-	case pm.dataCh <- struct{}{}: // send signal to any waiting goroutinel
-	default:
-	}
-}
-
-func (pm *PowerMonitor) Start(ctx context.Context) error {
-	pm.logger.Info("Monitor is running...")
-
-	if err := pm.cpu.Start(ctx); err != nil {
+func (pm *PowerMonitor) Init(ctx context.Context) error {
+	if err := pm.cpu.Init(ctx); err != nil {
 		return fmt.Errorf("failed to start cpu power meter: %w", err)
 	}
 
@@ -106,13 +97,25 @@ func (pm *PowerMonitor) Start(ctx context.Context) error {
 	}
 	pm.signalNewData()
 
+	return nil
+}
+
+func (pm *PowerMonitor) signalNewData() {
+	select {
+	case pm.dataCh <- struct{}{}: // send signal to any waiting goroutinel
+	default:
+	}
+}
+
+func (pm *PowerMonitor) Run(ctx context.Context) error {
+	pm.logger.Info("Monitor is running...")
 	<-ctx.Done()
 	pm.logger.Info("Monitor has terminated.")
 
 	return nil
 }
 
-func (pm *PowerMonitor) Stop() error {
+func (pm *PowerMonitor) Shutdown() error {
 	return pm.cpu.Stop()
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -89,8 +89,8 @@ func (s *APIServer) Name() string {
 	return "api-server"
 }
 
-func (s *APIServer) Start(ctx context.Context) error {
-	s.logger.Info("Starting HTTP server", "listening-on", s.listenAddrs)
+func (s *APIServer) Init(ctx context.Context) error {
+	s.logger.Info("Initializing HTTP server", "listening-on", s.listenAddrs)
 	if len(s.listenAddrs) == 0 {
 		return fmt.Errorf("no listening address provided")
 	}
@@ -120,6 +120,11 @@ func (s *APIServer) Start(ctx context.Context) error {
 		}
 	})
 
+	return nil
+}
+
+func (s *APIServer) Run(ctx context.Context) error {
+	s.logger.Info("Running HTTP server", "listening-on", s.listenAddrs)
 	errCh := make(chan error)
 	go func() {
 		webCfg := &web.FlagConfig{
@@ -132,7 +137,7 @@ func (s *APIServer) Start(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		s.logger.Info("shutting down HTTP server on context done")
-		return s.Stop()
+		return nil
 
 	case err := <-errCh:
 		s.logger.Error("HTTP server returned an error", "error", err)
@@ -144,7 +149,7 @@ func pointer[T any](t T) *T {
 	return &t
 }
 
-func (s *APIServer) Stop() error {
+func (s *APIServer) Shutdown() error {
 	s.logger.Info("shutting down API server on request")
 
 	// NOTE: ensure http server shuts down within 5 seconds

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -9,8 +9,24 @@ import "context"
 type Service interface {
 	// Name returns the name of the service
 	Name() string
-	// Start starts the service
-	Start(ctx context.Context) error
-	// Stop stops the service
-	Stop() error
+}
+
+// Initializer is the interface that all services must implement that are to be initialized
+type Initializer interface {
+	Service
+	Init(ctx context.Context) error
+}
+
+// Runner is the interface that all services must implement that needs to run in background
+type Runner interface {
+	Service
+	// Run runs the service and is expected to block and be thread safe
+	Run(ctx context.Context) error
+}
+
+// Shutdown is the interface that all services must implement that are to be shutdown / cleaned up
+type Shutdown interface {
+	Service
+	// Shutdown shuts down the service
+	Shutdown() error
 }


### PR DESCRIPTION
This commit modifies the start up behavior. It refactors the service lifecycle management, replacing the Start and Stop methods with
* `Init`: used to initiliaze a service and can assume it isn't called from go routines and must be called before `Run`. 
* `Run`: Runs the service and blocks until context is cancelled or an error is encountered
* `Shutdown`:  method is the cleanup and indicates that you can't call `Run` after `Shutdown`.

This change aims to separate initialization which is run serially and allows services to initialize without worrying about thread-safety. I.E. Its okay for an Init() to call another Init().

Thus, this change separates initialization, runtime, and cleanup phases for better clarity and control. All Methods are optional and main calls the methods if they are defined. 

Tests are updated keep up with the change.