### PR TITLE
refactor(pod): simplify Lookup returning Container Name

### DIFF
--- a/internal/resource/mock_procfs_test.go
+++ b/internal/resource/mock_procfs_test.go
@@ -102,12 +102,12 @@ func (m *mockPodInformer) Run(ctx context.Context) error {
 	return args.Error(0)
 }
 
-func (m *mockPodInformer) LookupByContainerID(containerID string) (*pod.PodInfo, string, error) {
+func (m *mockPodInformer) LookupByContainerID(containerID string) (*pod.ContainerInfo, bool, error) {
 	args := m.Called(containerID)
-	if podInfo, ok := args.Get(0).(*pod.PodInfo); ok {
-		return podInfo, args.String(1), args.Error(2)
+	if podInfo, ok := args.Get(0).(*pod.ContainerInfo); ok {
+		return podInfo, args.Bool(1), args.Error(2)
 	}
-	return nil, args.String(1), args.Error(2)
+	return nil, args.Bool(1), args.Error(2)
 }
 
 func (m *mockPodInformer) Name() string {

--- a/internal/resource/procfs_reader_test.go
+++ b/internal/resource/procfs_reader_test.go
@@ -477,11 +477,12 @@ func TestRefresh_PodInformer(t *testing.T) {
 
 		mockPodInformer := new(mockPodInformer)
 		mockPodInformer.On("LookupByContainerID", containerID).Return(
-			&pod.PodInfo{
-				ID:        "pod123",
-				Name:      "mypod",
-				Namespace: "default",
-			}, "my-container", nil,
+			&pod.ContainerInfo{
+				PodID:         "pod123",
+				PodName:       "mypod",
+				Namespace:     "default",
+				ContainerName: "my-container",
+			}, true, nil,
 		)
 
 		informer, err := NewInformer(WithProcReader(mockProcFS), WithPodInformer(mockPodInformer))
@@ -516,7 +517,7 @@ func TestRefresh_PodInformer(t *testing.T) {
 		mockProcFS.On("CPUUsageRatio").Return(0.5, nil).Once()
 
 		mockPodInformer := new(mockPodInformer)
-		mockPodInformer.On("LookupByContainerID", containerID).Return(nil, "", pod.ErrNoPod)
+		mockPodInformer.On("LookupByContainerID", containerID).Return(nil, false, nil)
 
 		informer, err := NewInformer(
 			WithProcReader(mockProcFS),
@@ -556,7 +557,7 @@ func TestRefresh_PodInformer(t *testing.T) {
 
 		podError := errors.New("general error")
 		mockPodInformer := new(mockPodInformer)
-		mockPodInformer.On("LookupByContainerID", containerID).Return(nil, "", podError)
+		mockPodInformer.On("LookupByContainerID", containerID).Return(nil, false, podError)
 
 		informer, err := NewInformer(
 			WithProcReader(mockProcFS),
@@ -602,11 +603,12 @@ func TestLookupByContainerID_UpdatesContainerName(t *testing.T) {
 		// Mock pod informer that returns container name from pod info
 		mockPodInformer := new(mockPodInformer)
 		mockPodInformer.On("LookupByContainerID", containerID).Return(
-			&pod.PodInfo{
-				ID:        "pod-12345",
-				Name:      "test-app-pod",
-				Namespace: "production",
-			}, "app-container-from-pod", nil, // Container name comes from pod status
+			&pod.ContainerInfo{
+				PodID:         "pod-12345",
+				PodName:       "test-app-pod",
+				Namespace:     "production",
+				ContainerName: "app-container-from-pod", // Container name comes from pod status
+			}, true, nil,
 		)
 
 		informer, err := NewInformer(
@@ -671,11 +673,12 @@ func TestLookupByContainerID_UpdatesContainerName(t *testing.T) {
 		// Pod informer returns different name than environment
 		mockPodInformer := new(mockPodInformer)
 		mockPodInformer.On("LookupByContainerID", containerID).Return(
-			&pod.PodInfo{
-				ID:        "web-pod-67890",
-				Name:      "web-server",
-				Namespace: "default",
-			}, "nginx-from-pod", nil, // Different from environment name
+			&pod.ContainerInfo{
+				PodID:         "web-pod-67890",
+				PodName:       "web-server",
+				Namespace:     "default",
+				ContainerName: "nginx-from-pod", // Different from environment name
+			}, true, nil,
 		)
 
 		informer, err := NewInformer(


### PR DESCRIPTION
This refactoring improves the API by:
  1. Making the "not found" case explicit with a boolean rather than a special error
  2. Consolidating related information into a single ContainerInfo struct

Changes:
  - modify LookupByContainerID to return (ContainerInfo, bool, error) instead of (PodInfo, string, error)
  - Replace PodInfo struct with ContainerInfo that includes container name
  - Remove ErrNoPod error, use boolean flag to indicate found/not found


--- 
For more context ... returning found/not-found follows the go idiom of returning bool if an item ins't found instead of returning `error` 
E.g. from docs .. 

```
os.LookupEnv -  func LookupEnv(key string) (value string, ok bool)
sync.Map.Load - func (m *Map) Load(key any) (value any, ok bool)
strings.Cut - string splitting: -   func Cut(s, sep string) (before, after string, found bool)
```
