### PR TITLE
chore(config): add skip validation logic from operator

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -412,3 +412,14 @@ func TestEnablePprof(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateWithSkip(t *testing.T) {
+	// Create a config with invalid host paths
+	cfg := DefaultConfig()
+	cfg.Host.SysFS = "/path/invalid"
+	cfg.Host.ProcFS = "/path/invalid"
+
+	// Validate with skipping host validation
+	err := cfg.Validate(SkipHostValidation)
+	assert.NoError(t, err, "Should pass when SkipHostValidation is provided")
+}


### PR DESCRIPTION
This commit adds the logic to skip validations for the config from the operator. With this we can skip certain configs that we don't want Kepler to validate.