### PR TITLE
chore(logger): prefer buffered stdout over stderr

### DIFF
--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -30,7 +30,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	logger := logger.New(cfg.Log.Level, cfg.Log.Format)
+	// Configure logger - use stderr if stdout exporter is enabled to prevent output interleaving
+	logOut := os.Stdout
+	if cfg.Exporter.Stdout {
+		logOut = os.Stderr
+	}
+	logger := logger.New(cfg.Log.Level, cfg.Log.Format, logOut)
+
 	logVersionInfo(logger)
 	printConfigInfo(logger, cfg)
 
@@ -78,7 +84,7 @@ func parseArgsAndConfig() (*config.Config, error) {
 	updateConfig := config.RegisterFlags(app)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
-	logger := logger.New("info", "text")
+	logger := logger.New("info", "text", os.Stdout)
 	cfg := config.DefaultConfig()
 	if *configFile != "" {
 		logger.Info("Loading configuration file", "path", *configFile)

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -5,27 +5,27 @@ package logger
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"strings"
 )
 
-func New(level, format string) *slog.Logger {
+func New(level, format string, w io.Writer) *slog.Logger {
 	logLevel := parseLogLevel(level)
-	return slog.New(handlerForFormat(format, logLevel))
+	return slog.New(handlerForFormat(format, logLevel, w))
 }
 
-func handlerForFormat(format string, logLevel slog.Level) slog.Handler {
+func handlerForFormat(format string, logLevel slog.Level, w io.Writer) slog.Handler {
 	switch format {
 	case "json":
-		return slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		return slog.NewJSONHandler(w, &slog.HandlerOptions{
 			Level:     logLevel,
 			AddSource: true,
 		})
 
 	case "text":
-		return slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		return slog.NewTextHandler(w, &slog.HandlerOptions{
 			Level:     logLevel,
 			AddSource: true,
 			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -66,7 +66,7 @@ func TestSetupLogger(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.expectPanic {
 				assert.Panics(t, func() {
-					_ = New(tt.logLevel, tt.format)
+					_ = New(tt.logLevel, tt.format, os.Stderr)
 				}, "Expected setupLogger to panic with invalid format")
 				//
 				return
@@ -78,7 +78,7 @@ func TestSetupLogger(t *testing.T) {
 			r, w, _ := os.Pipe()
 			os.Stderr = w
 
-			logger := New(tt.logLevel, tt.format)
+			logger := New(tt.logLevel, tt.format, os.Stderr)
 			logger.Info("test message", "key", "value")
 
 			// Restore stdout


### PR DESCRIPTION
This commit modified logger to use stdout (buffered out) unless the stdout exporter is enabled. On enabling stdout exporter, the logger is configured to write to stderr.