### PR TITLE
chore: update Dockerfile to make use production build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ WORKDIR /workspace
 
 COPY . .
 
-RUN make build
+RUN make build PRODUCTION=1
 
 FROM registry.access.redhat.com/ubi9:latest
 
-COPY --from=builder /workspace/bin/kepler /usr/bin/kepler
+COPY --from=builder /workspace/bin/kepler-release /usr/bin/kepler
 
 ENTRYPOINT ["/usr/bin/kepler"]

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,13 @@ GOARCH=$(shell go env GOARCH)
 
 # Project parameters
 BINARY_NAME=kepler
+
+PRODUCTION ?= 0
+ifeq ($(PRODUCTION), 1)
+	# add -release suffix to binary name
+	BINARY_NAME:=$(BINARY_NAME)-release
+endif
+
 BINARY_DIR=bin
 MAIN_GO_PATH=./cmd/kepler
 VERSION=$(shell git describe --tags --always --dirty | sed 's/-reboot//' || echo "dev")
@@ -29,7 +36,6 @@ LD_VERSION_FLAGS=\
 	-X github.com/sustainable-computing-io/kepler/internal/version.gitBranch=$(GIT_BRANCH) \
 	-X github.com/sustainable-computing-io/kepler/internal/version.gitCommit=$(GIT_COMMIT)
 
-PRODUCTION ?= 0
 ifeq ($(PRODUCTION), 1)
 	# strip debug symbols from production builds (to reduce binary size)
 	LD_STRIP_DEBUG_SYMBOLS=-s -w


### PR DESCRIPTION
This commit updates the Dockerfile to use the production build. It also adds the suffix `-release` to the binary name in case of production build.