### PR TITLE
ci: trigger equinix workflow only on source code changes

### DIFF
--- a/.github/workflows/k8s-equinix.yaml
+++ b/.github/workflows/k8s-equinix.yaml
@@ -26,7 +26,9 @@ jobs:
         with:
           filters: |
             changes:
-              - '**/*.go'
+              - 'cmd/**/*.go'
+              - 'internal/**/*.go'
+              - 'config/**/*.go'
               - 'go.mod'
               - 'go.sum'
   create-runner:


### PR DESCRIPTION
This commit ensures that the check changes job in the equinix workflow only look for the changes in the actual source code. i.e excluding any go code present in `hack/` folder