### PR TITLE
chore: announce kepler reboot

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: 🐛 Bug Report
+description: Report a bug or issue with Kepler
+labels: [kind/bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## ⚠️ Important Version Notice
+
+        **Kepler 0.10.0 Major Rewrite:** Starting with version 0.10.0, Kepler has undergone a complete rewrite with significant architectural changes.
+
+        - **Legacy versions (0.9.0 and earlier)** are now **frozen** - no bug fixes or feature updates will be provided
+        - **All new development** happens on the current version (0.10.0+)
+        - If you're using 0.9.0 or earlier, please consider upgrading to the latest version
+
+        📢 **Read more:** [CNCF Slack Announcement](https://cloud-native.slack.com/archives/C05QK3KN3HT/p1752049660866519)
+
+  - type: dropdown
+    id: version
+    attributes:
+      label: Kepler Version
+      description: Which version of Kepler are you using?
+      options:
+        - 0.10.0 or later (Current/Supported)
+        - 0.9.0 or earlier (Legacy/Frozen - No Support)
+        - I'm not sure
+      default: 0
+    validations:
+      required: true
+
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is
+      placeholder: Describe the issue you're experiencing
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Provide details about your environment
+      placeholder: |
+        - OS: [e.g. Ubuntu 20.04]
+        - Kubernetes Version: [e.g. 1.25]
+        - Container Runtime: [e.g. containerd 1.6]
+        - Hardware: [e.g. Intel CPU with RAPL support]
+        - Deployment Method: [e.g. Kubernetes DaemonSet, Docker Compose, Local Binary]
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and Error Messages
+      description: If applicable, add logs or error messages to help explain your problem
+      render: shell
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📋 General Support & Questions
+    url: https://github.com/sustainable-computing-io/kepler/discussions
+    about: For general questions, support, and community discussions
+
+  - name: 🚨 Security Issues
+    url: https://github.com/sustainable-computing-io/kepler/security/policy
+    about: For security vulnerabilities, please follow our security policy

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,66 @@
+name: ✨ Feature Request
+description: Suggest a new feature or enhancement for Kepler
+labels: [kind/feature]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## ⚠️ Important Version Notice
+
+        **Kepler 0.10.0 Major Rewrite:** Starting with version 0.10.0, Kepler has undergone a complete rewrite with significant architectural changes.
+
+        - **Legacy versions (0.9.0 and earlier)** are now **frozen** - no new features will be added
+        - **All new feature development** happens on the current version (0.10.0+) only
+        - Feature requests for legacy versions will not be accepted
+
+        📢 **Read more:** [CNCF Slack Announcement](https://cloud-native.slack.com/archives/C05QK3KN3HT/p1752049660866519)
+
+  - type: dropdown
+    id: version-target
+    attributes:
+      label: Target Version
+      description: Which version should this feature be developed for?
+      options:
+        - Current version (0.10.0+) - New Architecture
+        - Legacy version (0.9.0 or earlier) - NOT SUPPORTED
+      default: 0
+    validations:
+      required: true
+
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Feature Description
+      description: A clear and concise description of the feature you'd like to see
+      placeholder: Describe the feature you want
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve? What's the use case?
+      placeholder: Explain the problem this feature would solve
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: A clear and concise description of what you want to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: A clear and concise description of any alternative solutions or features you've considered
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, or examples about the feature request here

--- a/README.md
+++ b/README.md
@@ -4,6 +4,54 @@
 
 Kepler (Kubernetes-based Efficient Power Level Exporter) is a Prometheus exporter that measures energy consumption metrics at the container, pod, and node level in Kubernetes clusters.
 
+## 🚀 Major Rewrite: Kepler (0.10.0 and above)
+
+**Important Notice:** Starting with version 0.10.0, Kepler has undergone a complete ground-up rewrite.
+This represents a significant architectural improvement while maintaining the core mission of
+accurate energy consumption monitoring for cloud-native workloads.
+
+> 📢 **Read the full announcement:** [CNCF Slack Announcement](https://cloud-native.slack.com/archives/C05QK3KN3HT/p1752049660866519)
+
+### ✨ What's New in the Rewrite
+
+**Enhanced Performance & Accuracy:**
+
+- Dynamic detection of Nodes' RAPL zones - no more hardcoded RAPL zones
+- More accurate power attribution based on active CPU usage (no more idle/dynamic for workloads)
+- Improved VM, Container, and Pod detection with more meaningful label values
+- Significantly reduced resource usage compared to old Kepler
+
+**Reduced Security Requirements:**
+
+- Requires only readonly access to host `/proc` and `/sys`
+- No more `CAP_SYSADMIN` or `CAP_BPF` capabilities required
+- Much fewer privileges than previous versions
+
+**Modern Architecture:**
+
+- Service-oriented design with clean separation of concerns
+- Thread-safe operations throughout the codebase
+- Graceful shutdown handling with proper resource cleanup
+- Comprehensive error handling with structured logging
+
+**Current Limitations:**
+
+- Only supports Baremetal (platform power support in roadmap)
+- Supports only RAPL/powercap framework
+- No GPU power support yet
+
+### 📚 Migration & Legacy Support
+
+**For New Users:** Use the current version (0.10.0+) for the best experience and latest features.
+
+**For Existing Users:** If you need to continue using the old version:
+
+- Pin your deployment to version `0.9.0` (final legacy release)
+- Access the old codebase in the [archived branch](https://github.com/sustainable-computing-io/kepler/tree/archived)
+- **Important:** The legacy version (0.9.x and earlier) is now frozen - no bug fixes or feature requests will be accepted for the old version
+
+**Migration Note:** Please review the new configuration format and deployment methods below when upgrading to 0.10.0+.
+
 ## 🚀 Getting Started
 
 There are two main ways to run Kepler:


### PR DESCRIPTION
Key changes: 

README.md Updates

  - Added a prominent announcement section about the 0.10.0 rewrite
  - Included link to your CNCF Slack announcement
  - Clear migration guidance and legacy version information
  - Mentioned that 0.9.x is frozen with no more updates

GitHub Issue Templates

  1. config.yml - Disables blank issues and provides contact links
  2. bug_report.yml - Bug report template with version awareness
  3. feature_request.yml - Feature request template that clearly states legacy versions won't get new features

  Both issue templates include:
  - Prominent warning about the 0.10.0 rewrite
  - Clear indication that 0.9.0 and earlier are frozen
  - Version dropdown to identify what users are running
  - Link to your CNCF Slack announcement
