### PR TITLE
chore: fix missing maintainer link

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -18,7 +18,7 @@ Responsibilities include:
 - Actively engage in the technical committee meetings.
 
 The current list of technical committee members is published and updated in
-[Contributors.md](Contributors.md).
+[MAINTAINERS.md](./MAINTAINERS.md).
 
 ### Becoming a Technical Committee Member
 


### PR DESCRIPTION
`Contributors.md` is no longer existing. `CONTRIBUTORS.md` also does not contain the list. The maintainer list is in [MAINTAINERS.md](https://github.com/sustainable-computing-io/kepler/blob/main/MAINTAINERS.md)  

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>