### PR TITLE
feat(monitor): track terminated processes

### DIFF
--- a/docs/metrics/metrics.md
+++ b/docs/metrics/metrics.md
@@ -138,6 +138,7 @@ These metrics provide energy and power information for individual processes.
   - `comm`
   - `exe`
   - `type`
+  - `state`
   - `container_id`
   - `vm_id`
   - `zone`
@@ -167,6 +168,7 @@ These metrics provide energy and power information for individual processes.
   - `comm`
   - `exe`
   - `type`
+  - `state`
   - `container_id`
   - `vm_id`
   - `zone`

--- a/internal/monitor/clone_test.go
+++ b/internal/monitor/clone_test.go
@@ -297,6 +297,16 @@ func TestSnapshotClone(t *testing.T) {
 					},
 				},
 			},
+			TerminatedProcesses: Processes{
+				999: &Process{
+					PID:  999,
+					Comm: "terminated-proc",
+					Exe:  "/bin/terminated",
+					Zones: ZoneUsageMap{
+						zone: Usage{EnergyTotal: 150 * Joule, Power: 8 * Watt},
+					},
+				},
+			},
 			Containers: Containers{
 				"c1": &Container{
 					ID:   "c1",
@@ -335,12 +345,14 @@ func TestSnapshotClone(t *testing.T) {
 
 		// Verify maps are different instances by checking that they don't share the same underlying slice
 		assert.NotSame(t, &original.Processes, &clone.Processes, "Processes map should be a different instance")
+		assert.NotSame(t, &original.TerminatedProcesses, &clone.TerminatedProcesses, "TerminatedProcesses map should be a different instance")
 		assert.NotSame(t, &original.Containers, &clone.Containers, "Containers map should be a different instance")
 		assert.NotSame(t, &original.VirtualMachines, &clone.VirtualMachines, "VirtualMachines map should be a different instance")
 		assert.NotSame(t, &original.Pods, &clone.Pods, "Pods map should be a different instance")
 
 		// Verify map lengths
 		assert.Len(t, clone.Processes, len(original.Processes), "Processes length should match")
+		assert.Len(t, clone.TerminatedProcesses, len(original.TerminatedProcesses), "TerminatedProcesses length should match")
 		assert.Len(t, clone.Containers, len(original.Containers), "Containers length should match")
 		assert.Len(t, clone.VirtualMachines, len(original.VirtualMachines), "VirtualMachines length should match")
 		assert.Len(t, clone.Pods, len(original.Pods), "Pods length should match")
@@ -349,6 +361,8 @@ func TestSnapshotClone(t *testing.T) {
 		originalNodeRatio := original.Node.UsageRatio
 		originalNodeEnergy := original.Node.Zones[zone].EnergyTotal
 		originalProcessComm := original.Processes[1].Comm
+		originalTerminatedComm := original.TerminatedProcesses[999].Comm
+		originalTerminatedEnergy := original.TerminatedProcesses[999].Zones[zone].EnergyTotal
 		originalContainerName := original.Containers["c1"].Name
 		originalVMName := original.VirtualMachines["vm1"].Name
 		originalPodName := original.Pods["p1"].Name
@@ -357,6 +371,8 @@ func TestSnapshotClone(t *testing.T) {
 		clone.Node.UsageRatio = 0.9
 		clone.Node.Zones[zone] = NodeUsage{EnergyTotal: 2000 * Joule, Power: 100 * Watt}
 		clone.Processes[1].Comm = "modified"
+		clone.TerminatedProcesses[999].Comm = "modified-terminated"
+		clone.TerminatedProcesses[999].Zones[zone] = Usage{EnergyTotal: 999 * Joule, Power: 99 * Watt}
 		clone.Containers["c1"].Name = "modified"
 		clone.VirtualMachines["vm1"].Name = "modified"
 		clone.Pods["p1"].Name = "modified"
@@ -365,6 +381,8 @@ func TestSnapshotClone(t *testing.T) {
 		assert.Equal(t, originalNodeRatio, original.Node.UsageRatio, "Original Node UsageRatio should be unchanged")
 		assert.Equal(t, originalNodeEnergy, original.Node.Zones[zone].EnergyTotal, "Original Node zones should be unchanged")
 		assert.Equal(t, originalProcessComm, original.Processes[1].Comm, "Original Process should be unchanged")
+		assert.Equal(t, originalTerminatedComm, original.TerminatedProcesses[999].Comm, "Original TerminatedProcess should be unchanged")
+		assert.Equal(t, originalTerminatedEnergy, original.TerminatedProcesses[999].Zones[zone].EnergyTotal, "Original TerminatedProcess zones should be unchanged")
 		assert.Equal(t, originalContainerName, original.Containers["c1"].Name, "Original Container should be unchanged")
 		assert.Equal(t, originalVMName, original.VirtualMachines["vm1"].Name, "Original VirtualMachine should be unchanged")
 		assert.Equal(t, originalPodName, original.Pods["p1"].Name, "Original Pod should be unchanged")
@@ -373,9 +391,149 @@ func TestSnapshotClone(t *testing.T) {
 		assert.Equal(t, 0.9, clone.Node.UsageRatio, "Clone Node should have modified UsageRatio")
 		assert.Equal(t, 2000*Joule, clone.Node.Zones[zone].EnergyTotal, "Clone Node should have modified EnergyTotal")
 		assert.Equal(t, "modified", clone.Processes[1].Comm, "Clone Process should have modified Comm")
+		assert.Equal(t, "modified-terminated", clone.TerminatedProcesses[999].Comm, "Clone TerminatedProcess should have modified Comm")
+		assert.Equal(t, 999*Joule, clone.TerminatedProcesses[999].Zones[zone].EnergyTotal, "Clone TerminatedProcess should have modified EnergyTotal")
 		assert.Equal(t, "modified", clone.Containers["c1"].Name, "Clone Container should have modified Name")
 		assert.Equal(t, "modified", clone.VirtualMachines["vm1"].Name, "Clone VirtualMachine should have modified Name")
 		assert.Equal(t, "modified", clone.Pods["p1"].Name, "Clone Pod should have modified Name")
+	})
+}
+
+func TestSnapshotTerminatedProcessesClone(t *testing.T) {
+	t.Run("terminated_processes_deep_copy", func(t *testing.T) {
+		zone1 := &fakeZone{name: "package", index: 0}
+		zone2 := &fakeZone{name: "core", index: 1}
+
+		original := &Snapshot{
+			Timestamp: time.Now(),
+			Node:      &Node{Zones: make(NodeZoneUsageMap)},
+			Processes: make(Processes),
+			TerminatedProcesses: Processes{
+				100: &Process{
+					PID:          100,
+					Comm:         "term-proc-1",
+					Exe:          "/usr/bin/term-proc-1",
+					Type:         resource.ContainerProcess,
+					CPUTotalTime: 125.5,
+					ContainerID:  "container-abc",
+					Zones: ZoneUsageMap{
+						zone1: Usage{EnergyTotal: 500 * Joule, Power: 25 * Watt},
+						zone2: Usage{EnergyTotal: 300 * Joule, Power: 15 * Watt},
+					},
+				},
+				200: &Process{
+					PID:              200,
+					Comm:             "term-proc-2",
+					Exe:              "/usr/bin/term-proc-2",
+					Type:             resource.RegularProcess,
+					CPUTotalTime:     89.2,
+					VirtualMachineID: "vm-xyz",
+					Zones: ZoneUsageMap{
+						zone1: Usage{EnergyTotal: 750 * Joule, Power: 40 * Watt},
+						zone2: Usage{EnergyTotal: 450 * Joule, Power: 22 * Watt},
+					},
+				},
+			},
+			Containers:      make(Containers),
+			VirtualMachines: make(VirtualMachines),
+			Pods:            make(Pods),
+		}
+
+		clone := original.Clone()
+		require.NotNil(t, clone, "Clone should not be nil")
+
+		// Verify TerminatedProcesses map independence
+		assert.NotSame(t, &original.TerminatedProcesses, &clone.TerminatedProcesses, "TerminatedProcesses map should be different instance")
+		assert.Len(t, clone.TerminatedProcesses, 2, "Clone should have same number of terminated processes")
+
+		// Verify each terminated process is deeply cloned
+		for pid := range original.TerminatedProcesses {
+			originalProc := original.TerminatedProcesses[pid]
+			clonedProc := clone.TerminatedProcesses[pid]
+
+			require.NotNil(t, clonedProc, "Cloned terminated process %d should exist", pid)
+			assert.NotSame(t, originalProc, clonedProc, "Terminated process %d should be different instance", pid)
+
+			// Verify all fields are copied correctly
+			assert.Equal(t, originalProc.PID, clonedProc.PID)
+			assert.Equal(t, originalProc.Comm, clonedProc.Comm)
+			assert.Equal(t, originalProc.Exe, clonedProc.Exe)
+			assert.Equal(t, originalProc.Type, clonedProc.Type)
+			assert.Equal(t, originalProc.CPUTotalTime, clonedProc.CPUTotalTime)
+			assert.Equal(t, originalProc.ContainerID, clonedProc.ContainerID)
+			assert.Equal(t, originalProc.VirtualMachineID, clonedProc.VirtualMachineID)
+
+			// Verify zones map independence and content
+			assert.NotSame(t, &originalProc.Zones, &clonedProc.Zones, "Process %d zones map should be different instance", pid)
+			assert.Len(t, clonedProc.Zones, len(originalProc.Zones), "Process %d should have same number of zones", pid)
+
+			for zone, originalUsage := range originalProc.Zones {
+				clonedUsage, exists := clonedProc.Zones[zone]
+				require.True(t, exists, "Process %d should have zone %s", pid, zone.Name())
+				assert.Equal(t, originalUsage, clonedUsage, "Process %d zone %s usage should be identical", pid, zone.Name())
+			}
+		}
+
+		// Test deep copy isolation by modifying clone
+		clone.TerminatedProcesses[100].Comm = "modified-terminated"
+		clone.TerminatedProcesses[100].CPUTotalTime = 999.9
+		clone.TerminatedProcesses[100].Zones[zone1] = Usage{EnergyTotal: 9999 * Joule, Power: 888 * Watt}
+
+		// Add new terminated process to clone
+		clone.TerminatedProcesses[300] = &Process{
+			PID:  300,
+			Comm: "new-terminated",
+			Zones: ZoneUsageMap{
+				zone1: Usage{EnergyTotal: 111 * Joule, Power: 11 * Watt},
+			},
+		}
+
+		// Verify original is completely unchanged
+		assert.Equal(t, "term-proc-1", original.TerminatedProcesses[100].Comm, "Original process comm should be unchanged")
+		assert.Equal(t, 125.5, original.TerminatedProcesses[100].CPUTotalTime, "Original process CPU time should be unchanged")
+		assert.Equal(t, 500*Joule, original.TerminatedProcesses[100].Zones[zone1].EnergyTotal, "Original process zone energy should be unchanged")
+		assert.Equal(t, 25*Watt, original.TerminatedProcesses[100].Zones[zone1].Power, "Original process zone power should be unchanged")
+		assert.NotContains(t, original.TerminatedProcesses, 300, "Original should not have new terminated process")
+
+		// Verify clone has modified values
+		assert.Equal(t, "modified-terminated", clone.TerminatedProcesses[100].Comm, "Clone process should have modified comm")
+		assert.Equal(t, 999.9, clone.TerminatedProcesses[100].CPUTotalTime, "Clone process should have modified CPU time")
+		assert.Equal(t, 9999*Joule, clone.TerminatedProcesses[100].Zones[zone1].EnergyTotal, "Clone process should have modified energy")
+		assert.Equal(t, 888*Watt, clone.TerminatedProcesses[100].Zones[zone1].Power, "Clone process should have modified power")
+		assert.Contains(t, clone.TerminatedProcesses, 300, "Clone should have new terminated process")
+	})
+
+	t.Run("nil_terminated_processes", func(t *testing.T) {
+		original := &Snapshot{
+			Timestamp:           time.Now(),
+			Node:                &Node{Zones: make(NodeZoneUsageMap)},
+			Processes:           make(Processes),
+			TerminatedProcesses: nil, // Explicitly nil
+			Containers:          make(Containers),
+			VirtualMachines:     make(VirtualMachines),
+			Pods:                make(Pods),
+		}
+
+		clone := original.Clone()
+		require.NotNil(t, clone, "Clone should not be nil")
+		assert.Len(t, clone.TerminatedProcesses, 0, "Clone should have empty TerminatedProcesses map when original is nil")
+	})
+
+	t.Run("empty_terminated_processes", func(t *testing.T) {
+		original := &Snapshot{
+			Timestamp:           time.Now(),
+			Node:                &Node{Zones: make(NodeZoneUsageMap)},
+			Processes:           make(Processes),
+			TerminatedProcesses: make(Processes), // Empty but not nil
+			Containers:          make(Containers),
+			VirtualMachines:     make(VirtualMachines),
+			Pods:                make(Pods),
+		}
+
+		clone := original.Clone()
+		require.NotNil(t, clone, "Clone should not be nil")
+		assert.Len(t, clone.TerminatedProcesses, 0, "Clone should have empty TerminatedProcesses map")
+		assert.NotSame(t, &original.TerminatedProcesses, &clone.TerminatedProcesses, "Even empty maps should be different instances")
 	})
 }
 


### PR DESCRIPTION
Previously, between each call to `Snapshot()` (usually from Prometheus exporter),
processes that terminate go unaccounted for in power consumption metrics.
This creates a data loss problem where workloads that consumed significant power
but are no longer running will not be returned to Prometheus.

**Scenario Example:**
   - Prometheus scrapes every 30 seconds
   - Kepler monitor computes power every 5 seconds (default interval)
   - Between first and second Prometheus scrape, monitor computes 5-6 times
   - Each computation overwrites the snapshot with only currently running processes
   - Terminated processes that consumed power during those 25-30 seconds are lost

Changes include:
   - Add terminated process tracking to power monitor
   - Extend power collector to export terminated process metrics
   - Include comprehensive test coverage for terminated process scenarios
   - Enhance process lifecycle management for accurate power attribution

