### PR TITLE
chore(stdout) ensure stdout and stderr are not terminals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/prometheus/procfs v0.15.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/sync v0.10.0
+	golang.org/x/term v0.28.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e
 )

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.28.0 h1:/Ts8HFuMR2E6IP/jlo7QVLZHggjKQbhu/7H0LJFr3Gg=
+golang.org/x/term v0.28.0/go.mod h1:Sw/lC2IAUZ92udQNf3WodGtn4k/XoLyZoh8v/8uiwek=
 golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
 golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
 google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=

--- a/internal/exporter/stdout/stdout_test.go
+++ b/internal/exporter/stdout/stdout_test.go
@@ -100,11 +100,15 @@ func TestNewExporter(t *testing.T) {
 	}
 }
 
-type dummyWriteCloser struct {
+type dummyTarget struct {
 	io.Writer
 }
 
-func (dwc *dummyWriteCloser) Close() error {
+func (dwc *dummyTarget) Fd() uintptr {
+	return 0
+}
+
+func (dwc *dummyTarget) Close() error {
 	return nil
 }
 
@@ -112,7 +116,7 @@ func TestExporter_InitRunShotdown(t *testing.T) {
 	t.Run("starts successfully", func(t *testing.T) {
 		mockMonitor := &MockMonitor{}
 		mockMonitor.On("Snapshot").Return(&monitor.Snapshot{Node: getTestNodeData()}, nil)
-		out := &dummyWriteCloser{&bytes.Buffer{}}
+		out := &dummyTarget{&bytes.Buffer{}}
 		exporter := NewExporter(mockMonitor, WithOutput(out), WithInterval(1*time.Second))
 		err := exporter.Init()
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)


### PR DESCRIPTION
Previously when stdout exporter is enabled, it writes to stdout (by default) and logs get written to stderr. This messes up the output. This PR ensures that when stdout exporter is enabled, and log (stderr) isn't redirected, the application quits. 

```
sudo ./bin/kepler --exporter.stdout 

time=2025-05-21T08:45:43.484-04:00 level=ERROR source=cmd/kepler/main.go:53 msg="failed to initialize services" error="failed to initialize service stdout: stdout and stderr are both terminal streams; redirect stderr to a file"

```

```
sudo ./bin/kepler --exporter.stdout --no-exporter.prometheus 2>/dev/null

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Press Ctrl+C to shutdown
┌─────────┬─────────────┬─────────────┬────────────────┐
│  ZONE   │ DELTA ( W ) │ POWER ( W ) │ ABSOLUTE ( J ) │
├─────────┼─────────────┼─────────────┼────────────────┤
│    core │       0.86J │       0.43W │      33843.02J │
│ package │      20.84J │      10.42W │      64863.30J │
└─────────┴─────────────┴─────────────┴────────────────┘
```
