### PR TITLE
feat(experiments): added kube-rbac-proxy to kepler openshift deployment

### DIFF
--- a/hack/experiments/kube-rbac-proxy-setup/README.md
+++ b/hack/experiments/kube-rbac-proxy-setup/README.md
@@ -1,0 +1,13 @@
+# kube-rbac-proxy spike setup for openshift
+
+## Deploy
+
+1. Provision an Openshift cluster (remove fake-cpu-meter if rapl zones exist)
+
+2. Apply power-monitor-* (except for power-monitor-sm.yaml) and kube-rbac-proxy-secret.yaml files
+
+3. Apply test-* and confirm that kube-rbac-proxy successfully blocks test-wrong-job (default Service Account) and accepts test-correct-job (test-namespace ServiceAccount)
+
+4. For UserWorkloadMonitoring test, deploy the ServiceMonitor (power-monitor-sm.yaml) and confirm that prometheus-user-workload is successfully scraping uwm
+
+5. Note for uwm, it is essential you create the secret token for prometheus-user-workload service account in the openshift-user-workload-monitoring namespace

--- a/hack/experiments/kube-rbac-proxy-setup/kube-rbac-proxy-secret.yaml
+++ b/hack/experiments/kube-rbac-proxy-setup/kube-rbac-proxy-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/part-of: power-monitor
+  name: power-monitor-kube-rbac-proxy-config
+  namespace: power-monitor
+stringData:
+  config.yaml: |-
+    "authorization":
+      "static":
+      - "path": "/metrics"
+        "resourceRequest": false
+        "user":
+          "name": "system:serviceaccount:openshift-user-workload-monitoring:prometheus-user-workload"
+        "verb": "get"
+      - "path": "/metrics"
+        "resourceRequest": false
+        "user":
+          "name": "system:serviceaccount:test-namespace:test-monitoring-sa"
+        "verb": "get"
+type: Opaque

--- a/hack/experiments/kube-rbac-proxy-setup/power-monitor-ca.yaml
+++ b/hack/experiments/kube-rbac-proxy-setup/power-monitor-ca.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: power-monitor
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: power-monitor-serving-certs-ca-bundle
+data: {}

--- a/hack/experiments/kube-rbac-proxy-setup/power-monitor-clusterrole.yaml
+++ b/hack/experiments/kube-rbac-proxy-setup/power-monitor-clusterrole.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: power-monitor-exporter
+    app.kubernetes.io/part-of: power-monitor
+  name: power-monitor
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/metrics
+      - nodes/proxy
+      - nodes/stats
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups: [authentication.k8s.io]
+    resources:
+      - tokenreviews
+    verbs: [create]
+  - apiGroups: [authorization.k8s.io]
+    resources:
+      - subjectaccessreviews
+    verbs: [create]

--- a/hack/experiments/kube-rbac-proxy-setup/power-monitor-clusterrolebinding.yaml
+++ b/hack/experiments/kube-rbac-proxy-setup/power-monitor-clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: power-monitor-exporter
+    app.kubernetes.io/part-of: power-monitor
+  name: power-monitor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: power-monitor
+subjects:
+  - kind: ServiceAccount
+    name: power-monitor
+    namespace: power-monitor

--- a/hack/experiments/kube-rbac-proxy-setup/power-monitor-cm.yaml
+++ b/hack/experiments/kube-rbac-proxy-setup/power-monitor-cm.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+data:
+  kepler-config.yaml: |
+    log:
+        level: debug
+        format: text
+    dev:
+        fake-cpu-meter:
+            enabled: true
+    host:
+        sysfs: /host/sys
+        procfs: /host/proc
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: power-monitor-exporter
+    app.kubernetes.io/part-of: power-monitor
+  name: power-monitor
+  namespace: power-monitor

--- a/hack/experiments/kube-rbac-proxy-setup/power-monitor-daemonset.yaml
+++ b/hack/experiments/kube-rbac-proxy-setup/power-monitor-daemonset.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/part-of: power-monitor
+  name: power-monitor
+  namespace: power-monitor
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: power-monitor-exporter
+      app.kubernetes.io/part-of: power-monitor
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: power-monitor-exporter
+        app.kubernetes.io/part-of: power-monitor
+    spec:
+      containers:
+        - command:
+            - /usr/bin/kepler
+            - --config.file=/etc/kepler/kepler-config.yaml
+          image: quay.io/sustainable_computing_io/kepler-reboot:v0.0.4
+          imagePullPolicy: IfNotPresent
+          name: power-monitor
+          ports:
+            - containerPort: 28282
+              name: http
+              protocol: TCP
+          resources: {}
+          securityContext:
+            privileged: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /host/sys
+              name: sysfs
+              readOnly: true
+            - mountPath: /host/proc
+              name: procfs
+              readOnly: true
+            - mountPath: /etc/kepler
+              name: cfm
+        - args:
+            - --secure-listen-address=0.0.0.0:8443
+            - --upstream=http://127.0.0.1:28282
+            - --auth-token-audiences=power-monitor.power-monitor.svc
+            - --config-file=/etc/kube-rbac-proxy/config.yaml
+            - --tls-cert-file=/etc/tls/private/tls.crt
+            - --tls-private-key-file=/etc/tls/private/tls.key
+            - --allow-paths=/metrics
+            - --logtostderr=true
+            - --v=10
+          image: quay.io/brancz/kube-rbac-proxy:v0.19.0
+          name: kube-rbac-proxy
+          ports:
+            - containerPort: 8443
+              name: https
+          resources:
+            requests:
+              cpu: 1m
+              memory: 15Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/kube-rbac-proxy
+              name: power-monitor-kube-rbac-proxy-config
+              readOnly: true
+            - mountPath: /etc/tls/private
+              name: power-monitor-tls
+              readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccountName: power-monitor
+      terminationGracePeriodSeconds: 30
+      tolerations:
+        - operator: Exists
+      volumes:
+        - hostPath:
+            path: /sys
+            type: ""
+          name: sysfs
+        - hostPath:
+            path: /proc
+            type: ""
+          name: procfs
+        - name: power-monitor-tls
+          secret:
+            secretName: power-monitor-tls
+        - configMap:
+            defaultMode: 420
+            name: power-monitor
+          name: cfm
+        - name: power-monitor-kube-rbac-proxy-config
+          secret:
+            secretName: power-monitor-kube-rbac-proxy-config
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate

--- a/hack/experiments/kube-rbac-proxy-setup/power-monitor-namespace.yaml
+++ b/hack/experiments/kube-rbac-proxy-setup/power-monitor-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: power-monitor

--- a/hack/experiments/kube-rbac-proxy-setup/power-monitor-sa.yaml
+++ b/hack/experiments/kube-rbac-proxy-setup/power-monitor-sa.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/part-of: power-monitor
+  name: power-monitor
+  namespace: power-monitor

--- a/hack/experiments/kube-rbac-proxy-setup/power-monitor-scc.yaml
+++ b/hack/experiments/kube-rbac-proxy-setup/power-monitor-scc.yaml
@@ -1,0 +1,35 @@
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: true
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities:
+  - SYS_ADMIN
+fsGroup:
+  type: RunAsAny
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/part-of: power-monitor
+  name: power-monitor
+readOnlyRootFilesystem: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:power-monitor:power-monitor
+volumes:
+  - configMap
+  - emptyDir
+  - hostPath
+  - projected
+  - secret

--- a/hack/experiments/kube-rbac-proxy-setup/power-monitor-service.yaml
+++ b/hack/experiments/kube-rbac-proxy-setup/power-monitor-service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: power-monitor-tls
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: power-monitor-exporter
+    app.kubernetes.io/part-of: power-monitor
+  name: power-monitor
+  namespace: power-monitor
+spec:
+  clusterIP: None
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+    - name: https
+      port: 8443
+      targetPort: https
+  selector:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: power-monitor-exporter
+    app.kubernetes.io/part-of: power-monitor
+  sessionAffinity: None
+  type: ClusterIP

--- a/hack/experiments/kube-rbac-proxy-setup/power-monitor-sm.yaml
+++ b/hack/experiments/kube-rbac-proxy-setup/power-monitor-sm.yaml
@@ -1,0 +1,39 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: power-monitor-exporter
+    app.kubernetes.io/part-of: power-monitor
+    openshift.io/user-monitoring: true
+  name: power-monitor
+  namespace: power-monitor
+spec:
+  endpoints:
+    - interval: 15s
+      port: https
+      relabelings:
+        - action: replace
+          regex: (.*)
+          replacement: $1
+          sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: instance
+      scheme: https
+      authorization:
+        type: Bearer
+        credentials:
+          name: prometheus-user-workload-token
+          key: token
+      tlsConfig:
+        ca:
+          configMap:
+            name: power-monitor-serving-certs-ca-bundle
+            key: service-ca.crt
+        serverName: power-monitor.power-monitor.svc
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: power-monitor-exporter
+      app.kubernetes.io/part-of: power-monitor

--- a/hack/experiments/kube-rbac-proxy-setup/test-ca-default.yaml
+++ b/hack/experiments/kube-rbac-proxy-setup/test-ca-default.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: default
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: test-wrong-job-serving-certs-ca-bundle
+data: {}

--- a/hack/experiments/kube-rbac-proxy-setup/test-ca.yaml
+++ b/hack/experiments/kube-rbac-proxy-setup/test-ca.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: test-namespace
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: test-monitoring-sa-serving-certs-ca-bundle
+data: {}

--- a/hack/experiments/kube-rbac-proxy-setup/test-correct-job.yaml
+++ b/hack/experiments/kube-rbac-proxy-setup/test-correct-job.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: krp-curl
+  namespace: test-namespace
+spec:
+  template:
+    metadata:
+      name: krp-curl
+    spec:
+      serviceAccountName: test-monitoring-sa
+      restartPolicy: Never
+      containers:
+        - name: krp-curl
+          image: quay.io/brancz/krp-curl:v0.0.2
+          command:
+            - /bin/sh
+            - -c
+            - >-
+              curl -v -s --cacert /var/run/secrets/ca/service-ca.crt -H
+              "Authorization: Bearer `cat /service-account/token`"
+              https://power-monitor.power-monitor.svc:8443/metrics
+          volumeMounts:
+            - name: token-vol
+              mountPath: /service-account
+              readOnly: true
+            - name: ca-bundle
+              mountPath: /var/run/secrets/ca
+              readOnly: true
+      volumes:
+        - name: ca-bundle
+          configMap:
+            name: test-monitoring-sa-serving-certs-ca-bundle
+            items:
+              - key: service-ca.crt
+                path: service-ca.crt
+        - name: token-vol
+          projected:
+            sources:
+              - serviceAccountToken:
+                  audience: power-monitor.power-monitor.svc
+                  expirationSeconds: 3600
+                  path: token
+  backoffLimit: 4

--- a/hack/experiments/kube-rbac-proxy-setup/test-sa.yaml
+++ b/hack/experiments/kube-rbac-proxy-setup/test-sa.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-namespace
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/part-of: test-monitoring-sa
+  name: test-monitoring-sa
+  namespace: test-namespace

--- a/hack/experiments/kube-rbac-proxy-setup/test-wrong-job.yaml
+++ b/hack/experiments/kube-rbac-proxy-setup/test-wrong-job.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wrong-krp-curl
+spec:
+  template:
+    metadata:
+      name: wrong-krp-curl
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: krp-curl
+          image: quay.io/brancz/krp-curl:v0.0.2
+          command:
+            - /bin/sh
+            - -c
+            - >-
+              curl -v -s --cacert /var/run/secrets/ca/service-ca.crt -H
+              "Authorization: Bearer `cat /service-account/token`"
+              https://power-monitor.power-monitor.svc:8443/metrics
+          volumeMounts:
+            - name: token-vol
+              mountPath: /service-account
+              readOnly: true
+            - name: ca-bundle
+              mountPath: /var/run/secrets/ca
+              readOnly: true
+      volumes:
+        - name: ca-bundle
+          configMap:
+            name: test-wrong-job-serving-certs-ca-bundle
+            items:
+              - key: service-ca.crt
+                path: service-ca.crt
+        - name: token-vol
+          projected:
+            sources:
+              - serviceAccountToken:
+                  audience: power-monitor.power-monitor.svc
+                  expirationSeconds: 3600
+                  path: token
+  backoffLimit: 4


### PR DESCRIPTION
This experiment tests implementing kube-rbac-proxy into the kepler daemonset as a sidecar and proving that it can protect kepler's /metrics endpoint from certain service accounts. The experiment also demonstrates that prometheus instances like user workload monitoring through the ServiceMonitor can be granted or denied access to kepler's /metrics endpoint.