### PR TITLE
ci: use git archive for source version checkout

### DIFF
--- a/.github/check-x-crypto/action.yaml
+++ b/.github/check-x-crypto/action.yaml
@@ -13,8 +13,6 @@ runs:
   steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
 
     - name: Set up Go
       uses: actions/setup-go@v5.4.0

--- a/hack/reports/print-xcrypto-report.sh
+++ b/hack/reports/print-xcrypto-report.sh
@@ -25,8 +25,9 @@ print_help() {
 }
 
 generate_dependency_report() {
-	git worktree add "$tmp_base_ref" "$BASE_REF"
-	git worktree add "$tmp_head_sha" "$HEAD_SHA"
+	git archive "$BASE_REF" | tar -x -C "$tmp_base_ref"
+	git archive "$HEAD_SHA" | tar -x -C "$tmp_head_sha"
+
 	echo "$tmp_base_ref"
 	(
 		cd "$tmp_base_ref"
@@ -119,8 +120,6 @@ parse_args() {
 }
 
 cleanup() {
-	git worktree remove --force "$tmp_base_ref" 2>/dev/null || true
-	git worktree remove --force "$tmp_head_sha" 2>/dev/null || true
 	rm -rf "$tmp_base_ref" "$tmp_head_sha"
 }
 


### PR DESCRIPTION
This commit updates the x-crypto detection script to use git archive for checking out two different versions of source instead of using worktrees
It also fixes the issue where on CI the script fails when creating worktree for base branch as it already exists.