### PR TITLE
chore: Enable TLS in server creation process

### DIFF
--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -157,6 +157,7 @@ func createServices(logger *slog.Logger, cfg *config.Config) ([]service.Service,
 
 	apiServer := server.NewAPIServer(
 		server.WithLogger(logger),
+		server.WithWebConfig(cfg.Web.Config),
 	)
 
 	services = append(services,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,6 +22,7 @@ func TestDefaultConfig(t *testing.T) {
 	// Assert default values are set correctly
 	assert.Equal(t, "info", cfg.Log.Level)
 	assert.Equal(t, "text", cfg.Log.Format)
+	assert.Equal(t, "", cfg.Web.Config)
 }
 
 func TestLoadFromYAML(t *testing.T) {


### PR DESCRIPTION
I just checked the code in config/config_test.go and internal/server/server_tls_test.go I found that for kepler itself, we enabled TLS config in config structure but not add the invoke for supporting enable TLS in server creation. With this PR, patch this missing part of code.