### PR TITLE
 feat(monitor): add configurable limit for terminated workloads tracking

### DIFF
--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -153,6 +153,7 @@ func createServices(logger *slog.Logger, cfg *config.Config) ([]service.Service,
 		monitor.WithResourceInformer(resourceInformer),
 		monitor.WithInterval(cfg.Monitor.Interval),
 		monitor.WithMaxStaleness(cfg.Monitor.Staleness),
+		monitor.WithMaxTerminated(cfg.Monitor.MaxTerminated),
 	)
 
 	apiServer := server.NewAPIServer(

--- a/compose/dev/kepler-dev/etc/kepler/config.yaml
+++ b/compose/dev/kepler-dev/etc/kepler/config.yaml
@@ -20,6 +20,10 @@ monitor:
   # NOTE: Keep staleness shorter than the monitor interval.
   staleness: 1000ms
 
+  # maximum number of terminated workloads (process, container, VM, pods)
+  # to be kept in memory until the data is exported; 0 disables the limit
+  maxTerminated: 500
+
 host:
   sysfs: /host/sys # Path to sysfs filesystem (default: /sys)
   procfs: /host/proc # Path to procfs filesystem (default: /proc)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -23,6 +23,7 @@ You can configure Kepler by passing flags when starting the service. The followi
 | `--host.sysfs` | Path to sysfs filesystem | `/sys` | Any valid directory path |
 | `--host.procfs` | Path to procfs filesystem | `/proc` | Any valid directory path |
 | `--monitor.interval` | Monitor refresh interval | `5s` | Any valid duration |
+| `--monitor.max-terminated` | Maximum number of terminated workloads to keep in memory until exported | `500` | Any non-negative integer (0 for unlimited) |
 | `--web.config-file` | Path to TLS server config file | `""` | Any valid file path |
 | `--debug.pprof` | Enable pprof debugging endpoints | `false` | `true`, `false` |
 | `--exporter.stdout` | Enable stdout exporter | `false` | `true`, `false` |
@@ -55,6 +56,12 @@ kepler --metrics=node --metrics=container
 
 # Export only process level metrics
 kepler --metrics=process
+
+# Set maximum terminated workloads to 1000
+kepler --monitor.max-terminated=1000
+
+# Disable terminated workload tracking (unlimited)
+kepler --monitor.max-terminated=0
 ```
 
 ## 🗂️ Configuration File
@@ -69,8 +76,9 @@ log:
   format: text  # text or json (default: text)
 
 monitor:
-  interval: 5s      # Monitor refresh interval (default: 5s)
-  staleness: 1000ms # Duration after which data is considered stale (default: 1000ms)
+  interval: 5s        # Monitor refresh interval (default: 5s)
+  staleness: 1000ms   # Duration after which data is considered stale (default: 1000ms)
+  maxTerminated: 500  # Maximum number of terminated workloads to keep in memory (default: 500)
 
 host:
   sysfs: /sys   # Path to sysfs filesystem (default: /sys)
@@ -139,11 +147,14 @@ log:
 monitor:
   interval: 5s
   staleness: 1000ms
+  maxTerminated: 500
 ```
 
 - **interval**: The monitor's refresh interval. All processes with a lifetime less than this interval will be ignored. Setting to 0s disables monitor refreshes.
 
 - **staleness**: Duration after which data computed by the monitor is considered stale and recomputed when requested again. Especially useful when multiple Prometheus instances are scraping Kepler, ensuring they receive the same data within the staleness window. Should be shorter than the monitor interval.
+
+- **maxTerminated**: Maximum number of terminated workloads (processes, containers, VMs, pods) to keep in memory until the data is exported. This prevents unbounded memory growth in high-churn environments. Set to 0 for unlimited (no limit). When the limit is reached, the least power consuming terminated workloads are removed first.
 
 ### 🗄️ Host Configuration
 

--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -20,6 +20,10 @@ monitor:
   # NOTE: Keep staleness shorter than the monitor interval.
   staleness: 1000ms
 
+  # maximum number of terminated workloads (process, container, VM, pods)
+  # to be kept in memory until the data is exported; 0 disables the limit
+  maxTerminated: 500
+
 host:
   sysfs: /sys # Path to sysfs filesystem (default: /sys)
   procfs: /proc # Path to procfs filesystem (default: /proc)
@@ -54,7 +58,6 @@ kube: # kubernetes related config
   enabled: false # enable kubernetes monitoring (default: false)
   config: "" # path to kubeconfig file (optional if running in-cluster)
   nodeName: "" # name of the kubernetes node (required when enabled)
-
 
 # WARN DO NOT ENABLE THIS IN PRODUCTION - for development / testing only
 dev:

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -40,10 +40,11 @@ type PowerMonitor struct {
 	logger *slog.Logger
 	cpu    device.CPUPowerMeter
 
-	interval     time.Duration
-	clock        clock.WithTicker
-	maxStaleness time.Duration
-	resources    resource.Informer
+	interval      time.Duration
+	clock         clock.WithTicker
+	maxStaleness  time.Duration
+	maxTerminated int
+	resources     resource.Informer
 
 	// signals when a snapshot has been updated
 	dataCh chan struct{}
@@ -86,6 +87,7 @@ func NewPowerMonitor(meter device.CPUPowerMeter, applyOpts ...OptionFn) *PowerMo
 		resources:        opts.resources,
 		dataCh:           make(chan struct{}, 1),
 		maxStaleness:     opts.maxStaleness,
+		maxTerminated:    opts.maxTerminated,
 		collectionCtx:    ctx,
 		collectionCancel: cancel,
 	}

--- a/internal/monitor/options.go
+++ b/internal/monitor/options.go
@@ -12,23 +12,25 @@ import (
 )
 
 type Opts struct {
-	logger       *slog.Logger
-	sysfsPath    string
-	interval     time.Duration
-	clock        clock.WithTicker
-	maxStaleness time.Duration
-	resources    resource.Informer
+	logger        *slog.Logger
+	sysfsPath     string
+	interval      time.Duration
+	clock         clock.WithTicker
+	maxStaleness  time.Duration
+	maxTerminated int
+	resources     resource.Informer
 }
 
 // NewConfig returns a new Config with defaults set
 func DefaultOpts() Opts {
 	return Opts{
-		logger:       slog.Default(),
-		sysfsPath:    "/sys",
-		interval:     5 * time.Second,
-		clock:        clock.RealClock{},
-		maxStaleness: 500 * time.Millisecond,
-		resources:    nil,
+		logger:        slog.Default(),
+		sysfsPath:     "/sys",
+		interval:      5 * time.Second,
+		clock:         clock.RealClock{},
+		maxStaleness:  500 * time.Millisecond,
+		maxTerminated: 500,
+		resources:     nil,
 	}
 }
 
@@ -67,5 +69,12 @@ func WithMaxStaleness(d time.Duration) OptionFn {
 func WithResourceInformer(r resource.Informer) OptionFn {
 	return func(o *Opts) {
 		o.resources = r
+	}
+}
+
+// WithMaxTerminated sets the maximum number of terminated workloads to keep in memory
+func WithMaxTerminated(max int) OptionFn {
+	return func(o *Opts) {
+		o.maxTerminated = max
 	}
 }

--- a/manifests/k8s/configmap.yaml
+++ b/manifests/k8s/configmap.yaml
@@ -17,6 +17,7 @@ data:
     monitor:
       interval: 5s
       staleness: 500ms
+      maxTerminated: 100
     rapl:
       zones: []
     exporter:


### PR DESCRIPTION
Add new configuration option 'maxTerminated' to control the maximum number of terminated workloads (processes, containers, VMs, pods) kept in memory until exported. This prevents unbounded memory growth in high-churn environments.

Changes include:
  - Add Monitor.MaxTerminated field with default value of 500
  - Add --monitor.max-terminated CLI flag for runtime configuration
  - Add YAML configuration support for maxTerminated setting
  - Add validation to ensure maxTerminated is non-negative (0 = unlimited)
  - Update documentation with usage examples and configuration details
  - Pass maxTerminated parameter to PowerMonitor via WithMaxTerminated option