### PR TITLE
ci: exclude markdown descriptive link text rule

### DIFF
--- a/.github/workflows/developer_local.yml
+++ b/.github/workflows/developer_local.yml
@@ -13,6 +13,8 @@ jobs:
         kube_provider: [kind]
     env:
       CTR_CMD: docker
+      PROMETHEUS_ENABLE: false
+      GRAFANA_ENABLE: false
     steps:
       - uses: actions/checkout@v4
       - name: local cluster set up

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -33,12 +33,13 @@
   "ul-style": {
     "style": "dash"
   },
-  "no-duplicate-header" : {
+  "no-duplicate-header": {
     "allow_different_nesting": true
   },
-  "MD033" : false,
+  "MD033": false,
   "MD041": false,
   "MD045": false,
+  "MD059": false,
   "MD025": {
     "front_matter_title": ""
   }


### PR DESCRIPTION
This commit disables the markdown descriptive link text rule in the markdownlint configuration file allowing pre-commit hook to pass

NOTE: Disabling this rule for now since fixing this requires edits in multiple readme files
