### PR TITLE
ci: ensure pod level metrics are exported

### DIFF
--- a/.github/k8s/action.yaml
+++ b/.github/k8s/action.yaml
@@ -118,7 +118,9 @@ runs:
           kepler_node_cpu_idle_watts \
           kepler_process_cpu_joules_total \
           kepler_container_cpu_joules_total \
-          kepler_container_cpu_watts; do
+          kepler_container_cpu_watts \
+          kepler_pod_cpu_joules_total \
+          kepler_pod_cpu_watts; do
           echo "Checking metric: $metric"
           if ! grep -q "$metric" /tmp/metrics.txt; then
             echo "Metric $metric not found"

--- a/.github/workflows/k8s-equinix.yaml
+++ b/.github/workflows/k8s-equinix.yaml
@@ -171,7 +171,9 @@ jobs:
             kepler_node_cpu_idle_watts \
             kepler_process_cpu_joules_total \
             kepler_container_cpu_joules_total \
-            kepler_container_cpu_watts; do
+            kepler_container_cpu_watts \
+            kepler_pod_cpu_joules_total \
+            kepler_pod_cpu_watts; do
             echo "Checking metric: $metric"
             if ! grep -q "$metric" /tmp/metrics.txt; then
               echo "Metric $metric not found"

--- a/manifests/k8s/daemonset.yaml
+++ b/manifests/k8s/daemonset.yaml
@@ -35,6 +35,8 @@ spec:
             - /usr/bin/kepler
           args:
             - --config.file=/etc/kepler/config.yaml
+            - --kube.enable
+            - --kube.node-name=$(NODE_NAME)
           ports:
             - name: http
               containerPort: 28282
@@ -54,6 +56,12 @@ spec:
               port: http
             initialDelaySeconds: 10
             periodSeconds: 60
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
       volumes:
         - name: sysfs
           hostPath:


### PR DESCRIPTION
This commit ensures that pod level metrics are exported when Kepler is deployed on Kind cluster.