### PR TITLE
ci: enable Kepler deployment on Kind cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,30 @@ docker-compose up -d
 - **Prometheus**: <http://localhost:29090>
 - **Grafana**: <http://localhost:23000> (default credentials: admin/admin)
 
+### 3️⃣ Running on Kubernetes 🐳
+
+Deploy Kepler to your Kubernetes cluster:
+
+```bash
+# Set up a local development cluster with Kind
+make cluster-up
+
+# Deploy Kepler to the cluster
+make deploy
+```
+
+**Custom Image Deployment:**
+
+You can build, push, and deploy Kepler using your own image:
+
+```bash
+# Build and push image to your registry
+make image push IMG_BASE=<your registry> VERSION=<your version>
+
+# Deploy Kepler using the custom image
+make deploy IMG_BASE=<your registry> VERSION=<your version>
+```
+
 ## 📖 Documentation
 
 For more detailed documentation, please visit the [official Kepler documentation](https://sustainable-computing.io/kepler/).

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+# config
+declare -r VERSION=${VERSION:-v0.0.9}
+declare -r CLUSTER_PROVIDER=${CLUSTER_PROVIDER:-kind}
+declare -r GRAFANA_ENABLE=${GRAFANA_ENABLE:-false}
+declare -r KIND_WORKER_NODES=${KIND_WORKER_NODES:-2}
+
+# constants
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+declare -r PROJECT_ROOT
+declare -r TMP_DIR="$PROJECT_ROOT/tmp"
+declare -r DEV_CLUSTER_DIR="$TMP_DIR/local-dev-cluster"
+declare -r BIN_DIR="$TMP_DIR/bin"
+
+source "$PROJECT_ROOT/hack/utils.bash"
+
+git_checkout() {
+
+	[[ -d "$DEV_CLUSTER_DIR" ]] || {
+		info "git cloning local-dev-cluster - version $VERSION"
+		run git clone -b "$VERSION" \
+			https://github.com/sustainable-computing-io/local-dev-cluster.git \
+			"$DEV_CLUSTER_DIR"
+		return $?
+	}
+
+	cd "$DEV_CLUSTER_DIR"
+
+	# NOTE: bail out if the git status is dirty as changes will be overwritten by git reset
+	git diff --shortstat --exit-code >/dev/null || {
+		err "local-dev-cluster has been modified"
+		info "save/discard the changes and rerun the command"
+		return 1
+	}
+
+	run git fetch --tags
+	if [[ "$(git cat-file -t "$VERSION")" == tag ]]; then
+		run git reset --hard "$VERSION"
+	else
+		run git reset --hard "origin/$VERSION"
+	fi
+}
+
+on_cluster_up() {
+	info 'Next: "make deploy" to run Kepler'
+}
+
+on_cluster_restart() {
+	on_cluster_up
+}
+
+on_cluster_down() {
+	info "all done"
+}
+
+main() {
+	local op="$1"
+	shift
+	cd "$PROJECT_ROOT"
+	export PATH="$BIN_DIR:$PATH"
+	mkdir -p "${TMP_DIR}"
+
+	header "Running Cluster Setup Script for $op"
+	git_checkout
+	export CLUSTER_PROVIDER
+	export GRAFANA_ENABLE
+	export KIND_WORKER_NODES
+	cd "$DEV_CLUSTER_DIR"
+	"$DEV_CLUSTER_DIR/main.sh" "$op"
+
+	# NOTE: take additional actions after local-dev-cluster performs the "$OP"
+	cd "$PROJECT_ROOT"
+	on_cluster_"$op"
+}
+
+main "$@"

--- a/hack/utils.bash
+++ b/hack/utils.bash
@@ -1,0 +1,109 @@
+is_fn() {
+	[[ $(type -t "$1") == "function" ]]
+	return $?
+}
+
+header() {
+	local title=" 🔆🔆🔆  $*  🔆🔆🔆 "
+
+	local len=40
+	if [[ ${#title} -gt $len ]]; then
+		len=${#title}
+	fi
+
+	echo -e "\n\n  \033[1m${title}\033[0m"
+	echo -n "━━━━━"
+	printf '━%.0s' $(seq "$len")
+	echo "━━━━━━━"
+
+}
+
+info() {
+	echo -e " 🔔 $*" >&2
+}
+
+err() {
+	echo -e " 😱 $*" >&2
+}
+
+warn() {
+	echo -e "   $*" >&2
+}
+
+ok() {
+	echo -e "   ✅ $*" >&2
+}
+
+skip() {
+	echo -e " 🙈 SKIP: $*" >&2
+}
+
+fail() {
+	echo -e " ❌ FAIL: $*" >&2
+}
+
+info_run() {
+	echo -e "      $*\n" >&2
+}
+
+run() {
+	echo -e " ❯ $*\n" >&2
+	"$@"
+}
+
+die() {
+	echo -e "\n ✋ $* "
+	echo -e "──────────────────── ⛔️⛔️⛔️ ────────────────────────\n"
+	exit 1
+}
+
+line() {
+	local len="$1"
+	local style="${2:-thin}"
+	shift
+
+	local ch='─'
+	[[ "$style" == 'heavy' ]] && ch="━"
+
+	printf "$ch%.0s" $(seq "$len") >&2
+	echo
+}
+# condition_check <exp> <cond>
+# checks if the condition result matches the expected result
+condition_check() {
+	local exp="$1"
+	local cond="$2"
+	shift 2
+	[[ -n $exp ]] && [[ $("$cond" "$@") == "$exp" ]] && {
+		return 0
+	}
+	return 1
+}
+
+# wait_until <max_tries> <delay> <msg> <condition>
+# waits for condition to be true for a max of <max_tries> x <delay> seconds
+wait_until() {
+	local max_tries="$1"
+	local delay="$2"
+	local msg="$3"
+	local condition="$4"
+	shift 4
+
+	info "Waiting [$max_tries x ${delay}s] for $msg"
+	local tries=0
+	local -i ret=1
+	echo " ❯ $condition $*" 2>&1
+	while [[ $tries -lt $max_tries ]]; do
+
+		$condition "$@" && {
+			ret=0
+			break
+		}
+
+		tries=$((tries + 1))
+		echo "   ... [$tries / $max_tries] waiting ($delay secs) - $msg" >&2
+		sleep "$delay"
+	done
+
+	return $ret
+}

--- a/manifests/k8s/configmap.yaml
+++ b/manifests/k8s/configmap.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kepler
+  namespace: kepler
+  labels:
+    app.kubernetes.io/name: kepler
+    app.kubernetes.io/part-of: kepler
+data:
+  kepler-config.yaml: |
+    log:
+      level: debug
+      format: text
+    host:
+      sysfs: /host/sys
+      procfs: /host/proc
+    monitor:
+      interval: 5s
+      staleness: 500ms
+    rapl:
+      zones: []
+    enable-pprof: false
+    exporter:
+        stdout: false
+    web:
+        configFile: ""
+    dev:
+        fake-cpu-meter:
+            enabled: false
+            zones: []

--- a/manifests/k8s/daemonset.yaml
+++ b/manifests/k8s/daemonset.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kepler
+  namespace: kepler
+  labels:
+    app.kubernetes.io/name: kepler
+    app.kubernetes.io/part-of: kepler
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kepler
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kepler
+        app.kubernetes.io/part-of: kepler
+    spec:
+      serviceAccountName: kepler
+      hostPID: true
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: kepler
+          image: <KEPLER_IMAGE>
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          command:
+            - /usr/bin/kepler
+          args:
+            - --config.file=/etc/kepler/kepler-config.yaml
+          ports:
+            - name: http
+              containerPort: 28282
+              protocol: TCP
+          volumeMounts:
+            - name: sysfs
+              mountPath: /host/sys
+              readOnly: true
+            - name: procfs
+              mountPath: /host/proc
+              readOnly: true
+            - name: cfm
+              mountPath: /etc/kepler
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 60
+      volumes:
+        - name: sysfs
+          hostPath:
+            path: /sys
+        - name: procfs
+          hostPath:
+            path: /proc
+        - name: cfm
+          configMap:
+            name: kepler

--- a/manifests/k8s/kustomization.yaml
+++ b/manifests/k8s/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - rbac.yaml
+  - configmap.yaml
+  - daemonset.yaml
+  - service.yaml
+  - servicemonitor.yaml
+  - prometheus-rbac.yaml
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/name: kepler
+      app.kubernetes.io/part-of: kepler

--- a/manifests/k8s/namespace.yaml
+++ b/manifests/k8s/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kepler
+  labels:
+    app.kubernetes.io/name: kepler
+    app.kubernetes.io/part-of: kepler

--- a/manifests/k8s/prometheus-rbac.yaml
+++ b/manifests/k8s/prometheus-rbac.yaml
@@ -1,0 +1,46 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prom-kepler
+  namespace: kepler
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
+    app.kubernetes.io/name: prometheus
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prom-kepler
+  namespace: kepler
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
+    app.kubernetes.io/name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prom-kepler
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring

--- a/manifests/k8s/rbac.yaml
+++ b/manifests/k8s/rbac.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kepler
+  namespace: kepler
+  labels:
+    app.kubernetes.io/name: kepler
+    app.kubernetes.io/part-of: kepler
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kepler
+  labels:
+    app.kubernetes.io/name: kepler
+    app.kubernetes.io/part-of: kepler
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kepler
+  labels:
+    app.kubernetes.io/name: kepler
+    app.kubernetes.io/part-of: kepler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kepler
+subjects:
+  - kind: ServiceAccount
+    name: kepler
+    namespace: kepler

--- a/manifests/k8s/service.yaml
+++ b/manifests/k8s/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kepler
+  namespace: kepler
+  labels:
+    app.kubernetes.io/name: kepler
+    app.kubernetes.io/part-of: kepler
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 28282
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: kepler
+    app.kubernetes.io/part-of: kepler

--- a/manifests/k8s/servicemonitor.yaml
+++ b/manifests/k8s/servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kepler
+  namespace: kepler
+  labels:
+    app.kubernetes.io/name: kepler
+    app.kubernetes.io/part-of: kepler
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kepler
+      app.kubernetes.io/part-of: kepler
+  endpoints:
+    - port: http
+      interval: 5s
+      path: /metrics


### PR DESCRIPTION
This commit adds setup for Kind cluster and Kepler deployment. Changes include:
- `cluster.sh`: Sets up Kind cluster using `local-dev-cluster` repo.
- `manifests/k8s/`: Kubernetes manifests for Kepler deployment.
  - `namespace.yaml`: Creates namespace.
  - `configmap.yaml`: Configures Kepler.
  - `rbac.yaml`: Grants Kepler cluster access.
  - `prometheus-rbac.yaml`: Grants Prometheus access to Kepler.
  - `daemonset.yaml`: Deploys Kepler.
  - `service.yaml`: Exposes Kepler service.
  - `servicemonitor.yaml`: Exposes Kepler service monitor.
- New Makefile targets:
  - `cluster-up`: Starts Kind cluster.
  - `cluster-down`: Tears down Kind cluster.
  - `cluster-restart`: Restarts Kind cluster.
  - `deploy`: Deploys Kepler on Kind cluster.
  - `undeploy`: Deletes Kepler from Kind cluster.
- README update with instructions to deploy Kepler on Kind cluster.