### PR TITLE
ci: capture diff after running make deps

### DIFF
--- a/.github/publish-image/action.yaml
+++ b/.github/publish-image/action.yaml
@@ -41,7 +41,7 @@ runs:
 
     - name: make deps
       shell: bash
-      run: make deps
+      run: make deps && git diff --exit-code
 
     - name: Build Image
       shell: bash

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/oklog/run v1.1.0
+	github.com/olekukonko/tablewriter v1.0.5
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/exporter-toolkit v0.14.0
@@ -32,7 +33,6 @@ require (
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/olekukonko/errors v0.0.0-20250405072817-4e6d85265da6 // indirect
 	github.com/olekukonko/ll v0.0.7 // indirect
-	github.com/olekukonko/tablewriter v1.0.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect


### PR DESCRIPTION
This commit ensures that the diff is taken after running make deps and fails if the diff is not empty.

It also fixes the issue where the go.mod file contains the diff due to which VERSION being computed has `-dirty` suffix.