### PR TITLE
ci: use custom hook for linting PR commits

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -117,9 +117,6 @@ jobs:
       - name: Run Pre-commit
         run: pre-commit run --all-files
 
-  # Using vanilla commitlint instead of running via pre-commit because pre-commit
-  # hooks are meant to run on the commit-msg hook which will only run at the time of commit creation.
-  # Also it will only validate the current commit message, not the entire commit history.
   commit-msg-check:
     runs-on: ubuntu-latest
     steps:
@@ -128,14 +125,14 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all the history of PR commits
 
-      - name: Setup node
-        uses: actions/setup-node@v4
+      - name: Setup Pre-commit
+        run: pip install pre-commit
 
-      - name: Install commitlint
-        run: npm install @commitlint/cli @commitlint/config-conventional
-
-      - name: Validate PR commits
-        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+      - name: Run Pre-commit
+        run: pre-commit run --hook-stage manual pr-commit-lint --all-files
+        env:
+          FROM: ${{ github.event.pull_request.base.sha }}
+          TO: ${{ github.event.pull_request.head.sha }}
 
   build-images:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,20 @@ default_install_hook_types:
   - pre-commit
   - commit-msg
 repos:
+  # This hook lints commit messages within a specified range, ideal for validating all commits in a PR.
+  # Environment variables $FROM (start of range) and $TO (end of range) are set in PR Checks workflow.
+  - repo: local
+    hooks:
+      - id: pr-commit-lint
+        name: pr-commit-lint
+        stages: [manual]
+        language: node
+        additional_dependencies:
+          - "@commitlint/cli"
+          - "@commitlint/config-conventional"
+        pass_filenames: false
+        entry: bash -c "commitlint --from $FROM --to $TO --verbose"
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:


### PR DESCRIPTION
This commit adds a custom hook for linting PR commits. It takes commit range from the PR and uses commitlint to lint the commits.
It also removes the need to install commitlint tool separately using npm on CI