### PR TITLE
fix(cpu_info): change metric name to kepler_node_cpu_info

### DIFF
--- a/internal/exporter/prometheus/collector/cpuinfo.go
+++ b/internal/exporter/prometheus/collector/cpuinfo.go
@@ -54,7 +54,7 @@ func newCPUInfoCollectorWithFS(fs procFS) *cpuInfoCollector {
 	return &cpuInfoCollector{
 		fs: fs,
 		desc: prom.NewDesc(
-			prom.BuildFQName(namespace, "", "cpu_info"),
+			prom.BuildFQName(namespace, "node", "cpu_info"),
 			"CPU information from procfs",
 			[]string{"processor", "vendor_id", "model_name", "physical_id", "core_id"},
 			nil,

--- a/internal/exporter/prometheus/collector/cpuinfo_test.go
+++ b/internal/exporter/prometheus/collector/cpuinfo_test.go
@@ -74,7 +74,7 @@ func TestNewCPUInfoCollectorWithFS(t *testing.T) {
 	assert.NotNil(t, collector)
 	assert.Equal(t, mockFS, collector.fs)
 	assert.NotNil(t, collector.desc)
-	assert.Contains(t, collector.desc.String(), "kepler_cpu_info")
+	assert.Contains(t, collector.desc.String(), "kepler_node_cpu_info")
 	assert.Contains(t, collector.desc.String(), "variableLabels: {processor,vendor_id,model_name,physical_id,core_id}")
 }
 


### PR DESCRIPTION
change metric fqdn name to "kepler_node_cpu_info"