### PR TITLE
fix(zones): fix metric label for multiple sockets

### DIFF
--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -228,6 +228,7 @@ func createCPUMeter(logger *slog.Logger, cfg *config.Config) (device.CPUPowerMet
 
 	return device.NewCPUPowerMeter(
 		cfg.Host.SysFS,
+		cfg.Host.ProcFS,
 		device.WithRaplLogger(logger),
 		device.WithZoneFilter(cfg.Rapl.Zones),
 	)

--- a/internal/device/cpu_power_meter.go
+++ b/internal/device/cpu_power_meter.go
@@ -24,6 +24,11 @@ type EnergyZone interface {
 	// When energy usage reaches this value, the energy value returned by Energy()
 	// will wrap around and start again from zero.
 	MaxEnergy() Energy
+
+	// ZoneLabel returns a user-friendly zone label for metrics.
+	// Returns zone name without index for single zones of a type,
+	// or zone name with index for multiple zones of the same type.
+	ZoneLabel() string
 }
 
 // CPUPowerMeter implements powerMeter

--- a/internal/device/fake_cpu_power_meter.go
+++ b/internal/device/fake_cpu_power_meter.go
@@ -30,6 +30,7 @@ const defaultRaplPath = "/sys/class/powercap/intel-rapl"
 type fakeEnergyZone struct {
 	name      string
 	index     int
+	label     string
 	path      string
 	energy    Energy
 	maxEnergy Energy
@@ -50,6 +51,11 @@ func (z *fakeEnergyZone) Name() string {
 // Index returns the index of the zone
 func (z *fakeEnergyZone) Index() int {
 	return z.index
+}
+
+// Index returns the index of the zone
+func (z *fakeEnergyZone) ZoneLabel() string {
+	return z.label
 }
 
 // Path returns the path from which the energy usage value ie being read
@@ -140,6 +146,7 @@ func NewFakeCPUMeter(zones []string, opts ...FakeOptFn) (CPUPowerMeter, error) {
 		meter.zones = append(meter.zones, &fakeEnergyZone{
 			name:         zoneName,
 			index:        i,
+			label:        zoneName,
 			path:         filepath.Join(defaultRaplPath, fmt.Sprintf("energy_%s", zoneName)),
 			maxEnergy:    1000000,
 			increment:    Energy(100 + zoneIncrementFactor[zoneName]),

--- a/internal/device/mock_cpu_power_meter.go
+++ b/internal/device/mock_cpu_power_meter.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	validSysFSPath = "testdata/sys"
-	badSysFSPath   = "testdata/bad_sysfs"
+	validSysFSPath  = "testdata/sys"
+	validProcFSPath = "testdata/proc"
+	badSysFSPath    = "testdata/bad_sysfs"
 )
 
 type (
@@ -25,15 +26,17 @@ type (
 
 		name           string
 		index          int
+		label          string
 		path           string
 		maxMicroJoules Energy
 	}
 )
 
-func NewMockRaplZone(name string, index int, path string, maxMicroJoules Energy) *MockRaplZone {
+func NewMockRaplZone(name string, index int, label, path string, maxMicroJoules Energy) *MockRaplZone {
 	return &MockRaplZone{
 		name:           name,
 		index:          index,
+		label:          label,
 		path:           path,
 		maxMicroJoules: maxMicroJoules,
 	}
@@ -49,6 +52,10 @@ func (m MockRaplZone) Path() string {
 
 func (m MockRaplZone) Name() string {
 	return m.name
+}
+
+func (m *MockRaplZone) ZoneLabel() string {
+	return m.label
 }
 
 func (m MockRaplZone) Energy() (Energy, error) {

--- a/internal/device/rapl_sysfs_power_meter_test.go
+++ b/internal/device/rapl_sysfs_power_meter_test.go
@@ -19,7 +19,7 @@ func TestCPUPowerMeterInterface(t *testing.T) {
 }
 
 func TestNewCPUPowerMeter(t *testing.T) {
-	meter, err := NewCPUPowerMeter("testdata/sys")
+	meter, err := NewCPUPowerMeter("testdata/sys", "testdata/proc")
 	assert.NotNil(t, meter, "NewCPUPowerMeter should not return nil")
 	assert.NoError(t, err, "NewCPUPowerMeter should not return error")
 	assert.IsType(t, &raplPowerMeter{}, meter, "NewCPUPowerMeter should return a *cpuPowerMeter")
@@ -32,7 +32,7 @@ func TestCPUPowerMeter_Name(t *testing.T) {
 }
 
 func TestCPUPowerMeter_Init(t *testing.T) {
-	meter, err := NewCPUPowerMeter(validSysFSPath)
+	meter, err := NewCPUPowerMeter(validSysFSPath, validProcFSPath)
 	assert.NoError(t, err, "NewCPUPowerMeter should not return an error")
 
 	err = meter.Init()
@@ -189,7 +189,7 @@ func TestStandardPathPreference(t *testing.T) {
 		mockReader := &mockRaplReader{}
 		mockReader.On("Zones").Return(test.zones, nil)
 
-		rapl, err := NewCPUPowerMeter(validSysFSPath, WithSysFSReader(mockReader))
+		rapl, err := NewCPUPowerMeter(validSysFSPath, validProcFSPath, WithSysFSReader(mockReader))
 		assert.NoError(t, err)
 
 		zones, err := rapl.Zones()
@@ -229,7 +229,7 @@ func TestZoneCaching(t *testing.T) {
 	mockReader := &mockRaplReader{}
 	mockReader.On("Zones").Return(raplZones, nil).Once()
 
-	rapl, err := NewCPUPowerMeter(validSysFSPath, WithSysFSReader(mockReader))
+	rapl, err := NewCPUPowerMeter(validSysFSPath, validProcFSPath, WithSysFSReader(mockReader))
 	assert.NoError(t, err)
 
 	// Get zones multiple times to test that "Zone" is called only once
@@ -245,7 +245,7 @@ func TestZoneCaching(t *testing.T) {
 // TestZoneCaching_Error tests that zones are not cached when there is an error
 func TestZoneCaching_Error(t *testing.T) {
 	mockReader := &mockRaplReader{}
-	rapl, err := NewCPUPowerMeter(validSysFSPath, WithSysFSReader(mockReader))
+	rapl, err := NewCPUPowerMeter(validSysFSPath, validProcFSPath, WithSysFSReader(mockReader))
 
 	t.Run("Zone Read Error", func(t *testing.T) {
 		mockReader.On("Zones").Return([]EnergyZone(nil), errors.New("error")).Once()
@@ -283,7 +283,7 @@ func TestZoneCaching_Error(t *testing.T) {
 // TestZone_None tests that zones error when none are found
 func TestZone_None(t *testing.T) {
 	mockReader := &mockRaplReader{}
-	rapl, err := NewCPUPowerMeter(validSysFSPath, WithSysFSReader(mockReader))
+	rapl, err := NewCPUPowerMeter(validSysFSPath, validProcFSPath, WithSysFSReader(mockReader))
 	assert.NoError(t, err)
 
 	mockReader.On("Zones").Return([]EnergyZone(nil), nil).Once()
@@ -295,7 +295,7 @@ func TestZone_None(t *testing.T) {
 
 // TestNewCPUPowerMeter_InvalidPath tests that NewCPUPowerMeter returns an error with an invalid sysfs path
 func TestNewCPUPowerMeter_InvalidPath(t *testing.T) {
-	meter, err := NewCPUPowerMeter("/nonexistent/path")
+	meter, err := NewCPUPowerMeter("/nonexistent/path", "/nonexistent/proc")
 	assert.Error(t, err, "Should return an error with an invalid path")
 	assert.Nil(t, meter, "Should not return a meter with an invalid path")
 }

--- a/internal/device/rapl_zone_filtering_test.go
+++ b/internal/device/rapl_zone_filtering_test.go
@@ -244,6 +244,7 @@ func TestRaplZoneFiltering_WithOptions(t *testing.T) {
 	// Create meter with WithZoneFilter option
 	meter, err := NewCPUPowerMeter(
 		validSysFSPath,
+		validProcFSPath,
 		WithSysFSReader(mockReader),
 		WithZoneFilter([]string{"core"}),
 	)

--- a/internal/device/testdata/proc/cpuinfo
+++ b/internal/device/testdata/proc/cpuinfo
@@ -1,0 +1,53 @@
+processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 85
+model name	: Intel(R) Xeon(R) Gold 6152 CPU @ 2.10GHz
+stepping	: 4
+microcode	: 0x2000065
+cpu MHz		: 2100.000
+cache size	: 30976 KB
+physical id	: 0
+siblings	: 44
+core id		: 0
+cpu cores	: 22
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 22
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l3 cdp_l3 intel_ppin intel_pt ssbd mba ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm cqm mpx rdt_a avx512f avx512dq rdseed adx smap clflushopt clwb intel_pt avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local dtherm ida arat pln pts hwp hwp_act_window hwp_epp hwp_pkg_req pku ospke avx512_vnni md_clear flush_l1d arch_capabilities
+bugs		: spectre_v1 spectre_v2 spec_store_bypass swapgs
+bogomips	: 4200.00
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 85
+model name	: Intel(R) Xeon(R) Gold 6152 CPU @ 2.10GHz
+stepping	: 4
+microcode	: 0x2000065
+cpu MHz		: 2100.000
+cache size	: 30976 KB
+physical id	: 1
+siblings	: 44
+core id		: 0
+cpu cores	: 22
+apicid		: 64
+initial apicid	: 64
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 22
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l3 cdp_l3 intel_ppin intel_pt ssbd mba ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm cqm mpx rdt_a avx512f avx512dq rdseed adx smap clflushopt clwb intel_pt avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local dtherm ida arat pln pts hwp hwp_act_window hwp_epp hwp_pkg_req pku ospke avx512_vnni md_clear flush_l1d arch_capabilities
+bugs		: spectre_v1 spectre_v2 spec_store_bypass swapgs
+bogomips	: 4200.00
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 46 bits physical, 48 bits virtual
+power management:

--- a/internal/exporter/prometheus/collector/power_collector.go
+++ b/internal/exporter/prometheus/collector/power_collector.go
@@ -226,7 +226,7 @@ func (c *PowerCollector) collectNodeMetrics(ch chan<- prometheus.Metric, node *m
 	)
 	for zone, energy := range node.Zones {
 		path := zone.Path()
-		zoneName := fmt.Sprintf("%s-%d", zone.Name(), zone.Index())
+		zoneName := zone.ZoneLabel()
 
 		// joules
 		ch <- prometheus.MustNewConstMetric(
@@ -293,7 +293,7 @@ func (c *PowerCollector) collectProcessMetrics(ch chan<- prometheus.Metric, stat
 		)
 
 		for zone, usage := range proc.Zones {
-			zoneName := fmt.Sprintf("%s-%d", zone.Name(), zone.Index())
+			zoneName := zone.ZoneLabel()
 			ch <- prometheus.MustNewConstMetric(
 				c.processCPUJoulesDescriptor,
 				prometheus.CounterValue,
@@ -325,7 +325,7 @@ func (c *PowerCollector) collectContainerMetrics(ch chan<- prometheus.Metric, co
 	// No need to lock, already done by the calling function
 	for id, container := range containers {
 		for zone, usage := range container.Zones {
-			zoneName := fmt.Sprintf("%s-%d", zone.Name(), zone.Index())
+			zoneName := zone.ZoneLabel()
 
 			ch <- prometheus.MustNewConstMetric(
 				c.containerCPUJoulesDescriptor,
@@ -358,7 +358,7 @@ func (c *PowerCollector) collectVMMetrics(ch chan<- prometheus.Metric, vms monit
 	// No need to lock, already done by the calling function
 	for id, vm := range vms {
 		for zone, usage := range vm.Zones {
-			zoneName := fmt.Sprintf("%s-%d", zone.Name(), zone.Index())
+			zoneName := zone.ZoneLabel()
 			ch <- prometheus.MustNewConstMetric(
 				c.vmCPUJoulesDescriptor,
 				prometheus.CounterValue,
@@ -387,7 +387,7 @@ func (c *PowerCollector) collectPodMetrics(ch chan<- prometheus.Metric, pods mon
 	// No need to lock, already done by the calling function
 	for id, pod := range pods {
 		for zone, usage := range pod.Zones {
-			zoneName := fmt.Sprintf("%s-%d", zone.Name(), zone.Index())
+			zoneName := zone.ZoneLabel()
 			ch <- prometheus.MustNewConstMetric(
 				c.podCPUJoulesDescriptor,
 				prometheus.CounterValue,

--- a/internal/exporter/prometheus/collector/power_collector_concurrency_test.go
+++ b/internal/exporter/prometheus/collector/power_collector_concurrency_test.go
@@ -105,9 +105,9 @@ func TestPowerCollectorConcurrency(t *testing.T) {
 func TestPowerCollectorWithRegistry(t *testing.T) {
 	mockMonitor := NewMockPowerMonitor()
 
-	package0Zone := device.NewMockRaplZone("package", 0, "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000)
-	package1Zone := device.NewMockRaplZone("package", 1, "/sys/class/powercap/intel-rapl/intel-rapl:1", 1000)
-	dramZone := device.NewMockRaplZone("dram", 0, "/sys/class/powercap/intel-rapl/intel-rapl:0:1", 1000)
+	package0Zone := device.NewMockRaplZone("package", 0, "package-0", "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000)
+	package1Zone := device.NewMockRaplZone("package", 1, "package-1", "/sys/class/powercap/intel-rapl/intel-rapl:1", 1000)
+	dramZone := device.NewMockRaplZone("dram", 0, "dram-0", "/sys/class/powercap/intel-rapl/intel-rapl:0:1", 1000)
 
 	nodePkgAbs := 12300 * device.Joule
 	nodePkgDelta := 123 * device.Joule
@@ -233,7 +233,7 @@ func TestUpdateDuringCollection(t *testing.T) {
 	collectingCh := make(chan struct{})
 	allowCollectCh := make(chan struct{})
 
-	packageZone := device.NewMockRaplZone("package", 0, "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000)
+	packageZone := device.NewMockRaplZone("package", 0, "package", "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000)
 
 	mockMonitor.On("Snapshot").Run(func(args mock.Arguments) {
 		// NOTE: this waits for allow collect to close

--- a/internal/exporter/prometheus/collector/power_collector_test.go
+++ b/internal/exporter/prometheus/collector/power_collector_test.go
@@ -178,8 +178,8 @@ func TestPowerCollector(t *testing.T) {
 	mockMonitor := NewMockPowerMonitor()
 
 	// Setup test zones
-	packageZone := device.NewMockRaplZone("package", 0, "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000)
-	dramZone := device.NewMockRaplZone("dram", 0, "/sys/class/powercap/intel-rapl/intel-rapl:0:1", 1000)
+	packageZone := device.NewMockRaplZone("package", 0, "package", "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000)
+	dramZone := device.NewMockRaplZone("dram", 0, "dram", "/sys/class/powercap/intel-rapl/intel-rapl:0:1", 1000)
 
 	nodePkgAbs := 12300 * device.Joule
 	nodePkgDelta := 123 * device.Joule
@@ -425,7 +425,7 @@ func TestPowerCollector(t *testing.T) {
 			zonePaths = append(zonePaths, path)
 		}
 
-		assert.ElementsMatch(t, zoneNames, []string{"package-0", "dram-0"})
+		assert.ElementsMatch(t, zoneNames, []string{"package", "dram"})
 		assert.ElementsMatch(t, zonePaths, []string{
 			"/sys/class/powercap/intel-rapl/intel-rapl:0",
 			"/sys/class/powercap/intel-rapl/intel-rapl:0:1",
@@ -439,7 +439,7 @@ func TestPowerCollector(t *testing.T) {
 			"comm":      "test-process",
 			"exe":       "/usr/bin/123",
 			"type":      "regular",
-			"zone":      "package-0",
+			"zone":      "package",
 		}
 		assertMetricLabelValues(t, registry, "kepler_process_cpu_joules_total", expectedLabels, 100.0)
 		assertMetricLabelValues(t, registry, "kepler_process_cpu_watts", expectedLabels, 5.0)
@@ -451,7 +451,7 @@ func TestPowerCollector(t *testing.T) {
 			"container_id":   "abcd-efgh",
 			"container_name": "test-container",
 			"runtime":        "podman",
-			"zone":           "package-0",
+			"zone":           "package",
 		}
 		assertMetricLabelValues(t, registry, "kepler_container_cpu_joules_total", expectedLabels, 100.0)
 		assertMetricLabelValues(t, registry, "kepler_container_cpu_watts", expectedLabels, 5.0)
@@ -463,7 +463,7 @@ func TestPowerCollector(t *testing.T) {
 			"vm_id":      "abcd-efgh",
 			"vm_name":    "test-vm",
 			"hypervisor": "kvm",
-			"zone":       "package-0",
+			"zone":       "package",
 		}
 		assertMetricLabelValues(t, registry, "kepler_vm_cpu_joules_total", expectedLabels, 100.0)
 		assertMetricLabelValues(t, registry, "kepler_vm_cpu_watts", expectedLabels, 5.0)
@@ -475,7 +475,7 @@ func TestPowerCollector(t *testing.T) {
 			"pod_id":        "test-pod",
 			"pod_name":      "test-pod",
 			"pod_namespace": "default",
-			"zone":          "package-0",
+			"zone":          "package",
 		}
 		assertMetricLabelValues(t, registry, "kepler_pod_cpu_joules_total", expectedLabels, 100.0)
 		assertMetricLabelValues(t, registry, "kepler_pod_cpu_watts", expectedLabels, 5.0)
@@ -512,7 +512,7 @@ func TestTerminatedProcessExport(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockMonitor := NewMockPowerMonitor()
 
-	packageZone := device.NewMockRaplZone("package", 0, "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000)
+	packageZone := device.NewMockRaplZone("package", 0, "package", "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000)
 
 	testSnapshot := &monitor.Snapshot{
 		Timestamp: time.Now(),
@@ -618,7 +618,7 @@ func TestEnhancedErrorReporting(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockMonitor := NewMockPowerMonitor()
 
-	packageZone := device.NewMockRaplZone("package", 0, "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000)
+	packageZone := device.NewMockRaplZone("package", 0, "package", "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000)
 
 	testSnapshot := &monitor.Snapshot{
 		Timestamp: time.Now(),

--- a/internal/exporter/stdout/stdout_test.go
+++ b/internal/exporter/stdout/stdout_test.go
@@ -152,8 +152,8 @@ func getTestNodeSnapshot() *monitor.Snapshot {
 
 func getTestNodeData() *monitor.Node {
 	// Setup test zones
-	packageZone := device.NewMockRaplZone("package", 0, "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000)
-	dramZone := device.NewMockRaplZone("dram", 0, "/sys/class/powercap/intel-rapl/intel-rapl:0:1", 1000)
+	packageZone := device.NewMockRaplZone("package", 0, "package", "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000)
+	dramZone := device.NewMockRaplZone("dram", 0, "dram", "/sys/class/powercap/intel-rapl/intel-rapl:0:1", 1000)
 
 	nodePkgAbs := 12300 * device.Joule
 	nodePkgPower := 12 * device.Watt

--- a/internal/monitor/clone_test.go
+++ b/internal/monitor/clone_test.go
@@ -25,6 +25,7 @@ func (z *fakeZone) Index() int              { return z.index }
 func (z *fakeZone) Path() string            { return "/fake/path" }
 func (z *fakeZone) Energy() (Energy, error) { return 0, nil }
 func (z *fakeZone) MaxEnergy() Energy       { return 1000000 * Joule }
+func (z *fakeZone) ZoneLabel() string       { return z.name }
 
 func TestNodeClone(t *testing.T) {
 	t.Run("nil_safety", func(t *testing.T) {

--- a/internal/monitor/mock_utils.go
+++ b/internal/monitor/mock_utils.go
@@ -47,6 +47,11 @@ func (m *MockEnergyZone) Index() int {
 	return args.Int(0)
 }
 
+func (m *MockEnergyZone) ZoneLabel() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 func (m *MockEnergyZone) Path() string {
 	args := m.Called()
 	return args.String(0)
@@ -135,8 +140,8 @@ var _ resource.Informer = (*MockResourceInformer)(nil)
 
 // CreateTestZones creates mock energy zones for testing
 func CreateTestZones() []EnergyZone {
-	pkg := device.NewMockRaplZone("package-0", 0, "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000*Joule)
-	core := device.NewMockRaplZone("core-0", 0, "/sys/class/powercap/intel-rapl/intel-rapl:0/intel-rapl:0:0", 500*Joule)
+	pkg := device.NewMockRaplZone("package", 0, "package", "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000*Joule)
+	core := device.NewMockRaplZone("core", 0, "core", "/sys/class/powercap/intel-rapl/intel-rapl:0/intel-rapl:0:0", 500*Joule)
 	return []EnergyZone{pkg, core}
 }
 

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -388,11 +388,11 @@ func TestMonitorRefreshSnapshot(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
 	pkg := device.NewMockRaplZone(
-		"package-0",
-		0, "/sys/class/powercap/intel-rapl/intel-rapl:0", 200*Joule)
+		"package",
+		0, "package", "/sys/class/powercap/intel-rapl/intel-rapl:0", 200*Joule)
 
 	core := device.NewMockRaplZone(
-		"core-0", 0, "/sys/class/powercap/intel-rapl/intel-rapl:0/intel-rapl:0:0", 150*Joule)
+		"core", 0, "core", "/sys/class/powercap/intel-rapl/intel-rapl:0/intel-rapl:0:0", 150*Joule)
 
 	testZones := []EnergyZone{pkg, core}
 	mockCPUPowerMeter := &MockCPUPowerMeter{}
@@ -585,11 +585,11 @@ func TestRefreshSnapshotError(t *testing.T) {
 	t.Run("Fix first read", func(t *testing.T) {
 		mockCPUPowerMeter.ExpectedCalls = nil
 		pkg := device.NewMockRaplZone(
-			"package-0",
-			0, "/sys/class/powercap/intel-rapl/intel-rapl:0", 200*Joule)
+			"package",
+			0, "package", "/sys/class/powercap/intel-rapl/intel-rapl:0", 200*Joule)
 
 		core := device.NewMockRaplZone(
-			"core-0", 0, "/sys/class/powercap/intel-rapl/intel-rapl:0/intel-rapl:0:0", 150*Joule)
+			"core", 0, "core", "/sys/class/powercap/intel-rapl/intel-rapl:0/intel-rapl:0:0", 150*Joule)
 
 		testZones := []EnergyZone{pkg, core}
 		mockCPUPowerMeter.On("Zones").Return(testZones, nil)
@@ -618,11 +618,11 @@ func TestRefreshSnapshotError(t *testing.T) {
 	t.Run("Fix computePower", func(t *testing.T) {
 		mockCPUPowerMeter.ExpectedCalls = nil
 		pkg := device.NewMockRaplZone(
-			"package-0",
-			0, "/sys/class/powercap/intel-rapl/intel-rapl:0", 200*Joule)
+			"package",
+			0, "package", "/sys/class/powercap/intel-rapl/intel-rapl:0", 200*Joule)
 
 		core := device.NewMockRaplZone(
-			"core-0", 0, "/sys/class/powercap/intel-rapl/intel-rapl:0/intel-rapl:0:0", 150*Joule)
+			"core", 0, "core", "/sys/class/powercap/intel-rapl/intel-rapl:0/intel-rapl:0:0", 150*Joule)
 
 		testZones := []EnergyZone{pkg, core}
 		mockCPUPowerMeter.On("Zones").Return(testZones, nil)

--- a/internal/monitor/node_test.go
+++ b/internal/monitor/node_test.go
@@ -28,11 +28,11 @@ func TestNodePowerCollection(t *testing.T) {
 
 	// Create test zones
 	pkg := device.NewMockRaplZone(
-		"package-0",
-		0, "/sys/class/powercap/intel-rapl/intel-rapl:0", 200*Joule)
+		"package",
+		0, "package", "/sys/class/powercap/intel-rapl/intel-rapl:0", 200*Joule)
 
 	core := device.NewMockRaplZone(
-		"core-0", 0, "/sys/class/powercap/intel-rapl/intel-rapl:0/intel-rapl:0:0", 150*Joule)
+		"core", 0, "core", "/sys/class/powercap/intel-rapl/intel-rapl:0/intel-rapl:0:0", 150*Joule)
 
 	testZones := []EnergyZone{pkg, core}
 	mockCPUPowerMeter := &MockCPUPowerMeter{}
@@ -212,11 +212,11 @@ func TestNodeErrorHandling(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
 	pkg := device.NewMockRaplZone(
-		"package-0",
-		0, "/sys/class/powercap/intel-rapl/intel-rapl:0", 200*Joule)
+		"package",
+		0, "package", "/sys/class/powercap/intel-rapl/intel-rapl:0", 200*Joule)
 
 	core := device.NewMockRaplZone(
-		"core-0", 0, "/sys/class/powercap/intel-rapl/intel-rapl:0/intel-rapl:0:0", 150*Joule)
+		"core", 0, "core", "/sys/class/powercap/intel-rapl/intel-rapl:0/intel-rapl:0:0", 150*Joule)
 
 	testZones := []EnergyZone{pkg, core}
 
@@ -350,8 +350,8 @@ func TestNodeActiveEnergyCounterBehavior(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
 	pkg := device.NewMockRaplZone(
-		"package-0",
-		0, "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000*Joule)
+		"package",
+		0, "package", "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000*Joule)
 
 	testZones := []EnergyZone{pkg}
 	mockCPUPowerMeter := &MockCPUPowerMeter{}
@@ -526,8 +526,8 @@ func TestNodeActiveEnergyTotalAccumulation(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
 	pkg := device.NewMockRaplZone(
-		"package-0",
-		0, "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000*Joule)
+		"package",
+		0, "package", "/sys/class/powercap/intel-rapl/intel-rapl:0", 1000*Joule)
 
 	mockCPUPowerMeter := &MockCPUPowerMeter{}
 	testZones := []EnergyZone{pkg}


### PR DESCRIPTION
  This PR fixes the issue of zone label in metrics having a suffix  even when there is a single cpu socket.
  This commit makes sysfsRaplReader make use of number of cpu sockets to   decide a ZoneLabel which is then used in metrics.  if there is a single cpu socket, the index suffix is not used; but if   there are multiple cpu sockets, the zone label is set to use name and  index both.