### PR TITLE
ci: add breaking change label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,6 +5,9 @@ changelog:
       - github-actions[bot]
       - dependabot[bot]
   categories:
+    - title: 💥 Breaking Changes
+      labels:
+        - breaking-change
     - title: 🚀 Features
       labels:
         - feat

--- a/.github/workflows/assign-labels.yaml
+++ b/.github/workflows/assign-labels.yaml
@@ -50,5 +50,8 @@ jobs:
               - type: 'revert'
                 nouns: ['revert']
                 labels: ['revert']
+              - type: 'breaking'
+                nouns: ['!']
+                labels: ['breaking-change']
           maintain-labels-not-matched: false
           apply-changes: true


### PR DESCRIPTION
This commit adds a new label for any breaking change PRs. It also updates the release config to include the breaking change label.