### PR TITLE
nit: remove double validation on folder when register flag

### DIFF
--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -105,6 +105,12 @@ func parseArgsAndConfig() (*config.Config, error) {
 		return nil, err
 	}
 
+	// Validate config before run
+	if err := cfg.Validate(); err != nil {
+		logger.Error("Error validate command line flags", "error", err.Error())
+		return nil, err
+	}
+
 	return cfg, nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -186,10 +186,6 @@ func Load(r io.Reader) (*Config, error) {
 	}
 	cfg.sanitize()
 
-	if err := cfg.Validate(); err != nil {
-		return nil, err
-	}
-
 	return cfg, nil
 }
 
@@ -237,8 +233,8 @@ func RegisterFlags(app *kingpin.Application) ConfigUpdaterFn {
 	logLevel := app.Flag(LogLevelFlag, "Logging level: debug, info, warn, error").Default("info").Enum("debug", "info", "warn", "error")
 	logFormat := app.Flag(LogFormatFlag, "Logging format: text or json").Default("text").Enum("text", "json")
 	// host
-	hostSysFS := app.Flag(HostSysFSFlag, "Host sysfs path").Default("/sys").ExistingDir()
-	hostProcFS := app.Flag(HostProcFSFlag, "Host procfs path").Default("/proc").ExistingDir()
+	hostSysFS := app.Flag(HostSysFSFlag, "Host sysfs path").Default("/sys").String()
+	hostProcFS := app.Flag(HostProcFSFlag, "Host procfs path").Default("/proc").String()
 
 	// monitor
 	monitorInterval := app.Flag(MonitorIntervalFlag,
@@ -308,7 +304,7 @@ func RegisterFlags(app *kingpin.Application) ConfigUpdaterFn {
 		}
 
 		cfg.sanitize()
-		return cfg.Validate()
+		return nil
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -67,9 +67,9 @@ log:
 `
 	reader := strings.NewReader(yamlData)
 	cfg, err := Load(reader)
-	assert.Error(t, err)
+	assert.NoError(t, err)
+	err = cfg.Validate()
 	assert.Contains(t, err.Error(), "invalid configuration")
-	assert.Nil(t, cfg)
 }
 
 func TestCommandLinePrecedence(t *testing.T) {
@@ -359,7 +359,8 @@ func TestConfigValidation(t *testing.T) {
 			_, parseErr := app.Parse(tc.args)
 			assert.Error(t, parseErr, "expected test args to produce a parse error")
 			cfg := DefaultConfig()
-			err := updateConfig(cfg)
+			updateConfig(cfg)
+			err := cfg.Validate()
 			assert.Error(t, err, "invalid input should be rejected by validation")
 			assert.Contains(t, err.Error(), tc.expectedError)
 		})


### PR DESCRIPTION
I suppose we double validate `/sys` or `/proc` folder if we follow the default settings, or if we set up another folder other than `/sys` or `/proc` we still validate those folder during flag reg process and we have another validation function to check if the config is validated. So in this PR, just remove validation in flag reg process.