### PR TITLE
refactor(config): move metrics package to config

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/stretchr/testify/assert"
-	"github.com/sustainable-computing-io/kepler/internal/exporter/prometheus/metrics"
 	"gopkg.in/yaml.v3"
 	"k8s.io/utils/ptr"
 )
@@ -875,103 +874,103 @@ exporter:
 func TestMetricsLevelValue_Set(t *testing.T) {
 	tests := []struct {
 		name          string
-		initialLevel  metrics.Level
+		initialLevel  Level
 		setValue      string
-		expectedLevel metrics.Level
+		expectedLevel Level
 		expectError   bool
 		errorMessage  string
 	}{
 		{
 			name:          "Set node from default all",
-			initialLevel:  metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			initialLevel:  MetricsLevelAll,
 			setValue:      "node",
-			expectedLevel: metrics.MetricsLevelNode,
+			expectedLevel: MetricsLevelNode,
 			expectError:   false,
 		},
 		{
 			name:          "Set process from default all",
-			initialLevel:  metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			initialLevel:  MetricsLevelAll,
 			setValue:      "process",
-			expectedLevel: metrics.MetricsLevelProcess,
+			expectedLevel: MetricsLevelProcess,
 			expectError:   false,
 		},
 		{
 			name:          "Set container from default all",
-			initialLevel:  metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			initialLevel:  MetricsLevelAll,
 			setValue:      "container",
-			expectedLevel: metrics.MetricsLevelContainer,
+			expectedLevel: MetricsLevelContainer,
 			expectError:   false,
 		},
 		{
 			name:          "Set vm from default all",
-			initialLevel:  metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			initialLevel:  MetricsLevelAll,
 			setValue:      "vm",
-			expectedLevel: metrics.MetricsLevelVM,
+			expectedLevel: MetricsLevelVM,
 			expectError:   false,
 		},
 		{
 			name:          "Set pod from default all",
-			initialLevel:  metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			initialLevel:  MetricsLevelAll,
 			setValue:      "pod",
-			expectedLevel: metrics.MetricsLevelPod,
+			expectedLevel: MetricsLevelPod,
 			expectError:   false,
 		},
 		{
 			name:          "Accumulate node to existing process",
-			initialLevel:  metrics.MetricsLevelProcess,
+			initialLevel:  MetricsLevelProcess,
 			setValue:      "node",
-			expectedLevel: metrics.MetricsLevelProcess | metrics.MetricsLevelNode,
+			expectedLevel: MetricsLevelProcess | MetricsLevelNode,
 			expectError:   false,
 		},
 		{
 			name:          "Accumulate container to existing node+process",
-			initialLevel:  metrics.MetricsLevelNode | metrics.MetricsLevelProcess,
+			initialLevel:  MetricsLevelNode | MetricsLevelProcess,
 			setValue:      "container",
-			expectedLevel: metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer,
+			expectedLevel: MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer,
 			expectError:   false,
 		},
 		{
 			name:          "Invalid level returns error",
-			initialLevel:  metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			initialLevel:  MetricsLevelAll,
 			setValue:      "invalid",
-			expectedLevel: metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod, // Should remain unchanged
+			expectedLevel: MetricsLevelAll, // Should remain unchanged
 			expectError:   true,
 			errorMessage:  "unknown metrics level: invalid",
 		},
 		{
 			name:          "Empty string returns error",
-			initialLevel:  metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			initialLevel:  MetricsLevelAll,
 			setValue:      "",
-			expectedLevel: metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod, // Should remain unchanged
+			expectedLevel: MetricsLevelAll, // Should remain unchanged
 			expectError:   true,
 			errorMessage:  "unknown metrics level: ",
 		},
 		{
 			name:          "Case insensitive - NODE",
-			initialLevel:  metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			initialLevel:  MetricsLevelAll,
 			setValue:      "NODE",
-			expectedLevel: metrics.MetricsLevelNode,
+			expectedLevel: MetricsLevelNode,
 			expectError:   false,
 		},
 		{
 			name:          "Case insensitive - Process",
-			initialLevel:  metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			initialLevel:  MetricsLevelAll,
 			setValue:      "Process",
-			expectedLevel: metrics.MetricsLevelProcess,
+			expectedLevel: MetricsLevelProcess,
 			expectError:   false,
 		},
 		{
 			name:          "Whitespace handling - node with spaces",
-			initialLevel:  metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			initialLevel:  MetricsLevelAll,
 			setValue:      "  node  ",
-			expectedLevel: metrics.MetricsLevelNode,
+			expectedLevel: MetricsLevelNode,
 			expectError:   false,
 		},
 		{
 			name:          "Set same level twice (idempotent)",
-			initialLevel:  metrics.MetricsLevelNode,
+			initialLevel:  MetricsLevelNode,
 			setValue:      "node",
-			expectedLevel: metrics.MetricsLevelNode,
+			expectedLevel: MetricsLevelNode,
 			expectError:   false,
 		},
 	}
@@ -1002,30 +1001,30 @@ func TestMetricsLevelValue_AccumulativeBehavior(t *testing.T) {
 	// Test the cumulative behavior when multiple Set calls are made
 	tests := []struct {
 		name          string
-		initialLevel  metrics.Level
+		initialLevel  Level
 		setValues     []string
-		expectedLevel metrics.Level
+		expectedLevel Level
 		expectError   bool
 	}{
 		{
 			name:          "Accumulate multiple levels from all",
-			initialLevel:  metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			initialLevel:  MetricsLevelAll,
 			setValues:     []string{"node", "process"},
-			expectedLevel: metrics.MetricsLevelNode | metrics.MetricsLevelProcess,
+			expectedLevel: MetricsLevelNode | MetricsLevelProcess,
 			expectError:   false,
 		},
 		{
 			name:          "Accumulate multiple levels from none",
-			initialLevel:  metrics.Level(0),
+			initialLevel:  Level(0),
 			setValues:     []string{"node", "process", "container"},
-			expectedLevel: metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer,
+			expectedLevel: MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer,
 			expectError:   false,
 		},
 		{
 			name:          "Error in middle stops processing",
-			initialLevel:  metrics.Level(0),
+			initialLevel:  Level(0),
 			setValues:     []string{"node", "invalid", "process"},
-			expectedLevel: metrics.MetricsLevelNode, // Should have node from first call
+			expectedLevel: MetricsLevelNode, // Should have node from first call
 			expectError:   true,
 		},
 	}
@@ -1058,27 +1057,27 @@ func TestMetricsLevelValue_AccumulativeBehavior(t *testing.T) {
 func TestMetricsLevelValue_String(t *testing.T) {
 	tests := []struct {
 		name     string
-		level    metrics.Level
+		level    Level
 		expected string
 	}{
 		{
 			name:     "No levels (empty)",
-			level:    metrics.Level(0),
+			level:    Level(0),
 			expected: "",
 		},
 		{
 			name:     "All individual levels",
-			level:    metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			level:    MetricsLevelAll,
 			expected: "node,process,container,vm,pod",
 		},
 		{
 			name:     "Single level - node",
-			level:    metrics.MetricsLevelNode,
+			level:    MetricsLevelNode,
 			expected: "node",
 		},
 		{
 			name:     "Multiple levels - node and process",
-			level:    metrics.MetricsLevelNode | metrics.MetricsLevelProcess,
+			level:    MetricsLevelNode | MetricsLevelProcess,
 			expected: "node,process",
 		},
 	}
@@ -1093,14 +1092,14 @@ func TestMetricsLevelValue_String(t *testing.T) {
 }
 
 func TestMetricsLevelValue_IsCumulative(t *testing.T) {
-	level := metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod
+	level := MetricsLevelAll
 	mlv := NewMetricsLevelValue(&level)
 	assert.True(t, mlv.IsCumulative(), "MetricsLevelValue should be cumulative")
 }
 
 func TestNewMetricsLevelValue(t *testing.T) {
 	t.Run("Creates valid MetricsLevelValue", func(t *testing.T) {
-		level := metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod
+		level := MetricsLevelAll
 		mlv := NewMetricsLevelValue(&level)
 
 		assert.NotNil(t, mlv)
@@ -1108,14 +1107,14 @@ func TestNewMetricsLevelValue(t *testing.T) {
 	})
 
 	t.Run("Modifying target level affects MetricsLevelValue", func(t *testing.T) {
-		level := metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod
+		level := MetricsLevelAll
 		mlv := NewMetricsLevelValue(&level)
 
 		// Modify the original level
-		level = metrics.MetricsLevelNode
+		level = MetricsLevelNode
 
 		// MetricsLevelValue should reflect the change
-		assert.Equal(t, metrics.MetricsLevelNode, *mlv.level)
+		assert.Equal(t, MetricsLevelNode, *mlv.level)
 	})
 }
 
@@ -1124,31 +1123,31 @@ func TestMetricsLevelValue_CommandLineIntegration(t *testing.T) {
 	tests := []struct {
 		name          string
 		args          []string
-		expectedLevel metrics.Level
+		expectedLevel Level
 		expectError   bool
 	}{
 		{
 			name:          "Single flag value - node",
 			args:          []string{"--metrics", "node"},
-			expectedLevel: metrics.MetricsLevelNode,
+			expectedLevel: MetricsLevelNode,
 			expectError:   false,
 		},
 		{
 			name:          "Multiple flag values accumulate",
 			args:          []string{"--metrics", "node", "--metrics", "process"},
-			expectedLevel: metrics.MetricsLevelNode | metrics.MetricsLevelProcess,
+			expectedLevel: MetricsLevelNode | MetricsLevelProcess,
 			expectError:   false,
 		},
 		{
 			name:          "All flag values",
 			args:          []string{"--metrics", "node", "--metrics", "process", "--metrics", "container", "--metrics", "vm", "--metrics", "pod"},
-			expectedLevel: metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			expectedLevel: MetricsLevelAll,
 			expectError:   false,
 		},
 		{
 			name:          "Invalid flag value",
 			args:          []string{"--metrics", "invalid"},
-			expectedLevel: metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod, // Should remain at default
+			expectedLevel: MetricsLevelAll, // Should remain at default
 			expectError:   true,
 		},
 	}
@@ -1157,7 +1156,7 @@ func TestMetricsLevelValue_CommandLineIntegration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a kingpin application for testing
 			app := kingpin.New("test", "test application")
-			var metricsLevel = metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod
+			var metricsLevel = MetricsLevelAll
 			app.Flag("metrics", "Metrics levels to export").SetValue(NewMetricsLevelValue(&metricsLevel))
 
 			// Parse the arguments
@@ -1166,7 +1165,7 @@ func TestMetricsLevelValue_CommandLineIntegration(t *testing.T) {
 			if tt.expectError {
 				assert.Error(t, err)
 				// On error, the level should remain unchanged (default)
-				assert.Equal(t, metrics.MetricsLevelNode|metrics.MetricsLevelProcess|metrics.MetricsLevelContainer|metrics.MetricsLevelVM|metrics.MetricsLevelPod, metricsLevel)
+				assert.Equal(t, MetricsLevelAll, metricsLevel)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expectedLevel, metricsLevel)
@@ -1178,30 +1177,30 @@ func TestMetricsLevelValue_CommandLineIntegration(t *testing.T) {
 func TestMetricsLevelValue_EdgeCases(t *testing.T) {
 	tests := []struct {
 		name          string
-		initialLevel  metrics.Level
+		initialLevel  Level
 		setValue      string
-		expectedLevel metrics.Level
+		expectedLevel Level
 		expectError   bool
 	}{
 		{
 			name:          "Special characters in value",
-			initialLevel:  metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			initialLevel:  MetricsLevelAll,
 			setValue:      "node!@#",
-			expectedLevel: metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			expectedLevel: MetricsLevelAll,
 			expectError:   true,
 		},
 		{
 			name:          "Numeric value",
-			initialLevel:  metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			initialLevel:  MetricsLevelAll,
 			setValue:      "123",
-			expectedLevel: metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			expectedLevel: MetricsLevelAll,
 			expectError:   true,
 		},
 		{
 			name:          "Tab and newline whitespace",
-			initialLevel:  metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			initialLevel:  MetricsLevelAll,
 			setValue:      "\t\nnode\t\n",
-			expectedLevel: metrics.MetricsLevelNode,
+			expectedLevel: MetricsLevelNode,
 			expectError:   false,
 		},
 	}
@@ -1227,27 +1226,27 @@ func TestMetricsLevelValue_EdgeCases(t *testing.T) {
 func TestMetricsLevelYAMLMarshalling(t *testing.T) {
 	tests := []struct {
 		name         string
-		metricsLevel metrics.Level
+		metricsLevel Level
 		expectedYAML string
 	}{
 		{
 			name:         "All individual levels",
-			metricsLevel: metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+			metricsLevel: MetricsLevelAll,
 			expectedYAML: "metricsLevel:\n    - node\n    - process\n    - container\n    - vm\n    - pod",
 		},
 		{
 			name:         "Node only",
-			metricsLevel: metrics.MetricsLevelNode,
+			metricsLevel: MetricsLevelNode,
 			expectedYAML: "node",
 		},
 		{
 			name:         "Pod and Node",
-			metricsLevel: metrics.MetricsLevelPod | metrics.MetricsLevelNode,
+			metricsLevel: MetricsLevelPod | MetricsLevelNode,
 			expectedYAML: "metricsLevel:\n    - node\n    - pod",
 		},
 		{
 			name:         "Node and Process",
-			metricsLevel: metrics.MetricsLevelNode | metrics.MetricsLevelProcess,
+			metricsLevel: MetricsLevelNode | MetricsLevelProcess,
 			expectedYAML: "metricsLevel:\n    - node\n    - process",
 		},
 	}

--- a/config/level.go
+++ b/config/level.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 The Kepler Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package metrics
+package config
 
 import (
 	"fmt"
@@ -18,6 +18,9 @@ const (
 	MetricsLevelContainer                   // 4
 	MetricsLevelVM                          // 8
 	MetricsLevelPod                         // 16
+
+	// MetricsLevelAll represents all metric levels combined
+	MetricsLevelAll = MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod
 )
 
 // String returns the string representation of the level
@@ -69,7 +72,7 @@ func (l Level) IsPodEnabled() bool {
 // ParseLevel parses a slice of strings into a Level
 func ParseLevel(levels []string) (Level, error) {
 	if len(levels) == 0 {
-		return MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod, nil
+		return MetricsLevelAll, nil
 	}
 
 	var result Level

--- a/config/level_test.go
+++ b/config/level_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 The Kepler Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package metrics
+package config
 
 import (
 	"testing"
@@ -18,7 +18,7 @@ func TestLevel_IsEnabled(t *testing.T) {
 	}{
 		{
 			name:  "All levels",
-			level: MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+			level: MetricsLevelAll,
 			expected: map[string]bool{
 				"node":      true,
 				"process":   true,
@@ -81,7 +81,7 @@ func TestLevel_String(t *testing.T) {
 	}{
 		{
 			name:     "All levels",
-			level:    MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+			level:    MetricsLevelAll,
 			expected: "node,process,container,vm,pod",
 		},
 		{
@@ -123,7 +123,7 @@ func TestParseLevel(t *testing.T) {
 		{
 			name:        "Empty slice",
 			levels:      []string{},
-			expected:    MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+			expected:    MetricsLevelAll,
 			expectError: false,
 		},
 		{
@@ -141,7 +141,7 @@ func TestParseLevel(t *testing.T) {
 		{
 			name:        "All levels",
 			levels:      []string{"node", "process", "container", "vm", "pod"},
-			expected:    MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+			expected:    MetricsLevelAll,
 			expectError: false,
 		},
 		{
@@ -198,8 +198,8 @@ func TestBitPatterns(t *testing.T) {
 	assert.Equal(t, Level(16), MetricsLevelPod)      // 1 << 5 = 32
 
 	// Test that combined levels work correctly
-	expected := MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod
-	assert.Equal(t, expected, MetricsLevelNode|MetricsLevelProcess|MetricsLevelContainer|MetricsLevelVM|MetricsLevelPod)
+	expected := MetricsLevelAll
+	assert.Equal(t, expected, MetricsLevelAll)
 }
 
 func TestLevel_MarshalYAML(t *testing.T) {
@@ -210,7 +210,7 @@ func TestLevel_MarshalYAML(t *testing.T) {
 	}{
 		{
 			name:     "All levels",
-			level:    MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+			level:    MetricsLevelAll,
 			expected: "- node\n- process\n- container\n- vm\n- pod\n",
 		},
 		{
@@ -277,7 +277,7 @@ func TestLevel_UnmarshalYAML(t *testing.T) {
 		{
 			name:        "Array with all levels",
 			yamlData:    "- node\n- process\n- container\n- vm\n- pod",
-			expected:    MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+			expected:    MetricsLevelAll,
 			expectError: false,
 		},
 		{
@@ -327,7 +327,7 @@ func TestLevel_YAMLRoundTrip(t *testing.T) {
 		MetricsLevelNode | MetricsLevelProcess,
 		MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
 		MetricsLevelPod | MetricsLevelNode, // 17
-		MetricsLevelNode | MetricsLevelProcess | MetricsLevelContainer | MetricsLevelVM | MetricsLevelPod,
+		MetricsLevelAll,
 	}
 
 	for _, original := range tests {

--- a/hack/gen-metric-docs/main.go
+++ b/hack/gen-metric-docs/main.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sustainable-computing-io/kepler/config"
 	"github.com/sustainable-computing-io/kepler/internal/exporter/prometheus/collector"
-	"github.com/sustainable-computing-io/kepler/internal/exporter/prometheus/metrics"
 	"github.com/sustainable-computing-io/kepler/internal/monitor"
 )
 
@@ -261,7 +261,7 @@ func main() {
 	fmt.Println("Creating collectors...")
 	// Create a logger for the collectors
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	powerCollector := collector.NewPowerCollector(mockMonitor, "test-node", logger, metrics.MetricsLevelNode|metrics.MetricsLevelProcess|metrics.MetricsLevelContainer|metrics.MetricsLevelVM|metrics.MetricsLevelPod)
+	powerCollector := collector.NewPowerCollector(mockMonitor, "test-node", logger, config.MetricsLevelAll)
 	fmt.Println("Created power collector")
 	buildInfoCollector := collector.NewKeplerBuildInfoCollector()
 	fmt.Println("Created build info collector")

--- a/internal/exporter/prometheus/collector/power_collector.go
+++ b/internal/exporter/prometheus/collector/power_collector.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sustainable-computing-io/kepler/internal/exporter/prometheus/metrics"
+	"github.com/sustainable-computing-io/kepler/config"
 	"github.com/sustainable-computing-io/kepler/internal/monitor"
 )
 
@@ -23,7 +23,7 @@ type PowerDataProvider = monitor.PowerDataProvider
 type PowerCollector struct {
 	pm           PowerDataProvider
 	logger       *slog.Logger
-	metricsLevel metrics.Level
+	metricsLevel config.Level
 
 	// Lock to ensure thread safety during collection
 	mutex sync.RWMutex
@@ -97,7 +97,7 @@ func timeDesc(level, device, nodeName string, labels []string) *prometheus.Desc 
 
 // NewPowerCollector creates a collector that provides consistent metrics
 // by fetching all data in a single snapshot during collection
-func NewPowerCollector(monitor PowerDataProvider, nodeName string, logger *slog.Logger, metricsLevel metrics.Level) *PowerCollector {
+func NewPowerCollector(monitor PowerDataProvider, nodeName string, logger *slog.Logger, metricsLevel config.Level) *PowerCollector {
 	const (
 		// these labels should remain the same across all descriptors to ease querying
 		zone   = "zone"

--- a/internal/exporter/prometheus/collector/power_collector_concurrency_test.go
+++ b/internal/exporter/prometheus/collector/power_collector_concurrency_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/sustainable-computing-io/kepler/config"
 	"github.com/sustainable-computing-io/kepler/internal/device"
-	"github.com/sustainable-computing-io/kepler/internal/exporter/prometheus/metrics"
 	"github.com/sustainable-computing-io/kepler/internal/monitor"
 )
 
@@ -41,7 +41,7 @@ func TestPowerCollectorConcurrency(t *testing.T) {
 		musT(device.NewFakeCPUMeter(nil)),
 		monitor.WithResourceInformer(ri),
 	)
-	collector := NewPowerCollector(fakeMonitor, "test-node", newLogger(), metrics.MetricsLevelNode|metrics.MetricsLevelProcess|metrics.MetricsLevelContainer|metrics.MetricsLevelVM|metrics.MetricsLevelPod)
+	collector := NewPowerCollector(fakeMonitor, "test-node", newLogger(), config.MetricsLevelAll)
 
 	assert.NoError(t, fakeMonitor.Init())
 
@@ -156,7 +156,7 @@ func TestPowerCollectorWithRegistry(t *testing.T) {
 	}
 	mockMonitor.On("Snapshot").Return(snapshot, nil)
 
-	collector := NewPowerCollector(mockMonitor, "test-node", newLogger(), metrics.MetricsLevelNode|metrics.MetricsLevelProcess|metrics.MetricsLevelContainer|metrics.MetricsLevelVM|metrics.MetricsLevelPod)
+	collector := NewPowerCollector(mockMonitor, "test-node", newLogger(), config.MetricsLevelAll)
 	mockMonitor.TriggerUpdate()
 	time.Sleep(10 * time.Millisecond)
 
@@ -261,7 +261,7 @@ func TestUpdateDuringCollection(t *testing.T) {
 			},
 		}, nil)
 
-	collector := NewPowerCollector(mockMonitor, "test-node", newLogger(), metrics.MetricsLevelNode|metrics.MetricsLevelProcess|metrics.MetricsLevelContainer|metrics.MetricsLevelVM|metrics.MetricsLevelPod)
+	collector := NewPowerCollector(mockMonitor, "test-node", newLogger(), config.MetricsLevelAll)
 	mockMonitor.TriggerUpdate() // collector should now start building descriptors
 	time.Sleep(10 * time.Millisecond)
 
@@ -332,7 +332,7 @@ func TestConcurrentRegistration(t *testing.T) {
 		monitor.WithResourceInformer(ri),
 	)
 
-	collector := NewPowerCollector(fakeMonitor, "test-node", newLogger(), metrics.MetricsLevelNode|metrics.MetricsLevelProcess|metrics.MetricsLevelContainer|metrics.MetricsLevelVM|metrics.MetricsLevelPod)
+	collector := NewPowerCollector(fakeMonitor, "test-node", newLogger(), config.MetricsLevelAll)
 	assert.NoError(t, fakeMonitor.Init())
 
 	go func() {
@@ -388,7 +388,7 @@ func TestFastCollectAndDescribe(t *testing.T) {
 		musT(device.NewFakeCPUMeter(nil)),
 		monitor.WithResourceInformer(ri),
 	)
-	collector := NewPowerCollector(fakeMonitor, "test-node", newLogger(), metrics.MetricsLevelNode|metrics.MetricsLevelProcess|metrics.MetricsLevelContainer|metrics.MetricsLevelVM|metrics.MetricsLevelPod)
+	collector := NewPowerCollector(fakeMonitor, "test-node", newLogger(), config.MetricsLevelAll)
 
 	assert.NoError(t, fakeMonitor.Init())
 

--- a/internal/exporter/prometheus/collector/power_collector_test.go
+++ b/internal/exporter/prometheus/collector/power_collector_test.go
@@ -16,8 +16,8 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/sustainable-computing-io/kepler/config"
 	"github.com/sustainable-computing-io/kepler/internal/device"
-	"github.com/sustainable-computing-io/kepler/internal/exporter/prometheus/metrics"
 	"github.com/sustainable-computing-io/kepler/internal/monitor"
 	"github.com/sustainable-computing-io/kepler/internal/resource"
 )
@@ -285,7 +285,7 @@ func TestPowerCollector(t *testing.T) {
 	mockMonitor.On("Snapshot").Return(testData, nil)
 
 	// Create collector
-	allLevels := metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod
+	allLevels := config.MetricsLevelAll
 	collector := NewPowerCollector(mockMonitor, "test-node", logger, allLevels)
 
 	// Trigger update to ensure descriptors are created
@@ -567,7 +567,7 @@ func TestTerminatedProcessExport(t *testing.T) {
 
 	mockMonitor.On("Snapshot").Return(testSnapshot, nil)
 
-	collector := NewPowerCollector(mockMonitor, "test-node", logger, metrics.MetricsLevelNode|metrics.MetricsLevelProcess|metrics.MetricsLevelContainer|metrics.MetricsLevelVM|metrics.MetricsLevelPod)
+	collector := NewPowerCollector(mockMonitor, "test-node", logger, config.MetricsLevelAll)
 
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(collector)
@@ -672,7 +672,7 @@ func TestEnhancedErrorReporting(t *testing.T) {
 	}
 
 	mockMonitor.On("Snapshot").Return(testSnapshot, nil)
-	collector := NewPowerCollector(mockMonitor, "test-node", logger, metrics.MetricsLevelNode|metrics.MetricsLevelProcess|metrics.MetricsLevelContainer|metrics.MetricsLevelVM|metrics.MetricsLevelPod)
+	collector := NewPowerCollector(mockMonitor, "test-node", logger, config.MetricsLevelAll)
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(collector)
 	mockMonitor.TriggerUpdate()
@@ -690,12 +690,12 @@ func TestPowerCollector_MetricsLevelFiltering(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		metricsLevel    metrics.Level
+		metricsLevel    config.Level
 		expectedMetrics map[string]bool
 	}{
 		{
 			name:         "Only Node metrics",
-			metricsLevel: metrics.MetricsLevelNode,
+			metricsLevel: config.MetricsLevelNode,
 			expectedMetrics: map[string]bool{
 				"kepler_node_cpu_joules_total":        true,
 				"kepler_node_cpu_watts":               true,
@@ -712,7 +712,7 @@ func TestPowerCollector_MetricsLevelFiltering(t *testing.T) {
 		},
 		{
 			name:         "Only Process metrics",
-			metricsLevel: metrics.MetricsLevelProcess,
+			metricsLevel: config.MetricsLevelProcess,
 			expectedMetrics: map[string]bool{
 				"kepler_node_cpu_joules_total":      false,
 				"kepler_process_cpu_joules_total":   true,
@@ -725,7 +725,7 @@ func TestPowerCollector_MetricsLevelFiltering(t *testing.T) {
 		},
 		{
 			name:         "Node and Container metrics",
-			metricsLevel: metrics.MetricsLevelNode | metrics.MetricsLevelContainer,
+			metricsLevel: config.MetricsLevelNode | config.MetricsLevelContainer,
 			expectedMetrics: map[string]bool{
 				"kepler_node_cpu_joules_total":      true,
 				"kepler_node_cpu_watts":             true,
@@ -738,7 +738,7 @@ func TestPowerCollector_MetricsLevelFiltering(t *testing.T) {
 		},
 		{
 			name:         "No metrics",
-			metricsLevel: metrics.Level(0),
+			metricsLevel: config.Level(0),
 			expectedMetrics: map[string]bool{
 				"kepler_node_cpu_joules_total":      false,
 				"kepler_process_cpu_joules_total":   false,
@@ -911,7 +911,7 @@ func TestTerminatedContainerExport(t *testing.T) {
 
 	mockMonitor.On("Snapshot").Return(testSnapshot, nil)
 
-	allLevels := metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod
+	allLevels := config.MetricsLevelAll
 	collector := NewPowerCollector(mockMonitor, "test-node", logger, allLevels)
 
 	registry := prometheus.NewRegistry()
@@ -1008,7 +1008,7 @@ func TestTerminatedVMExport(t *testing.T) {
 
 	mockMonitor.On("Snapshot").Return(testSnapshot, nil)
 
-	allLevels := metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod
+	allLevels := config.MetricsLevelAll
 	collector := NewPowerCollector(mockMonitor, "test-node", logger, allLevels)
 
 	registry := prometheus.NewRegistry()

--- a/internal/exporter/prometheus/prometheus.go
+++ b/internal/exporter/prometheus/prometheus.go
@@ -11,8 +11,8 @@ import (
 	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sustainable-computing-io/kepler/config"
 	collector "github.com/sustainable-computing-io/kepler/internal/exporter/prometheus/collector"
-	"github.com/sustainable-computing-io/kepler/internal/exporter/prometheus/metrics"
 	"github.com/sustainable-computing-io/kepler/internal/monitor"
 	"github.com/sustainable-computing-io/kepler/internal/service"
 )
@@ -32,7 +32,7 @@ type Opts struct {
 	collectors      map[string]prom.Collector
 	procfs          string
 	nodeName        string
-	metricsLevel    metrics.Level
+	metricsLevel    config.Level
 }
 
 // DefaultOpts() returns a new Opts with defaults set
@@ -43,7 +43,7 @@ func DefaultOpts() Opts {
 			"go": true,
 		},
 		collectors:   map[string]prom.Collector{},
-		metricsLevel: metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+		metricsLevel: config.MetricsLevelAll,
 	}
 }
 
@@ -88,7 +88,7 @@ func WithNodeName(nodeName string) OptionFn {
 	}
 }
 
-func WithMetricsLevel(level metrics.Level) OptionFn {
+func WithMetricsLevel(level config.Level) OptionFn {
 	return func(o *Opts) {
 		o.metricsLevel = level
 	}
@@ -140,7 +140,7 @@ func CreateCollectors(pm Monitor, applyOpts ...OptionFn) (map[string]prom.Collec
 	opts := Opts{
 		logger:       slog.Default(),
 		procfs:       "/proc",
-		metricsLevel: metrics.MetricsLevelNode | metrics.MetricsLevelProcess | metrics.MetricsLevelContainer | metrics.MetricsLevelVM | metrics.MetricsLevelPod,
+		metricsLevel: config.MetricsLevelAll,
 	}
 	for _, apply := range applyOpts {
 		apply(&opts)


### PR DESCRIPTION
  - Move metrics level types from internal/exporter/prometheus/metrics to config package
  - Add MetricsLevelAll constant
  - Update imports
  - Update tesst