### PR TITLE
ci: enable comment on PR in case of config change

### DIFF
--- a/.github/workflows/config-change.yaml
+++ b/.github/workflows/config-change.yaml
@@ -1,0 +1,42 @@
+name: Check Config Changes
+
+on: #yamllint disable-line rule:truthy
+  pull_request_target:
+    branches: [reboot]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      changes: ${{ steps.filter.outputs.changes }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Filter changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            changes:
+              - 'config/**/*.go'
+
+  comment-on-pr:
+    needs: check-changes
+    if: needs.check-changes.outputs.changes == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on PR
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+            :warning: Config changes detected in this PR.
+            Please make sure that the config changes are updated in the following places as part of this PR:
+            - docs/configuration/configuration.md
+            - compose/dev/kepler-dev/etc/kepler/config.yaml
+            - hack/config.yaml
+            - manifests/k8s/configmap.yaml


### PR DESCRIPTION
This commit adds a new workflow that will check if the Kepler config/
directory has been changed in a PR. If it has, it will comment on the PR
to notify the author to make sure that the relevant changes are also
made to desired places like:
- docs/configuration/configuration.md
- compose/dev/kepler-dev/etc/kepler/config.yaml
- hack/config.yaml
- manifests/k8s/configmap.yaml