### PR TITLE
ci: switch to using ubuntu 22.04

### DIFF
--- a/.github/workflows/mock_acpi.yml
+++ b/.github/workflows/mock_acpi.yml
@@ -43,7 +43,7 @@ jobs:
           metal_project_id: ${{ secrets.EQUINIX_PROJECT_ID }}
           metro: da
           plan: c3.small.x86
-          os: ubuntu_20_04
+          os: ubuntu_22_04
           organization: sustainable-computing-io
 
   test-mock-acpi:


### PR DESCRIPTION
This commit switches the Equinix Metal CI to use Ubuntu 22.04 instead of Ubuntu 20.04