### PR TITLE
refactor(service): simplify service lifecycle

### DIFF
--- a/internal/device/fake_cpu_power_meter.go
+++ b/internal/device/fake_cpu_power_meter.go
@@ -4,7 +4,6 @@
 package device
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"math/rand"
@@ -157,22 +156,6 @@ func NewFakeCPUMeter(zones []string, opts ...FakeOptFn) (CPUPowerMeter, error) {
 
 func (m *fakeRaplMeter) Name() string {
 	return "fake-cpu-meter"
-}
-
-func (m *fakeRaplMeter) Init(ctx context.Context) error {
-	m.logger.Info("Initializing fake CPU power meter")
-	return nil
-}
-
-func (m *fakeRaplMeter) Run(ctx context.Context) error {
-	m.logger.Info("Running fake CPU power meter")
-	<-ctx.Done()
-	return nil
-}
-
-func (m *fakeRaplMeter) Stop() error {
-	m.logger.Info("Stopping fake CPU power meter")
-	return nil
 }
 
 func (m *fakeRaplMeter) Zones() ([]EnergyZone, error) {

--- a/internal/device/fake_cpu_power_meter_test.go
+++ b/internal/device/fake_cpu_power_meter_test.go
@@ -4,11 +4,9 @@
 package device
 
 import (
-	"context"
 	"log/slog"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -39,26 +37,6 @@ func TestNewFakeCPUMeter(t *testing.T) {
 func TestFakeRaplMeter_Name(t *testing.T) {
 	meter, _ := NewFakeCPUMeter(nil)
 	assert.Equal(t, "fake-cpu-meter", meter.Name())
-}
-
-func TestFakeRaplMeter_StartStop(t *testing.T) {
-	meter, _ := NewFakeCPUMeter(nil)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
-	errCh := make(chan error, 1)
-	start := time.Now()
-	go func() {
-		errCh <- meter.Run(ctx)
-	}()
-
-	err := <-errCh
-	duration := time.Since(start)
-	assert.NoError(t, err, "Run() should not return an error")
-	assert.GreaterOrEqual(t, duration, 50*time.Millisecond, "Run() should run until the context is cancelled")
-
-	err = meter.Stop()
-	assert.NoError(t, err)
 }
 
 func TestFakeEnergyZone_Basics(t *testing.T) {

--- a/internal/device/power_meter.go
+++ b/internal/device/power_meter.go
@@ -3,21 +3,9 @@
 
 package device
 
-import "context"
-
 // powerMeter is a generic interface for power meters which reads energy
 // or power readings from hardware devices like CPU/GPU/DRAM etc
 type powerMeter interface {
 	// Name() returns a string identifying the power meter
 	Name() string
-
-	// Init() initializes the power meter and makes it ready for use. This method
-	// is not required to be thread-safe
-	Init(ctx context.Context) error
-
-	// Run() power meter for reading energy or power
-	Run(ctx context.Context) error
-
-	// Stop() stops the power meter and releases any resources held
-	Stop() error
 }

--- a/internal/device/rapl_sysfs_power_meter.go
+++ b/internal/device/rapl_sysfs_power_meter.go
@@ -4,7 +4,6 @@
 package device
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -32,7 +31,7 @@ func WithSysFSReader(r sysfsReader) OptionFn {
 }
 
 // NewCPUPowerMeter creates a new CPU power meter
-func NewCPUPowerMeter(sysfsPath string, opts ...OptionFn) (CPUPowerMeter, error) {
+func NewCPUPowerMeter(sysfsPath string, opts ...OptionFn) (*raplPowerMeter, error) {
 	fs, err := sysfs.NewFS(sysfsPath)
 	if err != nil {
 		return nil, err
@@ -53,7 +52,7 @@ func (r *raplPowerMeter) Name() string {
 	return "rapl"
 }
 
-func (r *raplPowerMeter) Init(ctx context.Context) error {
+func (r *raplPowerMeter) Init() error {
 	// ensure zones can be read but don't cache them
 	zones, err := r.reader.Zones()
 	if err != nil {
@@ -65,15 +64,6 @@ func (r *raplPowerMeter) Init(ctx context.Context) error {
 	// try reading the first zone and return the error
 	_, err = zones[0].Energy()
 	return err
-}
-
-func (r *raplPowerMeter) Run(ctx context.Context) error {
-	<-ctx.Done()
-	return nil
-}
-
-func (r *raplPowerMeter) Stop() error {
-	return nil
 }
 
 func (r *raplPowerMeter) Zones() ([]EnergyZone, error) {

--- a/internal/device/rapl_sysfs_power_meter_test.go
+++ b/internal/device/rapl_sysfs_power_meter_test.go
@@ -4,11 +4,9 @@
 package device
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/prometheus/procfs/sysfs"
 	"github.com/stretchr/testify/assert"
@@ -37,37 +35,8 @@ func TestCPUPowerMeter_Init(t *testing.T) {
 	meter, err := NewCPUPowerMeter(validSysFSPath)
 	assert.NoError(t, err, "NewCPUPowerMeter should not return an error")
 
-	ctx := context.Background()
-	err = meter.Init(ctx)
+	err = meter.Init()
 	assert.NoError(t, err, "Start() should not return an error")
-}
-
-func TestCPUPowerMeter_Run(t *testing.T) {
-	meter, err := NewCPUPowerMeter(validSysFSPath)
-	assert.NoError(t, err, "NewCPUPowerMeter should not return an error")
-
-	ctx := context.Background()
-	err = meter.Init(ctx)
-	assert.NoError(t, err, "Start() should not return an error")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
-	errCh := make(chan error, 1)
-	start := time.Now()
-	go func() {
-		errCh <- meter.Run(ctx)
-	}()
-
-	err = <-errCh
-	duration := time.Since(start)
-	assert.NoError(t, err, "Run() should not return an error")
-	assert.GreaterOrEqual(t, duration, 50*time.Millisecond, "Run() should run until the context is cancelled")
-}
-
-func TestCPUPowerMeter_Stop(t *testing.T) {
-	meter := &raplPowerMeter{reader: sysfsRaplReader{fs: validSysFSFixtures(t)}}
-	err := meter.Stop()
-	assert.NoError(t, err, "Stop() should not return an error")
 }
 
 func TestCPUPowerMeter_Zones(t *testing.T) {
@@ -104,13 +73,13 @@ func TestSysFSRaplZoneInterface(t *testing.T) {
 
 func TestSysFSRaplPowerMeterInit(t *testing.T) {
 	rapl := raplPowerMeter{reader: sysfsRaplReader{fs: validSysFSFixtures(t)}}
-	err := rapl.Init(context.Background())
+	err := rapl.Init()
 	assert.NoError(t, err)
 }
 
 func TestSysFSRaplPowerMeterInitFail(t *testing.T) {
 	rapl := raplPowerMeter{reader: sysfsRaplReader{fs: invalidSysFSFixtures(t)}}
-	err := rapl.Init(context.Background())
+	err := rapl.Init()
 	assert.Error(t, err)
 }
 
@@ -366,7 +335,7 @@ func TestCPUPowerMeter_InitNoZones(t *testing.T) {
 	mockReader.On("Zones").Return([]EnergyZone{}, nil)
 
 	meter := &raplPowerMeter{reader: mockReader}
-	err := meter.Init(context.Background())
+	err := meter.Init()
 
 	assert.Error(t, err, "Start() should return an error when no zones are found")
 	assert.Equal(t, "no RAPL zones found", err.Error(), "Start() should return a specific error message")

--- a/internal/exporter/prometheus/collector/power_collector_concurrency_test.go
+++ b/internal/exporter/prometheus/collector/power_collector_concurrency_test.go
@@ -34,9 +34,7 @@ func TestPowerCollectorConcurrency(t *testing.T) {
 	fakeMonitor := monitor.NewPowerMonitor(musT(device.NewFakeCPUMeter(nil)))
 	collector := NewPowerCollector(fakeMonitor, newLogger())
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	assert.NoError(t, fakeMonitor.Init(ctx))
+	assert.NoError(t, fakeMonitor.Init())
 
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -287,10 +285,7 @@ func TestConcurrentRegistration(t *testing.T) {
 
 	fakeMonitor := monitor.NewPowerMonitor(musT(device.NewFakeCPUMeter(nil)))
 	collector := NewPowerCollector(fakeMonitor, newLogger())
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	assert.NoError(t, fakeMonitor.Init(ctx))
+	assert.NoError(t, fakeMonitor.Init())
 
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -339,9 +334,7 @@ func TestFastCollectAndDescribe(t *testing.T) {
 	fakeMonitor := monitor.NewPowerMonitor(musT(device.NewFakeCPUMeter(nil)))
 	collector := NewPowerCollector(fakeMonitor, newLogger())
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	assert.NoError(t, fakeMonitor.Init(ctx))
+	assert.NoError(t, fakeMonitor.Init())
 
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/internal/exporter/prometheus/prometheus.go
+++ b/internal/exporter/prometheus/prometheus.go
@@ -4,7 +4,6 @@
 package prometheus
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -18,8 +17,8 @@ import (
 )
 
 type (
-	Service = service.Service
-	Monitor = monitor.Service
+	Initializer = service.Initializer
+	Monitor     = monitor.Service
 )
 
 type APIRegistry interface {
@@ -85,7 +84,7 @@ type Exporter struct {
 	collectors      map[string]prom.Collector
 }
 
-var _ Service = (*Exporter)(nil)
+var _ Initializer = (*Exporter)(nil)
 
 // NewExporter creates a new PrometheusExporter instance
 func NewExporter(pm Monitor, s APIRegistry, applyOpts ...OptionFn) *Exporter {
@@ -137,7 +136,7 @@ func CreateCollectors(pm Monitor, applyOpts ...OptionFn) (map[string]prom.Collec
 	return collectors, nil
 }
 
-func (e *Exporter) Init(ctx context.Context) error {
+func (e *Exporter) Init() error {
 	e.logger.Info("Initializing Prometheus exporter")
 	for c := range e.debugCollectors {
 		collector, err := collectorForName(c)

--- a/internal/monitor/mock_cpu_meter_test.go
+++ b/internal/monitor/mock_cpu_meter_test.go
@@ -24,18 +24,8 @@ func (m *MockCPUPowerMeter) Name() string {
 	return args.String(0)
 }
 
-func (m *MockCPUPowerMeter) Init(ctx context.Context) error {
-	args := m.Called(ctx)
-	return args.Error(0)
-}
-
 func (m *MockCPUPowerMeter) Run(ctx context.Context) error {
 	args := m.Called(ctx)
-	return args.Error(0)
-}
-
-func (m *MockCPUPowerMeter) Stop() error {
-	args := m.Called()
 	return args.Error(0)
 }
 

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -75,13 +75,9 @@ func (pm *PowerMonitor) Name() string {
 	return "monitor"
 }
 
-func (pm *PowerMonitor) Init(ctx context.Context) error {
-	if err := pm.cpu.Init(ctx); err != nil {
-		return fmt.Errorf("failed to start cpu power meter: %w", err)
-	}
-
+func (pm *PowerMonitor) Init() error {
 	if err := pm.initZones(); err != nil {
-		return fmt.Errorf("failed to initialize zones: %w", err)
+		return fmt.Errorf("zone initialization failed: %w", err)
 	}
 	// signal now so that exporters can construct descriptors
 	pm.signalNewData()
@@ -101,11 +97,6 @@ func (pm *PowerMonitor) Run(ctx context.Context) error {
 	<-ctx.Done()
 	pm.logger.Info("Monitor has terminated.")
 	return nil
-}
-
-func (pm *PowerMonitor) Shutdown() error {
-	pm.logger.Info("shutting down monitor")
-	return pm.cpu.Stop()
 }
 
 func (pm *PowerMonitor) DataChannel() <-chan struct{} {

--- a/internal/server/pprof.go
+++ b/internal/server/pprof.go
@@ -4,7 +4,6 @@
 package server
 
 import (
-	"context"
 	"net/http"
 	"net/http/pprof"
 
@@ -15,8 +14,10 @@ type pp struct {
 	api APIService
 }
 
-var _ service.Service = (*pp)(nil)
-var _ service.Initializer = (*pp)(nil)
+var (
+	_ service.Service     = (*pp)(nil)
+	_ service.Initializer = (*pp)(nil)
+)
 
 func NewPprof(api APIService) *pp {
 	return &pp{
@@ -28,7 +29,7 @@ func (p *pp) Name() string {
 	return "pprof"
 }
 
-func (p *pp) Init(ctx context.Context) error {
+func (p *pp) Init() error {
 	return p.api.Register("/debug/pprof/", "pprof", "Profiling Data", handlers())
 }
 

--- a/internal/server/pprof_test.go
+++ b/internal/server/pprof_test.go
@@ -4,14 +4,12 @@
 package server
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"net/http/pprof"
 )
 
 // MockAPIService is an implementation of the APIService interface for testing.
@@ -54,7 +52,7 @@ func TestPprofInit_Success(t *testing.T) {
 	// Set up mock expectation
 	api.On("Register", "/debug/pprof/", "pprof", "Profiling Data", mock.AnythingOfType("*http.ServeMux")).Return(nil)
 
-	err := p.Init(context.Background())
+	err := p.Init()
 	assert.NoError(t, err, "Init should not return an error when registration succeeds")
 	api.AssertExpectations(t)
 }
@@ -68,7 +66,7 @@ func TestPprofInit_Failure(t *testing.T) {
 	expectedErr := assert.AnError
 	api.On("Register", "/debug/pprof/", "pprof", "Profiling Data", mock.AnythingOfType("*http.ServeMux")).Return(expectedErr)
 
-	err := p.Init(context.Background())
+	err := p.Init()
 	assert.Error(t, err, "Init should return an error when registration fails")
 	assert.Equal(t, expectedErr, err, "Init should return the expected error")
 	api.AssertExpectations(t)
@@ -82,14 +80,13 @@ func TestPprofHandlers(t *testing.T) {
 
 	// Test cases for each pprof endpoint
 	tests := []struct {
-		path        string
-		handlerFunc http.HandlerFunc
+		path string
 	}{
-		{"/debug/pprof/", pprof.Index},
-		{"/debug/pprof/cmdline", pprof.Cmdline},
-		{"/debug/pprof/profile", pprof.Profile},
-		{"/debug/pprof/symbol", pprof.Symbol},
-		{"/debug/pprof/trace", pprof.Trace},
+		{"/debug/pprof/"},
+		{"/debug/pprof/cmdline"},
+		{"/debug/pprof/profile?seconds=1"},
+		{"/debug/pprof/symbol"},
+		{"/debug/pprof/trace"},
 	}
 
 	for _, tt := range tests {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -89,7 +89,7 @@ func (s *APIServer) Name() string {
 	return "api-server"
 }
 
-func (s *APIServer) Init(ctx context.Context) error {
+func (s *APIServer) Init() error {
 	s.logger.Info("Initializing HTTP server", "listening-on", s.listenAddrs)
 	if len(s.listenAddrs) == 0 {
 		return fmt.Errorf("no listening address provided")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -96,9 +96,7 @@ func TestNewAPIServer(t *testing.T) {
 func TestAPIServer_Init(t *testing.T) {
 	server := NewAPIServer()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
-	err := server.Init(ctx)
+	err := server.Init()
 	assert.NoError(t, err)
 }
 
@@ -171,11 +169,7 @@ func TestAPIServer_Register(t *testing.T) {
 
 func TestAPIServer_InitWithNoListenAddr(t *testing.T) {
 	server := NewAPIServer(WithListenAddress([]string{}))
-
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
-
-	err := server.Init(ctx)
+	err := server.Init()
 	assert.Error(t, err, "Init should fail with no listen address")
 	assert.Contains(t, err.Error(), "no listening address provided")
 }
@@ -288,9 +282,7 @@ func TestAPIServer_RootEndpoint(t *testing.T) {
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 
 	server := NewAPIServer(WithListenAddress([]string{addr}))
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	assert.NoError(t, server.Init(ctx))
+	assert.NoError(t, server.Init())
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -302,6 +294,8 @@ func TestAPIServer_RootEndpoint(t *testing.T) {
 	// ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 
 	errCh := make(chan error, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
 	go func() {
 		errCh <- server.Run(ctx)
 	}()

--- a/internal/service/initializer.go
+++ b/internal/service/initializer.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+)
+
+// Init initializes all services that implement the Initializer interface.
+// If any service fails to initialize, it will shut down all previously initialized services
+// that implement the Shutdowner interface.
+func Init(logger *slog.Logger, services []Service) error {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
+	}
+
+	var retErr error
+	initialized := make([]Service, 0, len(services))
+
+	for _, s := range services {
+		srv, ok := s.(Initializer)
+		if !ok {
+			logger.Debug("skipping service initialization", "service", s.Name(),
+				"reason", "service does not implement Initializer")
+			continue
+		}
+
+		logger.Info("Initializing service", "service", s.Name())
+		if err := srv.Init(); err != nil {
+			retErr = fmt.Errorf("failed to initialize service %s: %w", s.Name(), err)
+			break
+		}
+		initialized = append(initialized, s)
+	}
+
+	if retErr == nil {
+		return nil
+	}
+
+	logger.Info("Shutting down initialized services")
+	for _, s := range initialized {
+		srv, ok := s.(Shutdowner)
+		if !ok {
+			logger.Debug("skipping service shutdown", "service", s.Name(),
+				"reason", "service does not implement Shutdowner")
+			continue
+		}
+		if err := srv.Shutdown(); err != nil {
+			logger.Error("failed to shutdown service", "service", s.Name(), "error", err)
+		} else {
+			logger.Debug("service shutdown successfully", "service", s.Name())
+		}
+	}
+	return retErr
+}

--- a/internal/service/initializer_test.go
+++ b/internal/service/initializer_test.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInit(t *testing.T) {
+	t.Run("all services initialize successfully", func(t *testing.T) {
+		svc1 := &mockInitializer{mockService: mockService{name: "svc1"}}
+		svc2 := &mockInitializer{mockService: mockService{name: "svc2"}}
+		svc3 := &mockService{name: "non-initializer"}
+
+		services := []Service{svc1, svc2, svc3}
+
+		err := Init(nil, services)
+
+		// Verify results
+		assert.NoError(t, err)
+		assert.Equal(t, 1, svc1.initCount)
+		assert.Equal(t, 1, svc2.initCount)
+	})
+
+	t.Run("initialization fails and shutdown is called", func(t *testing.T) {
+		svc1 := &mockInitShutdownService{mockService: mockService{name: "svc1"}}
+
+		initErr := errors.New("init error")
+		svc2 := &mockInitShutdownService{
+			mockService: mockService{name: "svc2"},
+			initFn:      func() error { return initErr },
+		}
+
+		svc3 := &mockInitShutdownService{mockService: mockService{name: "svc3"}}
+
+		services := []Service{svc1, svc2, svc3}
+
+		err := Init(nil, services)
+
+		// Verify results
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, initErr)
+
+		// svc1 should have been initialized and shut down
+		assert.Equal(t, 1, svc1.initCount)
+		assert.Equal(t, 1, svc1.shutdownCount)
+
+		// svc2 initialization failed, so it shouldn't be shut down
+		assert.Equal(t, 1, svc2.initCount)
+		assert.Equal(t, 0, svc2.shutdownCount)
+
+		// svc3 should not have been initialized or shut down
+		assert.Equal(t, 0, svc3.initCount)
+		assert.Equal(t, 0, svc3.shutdownCount)
+	})
+
+	t.Run("shutdown error is logged but doesn't affect return value", func(t *testing.T) {
+		svc1 := &mockInitShutdownService{mockService: mockService{name: "svc1"}}
+
+		initErr := errors.New("init error")
+		shutdownErr := errors.New("shutdown error")
+
+		svc2 := &mockInitShutdownService{
+			mockService: mockService{name: "svc2"},
+			initFn:      func() error { return initErr },
+		}
+
+		svc1.shutdownFn = func() error { return shutdownErr }
+
+		services := []Service{svc1, svc2}
+
+		err := Init(nil, services)
+
+		// Verify Init should return the init error, not the shutdown error
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, initErr)
+		assert.NotErrorIs(t, err, shutdownErr)
+
+		// svc1 should have been initialized and shut down
+		assert.Equal(t, 1, svc1.initCount)
+		assert.Equal(t, 1, svc1.shutdownCount)
+	})
+
+	t.Run("non-shutdowner service is skipped during cleanup", func(t *testing.T) {
+		svc1 := &mockInitializer{mockService: mockService{name: "svc1"}}
+
+		initErr := errors.New("init error")
+		svc2 := &mockInitializer{
+			mockService: mockService{name: "svc2"},
+			initFn:      func() error { return initErr },
+		}
+
+		services := []Service{svc1, svc2}
+
+		err := Init(nil, services)
+
+		// Verify results
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, initErr)
+
+		// svc1 should have been initialized but not shut down (as it doesn't implement Shutdowner)
+		assert.Equal(t, 1, svc1.initCount)
+	})
+
+	t.Run("empty service list completes successfully", func(t *testing.T) {
+		err := Init(nil, []Service{})
+		assert.NoError(t, err)
+	})
+}

--- a/internal/service/mock_service_test.go
+++ b/internal/service/mock_service_test.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import "context"
+
+// mockService implements Service interface
+type mockService struct {
+	name string
+}
+
+func (m *mockService) Name() string {
+	return m.name
+}
+
+// mockInitializer implements Initializer interface
+type mockInitializer struct {
+	mockService
+	initFn    func() error
+	initCount int
+}
+
+func (m *mockInitializer) Init() error {
+	m.initCount++
+	if m.initFn != nil {
+		return m.initFn()
+	}
+	return nil
+}
+
+// mockInitShutdownService implements both Initializer and Shutdowner
+type mockInitShutdownService struct {
+	mockService
+	initFn        func() error
+	shutdownFn    func() error
+	initCount     int
+	shutdownCount int
+}
+
+func (m *mockInitShutdownService) Init() error {
+	m.initCount++
+	if m.initFn != nil {
+		return m.initFn()
+	}
+	return nil
+}
+
+func (m *mockInitShutdownService) Shutdown() error {
+	m.shutdownCount++
+	if m.shutdownFn != nil {
+		return m.shutdownFn()
+	}
+	return nil
+}
+
+// mockRunner implements Runner interface
+type mockRunner struct {
+	mockService
+	runFn    func(ctx context.Context) error
+	runCount int
+}
+
+func (m *mockRunner) Run(ctx context.Context) error {
+	m.runCount++
+	if m.runFn != nil {
+		return m.runFn(ctx)
+	}
+	return nil
+}
+
+// mockRunShutdownService implements both Runner and Shutdowner
+type mockRunShutdownService struct {
+	mockService
+	runFn         func(ctx context.Context) error
+	shutdownFn    func() error
+	runCount      int
+	shutdownCount int
+}
+
+func (m *mockRunShutdownService) Run(ctx context.Context) error {
+	m.runCount++
+	if m.runFn != nil {
+		return m.runFn(ctx)
+	}
+	return nil
+}
+
+func (m *mockRunShutdownService) Shutdown() error {
+	m.shutdownCount++
+	if m.shutdownFn != nil {
+		return m.shutdownFn()
+	}
+	return nil
+}

--- a/internal/service/run.go
+++ b/internal/service/run.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/oklog/run"
+)
+
+// Run runs all services that implement the Runner interface.
+// It returns an error if any service fails.
+func Run(outer context.Context, logger *slog.Logger, services []Service) error {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
+	}
+
+	logger.Info("Running all services")
+	ctx, cancel := context.WithCancel(outer)
+	defer cancel()
+	// Create run group
+	var g run.Group
+
+	// Add services to run group
+	for _, s := range services {
+		runner, ok := s.(Runner)
+		if !ok {
+			logger.Warn("skipping service", "service", s.Name())
+			continue
+		}
+
+		// Create local copies of the variables for the closure
+		svc := s
+		r := runner
+		g.Add(
+			func() error {
+				logger.Info("Running service", "service", svc.Name())
+				return r.Run(ctx)
+			},
+			func(err error) {
+				cancel()
+				if err != nil {
+					logger.Warn("service terminated", "service", svc.Name(), "reason", err)
+				}
+
+				shutdowner, ok := svc.(Shutdowner)
+				if !ok {
+					logger.Debug("skipping service shutting down", "service", svc.Name(),
+						"reason", "service does not implement Shutdowner interface")
+					return
+				}
+
+				logger.Info("shutting down", "service", svc.Name())
+				if shutdownErr := shutdowner.Shutdown(); shutdownErr != nil {
+					logger.Warn("service shutdown failed with error", "service", svc.Name(), "error", shutdownErr)
+				}
+			},
+		)
+	}
+
+	return g.Run()
+}

--- a/internal/service/run_test.go
+++ b/internal/service/run_test.go
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRun(t *testing.T) {
+	t.Run("all services run successfully", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Create mock services that complete immediately
+		svc1 := &mockRunner{
+			mockService: mockService{name: "svc1"},
+			runFn: func(ctx context.Context) error {
+				return nil
+			},
+		}
+
+		svc2 := &mockRunner{
+			mockService: mockService{name: "svc2"},
+			runFn: func(ctx context.Context) error {
+				return nil
+			},
+		}
+
+		svc3 := &mockService{name: "non-runner"}
+
+		services := []Service{svc1, svc2, svc3}
+
+		// Set timeout to prevent test from hanging
+		ctxTimeout, cancelTimeout := context.WithTimeout(ctx, 100*time.Millisecond)
+		defer cancelTimeout()
+
+		// We need to run this in a goroutine since Run blocks until all services complete
+		errCh := make(chan error)
+		go func() {
+			errCh <- Run(ctxTimeout, nil, services)
+		}()
+
+		// Give services time to start
+		time.Sleep(50 * time.Millisecond)
+		// calling cancel should trigger shutdown
+		cancel()
+		err := <-errCh
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("service fails and triggers shutdown", func(t *testing.T) {
+		runErr := errors.New("run error")
+
+		// NOTE: This service will return an error
+		svc1 := &mockRunShutdownService{
+			mockService: mockService{name: "svc1"},
+			runFn: func(ctx context.Context) error {
+				return runErr
+			},
+		}
+
+		svc2 := &mockRunShutdownService{
+			mockService: mockService{name: "svc2"},
+			runFn: func(ctx context.Context) error {
+				// Block until context canceled
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		}
+
+		// We need to run this in a goroutine since Run blocks
+		errCh := make(chan error)
+		go func() {
+			services := []Service{svc1, svc2}
+			errCh <- Run(context.Background(), nil, services)
+		}()
+
+		// Give services time to run
+		time.Sleep(50 * time.Millisecond)
+
+		// Wait for Run to return
+		err := <-errCh
+
+		// Verify results
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, runErr)
+
+		// svc1's Shutdown should be called
+		assert.Equal(t, 1, svc1.shutdownCount)
+
+		// svc2's Shutdown might or might not be called depending on timing
+		// We can't reliably assert on this
+	})
+
+	t.Run("service shutdown error is logged", func(t *testing.T) {
+		ctx := context.Background()
+
+		runErr := errors.New("run error")
+		shutdownErr := errors.New("shutdown error")
+
+		svc := &mockRunShutdownService{
+			mockService: mockService{name: "svc"},
+			runFn: func(ctx context.Context) error {
+				return runErr
+			},
+			shutdownFn: func() error {
+				return shutdownErr
+			},
+		}
+
+		services := []Service{svc}
+
+		// Set timeout to prevent test from hanging
+		ctxTimeout, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+		defer cancel()
+
+		// Run the services
+		err := Run(ctxTimeout, nil, services)
+
+		// Verify results
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, runErr)
+		assert.Equal(t, 1, svc.runCount)
+		assert.Equal(t, 1, svc.shutdownCount)
+	})
+
+	t.Run("context cancellation stops all services", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Set up channels to track service state
+		svc1Started := make(chan struct{})
+		svc2Started := make(chan struct{})
+
+		svc1 := &mockRunShutdownService{
+			mockService: mockService{name: "svc1"},
+			runFn: func(ctx context.Context) error {
+				close(svc1Started)
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		}
+
+		svc2 := &mockRunShutdownService{
+			mockService: mockService{name: "svc2"},
+			runFn: func(ctx context.Context) error {
+				close(svc2Started)
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		}
+
+		services := []Service{svc1, svc2}
+
+		// Run the services in a goroutine
+		errCh := make(chan error)
+		go func() {
+			errCh <- Run(ctx, nil, services)
+		}()
+
+		// Wait for services to start
+		<-svc1Started
+		<-svc2Started
+
+		// Cancel context
+		cancel()
+
+		// Wait for Run to return
+		err := <-errCh
+
+		// Verify results
+		assert.Error(t, err)
+		assert.Equal(t, context.Canceled, err)
+		assert.Equal(t, 1, svc1.runCount)
+		assert.Equal(t, 1, svc2.runCount)
+	})
+
+	t.Run("non-shutdowner service is skipped during cleanup", func(t *testing.T) {
+		ctx := context.Background()
+
+		runErr := errors.New("run error")
+
+		svc1 := &mockRunner{
+			mockService: mockService{name: "svc1"},
+			runFn: func(ctx context.Context) error {
+				return runErr
+			},
+		}
+
+		svc2 := &mockRunner{
+			mockService: mockService{name: "svc2"},
+			runFn: func(ctx context.Context) error {
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		}
+
+		services := []Service{svc1, svc2}
+
+		// Set timeout to prevent test from hanging
+		ctxTimeout, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+		defer cancel()
+
+		// Run the services
+		err := Run(ctxTimeout, nil, services)
+
+		// Verify results
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, runErr)
+	})
+
+	t.Run("empty service list completes successfully", func(t *testing.T) {
+		err := Run(context.Background(), nil, []Service{})
+		assert.NoError(t, err)
+	})
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -14,7 +14,7 @@ type Service interface {
 // Initializer is the interface that all services must implement that are to be initialized
 type Initializer interface {
 	Service
-	Init(ctx context.Context) error
+	Init() error
 }
 
 // Runner is the interface that all services must implement that needs to run in background
@@ -24,8 +24,8 @@ type Runner interface {
 	Run(ctx context.Context) error
 }
 
-// Shutdown is the interface that all services must implement that are to be shutdown / cleaned up
-type Shutdown interface {
+// Shutdowner is the interface that all services must implement that are to be shutdown / cleaned up
+type Shutdowner interface {
 	Service
 	// Shutdown shuts down the service
 	Shutdown() error

--- a/internal/service/signal_handler.go
+++ b/internal/service/signal_handler.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+)
+
+type SignalHandler struct {
+	signals []os.Signal
+}
+
+func NewSignalHandler(signals ...os.Signal) *SignalHandler {
+	return &SignalHandler{
+		signals: signals,
+	}
+}
+
+func (sh *SignalHandler) Name() string {
+	return "signal-handler"
+}
+
+func (sh *SignalHandler) Run(ctx context.Context) error {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, sh.signals...)
+	fmt.Println("Press Ctrl+C to shutdown")
+
+	select {
+	case <-c:
+		return nil
+
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/internal/service/signal_handler_test.go
+++ b/internal/service/signal_handler_test.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"context"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSignalHandlerRun(t *testing.T) {
+	t.Run("returns when context is canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		sh := NewSignalHandler(syscall.SIGINT)
+
+		errCh := make(chan error)
+		go func() {
+			errCh <- sh.Run(ctx)
+		}()
+
+		// Cancel the context
+		cancel()
+
+		var err error
+		select {
+		case err = <-errCh:
+			// Got result
+		case <-time.After(time.Second):
+			t.Fatal("Run did not return after context cancellation")
+		}
+
+		assert.Equal(t, context.Canceled, err)
+	})
+}


### PR DESCRIPTION
This commit addresses comments on https://github.com/sustainable-computing-io/kepler/pull/2021

Simplify service lifecycle management by:
- Removing context.Context from Initializer.Init() method
- Renaming Shutdown to Shutdowner for clarity
- Removing Init, Run, and Stop methods from powerMeter interface
- Removing Shutdown from PowerMonitor and Stop from power meters
- Refactoring createPowerMonitor into createServices
- Introduce service.NewSignalHandler for SIGINT and SIGTERM, replacing custom signal handling.
- Replace runServices and initServices with service.Run and service.Init for testable lifecycle management.
- Simplify powerMeter interface by removing Init, Run, and Stop methods.
- Rename Shutdown to Shutdowner and remove context from Initializer.Init.
- Inline createPowerMonitor into createServices and reorder services.
- Add debug logging for skipped initializations and successful shutdowns.
- Update tests to reflect simplified lifecycle and context removal.