### PR TITLE
ci: update checkout action to check out head commit from forked repo

### DIFF
--- a/.github/check-x-crypto/action.yaml
+++ b/.github/check-x-crypto/action.yaml
@@ -11,14 +11,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5.4.0
-      with:
-        go-version-file: go.mod
-
     - name: Analyze crypto dependencies
       shell: bash
       run: ./hack/reports/print-xcrypto-report.sh --base-ref ${{ inputs.base_ref }} --head-sha ${{ inputs.head_sha }}

--- a/.github/workflows/check-x-crypto-deps.yaml
+++ b/.github/workflows/check-x-crypto-deps.yaml
@@ -9,12 +9,15 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write
     runs-on: ubuntu-latest
     name: Check x/crypto Dependencies in Pull Request
     steps:
       - name: checkout source
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
 
       - name: setup go
         uses: actions/setup-go@v5.4.0


### PR DESCRIPTION
Added fetch-depth, ref, and repository parameters to the checkout action. This should be safe because the workflow will not run any code from the forked repository making the pull request, and the workflow uses git archive. Specifically, the workflow will only search for the dependency graph (with go mod graph) and direct imports of "golang.org/x/crypto".