### PR TITLE
 feat(monitor): add terminated workload tracking and reporting

### DIFF
--- a/docs/metrics/metrics.md
+++ b/docs/metrics/metrics.md
@@ -107,6 +107,7 @@ These metrics provide energy and power information for containers.
   - `container_id`
   - `container_name`
   - `runtime`
+  - `state`
   - `zone`
   - `pod_id`
 - **Constant Labels**:
@@ -120,6 +121,7 @@ These metrics provide energy and power information for containers.
   - `container_id`
   - `container_name`
   - `runtime`
+  - `state`
   - `zone`
   - `pod_id`
 - **Constant Labels**:
@@ -187,6 +189,7 @@ These metrics provide energy and power information for virtual machines.
   - `vm_id`
   - `vm_name`
   - `hypervisor`
+  - `state`
   - `zone`
 - **Constant Labels**:
   - `node_name`
@@ -199,6 +202,7 @@ These metrics provide energy and power information for virtual machines.
   - `vm_id`
   - `vm_name`
   - `hypervisor`
+  - `state`
   - `zone`
 - **Constant Labels**:
   - `node_name`
@@ -215,6 +219,7 @@ These metrics provide energy and power information for pods.
   - `pod_id`
   - `pod_name`
   - `pod_namespace`
+  - `state`
   - `zone`
 - **Constant Labels**:
   - `node_name`
@@ -227,6 +232,7 @@ These metrics provide energy and power information for pods.
   - `pod_id`
   - `pod_name`
   - `pod_namespace`
+  - `state`
   - `zone`
 - **Constant Labels**:
   - `node_name`

--- a/internal/monitor/container.go
+++ b/internal/monitor/container.go
@@ -98,12 +98,7 @@ func (pm *PowerMonitor) calculateContainerPower(prev, newSnapshot *Snapshot) err
 		newSnapshot.TerminatedContainers[id] = terminatedContainer
 	}
 
-	// Skip if no containers
-	if len(cntrs.Running) == 0 {
-		pm.logger.Debug("No running containers found, skipping container power calculation")
-		return nil
-	}
-
+	// process running containers
 	zones := newSnapshot.Node.Zones
 	node := pm.resources.Node()
 	nodeCPUTimeDelta := node.ProcessTotalCPUTimeDelta

--- a/internal/monitor/pod_power_test.go
+++ b/internal/monitor/pod_power_test.go
@@ -1,0 +1,597 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package monitor
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/sustainable-computing-io/kepler/internal/resource"
+	testingclock "k8s.io/utils/clock/testing"
+)
+
+func TestPodPowerCalculation(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	fakeClock := testingclock.NewFakeClock(time.Now())
+
+	// Create mock CPU meter
+	zones := CreateTestZones()
+	mockMeter := &MockCPUPowerMeter{}
+	mockMeter.On("Zones").Return(zones, nil)
+
+	// Create mock resource informer
+	resInformer := &MockResourceInformer{}
+
+	// Create monitor with mocks
+	monitor := &PowerMonitor{
+		logger:    logger,
+		cpu:       mockMeter,
+		clock:     fakeClock,
+		resources: resInformer,
+	}
+
+	err := monitor.initZones()
+	require.NoError(t, err)
+
+	t.Run("firstPodRead", func(t *testing.T) {
+		tr := CreateTestResources(createOnly(testPods, testNode))
+		require.NotNil(t, tr.Pods)
+
+		resInformer.SetExpectations(t, tr)
+
+		snapshot := NewSnapshot()
+		err := monitor.firstNodeRead(snapshot.Node)
+		require.NoError(t, err)
+
+		err = monitor.firstPodRead(snapshot)
+		require.NoError(t, err)
+
+		// Verify pod power tracking was initialized
+		assert.Len(t, snapshot.Pods, len(tr.Pods.Running))
+
+		for id, pod := range snapshot.Pods {
+			originalPod := tr.Pods.Running[id]
+			assert.Equal(t, originalPod.ID, pod.ID)
+			assert.Equal(t, originalPod.Name, pod.Name)
+			assert.Equal(t, originalPod.Namespace, pod.Namespace)
+			assert.Equal(t, originalPod.CPUTotalTime, pod.CPUTotalTime)
+
+			// Verify zones were initialized with correct energy attribution
+			assert.Len(t, pod.Zones, len(zones))
+
+			// Calculate expected energy based on CPU ratio
+			nodeCPUTimeDelta := tr.Node.ProcessTotalCPUTimeDelta
+			cpuTimeRatio := originalPod.CPUTimeDelta / nodeCPUTimeDelta
+
+			for _, zone := range zones {
+				usage, exists := pod.Zones[zone]
+				assert.True(t, exists, "Zone %s should exist in pod zones", zone.Name())
+
+				nodeZoneUsage := snapshot.Node.Zones[zone]
+				expectedEnergy := Energy(cpuTimeRatio * float64(nodeZoneUsage.activeEnergy))
+
+				assert.Equal(t, expectedEnergy, usage.EnergyTotal, "Pod should get proportional share of node's active energy for zone %s", zone.Name())
+				assert.Equal(t, Power(0), usage.Power, "Power should be 0 for first read")
+			}
+		}
+	})
+
+	t.Run("calculatePodPower", func(t *testing.T) {
+		// Create previous snapshot with realistic node data and manually add pod data
+		prevSnapshot := NewSnapshot()
+		prevSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.5)
+
+		// Add existing pod data to previous snapshot (similar to container test pattern)
+		prevSnapshot.Pods["pod-1"] = &Pod{
+			ID:           "pod-1",
+			Name:         "test-pod-1",
+			Namespace:    "default",
+			CPUTotalTime: 5.0,
+			Zones:        make(ZoneUsageMap, len(zones)),
+		}
+
+		// Initialize zones for previous pod
+		for _, zone := range zones {
+			prevSnapshot.Pods["pod-1"].Zones[zone] = Usage{
+				EnergyTotal: 25 * Joule,
+				Power:       Power(0),
+			}
+		}
+
+		// Create new snapshot with updated node data
+		fakeClock.Step(time.Second * 2)
+		newSnapshot := NewSnapshot()
+		newSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now().Add(time.Second), 0.5)
+
+		// Setup mock to return updated pods
+		tr := CreateTestResources()
+		require.NotNil(t, tr.Node)
+		pods := tr.Pods
+		resInformer.On("Node").Return(tr.Node, nil)
+		resInformer.On("Pods").Return(pods)
+
+		err = monitor.calculatePodPower(prevSnapshot, newSnapshot)
+		require.NoError(t, err)
+
+		// Verify pod power was calculated
+		assert.Len(t, newSnapshot.Pods, len(pods.Running))
+
+		totalNodeActivePower := calculateTotalNodeActivePower(newSnapshot.Node.Zones)
+		totalPodPower := calculateTotalPodPower(newSnapshot.Pods)
+
+		// Pod power should be distributed from node active power
+		assert.Greater(t, totalPodPower, Power(0))
+		assert.LessOrEqual(t, totalPodPower, totalNodeActivePower)
+
+		for id, pod := range newSnapshot.Pods {
+			// Verify power and energy values are reasonable
+			for zone, usage := range pod.Zones {
+				assert.GreaterOrEqual(t, usage.EnergyTotal, Energy(0),
+					"Pod %s zone %s energy should be non-negative", id, zone.Name())
+				assert.GreaterOrEqual(t, usage.Power, Power(0),
+					"Pod %s zone %s power should be non-negative", id, zone.Name())
+			}
+		}
+	})
+
+	t.Run("calculatePodPower_with_zero_node_power", func(t *testing.T) {
+		tr := CreateTestResources(createOnly(testPods, testNode))
+		require.NotNil(t, tr.Pods)
+
+		resInformer.SetExpectations(t, tr)
+
+		// Create snapshots with zero node power
+		prevSnapshot := NewSnapshot()
+		prevSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.0) // Zero usage ratio
+		err = monitor.firstPodRead(prevSnapshot)
+		require.NoError(t, err)
+
+		newSnapshot := NewSnapshot()
+		newSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.0) // Zero usage ratio
+
+		err = monitor.calculatePodPower(prevSnapshot, newSnapshot)
+		require.NoError(t, err)
+
+		// With zero node power, all pod power should be zero
+		for id, pod := range newSnapshot.Pods {
+			for zone, usage := range pod.Zones {
+				assert.Equal(t, Power(0), usage.Power,
+					"Pod %s zone %s power should be zero when node power is zero", id, zone.Name())
+				assert.Equal(t, Energy(0), usage.EnergyTotal,
+					"Pod %s zone %s energy should be zero when node power is zero", id, zone.Name())
+			}
+		}
+	})
+
+	t.Run("calculatePodPower_without_pods", func(t *testing.T) {
+		// Create empty pods
+		emptyPods := &resource.Pods{
+			Running:    make(map[string]*resource.Pod),
+			Terminated: make(map[string]*resource.Pod),
+		}
+
+		tr := CreateTestResources(createOnly(testNode))
+		resInformer.On("Node").Return(tr.Node, nil).Once()
+		resInformer.On("Pods").Return(emptyPods).Once()
+
+		prevSnapshot := NewSnapshot()
+		prevSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.5)
+
+		newSnapshot := NewSnapshot()
+		newSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.5)
+
+		err = monitor.calculatePodPower(prevSnapshot, newSnapshot)
+		require.NoError(t, err)
+
+		// Should handle empty pods gracefully
+		assert.Empty(t, newSnapshot.Pods)
+	})
+}
+
+func TestPodPowerConsistency(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	fakeClock := testingclock.NewFakeClock(time.Now())
+
+	// Create mock CPU meter
+	zones := CreateTestZones()
+	mockMeter := &MockCPUPowerMeter{}
+	mockMeter.On("Zones").Return(zones, nil)
+
+	// Create mock resource informer
+	resInformer := &MockResourceInformer{}
+
+	// Create monitor with mocks
+	monitor := &PowerMonitor{
+		logger:    logger,
+		cpu:       mockMeter,
+		clock:     fakeClock,
+		resources: resInformer,
+	}
+
+	err := monitor.initZones()
+	require.NoError(t, err)
+
+	t.Run("power_conservation_across_pods", func(t *testing.T) {
+		tr := CreateTestResources(createOnly(testPods, testNode))
+		require.NotNil(t, tr.Pods)
+
+		resInformer.SetExpectations(t, tr)
+
+		// Create and calculate power
+		prevSnapshot := NewSnapshot()
+		prevSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.6)
+		err = monitor.firstPodRead(prevSnapshot)
+		require.NoError(t, err)
+
+		fakeClock.Step(time.Second * 2)
+		newSnapshot := NewSnapshot()
+		newSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.6)
+		err = monitor.calculatePodPower(prevSnapshot, newSnapshot)
+		require.NoError(t, err)
+
+		// Verify power conservation: sum of pod power should not exceed node active power
+		totalNodeActivePower := calculateTotalNodeActivePower(newSnapshot.Node.Zones)
+		totalPodPower := calculateTotalPodPower(newSnapshot.Pods)
+
+		assert.LessOrEqual(t, totalPodPower, totalNodeActivePower,
+			"Total pod power should not exceed total node active power")
+
+		// Verify energy conservation over time
+		totalNodeActiveEnergy := calculateTotalNodeActiveEnergy(newSnapshot.Node.Zones)
+		totalPodEnergy := calculateTotalPodEnergy(newSnapshot.Pods)
+
+		assert.LessOrEqual(t, totalPodEnergy, totalNodeActiveEnergy,
+			"Total pod energy should not exceed total node active energy")
+	})
+}
+
+func TestTerminatedPodTracking(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	zones := CreateTestZones()
+
+	t.Run("terminated_pod_energy_accumulation", func(t *testing.T) {
+		mockMeter := &MockCPUPowerMeter{}
+		mockMeter.On("Zones").Return(zones, nil)
+		resInformer := &MockResourceInformer{}
+
+		monitor := &PowerMonitor{
+			logger:    logger,
+			cpu:       mockMeter,
+			clock:     fakeClock,
+			resources: resInformer,
+		}
+
+		err := monitor.initZones()
+		require.NoError(t, err)
+
+		// Setup previous snapshot with pod data (similar to container test pattern)
+		prevSnapshot := NewSnapshot()
+		prevSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.7)
+
+		// Add existing pod data to previous snapshot
+		prevSnapshot.Pods["pod-1"] = &Pod{
+			ID:           "pod-1",
+			Name:         "test-pod-1",
+			Namespace:    "default",
+			CPUTotalTime: 5.0,
+			Zones:        make(ZoneUsageMap, len(zones)),
+		}
+		prevSnapshot.Pods["pod-2"] = &Pod{
+			ID:           "pod-2",
+			Name:         "test-pod-2",
+			Namespace:    "default",
+			CPUTotalTime: 3.0,
+			Zones:        make(ZoneUsageMap, len(zones)),
+		}
+
+		// Initialize zones for previous pods
+		for _, zone := range zones {
+			prevSnapshot.Pods["pod-1"].Zones[zone] = Usage{
+				EnergyTotal: 25 * Joule,
+				Power:       15,
+			}
+			prevSnapshot.Pods["pod-2"].Zones[zone] = Usage{
+				EnergyTotal: 15 * Joule,
+				Power:       10,
+			}
+		}
+
+		// Setup pods where pod-1 terminates
+		pods := &resource.Pods{
+			Running: map[string]*resource.Pod{
+				"pod-2": {ID: "pod-2", Name: "test-pod-2", Namespace: "default", CPUTimeDelta: 20.0},
+			},
+			Terminated: map[string]*resource.Pod{
+				"pod-1": {ID: "pod-1", Name: "test-pod-1", Namespace: "default", CPUTimeDelta: 30.0},
+			},
+		}
+
+		tr := CreateTestResources(createOnly(testNode))
+		resInformer.On("Node").Return(tr.Node, nil)
+		resInformer.On("Pods").Return(pods)
+
+		// Create new snapshot with updated node data
+		fakeClock.Step(time.Second * 2)
+		newSnapshot := NewSnapshot()
+		newSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now().Add(time.Second), 0.7)
+
+		err = monitor.calculatePodPower(prevSnapshot, newSnapshot)
+		require.NoError(t, err)
+
+		// Verify terminated pod tracking
+		assert.Len(t, newSnapshot.TerminatedPods, 1, "Terminated pods should be tracked")
+		assert.Contains(t, newSnapshot.TerminatedPods, "pod-1")
+
+		terminatedPod := newSnapshot.TerminatedPods["pod-1"]
+		originalPod := prevSnapshot.Pods["pod-1"]
+
+		// Verify terminated pod preserves energy and power from last running state
+		assert.Equal(t, originalPod.ID, terminatedPod.ID)
+		assert.Equal(t, originalPod.Name, terminatedPod.Name)
+		assert.Equal(t, originalPod.Namespace, terminatedPod.Namespace)
+
+		expectedEnergy := make(map[string]Energy)
+		expectedPower := make(map[string]Power)
+		for zoneName, usage := range originalPod.Zones {
+			expectedEnergy[zoneName.Name()] = usage.EnergyTotal
+			expectedPower[zoneName.Name()] = usage.Power
+		}
+
+		for zoneName, terminatedUsage := range terminatedPod.Zones {
+			assert.Equal(t, expectedEnergy[zoneName.Name()], terminatedUsage.EnergyTotal,
+				"Terminated pod energy should be preserved from last running state for zone %s", zoneName.Name())
+			assert.Equal(t, expectedPower[zoneName.Name()], terminatedUsage.Power,
+				"Terminated pod power should be preserved from last running state for zone %s", zoneName.Name())
+		}
+
+		// Verify running pods still exist
+		assert.Len(t, newSnapshot.Pods, 1)
+		assert.Contains(t, newSnapshot.Pods, "pod-2")
+	})
+
+	t.Run("terminated_pod_cleanup_after_export", func(t *testing.T) {
+		mockMeter := &MockCPUPowerMeter{}
+		mockMeter.On("Zones").Return(zones, nil)
+		resInformer := &MockResourceInformer{}
+
+		monitor := &PowerMonitor{
+			logger:    logger,
+			cpu:       mockMeter,
+			clock:     fakeClock,
+			resources: resInformer,
+		}
+
+		err := monitor.initZones()
+		require.NoError(t, err)
+
+		// Start with terminated pod already in system
+		pods1 := &resource.Pods{
+			Running: map[string]*resource.Pod{
+				"pod-2": {ID: "pod-2", Name: "test-pod-2", Namespace: "default", CPUTimeDelta: 20.0},
+			},
+			Terminated: map[string]*resource.Pod{
+				"pod-1": {ID: "pod-1", Name: "test-pod-1", Namespace: "default", CPUTimeDelta: 30.0},
+			},
+		}
+
+		tr1 := CreateTestResources(createOnly(testNode))
+		resInformer.On("Node").Return(tr1.Node, nil).Times(3)
+		resInformer.On("Pods").Return(pods1).Times(3)
+
+		// Create snapshot with terminated pod data
+		snapshot1 := NewSnapshot()
+		snapshot1.TerminatedPods["pod-1"] = &Pod{
+			ID:        "pod-1",
+			Name:      "test-pod-1",
+			Namespace: "default",
+			Zones:     make(ZoneUsageMap),
+		}
+
+		// Before export - terminated pods should be preserved
+		monitor.exported.Store(false)
+		snapshot1.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.5)
+
+		newSnapshot := NewSnapshot()
+		newSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.5)
+		err = monitor.calculatePodPower(snapshot1, newSnapshot)
+		require.NoError(t, err)
+
+		assert.Len(t, newSnapshot.TerminatedPods, 1, "Terminated pods should be preserved before export")
+
+		// After export - terminated pods should be cleaned up
+		monitor.exported.Store(true)
+		snapshot3 := NewSnapshot()
+		snapshot3.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.5)
+		err = monitor.calculatePodPower(newSnapshot, snapshot3)
+		require.NoError(t, err)
+
+		assert.Len(t, snapshot3.TerminatedPods, 0, "Terminated pods should be cleaned up after export")
+	})
+
+	t.Run("multiple_terminated_pods_accumulation", func(t *testing.T) {
+		mockMeter := &MockCPUPowerMeter{}
+		mockMeter.On("Zones").Return(zones, nil)
+		resInformer := &MockResourceInformer{}
+
+		monitor := &PowerMonitor{
+			logger:    logger,
+			cpu:       mockMeter,
+			clock:     fakeClock,
+			resources: resInformer,
+		}
+
+		err := monitor.initZones()
+		require.NoError(t, err)
+
+		// Reset monitor state
+		monitor.exported.Store(false)
+
+		// Create initial snapshot with multiple running pods
+		snapshot1 := NewSnapshot()
+		snapshot1.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.5)
+
+		podsInitial := &resource.Pods{
+			Running: map[string]*resource.Pod{
+				"pod-1": {ID: "pod-1", Name: "test-pod-1", Namespace: "default", CPUTimeDelta: 10.0},
+				"pod-2": {ID: "pod-2", Name: "test-pod-2", Namespace: "default", CPUTimeDelta: 20.0},
+				"pod-3": {ID: "pod-3", Name: "test-pod-3", Namespace: "default", CPUTimeDelta: 30.0},
+			},
+			Terminated: map[string]*resource.Pod{},
+		}
+
+		tr1 := CreateTestResources(createOnly(testNode))
+		resInformer.On("Node").Return(tr1.Node, nil).Maybe()
+		resInformer.On("Pods").Return(podsInitial).Once()
+
+		err = monitor.calculatePodPower(NewSnapshot(), snapshot1)
+		require.NoError(t, err)
+
+		// Step 2: First pod terminates
+		snapshot2 := NewSnapshot()
+		snapshot2.Node = createNodeSnapshot(zones, fakeClock.Now().Add(time.Second), 0.5)
+
+		pods2 := &resource.Pods{
+			Running: map[string]*resource.Pod{
+				"pod-2": {ID: "pod-2", Name: "test-pod-2", Namespace: "default", CPUTimeDelta: 20.0},
+				"pod-3": {ID: "pod-3", Name: "test-pod-3", Namespace: "default", CPUTimeDelta: 30.0},
+			},
+			Terminated: map[string]*resource.Pod{
+				"pod-1": {ID: "pod-1", Name: "test-pod-1", Namespace: "default", CPUTimeDelta: 10.0},
+			},
+		}
+
+		tr2 := CreateTestResources(createOnly(testNode))
+		resInformer.On("Node").Return(tr2.Node, nil).Maybe()
+		resInformer.On("Pods").Return(pods2).Once()
+
+		err = monitor.calculatePodPower(snapshot1, snapshot2)
+		require.NoError(t, err)
+
+		assert.Len(t, snapshot2.TerminatedPods, 1, "Should have 1 terminated pod")
+		assert.Contains(t, snapshot2.TerminatedPods, "pod-1")
+
+		// Step 3: Second pod terminates
+		snapshot3 := NewSnapshot()
+		snapshot3.Node = createNodeSnapshot(zones, fakeClock.Now().Add(2*time.Second), 0.5)
+
+		pods3 := &resource.Pods{
+			Running: map[string]*resource.Pod{
+				"pod-3": {ID: "pod-3", Name: "test-pod-3", Namespace: "default", CPUTimeDelta: 30.0},
+			},
+			Terminated: map[string]*resource.Pod{
+				"pod-2": {ID: "pod-2", Name: "test-pod-2", Namespace: "default", CPUTimeDelta: 20.0},
+			},
+		}
+
+		tr3 := CreateTestResources(createOnly(testNode))
+		resInformer.On("Node").Return(tr3.Node, nil).Maybe()
+		resInformer.On("Pods").Return(pods3).Once()
+
+		err = monitor.calculatePodPower(snapshot2, snapshot3)
+		require.NoError(t, err)
+
+		// Should now have 2 terminated pods accumulated
+		assert.Len(t, snapshot3.TerminatedPods, 2, "Should have 2 terminated pods accumulated")
+		assert.Contains(t, snapshot3.TerminatedPods, "pod-1", "First terminated pod should still be present")
+		assert.Contains(t, snapshot3.TerminatedPods, "pod-2", "Second terminated pod should be added")
+
+		assert.Len(t, snapshot3.Pods, 1, "Should have 1 running pod")
+		assert.Contains(t, snapshot3.Pods, "pod-3")
+	})
+
+	t.Run("terminated_pod_with_zero_energy_filtering", func(t *testing.T) {
+		mockMeter := &MockCPUPowerMeter{}
+		mockMeter.On("Zones").Return(zones, nil)
+		resInformer := &MockResourceInformer{}
+
+		monitor := &PowerMonitor{
+			logger:    logger,
+			cpu:       mockMeter,
+			clock:     fakeClock,
+			resources: resInformer,
+		}
+
+		err := monitor.initZones()
+		require.NoError(t, err)
+
+		// Pod with zero energy should be filtered out
+		pods1 := &resource.Pods{
+			Running: map[string]*resource.Pod{
+				"pod-1": {ID: "pod-1", Name: "test-pod-1", Namespace: "default", CPUTimeDelta: 0.0}, // Zero CPU time
+			},
+			Terminated: map[string]*resource.Pod{},
+		}
+
+		tr1 := CreateTestResources(createOnly(testNode))
+		resInformer.On("Node").Return(tr1.Node, nil).Once()
+		resInformer.On("Pods").Return(pods1).Once()
+
+		snapshot1 := NewSnapshot()
+		snapshot1.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.0) // Zero usage for zero energy
+		err = monitor.firstPodRead(snapshot1)
+		require.NoError(t, err)
+
+		// Pod terminates with zero energy
+		pods2 := &resource.Pods{
+			Running: map[string]*resource.Pod{},
+			Terminated: map[string]*resource.Pod{
+				"pod-1": {ID: "pod-1", Name: "test-pod-1", Namespace: "default", CPUTimeDelta: 0.0},
+			},
+		}
+
+		tr2 := CreateTestResources(createOnly(testNode))
+		resInformer.On("Node").Return(tr2.Node, nil).Once()
+		resInformer.On("Pods").Return(pods2).Once()
+
+		newSnapshot := NewSnapshot()
+		newSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.0) // Keep zero usage
+		err = monitor.calculatePodPower(snapshot1, newSnapshot)
+		require.NoError(t, err)
+
+		// Pod with zero energy should be filtered out from terminated tracking
+		assert.Len(t, newSnapshot.TerminatedPods, 0, "Pods with zero energy should be filtered out")
+	})
+}
+
+// Helper functions
+func calculateTotalPodPower(pods Pods) Power {
+	var total Power
+	for _, pod := range pods {
+		for _, usage := range pod.Zones {
+			total += usage.Power
+		}
+	}
+	return total
+}
+
+func calculateTotalPodEnergy(pods Pods) Energy {
+	var total Energy
+	for _, pod := range pods {
+		for _, usage := range pod.Zones {
+			total += usage.EnergyTotal
+		}
+	}
+	return total
+}
+
+func calculateTotalNodeActivePower(zones NodeZoneUsageMap) Power {
+	var total Power
+	for _, usage := range zones {
+		total += usage.ActivePower
+	}
+	return total
+}
+
+func calculateTotalNodeActiveEnergy(zones NodeZoneUsageMap) Energy {
+	var total Energy
+	for _, usage := range zones {
+		total += usage.activeEnergy
+	}
+	return total
+}

--- a/internal/monitor/process_power_test.go
+++ b/internal/monitor/process_power_test.go
@@ -411,24 +411,22 @@ func TestProcessPowerConsistency(t *testing.T) {
 func TestTerminatedProcessTracking(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	fakeClock := testingclock.NewFakeClock(time.Now())
-
 	zones := CreateTestZones()
-	mockMeter := &MockCPUPowerMeter{}
-	mockMeter.On("Zones").Return(zones, nil)
-
-	resInformer := &MockResourceInformer{}
-
-	monitor := &PowerMonitor{
-		logger:    logger,
-		cpu:       mockMeter,
-		clock:     fakeClock,
-		resources: resInformer,
-	}
-
-	err := monitor.initZones()
-	require.NoError(t, err)
 
 	t.Run("terminated process energy accumulation", func(t *testing.T) {
+		mockMeter := &MockCPUPowerMeter{}
+		mockMeter.On("Zones").Return(zones, nil)
+		resInformer := &MockResourceInformer{}
+
+		monitor := &PowerMonitor{
+			logger:    logger,
+			cpu:       mockMeter,
+			clock:     fakeClock,
+			resources: resInformer,
+		}
+
+		err := monitor.initZones()
+		require.NoError(t, err)
 		// Step 1: Create initial snapshot with running processes
 		snapshot1 := NewSnapshot()
 		snapshot1.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.5)
@@ -446,7 +444,7 @@ func TestTerminatedProcessTracking(t *testing.T) {
 		resInformer.On("Node").Return(tr1.Node, nil).Maybe()
 		resInformer.On("Processes").Return(procs1).Once()
 
-		err := monitor.calculateProcessPower(NewSnapshot(), snapshot1)
+		err = monitor.calculateProcessPower(NewSnapshot(), snapshot1)
 		require.NoError(t, err)
 
 		runningProc123 := snapshot1.Processes[123]
@@ -517,6 +515,20 @@ func TestTerminatedProcessTracking(t *testing.T) {
 	})
 
 	t.Run("terminated process cleanup after export", func(t *testing.T) {
+		mockMeter := &MockCPUPowerMeter{}
+		mockMeter.On("Zones").Return(zones, nil)
+		resInformer := &MockResourceInformer{}
+
+		monitor := &PowerMonitor{
+			logger:    logger,
+			cpu:       mockMeter,
+			clock:     fakeClock,
+			resources: resInformer,
+		}
+
+		err := monitor.initZones()
+		require.NoError(t, err)
+
 		// Reset monitor state
 		monitor.exported.Store(false)
 
@@ -554,7 +566,7 @@ func TestTerminatedProcessTracking(t *testing.T) {
 
 		// Before export terminated processes should be preserved
 		monitor.exported.Store(false)
-		err := monitor.calculateProcessPower(snapshot1, snapshot2)
+		err = monitor.calculateProcessPower(snapshot1, snapshot2)
 		require.NoError(t, err)
 
 		assert.Len(t, snapshot2.TerminatedProcesses, 1, "Terminated processes should be preserved before export")
@@ -577,6 +589,20 @@ func TestTerminatedProcessTracking(t *testing.T) {
 	})
 
 	t.Run("multiple terminated processes accumulation", func(t *testing.T) {
+		mockMeter := &MockCPUPowerMeter{}
+		mockMeter.On("Zones").Return(zones, nil)
+		resInformer := &MockResourceInformer{}
+
+		monitor := &PowerMonitor{
+			logger:    logger,
+			cpu:       mockMeter,
+			clock:     fakeClock,
+			resources: resInformer,
+		}
+
+		err := monitor.initZones()
+		require.NoError(t, err)
+
 		// Reset monitor state
 		monitor.exported.Store(false)
 
@@ -597,7 +623,7 @@ func TestTerminatedProcessTracking(t *testing.T) {
 		resInformer.On("Node").Return(tr1.Node, nil).Maybe()
 		resInformer.On("Processes").Return(procs1).Once()
 
-		err := monitor.calculateProcessPower(NewSnapshot(), snapshot1)
+		err = monitor.calculateProcessPower(NewSnapshot(), snapshot1)
 		require.NoError(t, err)
 
 		// Capture running process values
@@ -657,6 +683,20 @@ func TestTerminatedProcessTracking(t *testing.T) {
 	})
 
 	t.Run("terminated process with zero energy filtering", func(t *testing.T) {
+		mockMeter := &MockCPUPowerMeter{}
+		mockMeter.On("Zones").Return(zones, nil)
+		resInformer := &MockResourceInformer{}
+
+		monitor := &PowerMonitor{
+			logger:    logger,
+			cpu:       mockMeter,
+			clock:     fakeClock,
+			resources: resInformer,
+		}
+
+		err := monitor.initZones()
+		require.NoError(t, err)
+
 		// NOTE: Reset monitor state
 		monitor.exported.Store(false)
 
@@ -677,7 +717,7 @@ func TestTerminatedProcessTracking(t *testing.T) {
 		resInformer.On("Node").Return(tr1.Node, nil).Maybe()
 		resInformer.On("Processes").Return(procs1).Once()
 
-		err := monitor.calculateProcessPower(NewSnapshot(), snapshot1)
+		err = monitor.calculateProcessPower(NewSnapshot(), snapshot1)
 		require.NoError(t, err)
 
 		// Verify initial state: process 100 has energy, process 200 has zero energy
@@ -729,6 +769,4 @@ func TestTerminatedProcessTracking(t *testing.T) {
 
 		resInformer.AssertExpectations(t)
 	})
-
-	mockMeter.AssertExpectations(t)
 }

--- a/internal/monitor/types.go
+++ b/internal/monitor/types.go
@@ -197,9 +197,13 @@ type Snapshot struct {
 	Processes           Processes // Process power data, keyed by PID
 	TerminatedProcesses Processes // Terminated processes with accumulated energy since last snapshot
 
-	Containers      Containers      // Container power data, keyed by container ID
-	VirtualMachines VirtualMachines // VM power data, keyed by container ID
-	Pods            Pods            // Pod power data, keyed by pod ID
+	Containers           Containers // Container power data, keyed by container ID
+	TerminatedContainers Containers // Terminated containers with accumulated energy since last snapshot
+
+	VirtualMachines           VirtualMachines // VM power data, keyed by container ID
+	TerminatedVirtualMachines VirtualMachines // Terminated VMs with accumulated energy since last snapshot
+	Pods                      Pods            // Pod power data, keyed by pod ID
+	TerminatedPods            Pods            // Terminated pods with accumulated energy since last snapshot
 }
 
 // NewSnapshot creates a new Snapshot instance
@@ -209,23 +213,29 @@ func NewSnapshot() *Snapshot {
 		Node: &Node{
 			Zones: make(NodeZoneUsageMap),
 		},
-		Processes:           make(Processes),
-		Containers:          make(Containers),
-		VirtualMachines:     make(VirtualMachines),
-		Pods:                make(Pods),
-		TerminatedProcesses: make(Processes),
+		Processes:                 make(Processes),
+		TerminatedProcesses:       make(Processes),
+		Containers:                make(Containers),
+		TerminatedContainers:      make(Containers),
+		VirtualMachines:           make(VirtualMachines),
+		TerminatedVirtualMachines: make(VirtualMachines),
+		Pods:                      make(Pods),
+		TerminatedPods:            make(Pods),
 	}
 }
 
 func (s *Snapshot) Clone() *Snapshot {
 	clone := &Snapshot{
-		Timestamp:           s.Timestamp,
-		Node:                s.Node.Clone(),
-		Processes:           make(Processes, len(s.Processes)),
-		Containers:          make(Containers, len(s.Containers)),
-		VirtualMachines:     make(VirtualMachines, len(s.VirtualMachines)),
-		Pods:                make(Pods, len(s.Pods)),
-		TerminatedProcesses: make(Processes, len(s.TerminatedProcesses)),
+		Timestamp:                 s.Timestamp,
+		Node:                      s.Node.Clone(),
+		Processes:                 make(Processes, len(s.Processes)),
+		TerminatedProcesses:       make(Processes, len(s.TerminatedProcesses)),
+		Containers:                make(Containers, len(s.Containers)),
+		TerminatedContainers:      make(Containers, len(s.TerminatedContainers)),
+		VirtualMachines:           make(VirtualMachines, len(s.VirtualMachines)),
+		TerminatedVirtualMachines: make(VirtualMachines, len(s.TerminatedVirtualMachines)),
+		Pods:                      make(Pods, len(s.Pods)),
+		TerminatedPods:            make(Pods, len(s.TerminatedPods)),
 	}
 
 	// Deep copy the processes map
@@ -233,20 +243,32 @@ func (s *Snapshot) Clone() *Snapshot {
 		clone.Processes[pid] = src.Clone()
 	}
 
+	for pid, src := range s.TerminatedProcesses {
+		clone.TerminatedProcesses[pid] = src.Clone()
+	}
+
 	for id, src := range s.Containers {
 		clone.Containers[id] = src.Clone()
+	}
+
+	for id, src := range s.TerminatedContainers {
+		clone.TerminatedContainers[id] = src.Clone()
 	}
 
 	for id, src := range s.VirtualMachines {
 		clone.VirtualMachines[id] = src.Clone()
 	}
 
+	for id, src := range s.TerminatedVirtualMachines {
+		clone.TerminatedVirtualMachines[id] = src.Clone()
+	}
+
 	for id, src := range s.Pods {
 		clone.Pods[id] = src.Clone()
 	}
 
-	for pid, src := range s.TerminatedProcesses {
-		clone.TerminatedProcesses[pid] = src.Clone()
+	for id, src := range s.TerminatedPods {
+		clone.TerminatedPods[id] = src.Clone()
 	}
 
 	return clone

--- a/internal/monitor/vm.go
+++ b/internal/monitor/vm.go
@@ -73,11 +73,6 @@ func (pm *PowerMonitor) calculateVMPower(prev, newSnapshot *Snapshot) error {
 		newSnapshot.TerminatedVirtualMachines[id] = terminatedVM
 	}
 
-	if len(vms.Running) == 0 {
-		pm.logger.Debug("No running VM found, skipping power calculation")
-		return nil
-	}
-
 	nodeCPUTimeDelta := pm.resources.Node().ProcessTotalCPUTimeDelta
 	pm.logger.Debug("Calculating VM power",
 		"node.cpu.time", nodeCPUTimeDelta,


### PR DESCRIPTION
This commit extends the functionality to track terminated process (5e91e0fe) to now track all workloads - Containers, Pods, VMs. Changes include:

- Add terminated process/container/VM/pod tracking to Snapshot struct
- Extend power collector to expose terminated workload metrics
- Update monitor components to track terminated workload energy accumulation
- Add comprehensive test coverage for terminated workload scenarios