### PR TITLE
chore(compose): expose vm metrics in config

### DIFF
--- a/compose/dev/kepler-dev/etc/kepler/config.yaml
+++ b/compose/dev/kepler-dev/etc/kepler/config.yaml
@@ -38,8 +38,10 @@ exporter:
       - process
     metricsLevel:
       - node
-      - container
       - process
+      - container
+      - vm
+      - pod
 
 debug: # debug related config
   pprof: # pprof related config


### PR DESCRIPTION
This commit expose the vm metrics in the config file which was left in https://github.com/sustainable-computing-io/kepler/pull/2187