### PR TITLE
feat(energy_zone): Added Energy Zone Collector

### DIFF
--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -217,6 +217,7 @@ func createServices(logger *slog.Logger, cfg *config.Config) ([]service.Service,
 		pm,
 		prometheus.WithLogger(logger),
 		prometheus.WithProcFSPath(cfg.Host.ProcFS),
+		prometheus.WithSysFSPath(cfg.Host.SysFS),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Prometheus collectors: %w", err)

--- a/internal/exporter/prometheus/collector/cpuinfo.go
+++ b/internal/exporter/prometheus/collector/cpuinfo.go
@@ -8,29 +8,7 @@ import (
 	"sync"
 
 	prom "github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/procfs"
 )
-
-// procFS is an interface for CPUInfo.
-type procFS interface {
-	CPUInfo() ([]procfs.CPUInfo, error)
-}
-
-type realProcFS struct {
-	fs procfs.FS
-}
-
-func (r *realProcFS) CPUInfo() ([]procfs.CPUInfo, error) {
-	return r.fs.CPUInfo()
-}
-
-func newProcFS(mountPoint string) (procFS, error) {
-	fs, err := procfs.NewFS(mountPoint)
-	if err != nil {
-		return nil, err
-	}
-	return &realProcFS{fs: fs}, nil
-}
 
 // cpuInfoCollector collects CPU info metrics from procfs.
 type cpuInfoCollector struct {

--- a/internal/exporter/prometheus/collector/cpuinfo_test.go
+++ b/internal/exporter/prometheus/collector/cpuinfo_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
+	prom "github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/procfs"
 	"github.com/stretchr/testify/assert"
@@ -43,7 +43,7 @@ func sampleCPUInfo() []procfs.CPUInfo {
 	}
 }
 
-func expectedLabels() map[string]string {
+func expectedCPUInfoLabels() map[string]string {
 	return map[string]string{
 		"processor":   "",
 		"vendor_id":   "",
@@ -87,7 +87,7 @@ func TestCPUInfoCollector_Describe(t *testing.T) {
 	}
 	collector := newCPUInfoCollectorWithFS(mockFS)
 
-	ch := make(chan *prometheus.Desc, 1)
+	ch := make(chan *prom.Desc, 1)
 	collector.Describe(ch)
 	close(ch)
 
@@ -104,18 +104,18 @@ func TestCPUInfoCollector_Collect_Success(t *testing.T) {
 	}
 	collector := newCPUInfoCollectorWithFS(mockFS)
 
-	ch := make(chan prometheus.Metric, 10)
+	ch := make(chan prom.Metric, 10)
 	collector.Collect(ch)
 	close(ch)
 
-	var metrics []prometheus.Metric
+	var metrics []prom.Metric
 	for m := range ch {
 		metrics = append(metrics, m)
 	}
 
 	assert.Len(t, metrics, 2, "expected two CPU info metrics")
 
-	el := expectedLabels()
+	el := expectedCPUInfoLabels()
 
 	for _, m := range metrics {
 		dtoMetric := &dto.Metric{}
@@ -142,11 +142,11 @@ func TestCPUInfoCollector_Collect_Error(t *testing.T) {
 	}
 	collector := newCPUInfoCollectorWithFS(mockFS)
 
-	ch := make(chan prometheus.Metric, 10)
+	ch := make(chan prom.Metric, 10)
 	collector.Collect(ch)
 	close(ch)
 
-	var metrics []prometheus.Metric
+	var metrics []prom.Metric
 	for m := range ch {
 		metrics = append(metrics, m)
 	}
@@ -165,7 +165,7 @@ func TestCPUInfoCollector_Collect_Concurrency(t *testing.T) {
 
 	const numGoroutines = 10
 	var wg sync.WaitGroup
-	ch := make(chan prometheus.Metric, numGoroutines*len(sampleCPUInfo()))
+	ch := make(chan prom.Metric, numGoroutines*len(sampleCPUInfo()))
 
 	for i := 0; i < numGoroutines; i++ {
 		wg.Add(1)
@@ -178,7 +178,7 @@ func TestCPUInfoCollector_Collect_Concurrency(t *testing.T) {
 	wg.Wait()
 	close(ch)
 
-	var metrics []prometheus.Metric
+	var metrics []prom.Metric
 	for m := range ch {
 		metrics = append(metrics, m)
 	}

--- a/internal/exporter/prometheus/collector/energyzone.go
+++ b/internal/exporter/prometheus/collector/energyzone.go
@@ -1,0 +1,62 @@
+package collector
+
+import (
+	"fmt"
+	"sync"
+
+	prom "github.com/prometheus/client_golang/prometheus"
+)
+
+type energyZone struct {
+	sync.Mutex
+
+	sysfs sysFS
+	desc  *prom.Desc
+}
+
+var _ prom.Collector = &energyZone{}
+
+func NewEnergyZoneCollector(sysPath string) (*energyZone, error) {
+	sysfs, err := newSysFS(sysPath)
+	if err != nil {
+		return nil, fmt.Errorf("creating sysfs failed: %w", err)
+	}
+	return newEnergyCollectorWithFS(sysfs), nil
+}
+
+// newEnergyCollectorWithFS injects a sysFS interface
+func newEnergyCollectorWithFS(fs sysFS) *energyZone {
+	return &energyZone{
+		sysfs: fs,
+		desc: prom.NewDesc(
+			prom.BuildFQName(namespace, "node", "rapl_zone"),
+			"Rapl Zones from sysfs",
+			[]string{"name", "index", "path"},
+			nil,
+		),
+	}
+}
+
+func (e *energyZone) Describe(ch chan<- *prom.Desc) {
+	ch <- e.desc
+}
+
+func (e *energyZone) Collect(ch chan<- prom.Metric) {
+	e.Lock()
+	defer e.Unlock()
+
+	zones, err := e.sysfs.Zones()
+	if err != nil {
+		return
+	}
+	for _, z := range zones {
+		ch <- prom.MustNewConstMetric(
+			e.desc,
+			prom.GaugeValue,
+			1,
+			z.Name,
+			fmt.Sprintf("%d", z.Index),
+			z.Path,
+		)
+	}
+}

--- a/internal/exporter/prometheus/collector/energyzone_test.go
+++ b/internal/exporter/prometheus/collector/energyzone_test.go
@@ -1,0 +1,175 @@
+package collector
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	prom "github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/procfs/sysfs"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockSysFS is a mock implementation of the sysFS interface for testing.
+type mockSysFS struct {
+	zonesFunc func() ([]sysfs.RaplZone, error)
+}
+
+func (m *mockSysFS) Zones() ([]sysfs.RaplZone, error) {
+	return m.zonesFunc()
+}
+
+// sampleEnergyZoneInfo returns a sample RaplZone slice for testing.
+func sampleEnergyZoneInfo() []sysfs.RaplZone {
+	return []sysfs.RaplZone{{
+		Name:           "package-0",
+		Index:          0,
+		Path:           "/sys/class/powercap/intel-rapl:0",
+		MaxMicrojoules: 262143328850.0,
+	}, {
+		Name:           "dram",
+		Index:          0,
+		Path:           "/sys/class/powercap/intel-rapl:0:0",
+		MaxMicrojoules: 262143328850.0,
+	}}
+}
+
+func expectedEnergyZoneLabels() map[string]string {
+	return map[string]string{
+		"name":  "",
+		"index": "",
+		"path":  "",
+	}
+}
+
+// TestNewEnergyZoneCollector tests creation of EnergyZone Collector
+func TestNewEnergyZoneCollector(t *testing.T) {
+	collector, err := NewEnergyZoneCollector("/sys")
+	assert.NoError(t, err)
+	assert.NotNil(t, collector)
+	assert.NotNil(t, collector.sysfs)
+	assert.NotNil(t, collector.desc)
+}
+
+// TestNewEnergyZoneCollectorWithFS tests creator creation with injected sysfs
+func TestNewEnergyZoneCollectorWithFS(t *testing.T) {
+	mockFS := &mockSysFS{
+		zonesFunc: func() ([]sysfs.RaplZone, error) {
+			return sampleEnergyZoneInfo(), nil
+		},
+	}
+	collector := newEnergyCollectorWithFS(mockFS)
+	assert.NotNil(t, collector)
+	assert.Equal(t, mockFS, collector.sysfs)
+	assert.NotNil(t, collector.desc)
+	assert.Contains(t, collector.desc.String(), "kepler_node_rapl_zone")
+	assert.Contains(t, collector.desc.String(), "variableLabels: {name,index,path}")
+}
+
+// TestEnergyZoneCollector_Describe tests the Describe method.
+func TestEnergyZoneCollector_Describe(t *testing.T) {
+	mockFS := &mockSysFS{
+		zonesFunc: func() ([]sysfs.RaplZone, error) {
+			return sampleEnergyZoneInfo(), nil
+		},
+	}
+	collector := newEnergyCollectorWithFS(mockFS)
+
+	ch := make(chan *prom.Desc, 1)
+	collector.Describe(ch)
+	close(ch)
+
+	desc := <-ch
+	assert.Equal(t, collector.desc, desc)
+}
+
+func TestEnergyZoneCollector_Collect_Success(t *testing.T) {
+	mockFS := &mockSysFS{
+		zonesFunc: func() ([]sysfs.RaplZone, error) {
+			return sampleEnergyZoneInfo(), nil
+		},
+	}
+	collector := newEnergyCollectorWithFS(mockFS)
+
+	ch := make(chan prom.Metric, 10)
+	collector.Collect(ch)
+	close(ch)
+
+	var metrics []prom.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+
+	assert.Len(t, metrics, 2, "expected two zone info")
+
+	el := expectedEnergyZoneLabels()
+
+	for _, m := range metrics {
+		dtoMetric := &dto.Metric{}
+		err := m.Write(dtoMetric)
+		assert.NoError(t, err)
+		assert.NotNil(t, dtoMetric.Gauge)
+		assert.NotNil(t, dtoMetric.Gauge.Value)
+		assert.Equal(t, 1.0, *dtoMetric.Gauge.Value)
+		assert.NotNil(t, dtoMetric.Label)
+		for _, l := range dtoMetric.Label {
+			assert.NotNil(t, l.Name)
+			delete(el, *l.Name)
+		}
+	}
+	assert.Empty(t, el, "all expected labels not received")
+}
+
+func TestEnergyZoneCollector_Collect_Error(t *testing.T) {
+	mockFS := &mockSysFS{
+		zonesFunc: func() ([]sysfs.RaplZone, error) {
+			return nil, fmt.Errorf("cannot read zones")
+		},
+	}
+	collector := newEnergyCollectorWithFS(mockFS)
+
+	ch := make(chan prom.Metric, 10)
+	collector.Collect(ch)
+	close(ch)
+
+	var metrics []prom.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+
+	assert.Len(t, metrics, 0, "expected no metrics on error")
+}
+
+func TestEnergyZoneCollector_Collect_Concurrency(t *testing.T) {
+	mockFS := &mockSysFS{
+		zonesFunc: func() ([]sysfs.RaplZone, error) {
+			return sampleEnergyZoneInfo(), nil
+		},
+	}
+	collector := newEnergyCollectorWithFS(mockFS)
+
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	ch := make(chan prom.Metric, numGoroutines*len(sampleCPUInfo()))
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			collector.Collect(ch)
+		}()
+	}
+
+	wg.Wait()
+	close(ch)
+
+	var metrics []prom.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+
+	// Expect numGoroutines * number of CPUs metrics
+	expectedMetrics := numGoroutines * len(sampleCPUInfo())
+	assert.Equal(t, expectedMetrics, len(metrics), "expected metrics from all goroutines")
+}

--- a/internal/exporter/prometheus/collector/procfs.go
+++ b/internal/exporter/prometheus/collector/procfs.go
@@ -1,0 +1,26 @@
+package collector
+
+import (
+	"github.com/prometheus/procfs"
+)
+
+// procFS is an interface to prometheus/procfs
+type procFS interface {
+	CPUInfo() ([]procfs.CPUInfo, error)
+}
+
+type realProcFS struct {
+	fs procfs.FS
+}
+
+func (r *realProcFS) CPUInfo() ([]procfs.CPUInfo, error) {
+	return r.fs.CPUInfo()
+}
+
+func newProcFS(mountPoint string) (procFS, error) {
+	fs, err := procfs.NewFS(mountPoint)
+	if err != nil {
+		return nil, err
+	}
+	return &realProcFS{fs: fs}, nil
+}

--- a/internal/exporter/prometheus/collector/sysfs.go
+++ b/internal/exporter/prometheus/collector/sysfs.go
@@ -1,0 +1,24 @@
+package collector
+
+import "github.com/prometheus/procfs/sysfs"
+
+// sysFS is an interface to prometheus/procfs/sysfs
+type sysFS interface {
+	Zones() ([]sysfs.RaplZone, error)
+}
+
+type realSysFS struct {
+	sysfs sysfs.FS
+}
+
+func (s *realSysFS) Zones() ([]sysfs.RaplZone, error) {
+	return sysfs.GetRaplZones(s.sysfs)
+}
+
+func newSysFS(mountPoint string) (sysFS, error) {
+	sysfs, err := sysfs.NewFS(mountPoint)
+	if err != nil {
+		return nil, err
+	}
+	return &realSysFS{sysfs: sysfs}, nil
+}

--- a/internal/exporter/prometheus/prometheus.go
+++ b/internal/exporter/prometheus/prometheus.go
@@ -31,6 +31,7 @@ type Opts struct {
 	debugCollectors map[string]bool
 	collectors      map[string]prom.Collector
 	procfs          string
+	sysfs           string
 }
 
 // DefaultOpts() returns a new Opts with defaults set
@@ -66,6 +67,12 @@ func WithDebugCollectors(c *[]string) OptionFn {
 func WithProcFSPath(procfs string) OptionFn {
 	return func(o *Opts) {
 		o.procfs = procfs
+	}
+}
+
+func WithSysFSPath(sysfs string) OptionFn {
+	return func(o *Opts) {
+		o.sysfs = sysfs
 	}
 }
 
@@ -121,6 +128,7 @@ func CreateCollectors(pm Monitor, applyOpts ...OptionFn) (map[string]prom.Collec
 	opts := Opts{
 		logger: slog.Default(),
 		procfs: "/proc",
+		sysfs:  "/sys",
 	}
 	for _, apply := range applyOpts {
 		apply(&opts)
@@ -134,6 +142,11 @@ func CreateCollectors(pm Monitor, applyOpts ...OptionFn) (map[string]prom.Collec
 		return nil, err
 	}
 	collectors["cpu_info"] = cpuInfoCollector
+	energyZoneCollector, err := collector.NewEnergyZoneCollector(opts.sysfs)
+	if err != nil {
+		return nil, err
+	}
+	collectors["energy_zone"] = energyZoneCollector
 	return collectors, nil
 }
 

--- a/internal/exporter/prometheus/prometheus_test.go
+++ b/internal/exporter/prometheus/prometheus_test.go
@@ -336,6 +336,7 @@ func TestExporter_CreateCollectors(t *testing.T) {
 		mockMonitor,
 		WithLogger(slog.Default()),
 		WithProcFSPath("/proc"),
+		WithSysFSPath("/sys"),
 	)
 	time.Sleep(50 * time.Millisecond)
 
@@ -343,5 +344,5 @@ func TestExporter_CreateCollectors(t *testing.T) {
 	mockMonitor.AssertExpectations(t)
 
 	assert.NoError(t, err)
-	assert.Len(t, coll, 3)
+	assert.Len(t, coll, 4)
 }


### PR DESCRIPTION
- Added Energy Zone Collector
- Added Tests

```
❯ curl localhost:28282/metrics | grep _rapl_zone
# HELP kepler_node_rapl_zone Rapl Zones from sysfs
# TYPE kepler_node_rapl_zone gauge
kepler_node_rapl_zone{index="0",name="core",path="/sys/class/powercap/intel-rapl:0:0"} 1
kepler_node_rapl_zone{index="0",name="package",path="/sys/class/powercap/intel-rapl-mmio:0"} 1
kepler_node_rapl_zone{index="0",name="package",path="/sys/class/powercap/intel-rapl:0"} 1
kepler_node_rapl_zone{index="0",name="psys",path="/sys/class/powercap/intel-rapl:1"} 1
kepler_node_rapl_zone{index="0",name="uncore",path="/sys/class/powercap/intel-rapl:0:1"} 1
```