### PR TITLE
[feat] using exporter-toolkit/web for web config

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/exporter-toolkit/web"
+	"github.com/sustainable-computing-io/kepler/config"
 	"github.com/sustainable-computing-io/kepler/internal/service"
 )
 
@@ -23,22 +24,19 @@ type APIService interface {
 // APIServer implements APIServer
 type APIServer struct {
 	// input
-	logger      *slog.Logger
-	listenAddrs []string
-
+	logger *slog.Logger
 	// http
 	server              *http.Server
 	mux                 *http.ServeMux
 	endpointDescription string
-	webCfgPath          string
+	webConfig           *web.FlagConfig
 }
 
 var _ APIService = (*APIServer)(nil)
 
 type Opts struct {
-	logger      *slog.Logger
-	listenAddrs []string
-	webCfgPath  string
+	logger    *slog.Logger
+	webConfig *web.FlagConfig
 }
 
 // OptionFn is a function sets one more more options in Opts struct
@@ -51,25 +49,31 @@ func WithLogger(logger *slog.Logger) OptionFn {
 	}
 }
 
-// WithListenAddress sets the listening addresses for the APIServer
-func WithListenAddress(addr []string) OptionFn {
+// WithListen sets the listening addresses and webconfig path for the APIServer
+func WithListen(addr []string, path string) OptionFn {
 	return func(o *Opts) {
-		o.listenAddrs = addr
+		o.webConfig = &web.FlagConfig{
+			WebListenAddresses: &addr,
+			WebConfigFile:      &path,
+		}
 	}
 }
 
-func WithWebConfig(path string) OptionFn {
+func WithWebConfig(Config *web.FlagConfig) OptionFn {
 	return func(o *Opts) {
-		o.webCfgPath = path
+		o.webConfig = Config
 	}
 }
 
 // DefaultOpts returns the default options
 func DefaultOpts() Opts {
+	TLSconfig := ""
 	return Opts{
-		logger:      slog.Default(),
-		listenAddrs: []string{":28282"}, // Default HTTP Port
-		webCfgPath:  "",                 // Not present by default
+		logger: slog.Default(),
+		webConfig: &web.FlagConfig{
+			WebListenAddresses: &[]string{config.DefaultPort},
+			WebConfigFile:      &TLSconfig,
+		},
 	}
 }
 
@@ -85,11 +89,10 @@ func NewAPIServer(applyOpts ...OptionFn) *APIServer {
 		Handler: mux,
 	}
 	apiServer := &APIServer{
-		logger:      opts.logger.With("service", "api-server"),
-		listenAddrs: opts.listenAddrs,
-		mux:         mux,
-		server:      server,
-		webCfgPath:  opts.webCfgPath,
+		logger:    opts.logger.With("service", "api-server"),
+		mux:       mux,
+		server:    server,
+		webConfig: opts.webConfig,
 	}
 
 	return apiServer
@@ -100,11 +103,7 @@ func (s *APIServer) Name() string {
 }
 
 func (s *APIServer) Init() error {
-	s.logger.Info("Initializing HTTP server", "listening-on", s.listenAddrs)
-	if len(s.listenAddrs) == 0 {
-		return fmt.Errorf("no listening address provided")
-	}
-
+	s.logger.Info("Initializing kepler server")
 	// create landing page that shows all available endpoints
 	s.mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// Only respond to the root path
@@ -134,23 +133,19 @@ func (s *APIServer) Init() error {
 }
 
 func (s *APIServer) Run(ctx context.Context) error {
-	s.logger.Info("Running HTTP server", "listening-on", s.listenAddrs)
+	s.logger.Info("Running kepler server")
 	errCh := make(chan error)
 	go func() {
-		webCfg := &web.FlagConfig{
-			WebListenAddresses: &s.listenAddrs,
-			WebConfigFile:      &s.webCfgPath,
-		}
-		errCh <- web.ListenAndServe(s.server, webCfg, s.logger)
+		errCh <- web.ListenAndServe(s.server, s.webConfig, s.logger)
 	}()
 
 	select {
 	case <-ctx.Done():
-		s.logger.Info("shutting down HTTP server on context done")
+		s.logger.Info("shutting down kepler server on context done")
 		return nil
 
 	case err := <-errCh:
-		s.logger.Error("HTTP server returned an error", "error", err)
+		s.logger.Error("kepler server returned an error", "error", err)
 		return err
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -60,14 +60,14 @@ func TestNewAPIServer(t *testing.T) {
 	}, {
 		name: "with custom listen address",
 		opts: []OptionFn{
-			WithListenAddress([]string{":8080", ":8081"}),
+			WithListen([]string{":8080", ":8081"}, ""),
 		},
 		serviceName: "api-server",
 	}, {
 		name: "with multiple options",
 		opts: []OptionFn{
 			WithLogger(slog.Default().With("test", "custom")),
-			WithListenAddress([]string{":9090"}),
+			WithListen([]string{":9090"}, ""),
 		},
 		serviceName: "api-server",
 	}}
@@ -85,11 +85,10 @@ func TestNewAPIServer(t *testing.T) {
 	// check listen address
 	{
 		server := NewAPIServer(
-			WithListenAddress([]string{":8080", ":8081"}),
+			WithListen([]string{":8080", ":8081"}, ""),
 		)
 
 		assert.NotNil(t, server)
-		assert.Equal(t, []string{":8080", ":8081"}, server.listenAddrs)
 	}
 }
 
@@ -167,13 +166,6 @@ func TestAPIServer_Register(t *testing.T) {
 	})
 }
 
-func TestAPIServer_InitWithNoListenAddr(t *testing.T) {
-	server := NewAPIServer(WithListenAddress([]string{}))
-	err := server.Init()
-	assert.Error(t, err, "Init should fail with no listen address")
-	assert.Contains(t, err.Error(), "no listening address provided")
-}
-
 func TestAPIServer_InitWithContextCancellation(t *testing.T) {
 	server := NewAPIServer()
 
@@ -247,7 +239,7 @@ func TestAPIServer_PortConflict(t *testing.T) {
 	})
 
 	// Create our API server with the same port
-	apiServer := NewAPIServer(WithListenAddress([]string{addr}))
+	apiServer := NewAPIServer(WithListen([]string{addr}, ""))
 
 	// Initing the API server on the same port should fail due to port conflict
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -281,7 +273,7 @@ func TestAPIServer_RootEndpoint(t *testing.T) {
 
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 
-	server := NewAPIServer(WithListenAddress([]string{addr}))
+	server := NewAPIServer(WithListen([]string{addr}, ""))
 	assert.NoError(t, server.Init())
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_tls_test.go
+++ b/internal/server/server_tls_test.go
@@ -227,8 +227,7 @@ tls_server_config:
 		addr := fmt.Sprintf("127.0.0.1:%d", port)
 
 		server := NewAPIServer(
-			WithListenAddress([]string{addr}),
-			WithWebConfig(webConfigFile))
+			WithListen([]string{addr}, webConfigFile))
 		assert.NoError(t, server.Init())
 
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -281,8 +280,7 @@ tls_server_config:
 		addr := fmt.Sprintf("127.0.0.1:%d", port)
 
 		server := NewAPIServer(
-			WithListenAddress([]string{addr}),
-			WithWebConfig(webConfigFile))
+			WithListen([]string{addr}, webConfigFile))
 		assert.NoError(t, server.Init())
 
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -332,8 +330,7 @@ tls_server_config:
 		addr := fmt.Sprintf("127.0.0.1:%d", port)
 
 		server := NewAPIServer(
-			WithListenAddress([]string{addr}),
-			WithWebConfig(webConfigFile))
+			WithListen([]string{addr}, webConfigFile))
 		assert.NoError(t, server.Init())
 
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -383,8 +380,7 @@ tls_server_config:
 		addr := fmt.Sprintf("127.0.0.1:%d", port)
 
 		server := NewAPIServer(
-			WithListenAddress([]string{addr}),
-			WithWebConfig(webConfigFile))
+			WithListen([]string{addr}, webConfigFile))
 		assert.NoError(t, server.Init())
 
 		errCh := make(chan error, 1)


### PR DESCRIPTION
Let's use this PR to discuss how we integrate with exporter-toolkit/web.
From exporter-toolkit/web SDK, we need `*web.FlagConfig` structure ready before we start the server.
but the question here is how we make it in our configuration and code structure.
we now have config in yaml file and those flag reg in same pattern, if we fully moved to exporter-toolkit/web as one example impl in this PR shows.
We still need all config in one place, so that it will not impact main.go, but somehow breaks config.go in yaml and flag reg process.
The benefits here IMO, is that we can leave web config to upstream repo for feature supports and it seems for an exporter we don't need to support listen on multi socket, so... just a default port and default TLS config file will be good enough.