### PR TITLE
chore(k8s): rename config file for kepler

### DIFF
--- a/manifests/k8s/configmap.yaml
+++ b/manifests/k8s/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: kepler
     app.kubernetes.io/part-of: kepler
 data:
-  kepler-config.yaml: |
+  config.yaml: |
     log:
       level: debug
       format: text

--- a/manifests/k8s/daemonset.yaml
+++ b/manifests/k8s/daemonset.yaml
@@ -34,7 +34,7 @@ spec:
           command:
             - /usr/bin/kepler
           args:
-            - --config.file=/etc/kepler/kepler-config.yaml
+            - --config.file=/etc/kepler/config.yaml
           ports:
             - name: http
               containerPort: 28282


### PR DESCRIPTION
This commit renames the config file for kepler from kepler-config.yaml to config.yaml