### PR TITLE
chore(compose): update dashboard to support recent zone changes

### DIFF
--- a/compose/dev/grafana/dashboards/dev/dashboard.json
+++ b/compose/dev/grafana/dashboards/dev/dashboard.json
@@ -547,7 +547,7 @@
             "uid": "PDE6745920139CE56"
           },
           "editorMode": "code",
-          "expr": "sum(rate(node_rapl_${zone}_joules_total[20s]))",
+          "expr": "sum(rate(node_rapl_${zone_clean}_joules_total[20s]))",
           "instant": false,
           "legendFormat": "Node Exporter (${zone})",
           "range": true,
@@ -559,7 +559,7 @@
             "uid": "PDE6745920139CE56"
           },
           "editorMode": "code",
-          "expr": "sum(rate(kepler_node_${zone}_joules_total{job=\"kepler-latest\"}[20s]))",
+          "expr": "sum(rate(kepler_node_${zone_clean}_joules_total{job=\"kepler-latest\"}[20s]))",
           "instant": false,
           "legendFormat": "Kepler - OLD (${zone})",
           "range": true,
@@ -666,32 +666,7 @@
           },
           "unit": "watt"
         },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "Δ package J/s"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -726,7 +701,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(node_rapl_${zone}_joules_total[20s])) \n- sum(rate(kepler_node_cpu_joules_total{job=\"${job}\", zone=\"${zone}\"}[20s]))\n",
+          "expr": "sum(rate(node_rapl_${zone_clean}_joules_total[20s])) \n- sum(rate(kepler_node_cpu_joules_total{job=\"${job}\", zone=\"${zone}\"}[20s]))\n",
           "instant": false,
           "legendFormat": "Δ ${zone} J/s",
           "range": true,
@@ -868,7 +843,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(node_rapl_${zone}_joules_total[20s])) \n- sum(kepler_node_cpu_watts{job=\"${job}\", zone=\"${zone}\"})",
+          "expr": "sum(rate(node_rapl_${zone_clean}_joules_total[20s])) \n- sum(kepler_node_cpu_watts{job=\"${job}\", zone=\"${zone}\"})",
           "instant": false,
           "legendFormat": "Δ ${zone} J/s - W",
           "range": true,
@@ -980,7 +955,7 @@
             "uid": "PDE6745920139CE56"
           },
           "editorMode": "code",
-          "expr": "sum(rate(node_rapl_${zone}_joules_total[20s]))",
+          "expr": "sum(rate(node_rapl_${zone_clean}_joules_total[20s]))",
           "hide": false,
           "instant": false,
           "legendFormat": "Node Exporter (${zone})",
@@ -993,7 +968,7 @@
             "uid": "PDE6745920139CE56"
           },
           "editorMode": "code",
-          "expr": "sum(rate(kepler_node_${zone}_joules_total{job=\"kepler-latest\"}[20s]))",
+          "expr": "sum(rate(kepler_node_${zone_clean}_joules_total{job=\"kepler-latest\"}[20s]))",
           "hide": false,
           "instant": false,
           "legendFormat": "Kepler - OLD (${zone})",
@@ -1169,7 +1144,7 @@
             "uid": "PDE6745920139CE56"
           },
           "editorMode": "code",
-          "expr": "abs(\n  sum(rate(kepler_node_${zone}_joules_total{job=\"kepler-latest\"}[20s]))\n  - \n  sum(rate(kepler_process_${zone}_joules_total{job=\"kepler-latest\"}[20s]))\n)",
+          "expr": "abs(\n  sum(rate(kepler_node_${zone_clean}_joules_total{job=\"kepler-latest\"}[20s]))\n  - \n  sum(rate(kepler_process_${zone_clean}_joules_total{job=\"kepler-latest\"}[20s]))\n)",
           "instant": false,
           "legendFormat": "Kepler Attribution Gap",
           "range": true,
@@ -1352,7 +1327,7 @@
             "uid": "PDE6745920139CE56"
           },
           "editorMode": "code",
-          "expr": "sum(rate(kepler_node_${zone}_joules_total{job=\"kepler-latest\"}[20s])) \n- \nsum(rate(kepler_process_${zone}_joules_total{job=\"kepler-latest\"}[20s]))",
+          "expr": "sum(rate(kepler_node_${zone_clean}_joules_total{job=\"kepler-latest\"}[20s])) \n- \nsum(rate(kepler_process_${zone_clean}_joules_total{job=\"kepler-latest\"}[20s]))",
           "hide": false,
           "instant": false,
           "legendFormat": "Kepler OLD: Node - Process (J/s)",
@@ -1544,7 +1519,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(kepler_process_${zone}_joules_total{pid=\"$pid\",job=\"kepler-latest\"}[20s]))",
+          "expr": "sum(rate(kepler_process_${zone_clean}_joules_total{pid=\"$pid\",job=\"kepler-latest\"}[20s]))",
           "instant": false,
           "legendFormat": "Kepler OLD - ${pid} (Joules)",
           "range": true,
@@ -1723,7 +1698,7 @@
             "uid": "PDE6745920139CE56"
           },
           "editorMode": "code",
-          "expr": "abs(\n  sum(rate(kepler_process_${zone}_joules_total{job=\"kepler-latest\"}[20s]))\n  - \n  sum(rate(kepler_container_${zone}_joules_total{job=\"kepler-latest\"}[20s]))\n)",
+          "expr": "abs(\n  sum(rate(kepler_process_${zone_clean}_joules_total{job=\"kepler-latest\"}[20s]))\n  - \n  sum(rate(kepler_container_${zone_clean}_joules_total{job=\"kepler-latest\"}[20s]))\n)",
           "instant": false,
           "legendFormat": "Kepler Attribution Gap",
           "range": true,
@@ -1890,7 +1865,7 @@
             "uid": "PDE6745920139CE56"
           },
           "editorMode": "code",
-          "expr": "sum(rate(kepler_process_${zone}_joules_total{job=\"kepler-latest\"}[20s]))\n-\nsum(rate(kepler_container_${zone}_joules_total{job=\"kepler-latest\"}[20s]))",
+          "expr": "sum(rate(kepler_process_${zone_clean}_joules_total{job=\"kepler-latest\"}[20s]))\n-\nsum(rate(kepler_container_${zone_clean}_joules_total{job=\"kepler-latest\"}[20s]))",
           "hide": false,
           "instant": false,
           "legendFormat": "Kepler OLD:  Process - Container (J/s)",
@@ -2071,7 +2046,7 @@
             "uid": "PDE6745920139CE56"
           },
           "editorMode": "code",
-          "expr": "100 * (\n    sum(rate(kepler_node_${zone}_joules_total{job=\"kepler-latest\"}[20s])) - sum(rate(kepler_process_${zone}_joules_total{job=\"kepler-latest\"}[20s]))\n)  / \nsum(rate(kepler_node_${zone}_joules_total{job=\"kepler-latest\"}[20s]))",
+          "expr": "100 * (\n    sum(rate(kepler_node_${zone_clean}_joules_total{job=\"kepler-latest\"}[20s])) - sum(rate(kepler_process_${zone_clean}_joules_total{job=\"kepler-latest\"}[20s]))\n)  / \nsum(rate(kepler_node_${zone_clean}_joules_total{job=\"kepler-latest\"}[20s]))",
           "instant": false,
           "legendFormat": "Process Attribution Gap",
           "range": true,
@@ -2088,11 +2063,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "(sd-pam) | 3561",
-          "value": "3561"
-        },
         "datasource": {
           "type": "prometheus",
           "uid": "PDE6745920139CE56"
@@ -2117,11 +2087,6 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": true,
-          "text": "kepler-dev",
-          "value": "kepler-dev"
-        },
         "datasource": {
           "type": "prometheus",
           "uid": "PDE6745920139CE56"
@@ -2146,11 +2111,6 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "package",
-          "value": "package"
-        },
         "datasource": {
           "type": "prometheus",
           "uid": "PDE6745920139CE56"
@@ -2175,11 +2135,6 @@
         "type": "query"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "1",
-          "value": "1"
-        },
         "description": "Process ID extracted from process selection",
         "hide": 2,
         "includeAll": false,
@@ -2190,6 +2145,28 @@
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PDE6745920139CE56"
+        },
+        "definition": "label_values(kepler_node_cpu_watts{zone=\"$zone\"},zone)",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "zone_clean",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(kepler_node_cpu_watts{zone=\"$zone\"},zone)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/^(.*)-[0-9]+$/",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       }
     ]
   },


### PR DESCRIPTION
With the recent zone changes to include zone+index in the name the current dashboard fails to render the queries that don't follow the new zone name format. This commit updates the dashboard to include a `zone_clean` variable that filters out the zone index and then use that variable where zone+index is not supported.