### PR TITLE
ci: make the x-crypto workflow temporarily disable

### DIFF
--- a/.github/workflows/check-x-crypto-deps.yaml
+++ b/.github/workflows/check-x-crypto-deps.yaml
@@ -1,8 +1,9 @@
 name: Check x/crypto
 
 on:
-  pull_request_target:
-    branches: [reboot]
+  workflow_dispatch:
+  # pull_request_target:
+  #   branches: [reboot]
 
 jobs:
   check-x-crypto-deps:


### PR DESCRIPTION
This commit disables the x-crypto workflow temporarily to run on pull requests until the workflow and script are fixed