### PR TITLE
refactor(resource): split Refresh into smaller functions with parallel execution

### DIFF
--- a/internal/resource/pod_test.go
+++ b/internal/resource/pod_test.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPodClone(t *testing.T) {
+	t.Run("Clone full Pod with all fields", func(t *testing.T) {
+		original := &Pod{
+			ID:           "pod-123",
+			Name:         "test-pod",
+			Namespace:    "default",
+			CPUTotalTime: 42.5,
+			CPUTimeDelta: 10.2,
+		}
+
+		clone := original.Clone()
+		require.NotNil(t, clone)
+		assert.Equal(t, original.ID, clone.ID)
+		assert.Equal(t, original.Name, clone.Name)
+		assert.Equal(t, original.Namespace, clone.Namespace)
+		// CPU times should not be copied in Clone
+		assert.Equal(t, float64(0), clone.CPUTotalTime)
+		assert.Equal(t, float64(0), clone.CPUTimeDelta)
+
+		// Verify they are separate objects
+		assert.NotSame(t, original, clone)
+	})
+
+	t.Run("Clone nil Pod", func(t *testing.T) {
+		var nilPod *Pod
+		nilClone := nilPod.Clone()
+		assert.Nil(t, nilClone, "Cloning nil Pod should return nil")
+	})
+}

--- a/internal/resource/vm_test.go
+++ b/internal/resource/vm_test.go
@@ -357,3 +357,55 @@ func TestVMClone(t *testing.T) {
 		assert.Nil(t, nilClone, "Cloning nil VM should return nil")
 	})
 }
+
+func TestExtractVMID(t *testing.T) {
+	tests := []struct {
+		name       string
+		cmdline    []string
+		hypervisor Hypervisor
+		expected   string
+	}{{
+		name:       "no UUID or name returns empty",
+		cmdline:    []string{"/usr/bin/qemu-system-x86_64", "-m", "1024"},
+		hypervisor: KVMHypervisor,
+		expected:   "",
+	}, {
+		name:       "unknown hypervisor returns empty",
+		cmdline:    []string{"/usr/bin/qemu-system-x86_64", "-m", "1024"},
+		hypervisor: UnknownHypervisor,
+		expected:   "",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id := extractVMID(tc.cmdline, tc.hypervisor)
+			assert.Equal(t, tc.expected, id)
+		})
+	}
+}
+
+func TestVMNameFromCmdLine(t *testing.T) {
+	tests := []struct {
+		name       string
+		cmdline    []string
+		hypervisor Hypervisor
+		expected   string
+	}{{
+		name:       "empty cmdline returns empty",
+		cmdline:    []string{},
+		hypervisor: KVMHypervisor,
+		expected:   "",
+	}, {
+		name:       "non-KVM hypervisor returns empty",
+		cmdline:    []string{"/usr/bin/qemu-system-x86_64", "-name", "test"},
+		hypervisor: UnknownHypervisor,
+		expected:   "",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			name := vmNameFromCmdLine(tc.cmdline, tc.hypervisor)
+			assert.Equal(t, tc.expected, name)
+		})
+	}
+}


### PR DESCRIPTION

This change breaks down the Refresh method into smaller functions following Single Responsibility Principle. Changes are ..

- refreshProcesses: categorizes processes during initial scan
- refreshContainers/refreshVMs: build workload-specific collections
- refreshPods: handles container-to-pod mapping (depends on containers)
- refreshNode: calculates node-level aggregations

Note that this change introduces parallel execution using goroutines for independent workloads (containers+pods, VMs, and node calculations) while maintaining proper dependency ordering.

Also adds test coverage for concurrency testing, missing coverage and error handling scenarios.