### PR TITLE
chore: remove user-monitoring label from service monitor

### DIFF
--- a/hack/experiments/kube-rbac-proxy-setup/power-monitor-sm.yaml
+++ b/hack/experiments/kube-rbac-proxy-setup/power-monitor-sm.yaml
@@ -5,7 +5,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: power-monitor-exporter
     app.kubernetes.io/part-of: power-monitor
-    openshift.io/user-monitoring: true
   name: power-monitor
   namespace: power-monitor
 spec:


### PR DESCRIPTION
openshift.io/user-monitoring: true is not meant to be included in the service monitor deployment for hack/experiments/kube-rbac-proxy-setup/power-monitor-sm.yaml as it will result in an error.