### PR TITLE
chore: add dockerignore file to project

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Ignore test binary
+*.test
+
+# Ignore coverage file
+*.out
+
+# Ignore env file
+.env
+
+# Ignore bin directory
+bin/
+
+# Ignore tmp directory
+tmp
+
+# Ignore coverage file
+coverage.*


### PR DESCRIPTION
This commit adds a .dockerignore file to the project. This file is used to exclude certain files and directories from being included in the Docker image.

NOTE: Make sure that files and directories that are in .gitignore should always be there in .dockerignore to avoid any VERSION computation issues.