### PR TITLE
ci: track Makefile changes in check-changes job

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -22,6 +22,7 @@ jobs:
               - '**/*.go'
               - 'go.mod'
               - 'go.sum'
+              - 'Makefile'
   fmt:
     needs: check-changes
     if: needs.check-changes.outputs.changes == 'true'


### PR DESCRIPTION
This commit ensures that Makefile changes are also been tracked as part of the check-changes job.