### PR TITLE
ci: ensure must-gather runs irrespective of failure

### DIFF
--- a/.github/k8s/action.yaml
+++ b/.github/k8s/action.yaml
@@ -129,7 +129,6 @@ runs:
         done
 
     - name: Run must gather
-      if: failure()
       shell: bash
       run: |
         echo "::group::Get pods in kepler namespace"

--- a/.github/workflows/k8s-equinix.yaml
+++ b/.github/workflows/k8s-equinix.yaml
@@ -182,7 +182,7 @@ jobs:
           done
 
       - name: Run must gather
-        if: failure()
+        if: always()
         shell: bash
         run: |
           echo "::group::Get pods in kepler namespace"

--- a/manifests/k8s/configmap.yaml
+++ b/manifests/k8s/configmap.yaml
@@ -31,6 +31,10 @@ data:
     debug:
       pprof:
         enabled: false
+    kube:
+      enabled: false
+      config: ""
+      nodeName: ""
     dev:
       fake-cpu-meter:
         enabled: false


### PR DESCRIPTION
This commit ensures that must-gather runs irrespective of failure. It also adds the kube related config to the k8s configmap which was missing in #2153