### PR TITLE
feat(pod): retrieve real container name from pod cache

### DIFF
--- a/internal/resource/informer.go
+++ b/internal/resource/informer.go
@@ -213,7 +213,7 @@ func (ri *resourceInformer) Refresh() error {
 	containersNoPod := []string{}
 	if ri.podInformer != nil {
 		for _, container := range containersRunning {
-			podInfo, err := ri.podInformer.PodInfo(container.ID)
+			podInfo, containerName, err := ri.podInformer.LookupByContainerID(container.ID)
 			if err != nil {
 				if errors.Is(err, pod.ErrNoPod) {
 					containersNoPod = append(containersNoPod, container.ID)
@@ -229,6 +229,7 @@ func (ri *resourceInformer) Refresh() error {
 				Namespace: podInfo.Namespace,
 			}
 			container.Pod = pod
+			container.Name = containerName
 			_, seen := podsRunning[pod.ID]
 			// reset CPU Time of the pod if it is getting added to the running list for the first time
 			// in the subsequent iteration, the CPUTimeDelta should be incremented by container's CPUTimeDelta

--- a/internal/resource/mock_procfs_test.go
+++ b/internal/resource/mock_procfs_test.go
@@ -102,12 +102,12 @@ func (m *mockPodInformer) Run(ctx context.Context) error {
 	return args.Error(0)
 }
 
-func (m *mockPodInformer) PodInfo(containerID string) (*pod.PodInfo, error) {
+func (m *mockPodInformer) LookupByContainerID(containerID string) (*pod.PodInfo, string, error) {
 	args := m.Called(containerID)
 	if podInfo, ok := args.Get(0).(*pod.PodInfo); ok {
-		return podInfo, args.Error(1)
+		return podInfo, args.String(1), args.Error(2)
 	}
-	return nil, args.Error(1)
+	return nil, args.String(1), args.Error(2)
 }
 
 func (m *mockPodInformer) Name() string {


### PR DESCRIPTION
- use pod cache in pod informer to get container name as in kubernetes cluster
- added tests

![image](https://github.com/user-attachments/assets/b8a6482d-33a6-4a8e-8f4e-0205fbbff314)

