### PR TITLE
feat(metrics): add configurable metrics level filtering for Prometheus exporter

### DIFF
--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -194,11 +194,15 @@ func createServices(logger *slog.Logger, cfg *config.Config) ([]service.Service,
 func createPrometheusExporter(logger *slog.Logger, cfg *config.Config, apiServer *server.APIServer, pm *monitor.PowerMonitor) (*prometheus.Exporter, error) {
 	logger.Debug("Creating Prometheus exporter")
 
+	// Use metrics level from configuration (already parsed)
+	metricsLevel := cfg.Exporter.Prometheus.MetricsLevel
+
 	collectors, err := prometheus.CreateCollectors(
 		pm,
 		prometheus.WithLogger(logger),
 		prometheus.WithProcFSPath(cfg.Host.ProcFS),
 		prometheus.WithNodeName(cfg.Kube.Node),
+		prometheus.WithMetricsLevel(metricsLevel),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Prometheus collectors: %w", err)

--- a/compose/dev/kepler-dev/etc/kepler/config.yaml
+++ b/compose/dev/kepler-dev/etc/kepler/config.yaml
@@ -36,6 +36,10 @@ exporter:
     debugCollectors:
       - go
       - process
+    metricsLevel:
+      - node
+      - container
+      - process
 
 debug: # debug related config
   pprof: # pprof related config

--- a/hack/gen-metric-docs/main.go
+++ b/hack/gen-metric-docs/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sustainable-computing-io/kepler/internal/exporter/prometheus/collector"
+	"github.com/sustainable-computing-io/kepler/internal/exporter/prometheus/metrics"
 	"github.com/sustainable-computing-io/kepler/internal/monitor"
 )
 
@@ -260,7 +261,7 @@ func main() {
 	fmt.Println("Creating collectors...")
 	// Create a logger for the collectors
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	powerCollector := collector.NewPowerCollector(mockMonitor, "test-node", logger)
+	powerCollector := collector.NewPowerCollector(mockMonitor, "test-node", logger, metrics.MetricsLevelNode|metrics.MetricsLevelProcess|metrics.MetricsLevelContainer|metrics.MetricsLevelVM|metrics.MetricsLevelPod)
 	fmt.Println("Created power collector")
 	buildInfoCollector := collector.NewKeplerBuildInfoCollector()
 	fmt.Println("Created build info collector")

--- a/internal/exporter/prometheus/collector/power_collector_concurrency_test.go
+++ b/internal/exporter/prometheus/collector/power_collector_concurrency_test.go
@@ -19,6 +19,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/sustainable-computing-io/kepler/internal/device"
+	"github.com/sustainable-computing-io/kepler/internal/exporter/prometheus/metrics"
 	"github.com/sustainable-computing-io/kepler/internal/monitor"
 )
 
@@ -40,7 +41,7 @@ func TestPowerCollectorConcurrency(t *testing.T) {
 		musT(device.NewFakeCPUMeter(nil)),
 		monitor.WithResourceInformer(ri),
 	)
-	collector := NewPowerCollector(fakeMonitor, "test-node", newLogger())
+	collector := NewPowerCollector(fakeMonitor, "test-node", newLogger(), metrics.MetricsLevelNode|metrics.MetricsLevelProcess|metrics.MetricsLevelContainer|metrics.MetricsLevelVM|metrics.MetricsLevelPod)
 
 	assert.NoError(t, fakeMonitor.Init())
 
@@ -155,7 +156,7 @@ func TestPowerCollectorWithRegistry(t *testing.T) {
 	}
 	mockMonitor.On("Snapshot").Return(snapshot, nil)
 
-	collector := NewPowerCollector(mockMonitor, "test-node", newLogger())
+	collector := NewPowerCollector(mockMonitor, "test-node", newLogger(), metrics.MetricsLevelNode|metrics.MetricsLevelProcess|metrics.MetricsLevelContainer|metrics.MetricsLevelVM|metrics.MetricsLevelPod)
 	mockMonitor.TriggerUpdate()
 	time.Sleep(10 * time.Millisecond)
 
@@ -261,7 +262,7 @@ func TestUpdateDuringCollection(t *testing.T) {
 			},
 		}, nil)
 
-	collector := NewPowerCollector(mockMonitor, "test-node", newLogger())
+	collector := NewPowerCollector(mockMonitor, "test-node", newLogger(), metrics.MetricsLevelNode|metrics.MetricsLevelProcess|metrics.MetricsLevelContainer|metrics.MetricsLevelVM|metrics.MetricsLevelPod)
 	mockMonitor.TriggerUpdate() // collector should now start building descriptors
 	time.Sleep(10 * time.Millisecond)
 
@@ -332,7 +333,7 @@ func TestConcurrentRegistration(t *testing.T) {
 		monitor.WithResourceInformer(ri),
 	)
 
-	collector := NewPowerCollector(fakeMonitor, "test-node", newLogger())
+	collector := NewPowerCollector(fakeMonitor, "test-node", newLogger(), metrics.MetricsLevelNode|metrics.MetricsLevelProcess|metrics.MetricsLevelContainer|metrics.MetricsLevelVM|metrics.MetricsLevelPod)
 	assert.NoError(t, fakeMonitor.Init())
 
 	go func() {
@@ -388,7 +389,7 @@ func TestFastCollectAndDescribe(t *testing.T) {
 		musT(device.NewFakeCPUMeter(nil)),
 		monitor.WithResourceInformer(ri),
 	)
-	collector := NewPowerCollector(fakeMonitor, "test-node", newLogger())
+	collector := NewPowerCollector(fakeMonitor, "test-node", newLogger(), metrics.MetricsLevelNode|metrics.MetricsLevelProcess|metrics.MetricsLevelContainer|metrics.MetricsLevelVM|metrics.MetricsLevelPod)
 
 	assert.NoError(t, fakeMonitor.Init())
 

--- a/internal/exporter/prometheus/metrics/level.go
+++ b/internal/exporter/prometheus/metrics/level.go
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Level represents the metrics level configuration using bit patterns
+type Level uint32
+
+const (
+	// Individual metric levels using bit patterns
+	MetricsLevelNode      Level = 1 << iota // 1
+	MetricsLevelProcess                     // 2
+	MetricsLevelContainer                   // 4
+	MetricsLevelVM                          // 8
+	MetricsLevelPod                         // 16
+)
+
+// String returns the string representation of the level
+func (l Level) String() string {
+	var levels []string
+	if l.IsNodeEnabled() {
+		levels = append(levels, "node")
+	}
+	if l.IsProcessEnabled() {
+		levels = append(levels, "process")
+	}
+	if l.IsContainerEnabled() {
+		levels = append(levels, "container")
+	}
+	if l.IsVMEnabled() {
+		levels = append(levels, "vm")
+	}
+	if l.IsPodEnabled() {
+		levels = append(levels, "pod")
+	}
+	return strings.Join(levels, ",")
+}
+
+// IsNodeEnabled checks if node metrics are enabled
+func (l Level) IsNodeEnabled() bool {
+	return l&MetricsLevelNode != 0
+}
+
+// IsProcessEnabled checks if process metrics are enabled
+func (l Level) IsProcessEnabled() bool {
+	return l&MetricsLevelProcess != 0
+}
+
+// IsContainerEnabled checks if container metrics are enabled
+func (l Level) IsContainerEnabled() bool {
+	return l&MetricsLevelContainer != 0
+}
+
+// IsVMEnabled checks if VM metrics are enabled
+func (l Level) IsVMEnabled() bool {
+	return l&MetricsLevelVM != 0
+}
+
+// IsPodEnabled checks if pod metrics are enabled
+func (l Level) IsPodEnabled() bool {
+	return l&MetricsLevelPod != 0
+}
+
+// ParseLevel parses a slice of strings into a Level
+func ParseLevel(levels []string) (Level, error) {
+	if len(levels) == 0 {
+		return MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod, nil
+	}
+
+	var result Level
+	for _, level := range levels {
+		switch strings.ToLower(strings.TrimSpace(level)) {
+		case "node":
+			result |= MetricsLevelNode
+		case "process":
+			result |= MetricsLevelProcess
+		case "container":
+			result |= MetricsLevelContainer
+		case "vm":
+			result |= MetricsLevelVM
+		case "pod":
+			result |= MetricsLevelPod
+		default:
+			return 0, fmt.Errorf("unknown metrics level: %s", level)
+		}
+	}
+
+	return result, nil
+}
+
+// ValidLevels returns the list of valid metrics levels
+func ValidLevels() []string {
+	return []string{"node", "process", "container", "vm", "pod"}
+}
+
+// MarshalYAML implements yaml.Marshaler interface
+func (l Level) MarshalYAML() (interface{}, error) {
+	var levels []string
+	if l.IsNodeEnabled() {
+		levels = append(levels, "node")
+	}
+	if l.IsProcessEnabled() {
+		levels = append(levels, "process")
+	}
+	if l.IsContainerEnabled() {
+		levels = append(levels, "container")
+	}
+	if l.IsVMEnabled() {
+		levels = append(levels, "vm")
+	}
+	if l.IsPodEnabled() {
+		levels = append(levels, "pod")
+	}
+
+	// Return as slice for multiple levels, single string for one level
+	if len(levels) == 1 {
+		return levels[0], nil
+	}
+	return levels, nil
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler interface
+func (l *Level) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// Try to unmarshal as a string first
+	var single string
+	if err := unmarshal(&single); err == nil {
+		parsed, parseErr := ParseLevel([]string{single})
+		if parseErr != nil {
+			return parseErr
+		}
+		*l = parsed
+		return nil
+	}
+
+	// Try to unmarshal as a slice of strings
+	var multiple []string
+	if err := unmarshal(&multiple); err == nil {
+		parsed, parseErr := ParseLevel(multiple)
+		if parseErr != nil {
+			return parseErr
+		}
+		*l = parsed
+		return nil
+	}
+
+	return fmt.Errorf("cannot unmarshal metrics level: must be a string or array of strings")
+}

--- a/internal/exporter/prometheus/metrics/level_test.go
+++ b/internal/exporter/prometheus/metrics/level_test.go
@@ -1,0 +1,348 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestLevel_IsEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		level    Level
+		expected map[string]bool
+	}{
+		{
+			name:  "All levels",
+			level: MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+			expected: map[string]bool{
+				"node":      true,
+				"process":   true,
+				"container": true,
+				"vm":        true,
+				"pod":       true,
+			},
+		},
+		{
+			name:  "Node only",
+			level: MetricsLevelNode,
+			expected: map[string]bool{
+				"node":      true,
+				"process":   false,
+				"container": false,
+				"vm":        false,
+				"pod":       false,
+			},
+		},
+		{
+			name:  "Node and Process",
+			level: MetricsLevelNode | MetricsLevelProcess,
+			expected: map[string]bool{
+				"node":      true,
+				"process":   true,
+				"container": false,
+				"vm":        false,
+				"pod":       false,
+			},
+		},
+		{
+			name:  "Container, VM, and Pod",
+			level: MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+			expected: map[string]bool{
+				"node":      false,
+				"process":   false,
+				"container": true,
+				"vm":        true,
+				"pod":       true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected["node"], tt.level.IsNodeEnabled())
+			assert.Equal(t, tt.expected["process"], tt.level.IsProcessEnabled())
+			assert.Equal(t, tt.expected["container"], tt.level.IsContainerEnabled())
+			assert.Equal(t, tt.expected["vm"], tt.level.IsVMEnabled())
+			assert.Equal(t, tt.expected["pod"], tt.level.IsPodEnabled())
+		})
+	}
+}
+
+func TestLevel_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		level    Level
+		expected string
+	}{
+		{
+			name:     "All levels",
+			level:    MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+			expected: "node,process,container,vm,pod",
+		},
+		{
+			name:     "Node only",
+			level:    MetricsLevelNode,
+			expected: "node",
+		},
+		{
+			name:     "Process only",
+			level:    MetricsLevelProcess,
+			expected: "process",
+		},
+		{
+			name:     "Node and Process",
+			level:    MetricsLevelNode | MetricsLevelProcess,
+			expected: "node,process",
+		},
+		{
+			name:     "Container, VM, and Pod",
+			level:    MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+			expected: "container,vm,pod",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.level.String())
+		})
+	}
+}
+
+func TestParseLevel(t *testing.T) {
+	tests := []struct {
+		name        string
+		levels      []string
+		expected    Level
+		expectError bool
+	}{
+		{
+			name:        "Empty slice",
+			levels:      []string{},
+			expected:    MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+			expectError: false,
+		},
+		{
+			name:        "Single level",
+			levels:      []string{"node"},
+			expected:    MetricsLevelNode,
+			expectError: false,
+		},
+		{
+			name:        "Multiple levels",
+			levels:      []string{"node", "process"},
+			expected:    MetricsLevelNode | MetricsLevelProcess,
+			expectError: false,
+		},
+		{
+			name:        "All levels",
+			levels:      []string{"node", "process", "container", "vm", "pod"},
+			expected:    MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+			expectError: false,
+		},
+		{
+			name:        "Case insensitive",
+			levels:      []string{"NODE", "Process", "CONTAINER"},
+			expected:    MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer,
+			expectError: false,
+		},
+		{
+			name:        "With whitespace",
+			levels:      []string{" node ", " process "},
+			expected:    MetricsLevelNode | MetricsLevelProcess,
+			expectError: false,
+		},
+		{
+			name:        "Invalid level",
+			levels:      []string{"invalid"},
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name:        "Mixed valid and invalid",
+			levels:      []string{"node", "invalid"},
+			expected:    0,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseLevel(tt.levels)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestValidLevels(t *testing.T) {
+	expected := []string{"node", "process", "container", "vm", "pod"}
+	result := ValidLevels()
+	assert.Equal(t, expected, result)
+}
+
+func TestBitPatterns(t *testing.T) {
+	// Test that bit patterns are unique powers of 2
+	assert.Equal(t, Level(1), MetricsLevelNode)      // 1 << 1 = 2 (corrected after fix)
+	assert.Equal(t, Level(2), MetricsLevelProcess)   // 1 << 2 = 4
+	assert.Equal(t, Level(4), MetricsLevelContainer) // 1 << 3 = 8
+	assert.Equal(t, Level(8), MetricsLevelVM)        // 1 << 4 = 16
+	assert.Equal(t, Level(16), MetricsLevelPod)      // 1 << 5 = 32
+
+	// Test that combined levels work correctly
+	expected := MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod
+	assert.Equal(t, expected, MetricsLevelNode|MetricsLevelProcess|MetricsLevelContainer|MetricsLevelVM|MetricsLevelPod)
+}
+
+func TestLevel_MarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		level    Level
+		expected string
+	}{
+		{
+			name:     "All levels",
+			level:    MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+			expected: "- node\n- process\n- container\n- vm\n- pod\n",
+		},
+		{
+			name:     "Node only",
+			level:    MetricsLevelNode,
+			expected: "node\n",
+		},
+		{
+			name:     "Process only",
+			level:    MetricsLevelProcess,
+			expected: "process\n",
+		},
+		{
+			name:     "Node and Process",
+			level:    MetricsLevelNode | MetricsLevelProcess,
+			expected: "- node\n- process\n",
+		},
+		{
+			name:     "Container, VM, and Pod",
+			level:    MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+			expected: "- container\n- vm\n- pod\n",
+		},
+		{
+			name:     "Pod and Node (17)",
+			level:    MetricsLevelPod | MetricsLevelNode, // 16 + 1 = 17
+			expected: "- node\n- pod\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := yaml.Marshal(tt.level)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+		})
+	}
+}
+
+func TestLevel_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name        string
+		yamlData    string
+		expected    Level
+		expectError bool
+	}{
+		{
+			name:        "Node string",
+			yamlData:    "node",
+			expected:    MetricsLevelNode,
+			expectError: false,
+		},
+		{
+			name:        "Process string",
+			yamlData:    "process",
+			expected:    MetricsLevelProcess,
+			expectError: false,
+		},
+		{
+			name:        "Array of levels",
+			yamlData:    "- node\n- process",
+			expected:    MetricsLevelNode | MetricsLevelProcess,
+			expectError: false,
+		},
+		{
+			name:        "Array with all levels",
+			yamlData:    "- node\n- process\n- container\n- vm\n- pod",
+			expected:    MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+			expectError: false,
+		},
+		{
+			name:        "Pod and Node array (should be 17)",
+			yamlData:    "- node\n- pod",
+			expected:    MetricsLevelPod | MetricsLevelNode, // 16 + 1 = 17
+			expectError: false,
+		},
+		{
+			name:        "Case insensitive",
+			yamlData:    "- NODE\n- Process",
+			expected:    MetricsLevelNode | MetricsLevelProcess,
+			expectError: false,
+		},
+		{
+			name:        "Invalid level string",
+			yamlData:    "invalid",
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name:        "Invalid level in array",
+			yamlData:    "- node\n- invalid",
+			expected:    0,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var level Level
+			err := yaml.Unmarshal([]byte(tt.yamlData), &level)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, level)
+			}
+		})
+	}
+}
+
+func TestLevel_YAMLRoundTrip(t *testing.T) {
+	tests := []Level{
+		MetricsLevelNode,
+		MetricsLevelProcess,
+		MetricsLevelNode | MetricsLevelProcess,
+		MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+		MetricsLevelPod | MetricsLevelNode, // 17
+		MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+	}
+
+	for _, original := range tests {
+		t.Run(original.String(), func(t *testing.T) {
+			// Marshal to YAML
+			data, err := yaml.Marshal(original)
+			assert.NoError(t, err)
+
+			// Unmarshal back
+			var roundTrip Level
+			err = yaml.Unmarshal(data, &roundTrip)
+			assert.NoError(t, err)
+
+			// Should be equal
+			assert.Equal(t, original, roundTrip)
+		})
+	}
+}


### PR DESCRIPTION


  - Add configurable metrics level filtering to control which metric types are exported by the Prometheus exporter
  - Implement metrics level configuration via command line flags and YAML config
  - Add support for granular control over node, process, container, VM, and pod metrics
  - Added tests

  Supported metric levels: `node, process, container, vm, pod, all, none`

Usage: 
```
sudo ./bin/kepler  --metrics=node --metrics=pod --kube.enable --kube.node-name="kind-worker2" --kube.config=/home/vimalkum/.kube/config
```