### PR TITLE
Introduce PRODUCTION flag to enable/disable stripping binaries after build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,19 @@ ifeq ($(shell ldconfig -p | grep -q libhlml.so && echo exists),exists)
     GPU_TAGS := habana
 endif
 
+# Use PRODUCTION to enable/disable stripping binaries for the kepler exporter
+# 	and validator. That reduces the size of the binaries and removes debug symbols.
+# Expected values for this flag are:
+#	0 - Unstripped binaries including debug symbols (default);
+#	1 - Stripped binaries.
+# More about stripped binaries and debug symbols can be found at the RedHat's developer portal here:
+#	* https://developers.redhat.com/articles/2024/04/03/how-add-debug-support-go-stripped-binaries
+#
+PRODUCTION ?= 0
+ifeq ($(PRODUCTION),1)
+  LDFLAGS+= -s -w
+endif
+
 # set GOENV
 GOOS := $(shell go env GOOS)
 GOARCH := $(shell go env GOARCH)


### PR DESCRIPTION
by merging this PR we would:

* be able to set `PRODUCTION` to strip the exporter and validator binaries;
* avoid adding [DWARF](https://dwarfstd.org/doc/DWARF5.pdf) debug information to newer releases;
* reduce the size/footprint of the built binaries;
* still be able to find/follow debug symbols using [Delve](https://github.com/go-delve/delve), should necessary;
* promote the usage of less energy/power consumption.

example using `PRODUCTION` to enable/disable stripped build for the exporter locally:

```bash
$ PRODUCTION=1 make _build_local
$ file _output/bin/linux_amd64/kepler 
_output/bin/linux_amd64/kepler: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=45a457a614ec12d4f18e983f7f28c9bfd3dfc9f3, for GNU/Linux 3.2.0, stripped
$ ls -laish _output/bin/linux_amd64/kepler
27662536 37M -rwxrwxr-x 1 egypcio egypcio 37M May  8 11:42 _output/bin/linux_amd64/kepler
```
```bash
$ make _build_local
$ file _output/bin/linux_amd64/kepler 
_output/bin/linux_amd64/kepler: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=ee248b3f1e691fa128d33baa5f91eaa82286a12b, for GNU/Linux 3.2.0, with debug_info, not stripped
$ ls -laish _output/bin/linux_amd64/kepler
27662536 53M -rwxrwxr-x 1 egypcio egypcio 53M May  8 11:46 _output/bin/linux_amd64/kepler
```

impact on the binary created after building the validator:

```
8.4M -rwxrwxr-x 1 egypcio egypcio 8.4M May  8 11:49 _output/bin/validator-debug
5.7M -rwxrwxr-x 1 egypcio egypcio 5.7M May  8 11:49 _output/bin/validator
```

> Host: Linux version 6.11.0-25-generic (buildd@lcy02-amd64-027) (x86_64-linux-gnu-gcc-13 (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0, GNU ld (GNU Binutils for Ubuntu) 2.42), a.k.a. Ubuntu 24.04.2 LTS (Noble Numbat)