### PR TITLE
feat: implement energy-based terminated workload tracking

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,10 @@ type (
 		Interval  time.Duration `yaml:"interval"`  // Interval for monitoring resources
 		Staleness time.Duration `yaml:"staleness"` // Time after which calculated values are considered stale
 
+		// MaxTerminated controls terminated workload tracking behavior:
+		// <0: Any negative value indicates to track unlimited terminated workloads (no capacity limit)
+		// =0: Disable terminated workload tracking completely
+		// >0: Track top N terminated workloads by energy consumption
 		MaxTerminated int `yaml:"maxTerminated"`
 	}
 
@@ -297,8 +301,8 @@ func RegisterFlags(app *kingpin.Application) ConfigUpdaterFn {
 	// monitor
 	monitorInterval := app.Flag(MonitorIntervalFlag,
 		"Interval for monitoring resources (processes, container, vm, etc...); 0 to disable").Default("5s").Duration()
-	maxTerminated := app.Flag(MonitorMaxTerminatedFlag,
-		"Maximum number of terminated workloads to keep in memory until exported; 0 for unlimited").Default("500").Int()
+	monitorMaxTerminated := app.Flag(MonitorMaxTerminatedFlag,
+		"Maximum number of terminated workloads to track; 0 to disable, -1 for unlimited").Default("500").Int()
 
 	enablePprof := app.Flag(pprofEnabledFlag, "Enable pprof debug endpoints").Default("false").Bool()
 	webConfig := app.Flag(WebConfigFlag, "Web config file path").Default("").String()
@@ -338,9 +342,8 @@ func RegisterFlags(app *kingpin.Application) ConfigUpdaterFn {
 		if flagsSet[MonitorIntervalFlag] {
 			cfg.Monitor.Interval = *monitorInterval
 		}
-
 		if flagsSet[MonitorMaxTerminatedFlag] {
-			cfg.Monitor.MaxTerminated = *maxTerminated
+			cfg.Monitor.MaxTerminated = *monitorMaxTerminated
 		}
 
 		if flagsSet[pprofEnabledFlag] {

--- a/internal/device/cpu_power_meter.go
+++ b/internal/device/cpu_power_meter.go
@@ -32,4 +32,9 @@ type CPUPowerMeter interface {
 
 	// Zones() returns a slice of the energy measurement zones
 	Zones() ([]EnergyZone, error)
+
+	// PrimaryEnergyZone() returns the zone with the highest energy coverage/priority
+	// This zone represents the most comprehensive energy measurement available
+	// E.g. Psys > Package > Core > DRAM > Uncore
+	PrimaryEnergyZone() (EnergyZone, error)
 }

--- a/internal/device/fake_cpu_power_meter.go
+++ b/internal/device/fake_cpu_power_meter.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"math/rand"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 
@@ -150,4 +151,26 @@ func (m *fakeRaplMeter) Name() string {
 
 func (m *fakeRaplMeter) Zones() ([]EnergyZone, error) {
 	return m.zones, nil
+}
+
+// PrimaryEnergyZone returns the zone with the highest energy coverage/priority
+func (m *fakeRaplMeter) PrimaryEnergyZone() (EnergyZone, error) {
+	zones, err := m.Zones()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(zones) == 0 {
+		return nil, fmt.Errorf("no zones available in fake meter")
+	}
+
+	// For fake meter, prefer package if available, otherwise first zone
+	for _, zone := range zones {
+		if strings.Contains(strings.ToLower(zone.Name()), "package") {
+			return zone, nil
+		}
+	}
+
+	// Fallback to first zone
+	return zones[0], nil
 }

--- a/internal/exporter/prometheus/collector/power_collector.go
+++ b/internal/exporter/prometheus/collector/power_collector.go
@@ -311,13 +311,12 @@ func (c *PowerCollector) collectProcessMetrics(ch chan<- prometheus.Metric, stat
 
 	// No need to lock, already done by the calling function
 	for pid, proc := range processes {
-		pidStr := fmt.Sprintf("%d", pid)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.processCPUTimeDescriptor,
 			prometheus.CounterValue,
 			proc.CPUTotalTime,
-			pidStr, proc.Comm, proc.Exe, string(proc.Type),
+			pid, proc.Comm, proc.Exe, string(proc.Type),
 			proc.ContainerID, proc.VirtualMachineID,
 		)
 
@@ -327,7 +326,7 @@ func (c *PowerCollector) collectProcessMetrics(ch chan<- prometheus.Metric, stat
 				c.processCPUJoulesDescriptor,
 				prometheus.CounterValue,
 				usage.EnergyTotal.Joules(),
-				pidStr, proc.Comm, proc.Exe, string(proc.Type), state,
+				pid, proc.Comm, proc.Exe, string(proc.Type), state,
 				proc.ContainerID, proc.VirtualMachineID,
 				zoneName,
 			)
@@ -336,7 +335,7 @@ func (c *PowerCollector) collectProcessMetrics(ch chan<- prometheus.Metric, stat
 				c.processCPUWattsDescriptor,
 				prometheus.GaugeValue,
 				usage.Power.Watts(),
-				pidStr, proc.Comm, proc.Exe, string(proc.Type), state,
+				pid, proc.Comm, proc.Exe, string(proc.Type), state,
 				proc.ContainerID, proc.VirtualMachineID,
 				zoneName,
 			)

--- a/internal/exporter/prometheus/collector/power_collector_test.go
+++ b/internal/exporter/prometheus/collector/power_collector_test.go
@@ -215,7 +215,7 @@ func TestPowerCollector(t *testing.T) {
 	}
 
 	testProcesses := monitor.Processes{
-		123: {
+		"123": {
 			PID:          123,
 			Comm:         "test-process",
 			Exe:          "/usr/bin/123",
@@ -527,7 +527,7 @@ func TestTerminatedProcessExport(t *testing.T) {
 			},
 		},
 		Processes: monitor.Processes{
-			123: &monitor.Process{
+			"123": &monitor.Process{
 				PID:          123,
 				Comm:         "running-proc",
 				Exe:          "/usr/bin/running-proc",
@@ -544,7 +544,7 @@ func TestTerminatedProcessExport(t *testing.T) {
 			},
 		},
 		TerminatedProcesses: monitor.Processes{
-			456: &monitor.Process{
+			"456": &monitor.Process{
 				PID:          456,
 				Comm:         "terminated-proc",
 				Exe:          "/usr/bin/terminated-proc",
@@ -633,7 +633,7 @@ func TestEnhancedErrorReporting(t *testing.T) {
 			},
 		},
 		Processes: monitor.Processes{
-			123: &monitor.Process{
+			"123": &monitor.Process{
 				PID:          123,
 				Comm:         "actual-proc",
 				Exe:          "/usr/bin/actual-proc",
@@ -650,7 +650,7 @@ func TestEnhancedErrorReporting(t *testing.T) {
 			},
 		},
 		TerminatedProcesses: monitor.Processes{
-			456: &monitor.Process{
+			"456": &monitor.Process{
 				PID:          456,
 				Comm:         "terminated-proc",
 				Exe:          "/usr/bin/terminated-proc",
@@ -771,7 +771,7 @@ func TestPowerCollector_MetricsLevelFiltering(t *testing.T) {
 					UsageRatio: 0.5,
 				},
 				Processes: monitor.Processes{
-					123: &monitor.Process{
+					"123": &monitor.Process{
 						PID:          123,
 						Comm:         "test-process",
 						Exe:          "/usr/bin/test-process",

--- a/internal/monitor/clone_test.go
+++ b/internal/monitor/clone_test.go
@@ -289,7 +289,7 @@ func TestSnapshotClone(t *testing.T) {
 				},
 			},
 			Processes: Processes{
-				1: &Process{
+				"1": &Process{
 					PID:  1,
 					Comm: "init",
 					Zones: ZoneUsageMap{
@@ -298,7 +298,7 @@ func TestSnapshotClone(t *testing.T) {
 				},
 			},
 			TerminatedProcesses: Processes{
-				999: &Process{
+				"999": &Process{
 					PID:  999,
 					Comm: "terminated-proc",
 					Exe:  "/bin/terminated",
@@ -360,9 +360,9 @@ func TestSnapshotClone(t *testing.T) {
 		// Store original values
 		originalNodeRatio := original.Node.UsageRatio
 		originalNodeEnergy := original.Node.Zones[zone].EnergyTotal
-		originalProcessComm := original.Processes[1].Comm
-		originalTerminatedComm := original.TerminatedProcesses[999].Comm
-		originalTerminatedEnergy := original.TerminatedProcesses[999].Zones[zone].EnergyTotal
+		originalProcessComm := original.Processes["1"].Comm
+		originalTerminatedComm := original.TerminatedProcesses["999"].Comm
+		originalTerminatedEnergy := original.TerminatedProcesses["999"].Zones[zone].EnergyTotal
 		originalContainerName := original.Containers["c1"].Name
 		originalVMName := original.VirtualMachines["vm1"].Name
 		originalPodName := original.Pods["p1"].Name
@@ -370,9 +370,9 @@ func TestSnapshotClone(t *testing.T) {
 		// Verify deep copy by modifying clone
 		clone.Node.UsageRatio = 0.9
 		clone.Node.Zones[zone] = NodeUsage{EnergyTotal: 2000 * Joule, Power: 100 * Watt}
-		clone.Processes[1].Comm = "modified"
-		clone.TerminatedProcesses[999].Comm = "modified-terminated"
-		clone.TerminatedProcesses[999].Zones[zone] = Usage{EnergyTotal: 999 * Joule, Power: 99 * Watt}
+		clone.Processes["1"].Comm = "modified"
+		clone.TerminatedProcesses["999"].Comm = "modified-terminated"
+		clone.TerminatedProcesses["999"].Zones[zone] = Usage{EnergyTotal: 999 * Joule, Power: 99 * Watt}
 		clone.Containers["c1"].Name = "modified"
 		clone.VirtualMachines["vm1"].Name = "modified"
 		clone.Pods["p1"].Name = "modified"
@@ -380,9 +380,9 @@ func TestSnapshotClone(t *testing.T) {
 		// Verify original is unchanged
 		assert.Equal(t, originalNodeRatio, original.Node.UsageRatio, "Original Node UsageRatio should be unchanged")
 		assert.Equal(t, originalNodeEnergy, original.Node.Zones[zone].EnergyTotal, "Original Node zones should be unchanged")
-		assert.Equal(t, originalProcessComm, original.Processes[1].Comm, "Original Process should be unchanged")
-		assert.Equal(t, originalTerminatedComm, original.TerminatedProcesses[999].Comm, "Original TerminatedProcess should be unchanged")
-		assert.Equal(t, originalTerminatedEnergy, original.TerminatedProcesses[999].Zones[zone].EnergyTotal, "Original TerminatedProcess zones should be unchanged")
+		assert.Equal(t, originalProcessComm, original.Processes["1"].Comm, "Original Process should be unchanged")
+		assert.Equal(t, originalTerminatedComm, original.TerminatedProcesses["999"].Comm, "Original TerminatedProcess should be unchanged")
+		assert.Equal(t, originalTerminatedEnergy, original.TerminatedProcesses["999"].Zones[zone].EnergyTotal, "Original TerminatedProcess zones should be unchanged")
 		assert.Equal(t, originalContainerName, original.Containers["c1"].Name, "Original Container should be unchanged")
 		assert.Equal(t, originalVMName, original.VirtualMachines["vm1"].Name, "Original VirtualMachine should be unchanged")
 		assert.Equal(t, originalPodName, original.Pods["p1"].Name, "Original Pod should be unchanged")
@@ -390,9 +390,9 @@ func TestSnapshotClone(t *testing.T) {
 		// Verify clone has modified values
 		assert.Equal(t, 0.9, clone.Node.UsageRatio, "Clone Node should have modified UsageRatio")
 		assert.Equal(t, 2000*Joule, clone.Node.Zones[zone].EnergyTotal, "Clone Node should have modified EnergyTotal")
-		assert.Equal(t, "modified", clone.Processes[1].Comm, "Clone Process should have modified Comm")
-		assert.Equal(t, "modified-terminated", clone.TerminatedProcesses[999].Comm, "Clone TerminatedProcess should have modified Comm")
-		assert.Equal(t, 999*Joule, clone.TerminatedProcesses[999].Zones[zone].EnergyTotal, "Clone TerminatedProcess should have modified EnergyTotal")
+		assert.Equal(t, "modified", clone.Processes["1"].Comm, "Clone Process should have modified Comm")
+		assert.Equal(t, "modified-terminated", clone.TerminatedProcesses["999"].Comm, "Clone TerminatedProcess should have modified Comm")
+		assert.Equal(t, 999*Joule, clone.TerminatedProcesses["999"].Zones[zone].EnergyTotal, "Clone TerminatedProcess should have modified EnergyTotal")
 		assert.Equal(t, "modified", clone.Containers["c1"].Name, "Clone Container should have modified Name")
 		assert.Equal(t, "modified", clone.VirtualMachines["vm1"].Name, "Clone VirtualMachine should have modified Name")
 		assert.Equal(t, "modified", clone.Pods["p1"].Name, "Clone Pod should have modified Name")
@@ -409,7 +409,7 @@ func TestSnapshotTerminatedProcessesClone(t *testing.T) {
 			Node:      &Node{Zones: make(NodeZoneUsageMap)},
 			Processes: make(Processes),
 			TerminatedProcesses: Processes{
-				100: &Process{
+				"100": &Process{
 					PID:          100,
 					Comm:         "term-proc-1",
 					Exe:          "/usr/bin/term-proc-1",
@@ -421,7 +421,7 @@ func TestSnapshotTerminatedProcessesClone(t *testing.T) {
 						zone2: Usage{EnergyTotal: 300 * Joule, Power: 15 * Watt},
 					},
 				},
-				200: &Process{
+				"200": &Process{
 					PID:              200,
 					Comm:             "term-proc-2",
 					Exe:              "/usr/bin/term-proc-2",
@@ -447,12 +447,11 @@ func TestSnapshotTerminatedProcessesClone(t *testing.T) {
 		assert.Len(t, clone.TerminatedProcesses, 2, "Clone should have same number of terminated processes")
 
 		// Verify each terminated process is deeply cloned
-		for pid := range original.TerminatedProcesses {
-			originalProc := original.TerminatedProcesses[pid]
-			clonedProc := clone.TerminatedProcesses[pid]
+		for id, originalProc := range original.TerminatedProcesses {
+			clonedProc := clone.TerminatedProcesses[id]
 
-			require.NotNil(t, clonedProc, "Cloned terminated process %d should exist", pid)
-			assert.NotSame(t, originalProc, clonedProc, "Terminated process %d should be different instance", pid)
+			require.NotNil(t, clonedProc, "Cloned terminated process %d should exist", originalProc.PID)
+			assert.NotSame(t, originalProc, clonedProc, "Terminated process %d should be different instance", originalProc.PID)
 
 			// Verify all fields are copied correctly
 			assert.Equal(t, originalProc.PID, clonedProc.PID)
@@ -464,43 +463,44 @@ func TestSnapshotTerminatedProcessesClone(t *testing.T) {
 			assert.Equal(t, originalProc.VirtualMachineID, clonedProc.VirtualMachineID)
 
 			// Verify zones map independence and content
-			assert.NotSame(t, &originalProc.Zones, &clonedProc.Zones, "Process %d zones map should be different instance", pid)
-			assert.Len(t, clonedProc.Zones, len(originalProc.Zones), "Process %d should have same number of zones", pid)
+			assert.NotSame(t, &originalProc.Zones, &clonedProc.Zones, "Process %d zones map should be different instance", originalProc.PID)
+			assert.Len(t, clonedProc.Zones, len(originalProc.Zones), "Process %d should have same number of zones", originalProc.PID)
 
 			for zone, originalUsage := range originalProc.Zones {
 				clonedUsage, exists := clonedProc.Zones[zone]
-				require.True(t, exists, "Process %d should have zone %s", pid, zone.Name())
-				assert.Equal(t, originalUsage, clonedUsage, "Process %d zone %s usage should be identical", pid, zone.Name())
+				require.True(t, exists, "Process %d should have zone %s", originalProc.PID, zone.Name())
+				assert.Equal(t, originalUsage, clonedUsage, "Process %d zone %s usage should be identical", originalProc.PID, zone.Name())
 			}
 		}
 
 		// Test deep copy isolation by modifying clone
-		clone.TerminatedProcesses[100].Comm = "modified-terminated"
-		clone.TerminatedProcesses[100].CPUTotalTime = 999.9
-		clone.TerminatedProcesses[100].Zones[zone1] = Usage{EnergyTotal: 9999 * Joule, Power: 888 * Watt}
+		clone.TerminatedProcesses["100"].Comm = "modified-terminated"
+		clone.TerminatedProcesses["100"].CPUTotalTime = 999.9
+		clone.TerminatedProcesses["100"].Zones[zone1] = Usage{EnergyTotal: 9999 * Joule, Power: 888 * Watt}
 
 		// Add new terminated process to clone
-		clone.TerminatedProcesses[300] = &Process{
+		newProcess := &Process{
 			PID:  300,
 			Comm: "new-terminated",
 			Zones: ZoneUsageMap{
 				zone1: Usage{EnergyTotal: 111 * Joule, Power: 11 * Watt},
 			},
 		}
+		clone.TerminatedProcesses[newProcess.StringID()] = newProcess
 
 		// Verify original is completely unchanged
-		assert.Equal(t, "term-proc-1", original.TerminatedProcesses[100].Comm, "Original process comm should be unchanged")
-		assert.Equal(t, 125.5, original.TerminatedProcesses[100].CPUTotalTime, "Original process CPU time should be unchanged")
-		assert.Equal(t, 500*Joule, original.TerminatedProcesses[100].Zones[zone1].EnergyTotal, "Original process zone energy should be unchanged")
-		assert.Equal(t, 25*Watt, original.TerminatedProcesses[100].Zones[zone1].Power, "Original process zone power should be unchanged")
-		assert.NotContains(t, original.TerminatedProcesses, 300, "Original should not have new terminated process")
+		assert.Equal(t, "term-proc-1", original.TerminatedProcesses["100"].Comm, "Original process comm should be unchanged")
+		assert.Equal(t, 125.5, original.TerminatedProcesses["100"].CPUTotalTime, "Original process CPU time should be unchanged")
+		assert.Equal(t, 500*Joule, original.TerminatedProcesses["100"].Zones[zone1].EnergyTotal, "Original process zone energy should be unchanged")
+		assert.Equal(t, 25*Watt, original.TerminatedProcesses["100"].Zones[zone1].Power, "Original process zone power should be unchanged")
+		assert.Len(t, original.TerminatedProcesses, 2, "Original should not have new terminated process")
 
 		// Verify clone has modified values
-		assert.Equal(t, "modified-terminated", clone.TerminatedProcesses[100].Comm, "Clone process should have modified comm")
-		assert.Equal(t, 999.9, clone.TerminatedProcesses[100].CPUTotalTime, "Clone process should have modified CPU time")
-		assert.Equal(t, 9999*Joule, clone.TerminatedProcesses[100].Zones[zone1].EnergyTotal, "Clone process should have modified energy")
-		assert.Equal(t, 888*Watt, clone.TerminatedProcesses[100].Zones[zone1].Power, "Clone process should have modified power")
-		assert.Contains(t, clone.TerminatedProcesses, 300, "Clone should have new terminated process")
+		assert.Equal(t, "modified-terminated", clone.TerminatedProcesses["100"].Comm, "Clone process should have modified comm")
+		assert.Equal(t, 999.9, clone.TerminatedProcesses["100"].CPUTotalTime, "Clone process should have modified CPU time")
+		assert.Equal(t, 9999*Joule, clone.TerminatedProcesses["100"].Zones[zone1].EnergyTotal, "Clone process should have modified energy")
+		assert.Equal(t, 888*Watt, clone.TerminatedProcesses["100"].Zones[zone1].Power, "Clone process should have modified power")
+		assert.Len(t, clone.TerminatedProcesses, 3, "Clone should have new terminated process")
 	})
 
 	t.Run("nil_terminated_processes", func(t *testing.T) {
@@ -516,7 +516,7 @@ func TestSnapshotTerminatedProcessesClone(t *testing.T) {
 
 		clone := original.Clone()
 		require.NotNil(t, clone, "Clone should not be nil")
-		assert.Len(t, clone.TerminatedProcesses, 0, "Clone should have empty TerminatedProcesses map when original is nil")
+		assert.Len(t, clone.TerminatedProcesses, 0, "Clone should have empty TerminatedProcesses slice when original is nil")
 	})
 
 	t.Run("empty_terminated_processes", func(t *testing.T) {
@@ -532,8 +532,8 @@ func TestSnapshotTerminatedProcessesClone(t *testing.T) {
 
 		clone := original.Clone()
 		require.NotNil(t, clone, "Clone should not be nil")
-		assert.Len(t, clone.TerminatedProcesses, 0, "Clone should have empty TerminatedProcesses map")
-		assert.NotSame(t, &original.TerminatedProcesses, &clone.TerminatedProcesses, "Even empty maps should be different instances")
+		assert.Len(t, clone.TerminatedProcesses, 0, "Clone should have empty TerminatedProcesses slice")
+		assert.NotSame(t, &original.TerminatedProcesses, &clone.TerminatedProcesses, "Even empty slices should be different instances")
 	})
 }
 
@@ -595,7 +595,7 @@ func TestCloneConcurrency(t *testing.T) {
 				},
 			},
 			Processes: Processes{
-				1: &Process{PID: 1, Zones: ZoneUsageMap{zone: Usage{EnergyTotal: 100 * Joule}}},
+				"1": &Process{PID: 1, Zones: ZoneUsageMap{zone: Usage{EnergyTotal: 100 * Joule}}},
 			},
 		}
 

--- a/internal/monitor/mock_utils.go
+++ b/internal/monitor/mock_utils.go
@@ -23,6 +23,11 @@ func (m *MockCPUPowerMeter) Zones() ([]EnergyZone, error) {
 	return args.Get(0).([]EnergyZone), args.Error(1)
 }
 
+func (m *MockCPUPowerMeter) PrimaryEnergyZone() (EnergyZone, error) {
+	args := m.Called()
+	return args.Get(0).(EnergyZone), args.Error(1)
+}
+
 func (m *MockCPUPowerMeter) Name() string {
 	args := m.Called()
 	return args.String(0)

--- a/internal/monitor/monitor_collection_test.go
+++ b/internal/monitor/monitor_collection_test.go
@@ -24,6 +24,7 @@ func TestCollectionLoop(t *testing.T) {
 
 	mockMeter := &MockCPUPowerMeter{}
 	mockMeter.On("Zones").Return([]EnergyZone{pkg}, nil)
+	mockMeter.On("PrimaryEnergyZone").Return(pkg, nil)
 	fakeClock := testingclock.NewFakeClock(time.Now())
 
 	tr := CreateTestResources()
@@ -74,6 +75,7 @@ func TestPeriodicCollection(t *testing.T) {
 
 	mockMeter := &MockCPUPowerMeter{}
 	mockMeter.On("Zones").Return([]EnergyZone{pkg}, nil)
+	mockMeter.On("PrimaryEnergyZone").Return(pkg, nil)
 	fakeClock := testingclock.NewFakeClock(time.Now())
 
 	resourceInformer := &MockResourceInformer{}
@@ -139,6 +141,7 @@ func TestCollectionCancellation(t *testing.T) {
 
 	mockMeter := &MockCPUPowerMeter{}
 	mockMeter.On("Zones").Return([]EnergyZone{pkg}, nil)
+	mockMeter.On("PrimaryEnergyZone").Return(pkg, nil)
 
 	resourceInformer := &MockResourceInformer{}
 
@@ -216,6 +219,7 @@ func TestScheduleNextCollection(t *testing.T) {
 	pkg.On("MaxEnergy").Return(Energy(1000 * Joule))
 
 	mockMeter.On("Zones").Return([]EnergyZone{pkg}, nil)
+	mockMeter.On("PrimaryEnergyZone").Return(pkg, nil)
 
 	fakeClock := testingclock.NewFakeClock(time.Now())
 
@@ -270,6 +274,7 @@ func TestCollectionWithDataSignaling(t *testing.T) {
 	pkg.On("MaxEnergy").Return(Energy(1000*Joule), nil).Once()
 
 	mockMeter.On("Zones").Return([]EnergyZone{pkg}, nil)
+	mockMeter.On("PrimaryEnergyZone").Return(pkg, nil)
 
 	fakeClock := testingclock.NewFakeClock(time.Now())
 	tr := CreateTestResources()
@@ -321,6 +326,7 @@ func TestCollectionErrorHandling(t *testing.T) {
 	pkg.On("MaxEnergy").Return(Energy(1000 * Joule))
 
 	mockMeter.On("Zones").Return([]EnergyZone{pkg}, nil)
+	mockMeter.On("PrimaryEnergyZone").Return(pkg, nil)
 
 	fakeClock := testingclock.NewFakeClock(time.Now())
 	tr := CreateTestResources()

--- a/internal/monitor/monitor_concurrency_test.go
+++ b/internal/monitor/monitor_concurrency_test.go
@@ -87,6 +87,7 @@ func TestFreshSnapshotCaching(t *testing.T) {
 
 	energyZones := []device.EnergyZone{pkg}
 	mockMeter.On("Zones").Return(energyZones, nil)
+	mockMeter.On("PrimaryEnergyZone").Return(pkg, nil)
 
 	fakeClock := testingclock.NewFakeClock(time.Now())
 	tr := CreateTestResources()
@@ -204,6 +205,7 @@ func TestSingleflightSnapshot(t *testing.T) {
 
 	energyZones := []device.EnergyZone{pkg}
 	mockMeter.On("Zones").Return(energyZones, nil)
+	mockMeter.On("PrimaryEnergyZone").Return(pkg, nil)
 
 	// Create a fake clock to control time
 	fakeClock := testingclock.NewFakeClock(time.Now())
@@ -290,6 +292,7 @@ func TestSnapshot_ComputeFailures(t *testing.T) {
 	pkg.On("Energy").Return(Energy(0), assert.AnError).Once()
 
 	mockMeter.On("Zones").Return([]device.EnergyZone{pkg}, nil)
+	mockMeter.On("PrimaryEnergyZone").Return(pkg, nil)
 
 	fakeClock := testingclock.NewFakeClock(time.Now())
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
@@ -359,6 +362,7 @@ func TestSnapshot_ConcurrentAfterError(t *testing.T) {
 	mockMeter.On("Name").Return("mock-cpu")
 	mockMeter.On("Init", mock.Anything).Return(nil)
 	mockMeter.On("Zones").Return([]device.EnergyZone{pkg}, nil)
+	mockMeter.On("PrimaryEnergyZone").Return(pkg, nil)
 
 	// Create the monitor
 	fakeClock := testingclock.NewFakeClock(time.Now())
@@ -465,6 +469,7 @@ func TestPowerMonitor_ConcurrentCollection(t *testing.T) {
 		}).Return(Energy(energyVal.Load()), nil).Maybe()
 
 		mockMeter.On("Zones").Return([]EnergyZone{pkg}, nil)
+		mockMeter.On("PrimaryEnergyZone").Return(pkg, nil)
 
 		fakeClock := testingclock.NewFakeClock(time.Now())
 
@@ -569,6 +574,7 @@ func TestPowerMonitor_ConcurrentCollection(t *testing.T) {
 		}).Return(Energy(100*Joule), nil).Maybe()
 
 		mockMeter.On("Zones").Return([]EnergyZone{pkg}, nil)
+		mockMeter.On("PrimaryEnergyZone").Return(pkg, nil)
 
 		fakeClock := testingclock.NewFakeClock(time.Now())
 

--- a/internal/monitor/monitor_snapshot_integration_test.go
+++ b/internal/monitor/monitor_snapshot_integration_test.go
@@ -1,0 +1,465 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package monitor
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	testingclock "k8s.io/utils/clock/testing"
+)
+
+// TestIntegration_Monitor_Snapshot validates the complete lifecycle of monitor snapshots
+// and core behaviors of Kepler's power attribution logic.
+//
+// ## Validations
+//
+// ### 1. Energy-First Attribution Pattern
+// - **First snapshot**: Only energy is available (no time delta for power calculation)
+// - Energy is distributed to workloads based on CPU utilization ratios
+// - Node receives total hardware energy from RAPL sensors
+// - Workloads receive proportional energy based on their CPU time delta
+//
+// ### 2. Power Calculation Evolution
+// - **Second snapshot**: Power calculations appear once time delta is available
+// - Power = resource.CPUTimeDelta / node.CPUTotalTime * Node Active Power
+// - Both node and workloads show power consumption based on energy deltas
+//
+// ### 3. Terminated Workload Tracking Infrastructure
+// - Verifies all terminated resource trackers are properly initialized
+// - Confirms correct capacity configuration (configurable via WithMaxTerminated)
+// - Validates energy zone assignment (uses top energy zone from power meter)
+// - Tests reflection-based resource type detection for logging
+//
+// ### 4. Active/Idle Energy Split and Attribution Conservation
+// - Node energy is split into Active (60%) and Idle (40%) based on CPU usage ratio
+// - Active energy is distributed to processes proportionally based on their CPU time
+// - Sum of all process energy equals node active energy (energy conservation)
+// - Sum of all process power equals node active power (power conservation)
+//
+// ### 5. Energy Accumulation and Consistency
+// - Node energy continuously increases as hardware sensors report higher values
+// - Energy attribution remains consistent across multiple collections
+// - System handles realistic energy progression (100J → 150J → 200J)
+//
+// ## Test Architecture
+//
+// This integration test uses controlled mocks to simulate realistic hardware behavior:
+// - **Mock Power Meter**: Provides predictable energy readings with realistic progression
+// - **Fake Clock**: Enables deterministic timing for power calculations
+// - **Test Resources**: Pre-configured workloads with active CPU usage patterns
+// - **Resource Informer**: Simulates process/container discovery from /proc filesystem
+//
+// ## Key Behaviors Validated
+//
+// 1. **Hardware Integration**: RAPL sensor simulation with energy zones
+// 2. **Attribution Algorithm**: CPU-ratio based energy distribution
+// 3. **Power Calculation**: Time-based power derivation from energy deltas
+// 4. **Workload Tracking**: Process/container lifecycle management
+// 5. **Configuration**: Terminated workload tracking with configurable limits
+// 6. **Logging**: Resource type detection using reflection for structured logging
+//
+// This test serves as both validation and documentation of how Kepler's monitor
+// orchestrates measurement, attribution, and export of energy/power data.
+//
+// NOTE:: This test doesn't show actual terminated workloads because that would require
+// more complex mock setup to simulate resource lifecycle changes. The key behaviors
+// that are validated are:
+// 1. ✅ First snapshot: Energy allocation without power
+// 2. ✅ Subsequent snapshots: Power calculations based on time deltas
+// 3. ✅ Active/Idle energy split: Correctly computed based on CPU usage ratio
+// 4. ✅ Energy conservation: Sum of process energy equals node active energy
+// 5. ✅ Power attribution: Sum of process power equals node active power
+// 6. ✅ Terminated workload tracking: Properly configured and operational
+// 7. ✅ Resource type logging: Works through reflection
+// 8. ✅ Energy accumulation: Node energy increases over time
+func TestIntegration_Monitor_Snapshot(t *testing.T) {
+	// Create test resources with active CPU usage
+	tr := CreateTestResources(
+		withNodeCpuUsage(0.6),        // 60% CPU usage for active energy
+		withNodeCpuTimeDelta(2000.0), // 2000ms total CPU time delta
+	)
+
+	// Setup mock power meter with realistic energy progression
+	mockPowerMeter := &MockCPUPowerMeter{}
+	pkg := &MockEnergyZone{}
+	pkg.On("Name").Return("package").Maybe()
+	pkg.On("Index").Return(0).Maybe()
+	pkg.On("MaxEnergy").Return(1000 * Joule).Maybe()
+
+	// Energy readings show consumption over time
+	pkg.On("Energy").Return(100*Joule, nil).Once() // Initial: 100J
+	pkg.On("Energy").Return(150*Joule, nil).Once() // +50J after 5s = 10W average
+	pkg.On("Energy").Return(200*Joule, nil).Once() // +50J after 5s = 10W average
+
+	energyZones := []EnergyZone{pkg}
+	mockPowerMeter.On("Zones").Return(energyZones, nil).Maybe()
+	mockPowerMeter.On("PrimaryEnergyZone").Return(pkg, nil).Maybe()
+	mockPowerMeter.On("Name").Return("mock-cpu").Maybe()
+
+	// Setup resource informer
+	resourceInformer := &MockResourceInformer{}
+	resourceInformer.SetExpectations(t, tr)
+	resourceInformer.On("Refresh").Return(nil).Times(3)
+
+	// let there be time
+	startTime := time.Date(2025, 07, 10, 12, 0, 0, 0, time.UTC)
+	fakeClock := testingclock.NewFakeClock(startTime)
+
+	// Create monitor with terminated workload tracking
+	monitor := NewPowerMonitor(
+		mockPowerMeter,
+		WithResourceInformer(resourceInformer),
+		WithClock(fakeClock),
+		WithMaxTerminated(10), // Enable terminated workload tracking
+		WithLogger(slog.Default().With("test", "snapshot-evolution")),
+	)
+
+	err := monitor.Init()
+	require.NoError(t, err)
+
+	// === Collection 1: First reading shows energy distribution ===
+	snapshot1, err := monitor.Snapshot()
+	require.NoError(t, err)
+	require.NotNil(t, snapshot1)
+
+	t.Logf("=== First Snapshot ===")
+	t.Logf("Node energy: %.0f J, power: %.0f W",
+		snapshot1.Node.Zones[pkg].EnergyTotal.Joules(),
+		snapshot1.Node.Zones[pkg].Power.Watts())
+	t.Logf("Running processes: %d, terminated: %d",
+		len(snapshot1.Processes), len(snapshot1.TerminatedProcesses))
+	t.Logf("Running containers: %d, terminated: %d",
+		len(snapshot1.Containers), len(snapshot1.TerminatedContainers))
+
+	// First reading: Node should have energy but no power
+	assert.True(t, snapshot1.Node.Zones[pkg].EnergyTotal > 0, "Node should have energy")
+	assert.Equal(t, Power(0), snapshot1.Node.Zones[pkg].Power, "Node should have no power on first reading")
+
+	// First reading: Energy split should be calculated based on first energy reading
+	// First reading gets 100J, split 60% active / 40% idle
+	expectedActiveEnergy1 := 60 * Joule // 100J * 0.6
+	expectedIdleEnergy1 := 40 * Joule   // 100J * 0.4
+	assert.Equal(t, expectedActiveEnergy1, snapshot1.Node.Zones[pkg].ActiveEnergyTotal,
+		"Active energy total should be 60% of first reading")
+	assert.Equal(t, expectedIdleEnergy1, snapshot1.Node.Zones[pkg].IdleEnergyTotal,
+		"Idle energy total should be 40% of first reading")
+
+	// Workloads should exist and have energy attributed from first reading
+	assert.NotEmpty(t, snapshot1.Processes, "Should have processes")
+	assert.NotEmpty(t, snapshot1.Containers, "Should have containers")
+
+	// On first reading, processes get attribution based on activeEnergy (not ActiveEnergyTotal)
+	// activeEnergy for first reading is 60kJ, but this value is internal to NodeUsage
+	// Process energy attribution should be 0 because there's no CPU time delta on first reading
+	totalProcessEnergy1 := 0 * Joule
+	for _, proc := range snapshot1.Processes {
+		totalProcessEnergy1 += proc.Zones[pkg].EnergyTotal
+	}
+	// First reading typically has zero process energy due to no CPU time delta
+	assert.Equal(t, 0*Joule, totalProcessEnergy1,
+		"Process energy should be 0 on first reading (no CPU time delta for attribution)")
+
+	// No terminated workloads initially
+	assert.Empty(t, snapshot1.TerminatedProcesses, "Should have no terminated processes")
+	assert.Empty(t, snapshot1.TerminatedContainers, "Should have no terminated containers")
+
+	// === Collection 2: Time passes, power calculations appear ===
+	fakeClock.Step(5 * time.Second) // Advance time to enable power calculation
+
+	snapshot2, err := monitor.Snapshot()
+	require.NoError(t, err)
+	require.NotNil(t, snapshot2)
+
+	t.Logf("=== Second Snapshot (after 5s) ===")
+	t.Logf("Node energy: %.0f J, power: %.0f W",
+		snapshot2.Node.Zones[pkg].EnergyTotal.Joules(),
+		snapshot2.Node.Zones[pkg].Power.Watts())
+	t.Logf("Node active energy: %.0f J, active power: %.0f W",
+		snapshot2.Node.Zones[pkg].ActiveEnergyTotal.Joules(),
+		snapshot2.Node.Zones[pkg].ActivePower.Watts())
+
+	// Second reading: Node should now have power (energy delta / time delta)
+	assert.Greater(t, snapshot2.Node.Zones[pkg].Power, 0*Watt, "Node should have power on second reading")
+	assert.Greater(t, snapshot2.Node.Zones[pkg].ActivePower, 0*Watt, "Node should have active power on second reading")
+	assert.Greater(t, snapshot2.Node.Zones[pkg].EnergyTotal, snapshot1.Node.Zones[pkg].EnergyTotal,
+		"Node energy should have accumulated")
+
+	// Validate Active/Idle energy split (60% CPU usage = 60% of energy delta)
+	// Cumulative active energy: 60J (first) + 30J (delta) = 90J
+	expectedActiveEnergyTotal2 := 90 * Joule // 60J + 30J
+	assert.Equal(t, expectedActiveEnergyTotal2, snapshot2.Node.Zones[pkg].ActiveEnergyTotal,
+		"Active energy total should accumulate: 60J + 30J = 90J")
+
+	// Cumulative idle energy: 40J (first) + 20J (delta) = 60J
+	expectedIdleEnergyTotal2 := 60 * Joule // 40J + 20J
+	assert.Equal(t, expectedIdleEnergyTotal2, snapshot2.Node.Zones[pkg].IdleEnergyTotal,
+		"Idle energy total should accumulate: 40J + 20J = 60J")
+
+	// Validate Active/Idle power split (should match 60% CPU usage)
+	expectedActivePower := Power(float64(snapshot2.Node.Zones[pkg].Power) * 0.6)
+	assert.Equal(t, expectedActivePower, snapshot2.Node.Zones[pkg].ActivePower,
+		"Active power should be 60% of total power")
+
+	expectedIdlePower := snapshot2.Node.Zones[pkg].Power - expectedActivePower
+	assert.Equal(t, expectedIdlePower, snapshot2.Node.Zones[pkg].IdlePower,
+		"Idle power should be 40% of total power")
+
+	// Verify energy attribution: sum of all process energy should equal current energy delta
+	// In second reading, the energy delta is 50J, active portion is 30J
+	totalProcessEnergy := 0 * Joule
+	for _, proc := range snapshot2.Processes {
+		totalProcessEnergy += proc.Zones[pkg].EnergyTotal
+	}
+	expectedActiveEnergyDelta := 30 * Joule // 50J * 0.6 = 30J (current delta)
+	assert.Equal(t, expectedActiveEnergyDelta, totalProcessEnergy,
+		"Sum of process energy should equal current active energy delta (30J)")
+
+	// Verify power attribution: sum of all process power should equal node active power
+	totalProcessPower := 0 * Watt
+	for _, proc := range snapshot2.Processes {
+		totalProcessPower += proc.Zones[pkg].Power
+	}
+	assert.Equal(t, snapshot2.Node.Zones[pkg].ActivePower, totalProcessPower,
+		"Sum of process power should equal node active power")
+
+	// === Collection 3: Continued operation ===
+	fakeClock.Step(5 * time.Second) // Advance time again
+
+	snapshot3, err := monitor.Snapshot()
+	require.NoError(t, err)
+	require.NotNil(t, snapshot3)
+
+	t.Logf("=== Third Snapshot (after 10s total) ===")
+	t.Logf("Node energy: %.0f J, power: %.0f W",
+		snapshot3.Node.Zones[pkg].EnergyTotal.Joules(),
+		snapshot3.Node.Zones[pkg].Power.Watts())
+	t.Logf("Node active energy: %.0f J, active power: %.0f µW",
+		snapshot3.Node.Zones[pkg].ActiveEnergyTotal.Joules(),
+		snapshot3.Node.Zones[pkg].ActivePower.Watts())
+
+	// Third reading: Power should continue, energy should continue accumulating
+	assert.True(t, snapshot3.Node.Zones[pkg].Power > 0, "Node should maintain power")
+	assert.True(t, snapshot3.Node.Zones[pkg].ActivePower > 0, "Node should maintain active power")
+	assert.True(t, snapshot3.Node.Zones[pkg].EnergyTotal >= snapshot2.Node.Zones[pkg].EnergyTotal,
+		"Node energy should continue accumulating")
+
+	// Validate cumulative energy accumulation
+	// Third reading: Active energy total should now be 60J + 30J + 30J = 120J
+	expectedActiveEnergyTotal3 := 120 * Joule // 60J + 30J + 30J
+	assert.Equal(t, expectedActiveEnergyTotal3, snapshot3.Node.Zones[pkg].ActiveEnergyTotal,
+		"Active energy total should accumulate: 60J + 30J + 30J = 120J")
+
+	expectedIdleEnergyTotal3 := 80 * Joule // 40J + 20J + 20J
+	assert.Equal(t, expectedIdleEnergyTotal3, snapshot3.Node.Zones[pkg].IdleEnergyTotal,
+		"Idle energy total should accumulate: 40J + 20J + 20J = 80J")
+
+	// Verify consistent attribution in third snapshot
+	// Process energy accumulates: first delta (30J) + second delta (30J) = 60J
+	totalProcessEnergy3 := 0 * Joule
+	totalProcessPower3 := Power(0)
+	for _, proc := range snapshot3.Processes {
+		totalProcessEnergy3 += proc.Zones[pkg].EnergyTotal
+		totalProcessPower3 += proc.Zones[pkg].Power
+	}
+	expectedTotalProcessEnergy3 := 60 * Joule // 30J + 30J (accumulated process energy
+	assert.Equal(t, expectedTotalProcessEnergy3, totalProcessEnergy3,
+		"Sum of process energy should equal accumulated process attribution (60J)")
+	assert.Equal(t, snapshot3.Node.Zones[pkg].ActivePower, totalProcessPower3,
+		"Sum of process power should equal node active power in third snapshot")
+
+	// === Verify terminated workload tracking is configured ===
+	t.Run("Terminated workload tracking configuration", func(t *testing.T) {
+		// Verify all trackers are initialized
+		assert.NotNil(t, monitor.terminatedProcessesTracker, "Process tracker should be initialized")
+		assert.NotNil(t, monitor.terminatedContainersTracker, "Container tracker should be initialized")
+		assert.NotNil(t, monitor.terminatedVMsTracker, "VM tracker should be initialized")
+		assert.NotNil(t, monitor.terminatedPodsTracker, "Pod tracker should be initialized")
+
+		// Verify configuration
+		assert.Equal(t, 10, monitor.terminatedProcessesTracker.MaxSize(), "Should have correct capacity")
+		assert.Equal(t, pkg, monitor.terminatedProcessesTracker.EnergyZone(), "Should use top energy zone")
+
+		// Verify tracker types are logged correctly
+		processTracker := monitor.terminatedProcessesTracker.String()
+		assert.Contains(t, processTracker, "TerminatedResourceTracker", "Should identify as terminated resource tracker")
+		assert.Contains(t, processTracker, "0/10", "Should show current usage")
+		assert.Contains(t, processTracker, "package", "Should show energy zone")
+
+		t.Logf("Process tracker: %s", processTracker)
+		t.Logf("Container tracker: %s", monitor.terminatedContainersTracker.String())
+	})
+
+	// === Test terminated workload prioritization ===
+	t.Run("Terminated workload tracker prioritization", func(t *testing.T) {
+		// Create a new monitor with small capacity for testing prioritization
+		smallCapacityMonitor := NewPowerMonitor(
+			mockPowerMeter,
+			WithResourceInformer(resourceInformer),
+			WithClock(fakeClock),
+			WithMaxTerminated(2), // Small capacity to test eviction
+			WithLogger(slog.Default().With("test", "prioritization")),
+		)
+
+		err := smallCapacityMonitor.Init()
+		require.NoError(t, err)
+
+		// === Step 1: Create terminated processes with different energy levels ===
+
+		// High energy process
+		highEnergyProcess := &Process{
+			PID:   1001,
+			Comm:  "high-energy-proc",
+			Zones: make(ZoneUsageMap),
+		}
+		highEnergyProcess.Zones[pkg] = Usage{
+			EnergyTotal: 100 * Joule, // High energy
+			Power:       Power(20 * Watt),
+		}
+
+		// Medium energy process
+		mediumEnergyProcess := &Process{
+			PID:   1002,
+			Comm:  "medium-energy-proc",
+			Zones: make(ZoneUsageMap),
+		}
+		mediumEnergyProcess.Zones[pkg] = Usage{
+			EnergyTotal: 50 * Joule, // Medium energy
+			Power:       Power(10 * Watt),
+		}
+
+		// Low energy process
+		lowEnergyProcess := &Process{
+			PID:   1003,
+			Comm:  "low-energy-proc",
+			Zones: make(ZoneUsageMap),
+		}
+		lowEnergyProcess.Zones[pkg] = Usage{
+			EnergyTotal: 20 * Joule, // Low energy
+			Power:       Power(5 * Watt),
+		}
+
+		// === Step 2: Add processes to tracker (under capacity) ===
+
+		// Add first two processes (within capacity)
+		smallCapacityMonitor.terminatedProcessesTracker.Add(mediumEnergyProcess)
+		smallCapacityMonitor.terminatedProcessesTracker.Add(lowEnergyProcess)
+
+		// Verify both processes are tracked
+		trackedProcesses := smallCapacityMonitor.terminatedProcessesTracker.Items()
+		assert.Len(t, trackedProcesses, 2, "Should track both processes when under capacity")
+
+		// === Step 3: Add high energy process (should evict lowest) ===
+
+		// Add high energy process - should evict low energy process
+		smallCapacityMonitor.terminatedProcessesTracker.Add(highEnergyProcess)
+
+		// Verify tracker maintains only top 2 processes
+		trackedProcesses = smallCapacityMonitor.terminatedProcessesTracker.Items()
+		assert.Len(t, trackedProcesses, 2, "Should maintain capacity limit")
+
+		// Verify high and medium energy processes are retained
+		trackedPIDs := make(map[int]bool)
+		trackedEnergies := make(map[int]Energy)
+		for _, proc := range trackedProcesses {
+			trackedPIDs[proc.PID] = true
+			trackedEnergies[proc.PID] = proc.Zones[pkg].EnergyTotal
+		}
+
+		assert.True(t, trackedPIDs[1001], "High energy process should be retained")
+		assert.True(t, trackedPIDs[1002], "Medium energy process should be retained")
+		assert.False(t, trackedPIDs[1003], "Low energy process should be evicted")
+
+		// Verify energy values are preserved correctly
+		assert.Equal(t, 100*Joule, trackedEnergies[1001], "High energy process should have correct energy")
+		assert.Equal(t, 50*Joule, trackedEnergies[1002], "Medium energy process should have correct energy")
+
+		// === Step 4: Add another low energy process (should be rejected) ===
+
+		veryLowEnergyProcess := &Process{
+			PID:   1004,
+			Comm:  "very-low-energy-proc",
+			Zones: make(ZoneUsageMap),
+		}
+		veryLowEnergyProcess.Zones[pkg] = Usage{
+			EnergyTotal: 10 * Joule, // Very low energy
+			Power:       Power(2 * Watt),
+		}
+
+		smallCapacityMonitor.terminatedProcessesTracker.Add(veryLowEnergyProcess)
+
+		// Verify tracker still maintains the same top 2 processes
+		trackedProcesses = smallCapacityMonitor.terminatedProcessesTracker.Items()
+		assert.Len(t, trackedProcesses, 2, "Should still maintain capacity limit")
+
+		// Verify the same high energy processes are still tracked
+		trackedPIDs = make(map[int]bool)
+		for _, proc := range trackedProcesses {
+			trackedPIDs[proc.PID] = true
+		}
+
+		assert.True(t, trackedPIDs[1001], "High energy process should still be retained")
+		assert.True(t, trackedPIDs[1002], "Medium energy process should still be retained")
+		assert.False(t, trackedPIDs[1004], "Very low energy process should be rejected")
+
+		// === Step 5: Add ultra high energy process (should evict medium) ===
+
+		ultraHighEnergyProcess := &Process{
+			PID:   1005,
+			Comm:  "ultra-high-energy-proc",
+			Zones: make(ZoneUsageMap),
+		}
+		ultraHighEnergyProcess.Zones[pkg] = Usage{
+			EnergyTotal: 200 * Joule, // Ultra high energy
+			Power:       Power(40 * Watt),
+		}
+
+		smallCapacityMonitor.terminatedProcessesTracker.Add(ultraHighEnergyProcess)
+
+		// Verify tracker now has ultra high and high energy processes
+		trackedProcesses = smallCapacityMonitor.terminatedProcessesTracker.Items()
+		assert.Len(t, trackedProcesses, 2, "Should maintain capacity limit")
+
+		// Verify ultra high and high energy processes are retained
+		trackedPIDs = make(map[int]bool)
+		trackedEnergies = make(map[int]Energy)
+		for _, proc := range trackedProcesses {
+			trackedPIDs[proc.PID] = true
+			trackedEnergies[proc.PID] = proc.Zones[pkg].EnergyTotal
+		}
+
+		assert.True(t, trackedPIDs[1005], "Ultra high energy process should be retained")
+		assert.True(t, trackedPIDs[1001], "High energy process should be retained")
+		assert.False(t, trackedPIDs[1002], "Medium energy process should be evicted")
+
+		// Verify energy values are preserved correctly
+		assert.Equal(t, 200*Joule, trackedEnergies[1005], "Ultra high energy process should have correct energy")
+		assert.Equal(t, 100*Joule, trackedEnergies[1001], "High energy process should have correct energy")
+
+		t.Logf("=== Priority-based Tracking Validated ===")
+		t.Logf("✅ Under capacity: All processes tracked")
+		t.Logf("✅ At capacity: Higher energy processes evict lower energy ones")
+		t.Logf("✅ Rejection: Very low energy processes are rejected when tracker is full")
+		t.Logf("✅ Eviction: Medium energy processes are evicted for ultra high energy ones")
+		t.Logf("✅ Energy preservation: Tracked processes maintain exact energy values")
+	})
+
+	t.Logf("=== Integration Test Summary ===")
+	// NOTE: if you modify the test, make sure to update this summary
+	t.Logf("✅ First reading behavior: Energy without power")
+	t.Logf("✅ Power calculation behavior: Appears in subsequent readings")
+	t.Logf("✅ Active/Idle split: 60%% CPU usage → 60%% active energy/power")
+	t.Logf("✅ Energy conservation: Process energy sums to node active energy")
+	t.Logf("✅ Power attribution: Process power sums to node active power")
+	t.Logf("✅ Terminated workload tracking: Configured with capacity %d",
+		monitor.terminatedProcessesTracker.MaxSize())
+	t.Logf("✅ Resource type detection: Using reflection-based logging")
+	t.Logf("✅ Priority-based tracking: Maintains only top energy consuming terminated resources")
+	t.Logf("✅ Energy accumulation: Node energy increased from %.0f to %.0f J",
+		snapshot1.Node.Zones[pkg].EnergyTotal.Joules(),
+		snapshot3.Node.Zones[pkg].EnergyTotal.Joules())
+}

--- a/internal/monitor/node_test.go
+++ b/internal/monitor/node_test.go
@@ -42,7 +42,7 @@ func TestNodePowerCollection(t *testing.T) {
 		startTime := time.Date(2025, 4, 14, 5, 40, 0, 0, time.UTC)
 		mockClock := test_clock.NewFakeClock(startTime)
 
-		mockCPUPowerMeter.On("Zones").Return(testZones, nil).Once()
+		mockCPUPowerMeter.On("Zones").Return(testZones, nil)
 
 		// Create mock resource informer
 		mockResourceInformer := &MockResourceInformer{}
@@ -373,7 +373,7 @@ func TestNodeActiveEnergyCounterBehavior(t *testing.T) {
 		WithResourceInformer(mockResourceInformer))
 
 	t.Run("Initial measurement", func(t *testing.T) {
-		mockCPUPowerMeter.On("Zones").Return(testZones, nil).Once()
+		mockCPUPowerMeter.On("Zones").Return(testZones, nil)
 		pkg.Inc(100 * Joule) // Start at 100J
 
 		snapshot := NewSnapshot()
@@ -396,7 +396,7 @@ func TestNodeActiveEnergyCounterBehavior(t *testing.T) {
 	t.Run("Second measurement - verify interval-based attribution", func(t *testing.T) {
 		mockClock.Step(2 * time.Second)
 		mockCPUPowerMeter.ExpectedCalls = nil
-		mockCPUPowerMeter.On("Zones").Return(testZones, nil).Once()
+		mockCPUPowerMeter.On("Zones").Return(testZones, nil)
 
 		pkg.Inc(50 * Joule) // Total: 150J, Delta: 50J
 
@@ -435,7 +435,7 @@ func TestNodeActiveEnergyCounterBehavior(t *testing.T) {
 	t.Run("Third measurement - verify values reset per interval", func(t *testing.T) {
 		mockClock.Step(3 * time.Second)
 		mockCPUPowerMeter.ExpectedCalls = nil
-		mockCPUPowerMeter.On("Zones").Return(testZones, nil).Once()
+		mockCPUPowerMeter.On("Zones").Return(testZones, nil)
 
 		pkg.Inc(60 * Joule) // Total: 210J, Delta: 60J
 
@@ -476,7 +476,7 @@ func TestNodeActiveEnergyCounterBehavior(t *testing.T) {
 
 		mockClock.Step(1 * time.Second)
 		mockCPUPowerMeter.ExpectedCalls = nil
-		mockCPUPowerMeter.On("Zones").Return(testZones, nil).Once()
+		mockCPUPowerMeter.On("Zones").Return(testZones, nil)
 
 		pkg.Inc(40 * Joule) // Total: 250J, Delta: 40J
 
@@ -532,6 +532,7 @@ func TestNodeActiveEnergyTotalAccumulation(t *testing.T) {
 	mockCPUPowerMeter := &MockCPUPowerMeter{}
 	testZones := []EnergyZone{pkg}
 	mockCPUPowerMeter.On("Zones").Return(testZones, nil)
+	mockCPUPowerMeter.On("PrimaryEnergyZone").Return(testZones[0], nil)
 
 	mockResourceInformer := &MockResourceInformer{}
 	mockNode := &resource.Node{
@@ -549,7 +550,7 @@ func TestNodeActiveEnergyTotalAccumulation(t *testing.T) {
 		resources: mockResourceInformer,
 	}
 
-	err := pm.initZones()
+	err := pm.Init()
 	require.NoError(t, err)
 
 	t.Run("measurement 1 - initial", func(t *testing.T) {

--- a/internal/monitor/options.go
+++ b/internal/monitor/options.go
@@ -13,7 +13,6 @@ import (
 
 type Opts struct {
 	logger        *slog.Logger
-	sysfsPath     string
 	interval      time.Duration
 	clock         clock.WithTicker
 	maxStaleness  time.Duration
@@ -25,7 +24,6 @@ type Opts struct {
 func DefaultOpts() Opts {
 	return Opts{
 		logger:        slog.Default(),
-		sysfsPath:     "/sys",
 		interval:      5 * time.Second,
 		clock:         clock.RealClock{},
 		maxStaleness:  500 * time.Millisecond,

--- a/internal/monitor/options.go
+++ b/internal/monitor/options.go
@@ -15,9 +15,9 @@ type Opts struct {
 	logger        *slog.Logger
 	interval      time.Duration
 	clock         clock.WithTicker
+	resources     resource.Informer
 	maxStaleness  time.Duration
 	maxTerminated int
-	resources     resource.Informer
 }
 
 // NewConfig returns a new Config with defaults set
@@ -27,8 +27,8 @@ func DefaultOpts() Opts {
 		interval:      5 * time.Second,
 		clock:         clock.RealClock{},
 		maxStaleness:  500 * time.Millisecond,
-		maxTerminated: 500,
 		resources:     nil,
+		maxTerminated: 500,
 	}
 }
 

--- a/internal/monitor/options_test.go
+++ b/internal/monitor/options_test.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package monitor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestWithMaxTerminated tests the WithMaxTerminated option function
+func TestWithMaxTerminated(t *testing.T) {
+	tests := []struct {
+		name     string
+		maxValue int
+	}{
+		{"zero", 0},
+		{"positive", 100},
+		{"unlimited", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := DefaultOpts()
+			option := WithMaxTerminated(tt.maxValue)
+			option(&opts)
+			assert.Equal(t, tt.maxValue, opts.maxTerminated)
+		})
+	}
+}

--- a/internal/monitor/terminated_resource_tracker.go
+++ b/internal/monitor/terminated_resource_tracker.go
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package monitor
+
+import (
+	"container/heap"
+	"fmt"
+	"log/slog"
+	"reflect"
+
+	"github.com/sustainable-computing-io/kepler/internal/device"
+)
+
+// Resource represents any resource type that can be tracked by energy consumption
+type Resource interface {
+	StringID() string
+	ZoneUsage() ZoneUsageMap
+}
+
+// TerminatedResourceTracker tracks the top N highest energy consuming terminated resources
+// using a priority queue (min-heap) for fast insertion operations.
+//
+// IMPORTANT: This tracker is designed specifically for terminated resources, which  should ..
+// follow these properties:
+// - Once terminated, a resource cannot be terminated again
+// - Energy consumption of terminated resources is immutable (frozen at termination)
+// - No updates or re-additions of the same resource will occur
+//
+// These constraints allow for optimizations like skipping duplicate checks
+type TerminatedResourceTracker[T Resource] struct {
+	logger     *slog.Logger
+	heap       Heap[T]           // min-heap for efficient eviction of lowest energy items
+	resources  map[string]T      // ID -> Resource for O(1) lookup
+	targetZone device.EnergyZone // zone to use for energy comparison
+	maxSize    int               // maximum number of resources to track
+}
+
+// Heap implements a min-heap of resources sorted by energy consumption
+type Heap[T Resource] []HeapItem[T]
+
+// HeapItem represents a resource with its energy value in the heap
+type HeapItem[T Resource] struct {
+	resource    T
+	ID          string
+	EnergyTotal Energy
+}
+
+// NewTerminatedResourceTracker creates a new tracker with the specified energy zone and capacity
+func NewTerminatedResourceTracker[T Resource](zone device.EnergyZone, maxSize int, logger *slog.Logger) *TerminatedResourceTracker[T] {
+	h := Heap[T]{}
+	heap.Init(&h)
+
+	// get the resource typename (Process, Container) and add it to logger context
+	var zero T
+	resourceType := reflect.TypeOf(zero).Elem().Name()
+	loggerWithType := logger.With("service", "terminated-resource-tracker", "resource", resourceType)
+
+	return &TerminatedResourceTracker[T]{
+		logger:     loggerWithType,
+		heap:       h,
+		resources:  make(map[string]T),
+		targetZone: zone,
+		maxSize:    maxSize,
+	}
+}
+
+// Add adds a terminated resource to the tracker.
+//
+// NOTE: OPTIMIZATION: Since terminated resources are immutable and
+// cannot be re-terminated, this method assumes that:
+// - The same resource ID will never be added twice in normal operation
+// - No energy updates for existing resources will occur
+// - Resources added here represent the final energy state at termination
+//
+// If the tracker is at capacity, the resource with the lowest energy will be evicted
+// if the new resource has higher energy.
+func (trt *TerminatedResourceTracker[T]) Add(resource T) {
+	// If maxSize is 0, feature is disabled - don't track anything
+	if trt.maxSize == 0 {
+		return
+	}
+
+	// Check if already tracking this resource
+	// NOTE: Since terminated resources are immutable and should never be re-added,
+	// this check is for safety but should never trigger in normal operation
+	id := resource.StringID()
+	if _, exists := trt.resources[id]; exists {
+		trt.logger.Warn("Resource already tracked in terminated resource tracker", "id", id)
+		return // Ignore duplicate - terminated resource already tracked
+	}
+
+	zones := resource.ZoneUsage()
+
+	// Get energy for the configured zone
+	zoneUsage, exists := zones[trt.targetZone]
+	if !exists || zoneUsage.EnergyTotal == 0 {
+		trt.logger.Debug("Resource has no energy in target zone", "id", id, "zone", trt.targetZone, "action", "skip")
+		return // skip resources with no energy in this zone
+	}
+
+	newItem := HeapItem[T]{
+		ID:          id,
+		EnergyTotal: zoneUsage.EnergyTotal,
+		resource:    resource,
+	}
+
+	// nothing more to do if there is room or maxSize is unlimited
+	if len(trt.heap) < trt.maxSize || trt.maxSize < 0 {
+		// Room available, just add
+		heap.Push(&trt.heap, newItem)
+		trt.resources[id] = resource
+		return
+	}
+
+	// At capacity, check if new item has higher energy than minimum
+	if len(trt.heap) > 0 && newItem.EnergyTotal > trt.heap[0].EnergyTotal {
+		// Evict lowest energy resource
+		minItem := heap.Pop(&trt.heap).(HeapItem[T])
+		delete(trt.resources, minItem.ID)
+
+		// Add new higher-energy resource
+		heap.Push(&trt.heap, newItem)
+		trt.resources[id] = resource
+	}
+}
+
+// Items returns all tracked workloads as a map[string]T where the key is the resource ID
+func (trt *TerminatedResourceTracker[T]) Items() map[string]T {
+	// Return a copy of the map to prevent external modifications
+	result := make(map[string]T, len(trt.resources))
+	for id, resource := range trt.resources {
+		result[id] = resource
+	}
+	return result
+}
+
+// Size returns the current number of tracked resources
+func (trt *TerminatedResourceTracker[T]) Size() int {
+	return len(trt.resources)
+}
+
+// MaxSize returns the maximum capacity of the tracker
+func (trt *TerminatedResourceTracker[T]) MaxSize() int {
+	return trt.maxSize
+}
+
+// Clear removes all tracked resources
+func (trt *TerminatedResourceTracker[T]) Clear() {
+	trt.resources = make(map[string]T)
+	trt.heap = trt.heap[:0] // Clear the slice but keep the underlying array
+	heap.Init(&trt.heap)    // Re-initialize the heap
+}
+
+// EnergyZone returns the energy zone used for prioritization
+func (trt *TerminatedResourceTracker[T]) EnergyZone() device.EnergyZone {
+	return trt.targetZone
+}
+
+// String returns a string representation for debugging
+func (trt *TerminatedResourceTracker[T]) String() string {
+	maxSizeStr := fmt.Sprintf("%d", trt.MaxSize())
+	if trt.MaxSize() == -1 {
+		maxSizeStr = "unlimited"
+	} else if trt.MaxSize() == 0 {
+		maxSizeStr = "disabled"
+	}
+
+	return fmt.Sprintf("TerminatedResourceTracker{size: %d/%s, zone: %s}",
+		trt.Size(), maxSizeStr, trt.targetZone.Name())
+}
+
+// stdlib/Heap interface implementation for Heap
+
+func (h Heap[T]) Len() int { return len(h) }
+
+func (h Heap[T]) Less(i, j int) bool {
+	// Min-heap: smallest energy value at the root
+	return h[i].EnergyTotal < h[j].EnergyTotal
+}
+
+func (h Heap[T]) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+
+func (h *Heap[T]) Push(x any) {
+	*h = append(*h, x.(HeapItem[T]))
+}
+
+func (h *Heap[T]) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	*h = old[0 : n-1]
+	return item
+}

--- a/internal/monitor/terminated_resource_tracker_test.go
+++ b/internal/monitor/terminated_resource_tracker_test.go
@@ -1,0 +1,489 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package monitor
+
+import (
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/sustainable-computing-io/kepler/internal/device"
+)
+
+// MockResource implements the Resource interface for testing
+type MockResource struct {
+	id    string
+	zones ZoneUsageMap
+}
+
+func (mr *MockResource) StringID() string {
+	return mr.id
+}
+
+func (mr *MockResource) ZoneUsage() ZoneUsageMap {
+	return mr.zones
+}
+
+// Helper function to create a mock resource with specific energy in a zone
+func createMockResource(id string, zone device.EnergyZone, energy Energy) *MockResource {
+	zones := make(ZoneUsageMap)
+	zones[zone] = Usage{
+		EnergyTotal: energy,
+		Power:       Power(0),
+	}
+	return &MockResource{
+		id:    id,
+		zones: zones,
+	}
+}
+
+// Helper function to create a mock resource with energy in multiple zones
+func createMockResourceMultiZone(id string, zoneEnergies map[device.EnergyZone]Energy) *MockResource {
+	zones := make(ZoneUsageMap)
+	for zone, energy := range zoneEnergies {
+		zones[zone] = Usage{
+			EnergyTotal: energy,
+			Power:       Power(0),
+		}
+	}
+	return &MockResource{
+		id:    id,
+		zones: zones,
+	}
+}
+
+func TestTerminatedResourceTracker_New(t *testing.T) {
+	zones := CreateTestZones()
+	zone := zones[0]
+	maxSize := 10
+
+	tracker := NewTerminatedResourceTracker[*MockResource](zone, maxSize, slog.Default().With("test", "tracker"))
+
+	assert.NotNil(t, tracker)
+	assert.Equal(t, 0, tracker.Size())
+	assert.Equal(t, maxSize, tracker.MaxSize())
+	assert.Equal(t, zone, tracker.EnergyZone())
+	assert.Equal(t, 0, len(tracker.Items()))
+}
+
+func TestTerminatedResourceTracker_AddSingleResource(t *testing.T) {
+	zones := CreateTestZones()
+	zone := zones[0]
+	tracker := NewTerminatedResourceTracker[*MockResource](zone, 5, slog.Default())
+
+	// Add a resource with energy
+	resource := createMockResource("resource-1", zone, 1000*Joule)
+	tracker.Add(resource)
+
+	assert.Equal(t, 1, tracker.Size())
+	items := tracker.Items()
+	require.Len(t, items, 1)
+	assert.Contains(t, items, "resource-1")
+}
+
+func TestTerminatedResourceTracker_AddResourceWithZeroEnergy(t *testing.T) {
+	zones := CreateTestZones()
+	zone := zones[0]
+	tracker := NewTerminatedResourceTracker[*MockResource](zone, 5, slog.Default())
+
+	// Add a resource with zero energy - should be ignored
+	resource := createMockResource("resource-1", zone, 0*Joule)
+	tracker.Add(resource)
+
+	assert.Equal(t, 0, tracker.Size())
+	assert.Equal(t, 0, len(tracker.Items()))
+}
+
+func TestTerminatedResourceTracker_AddResourceWithoutTrackedZone(t *testing.T) {
+	zones := CreateTestZones()
+	trackedZone := zones[0]
+	otherZone := zones[1]
+	tracker := NewTerminatedResourceTracker[*MockResource](trackedZone, 5, slog.Default())
+
+	// Add a resource that only has energy in a different zone
+	resource := createMockResource("resource-1", otherZone, 1000*Joule)
+	tracker.Add(resource)
+
+	assert.Equal(t, 0, tracker.Size())
+	assert.Equal(t, 0, len(tracker.Items()))
+}
+
+func TestTerminatedResourceTracker_AddMultipleResources(t *testing.T) {
+	zones := CreateTestZones()
+	zone := zones[0]
+	tracker := NewTerminatedResourceTracker[*MockResource](zone, 5, slog.Default())
+
+	// Add multiple resources with different energies
+	resources := []*MockResource{
+		createMockResource("resource-1", zone, 1000*Joule),
+		createMockResource("resource-2", zone, 2000*Joule),
+		createMockResource("resource-3", zone, 500*Joule),
+	}
+
+	for _, resource := range resources {
+		tracker.Add(resource)
+	}
+
+	assert.Equal(t, 3, tracker.Size())
+	items := tracker.Items()
+	assert.Len(t, items, 3)
+
+	// Check all resources are present (order doesn't matter in Items())
+	ids := make(map[string]bool)
+	for _, item := range items {
+		ids[item.StringID()] = true
+	}
+	assert.True(t, ids["resource-1"])
+	assert.True(t, ids["resource-2"])
+	assert.True(t, ids["resource-3"])
+}
+
+func TestTerminatedResourceTracker_DuplicatesIgnored(t *testing.T) {
+	zones := CreateTestZones()
+	zone := zones[0]
+	tracker := NewTerminatedResourceTracker[*MockResource](zone, 5, slog.Default())
+
+	// Add initial resource
+	resource1 := createMockResource("resource-1", zone, 1000*Joule)
+	tracker.Add(resource1)
+	assert.Equal(t, 1, tracker.Size())
+
+	// NOTE: In normal operation, the same terminated resource should never
+	// be added twice. Verify that if it happens, the duplicate is ignored.
+
+	// Adding the same resource ID again should be ignored (safety check)
+	resource2 := createMockResource("resource-1", zone, 2000*Joule)
+	tracker.Add(resource2)
+	assert.Equal(t, 1, tracker.Size()) // Still only one entry
+
+	items := tracker.Items()
+	require.Len(t, items, 1)
+	// Original resource energy is preserved (duplicate was ignored)
+	assert.Equal(t, Energy(1000*Joule), items["resource-1"].ZoneUsage()[zone].EnergyTotal)
+}
+
+// TestTerminatedResourceTracker_EvictOnCapactity validates that when the
+// capacity is reached, the lowest energy resource is evicted.
+func TestTerminatedResourceTracker_EvictOnCapactity(t *testing.T) {
+	zones := CreateTestZones()
+	zone := zones[0]
+	maxSize := 3
+	tracker := NewTerminatedResourceTracker[*MockResource](zone, maxSize, slog.Default().With("test", "tracker"))
+
+	// Fill to capacity with different energy levels
+	resources := []*MockResource{
+		createMockResource("low", zone, 100*Joule), // Lowest energy - should be evicted
+		createMockResource("medium", zone, 500*Joule),
+		createMockResource("high", zone, 1000*Joule), // Highest energy
+	}
+
+	for _, resource := range resources {
+		tracker.Add(resource)
+	}
+	assert.Equal(t, maxSize, tracker.Size())
+
+	// Add a new resource with higher energy than the lowest
+	newResource := createMockResource("new-medium", zone, 300*Joule)
+	tracker.Add(newResource)
+
+	// Should still be at capacity
+	assert.Equal(t, maxSize, tracker.Size())
+
+	// Check that the lowest energy resource was evicted
+	items := tracker.Items()
+	ids := make(map[string]bool)
+	for _, item := range items {
+		ids[item.StringID()] = true
+	}
+
+	assert.False(t, ids["low"], "Lowest energy resource should be evicted")
+	assert.True(t, ids["medium"], "Medium energy resource should remain")
+	assert.True(t, ids["high"], "High energy resource should remain")
+	assert.True(t, ids["new-medium"], "New medium energy resource should be added")
+}
+
+// TestTerminatedResourceTracker_CapacityEvictionWithLowerEnergy validates that
+// when the capacity is reached, and a new low energy resource is asked to be added,
+// it will be ignored.
+func TestTerminatedResourceTracker_CapacityEvictionWithLowerEnergy(t *testing.T) {
+	zones := CreateTestZones()
+	zone := zones[0]
+	maxSize := 2
+	tracker := NewTerminatedResourceTracker[*MockResource](zone, maxSize, slog.Default().With("test", "tracker"))
+
+	// Fill to capacity
+	resources := []*MockResource{
+		createMockResource("high1", zone, 1000*Joule),
+		createMockResource("high2", zone, 2000*Joule),
+	}
+
+	for _, resource := range resources {
+		tracker.Add(resource)
+	}
+	assert.Equal(t, maxSize, tracker.Size())
+
+	// Try to add a resource with lower energy than any existing
+	lowResource := createMockResource("low", zone, 50*Joule)
+	tracker.Add(lowResource)
+
+	// Should still be at capacity and the low energy resource should not be added
+	assert.Equal(t, maxSize, tracker.Size())
+
+	items := tracker.Items()
+	ids := make(map[string]bool)
+	for _, item := range items {
+		ids[item.StringID()] = true
+	}
+
+	assert.True(t, ids["high1"], "High energy resource 1 should remain")
+	assert.True(t, ids["high2"], "High energy resource 2 should remain")
+	assert.False(t, ids["low"], "Low energy resource should not be added")
+}
+
+func TestTerminatedResourceTracker_Clear(t *testing.T) {
+	zones := CreateTestZones()
+	zone := zones[0]
+	tracker := NewTerminatedResourceTracker[*MockResource](zone, 5, slog.Default())
+
+	// Add some resources
+	resources := []*MockResource{
+		createMockResource("resource-1", zone, 1000*Joule),
+		createMockResource("resource-2", zone, 2000*Joule),
+	}
+
+	for _, resource := range resources {
+		tracker.Add(resource)
+	}
+	assert.Equal(t, 2, tracker.Size())
+
+	// Clear the tracker
+	tracker.Clear()
+
+	assert.Equal(t, 0, tracker.Size())
+	assert.Equal(t, 0, len(tracker.Items()))
+}
+
+func TestTerminatedResourceTracker_MultiZoneResource(t *testing.T) {
+	zones := CreateTestZones()
+	trackedZone := zones[0]
+	otherZone := zones[1]
+	tracker := NewTerminatedResourceTracker[*MockResource](trackedZone, 5, slog.Default())
+
+	// Create a resource with energy in multiple zones
+	zoneEnergies := map[device.EnergyZone]Energy{
+		trackedZone: 1000 * Joule, // This is the zone the tracker cares about
+		otherZone:   5000 * Joule, // Higher energy, but tracker doesn't use this zone
+	}
+	resource := createMockResourceMultiZone("multi-zone", zoneEnergies)
+
+	tracker.Add(resource)
+
+	assert.Equal(t, 1, tracker.Size())
+	items := tracker.Items()
+	require.Len(t, items, 1)
+	assert.Contains(t, items, "multi-zone")
+
+	// Verify the resource has the expected energy values
+	resourceZones := items["multi-zone"].ZoneUsage()
+	assert.Equal(t, Energy(1000*Joule), resourceZones[trackedZone].EnergyTotal)
+	assert.Equal(t, Energy(5000*Joule), resourceZones[otherZone].EnergyTotal)
+}
+
+func TestTerminatedResourceTracker_String(t *testing.T) {
+	zones := CreateTestZones()
+	zone := zones[0]
+
+	t.Run("normal capacity", func(t *testing.T) {
+		tracker := NewTerminatedResourceTracker[*MockResource](zone, 10, slog.Default())
+
+		// Add a few resources
+		tracker.Add(createMockResource("resource-1", zone, 1000*Joule))
+		tracker.Add(createMockResource("resource-2", zone, 2000*Joule))
+
+		str := tracker.String()
+		assert.Contains(t, str, "2/10")      // size/maxSize
+		assert.Contains(t, str, zone.Name()) // zone name
+	})
+
+	t.Run("disabled capacity", func(t *testing.T) {
+		tracker := NewTerminatedResourceTracker[*MockResource](zone, 0, slog.Default())
+
+		str := tracker.String()
+		assert.Contains(t, str, "0/disabled") // size/maxSize for disabled
+		assert.Contains(t, str, zone.Name())  // zone name
+	})
+
+	t.Run("unlimited capacity", func(t *testing.T) {
+		tracker := NewTerminatedResourceTracker[*MockResource](zone, -1, slog.Default())
+
+		str := tracker.String()
+		assert.Contains(t, str, "0/unlimited") // size/maxSize for unlimited
+		assert.Contains(t, str, zone.Name())   // zone name
+	})
+}
+
+func TestTerminatedResourceTracker_EdgeCases(t *testing.T) {
+	zones := CreateTestZones()
+	zone := zones[0]
+
+	t.Run("zero capacity tracker - feature disabled", func(t *testing.T) {
+		tracker := NewTerminatedResourceTracker[*MockResource](zone, 0, slog.Default())
+		resource := createMockResource("resource-1", zone, 1000*Joule)
+
+		tracker.Add(resource)
+
+		assert.Equal(t, 0, tracker.Size())
+		assert.Equal(t, 0, len(tracker.Items()))
+	})
+
+	t.Run("negative capacity tracker is unlimited", func(t *testing.T) {
+		tracker := NewTerminatedResourceTracker[*MockResource](zone, -5, slog.Default())
+
+		// Add many resources beyond what would normally be capacity
+		for i := 0; i < 100; i++ {
+			resource := createMockResource(fmt.Sprintf("resource-%d", i), zone, Energy(i+1)*Joule)
+			tracker.Add(resource)
+		}
+
+		assert.Equal(t, 100, tracker.Size())
+		assert.Equal(t, 100, len(tracker.Items()))
+		assert.Equal(t, -5, tracker.MaxSize())
+	})
+
+	t.Run("unlimited capacity tracker", func(t *testing.T) {
+		tracker := NewTerminatedResourceTracker[*MockResource](zone, -1, slog.Default())
+
+		// Add many resources beyond what would normally be capacity
+		for i := 0; i < 100; i++ {
+			resource := createMockResource(fmt.Sprintf("resource-%d", i), zone, Energy(i+1)*Joule)
+			tracker.Add(resource)
+		}
+
+		assert.Equal(t, 100, tracker.Size())
+		assert.Equal(t, 100, len(tracker.Items()))
+		assert.Equal(t, -1, tracker.MaxSize())
+	})
+
+	t.Run("capacity of 1", func(t *testing.T) {
+		tracker := NewTerminatedResourceTracker[*MockResource](zone, 1, slog.Default())
+
+		// Add first resource
+		resource1 := createMockResource("resource-1", zone, 1000*Joule)
+		tracker.Add(resource1)
+		assert.Equal(t, 1, tracker.Size())
+
+		// Add second resource with higher energy - should replace first
+		resource2 := createMockResource("resource-2", zone, 2000*Joule)
+		tracker.Add(resource2)
+		assert.Equal(t, 1, tracker.Size())
+
+		items := tracker.Items()
+		require.Len(t, items, 1)
+		assert.Contains(t, items, "resource-2")
+	})
+
+	t.Run("empty resource ID", func(t *testing.T) {
+		tracker := NewTerminatedResourceTracker[*MockResource](zone, 5, slog.Default())
+		resource := createMockResource("", zone, 1000*Joule)
+
+		tracker.Add(resource)
+
+		assert.Equal(t, 1, tracker.Size())
+		items := tracker.Items()
+		require.Len(t, items, 1)
+		assert.Contains(t, items, "")
+	})
+}
+
+func TestTerminatedResourceTracker_HeapIntegrity(t *testing.T) {
+	zones := CreateTestZones()
+	zone := zones[0]
+	tracker := NewTerminatedResourceTracker[*MockResource](zone, 5, slog.Default())
+
+	// Add resources in various orders to test heap integrity
+	energies := []Energy{500 * Joule, 1000 * Joule, 100 * Joule, 2000 * Joule, 300 * Joule}
+
+	for i, energy := range energies {
+		resource := createMockResource(
+			fmt.Sprintf("resource-%d", i),
+			zone,
+			energy,
+		)
+		tracker.Add(resource)
+	}
+
+	assert.Equal(t, 5, tracker.Size())
+	assert.Equal(t, 5, len(tracker.Items()))
+
+	// Test that all resources are retrievable
+	items := tracker.Items()
+	totalEnergy := Energy(0)
+	for _, item := range items {
+		totalEnergy += item.ZoneUsage()[zone].EnergyTotal
+	}
+
+	expectedTotal := Energy(500+1000+100+2000+300) * Joule
+	assert.Equal(t, expectedTotal, totalEnergy)
+}
+
+// Integration test that mimics the real usage pattern
+func TestTerminatedResourceTracker_RealWorldScenario(t *testing.T) {
+	zones := CreateTestZones()
+	zone := zones[0]
+	maxTerminated := 100
+	tracker := NewTerminatedResourceTracker[*MockResource](zone, maxTerminated, slog.Default())
+
+	// Simulate adding many terminated processes over time
+	processCount := 0
+
+	// First batch: Add 50 processes with varying energy
+	for i := 0; i < 50; i++ {
+		energy := Energy((i + 1) * 100 * int(Joule)) // 100, 200, 300, ... 5000 Joules
+		resource := createMockResource(
+			fmt.Sprintf("process-%d", processCount),
+			zone,
+			energy,
+		)
+		tracker.Add(resource)
+		processCount++
+	}
+
+	assert.Equal(t, 50, tracker.Size())
+
+	// Second batch: Add 75 more processes (some will evict lower energy ones)
+	for i := 0; i < 75; i++ {
+		energy := Energy((i + 1) * 50 * int(Joule)) // 50, 100, 150, ... 3750 Joules
+		resource := createMockResource(
+			fmt.Sprintf("process-%d", processCount),
+			zone,
+			energy,
+		)
+		tracker.Add(resource)
+		processCount++
+	}
+
+	// Should be at max capacity
+	assert.Equal(t, maxTerminated, tracker.Size())
+
+	// Verify that the highest energy processes are retained
+	items := tracker.Items()
+	minEnergy := Energy(^uint64(0)) // Max uint64 as starting point for finding min
+	for _, item := range items {
+		energy := item.ZoneUsage()[zone].EnergyTotal
+		if energy < minEnergy {
+			minEnergy = energy
+		}
+	}
+
+	// The minimum energy in the tracker should be reasonably high
+	// (exact value depends on the eviction logic, but it should be > 0)
+	assert.Greater(t, minEnergy, Energy(0))
+
+	// Clear and verify
+	tracker.Clear()
+	assert.Equal(t, 0, tracker.Size())
+	assert.Equal(t, 0, len(tracker.Items()))
+}


### PR DESCRIPTION

Replace unbounded terminated workload maps with bounded, energy-prioritized
tracking system. Automatically retain the N highest energy consuming
terminated resources (processes, containers, VMs, pods) based on optimal
RAPL energy zone selection.

Key changes:
- Add TopEnergyZone() method to CPUPowerMeter interface
- Implement generic TerminatedResourceTracker with min-heap priority queue
- Add Resource interface to Process, Container, VM, and Pod types
- Replace map-based terminated fields with bounded slices in Snapshot
- Add maxTerminated configuration option (default: 500)
