### PR TITLE
feat: add Helm chart for Kepler deployment

### DIFF
--- a/.github/k8s/action.yaml
+++ b/.github/k8s/action.yaml
@@ -45,6 +45,11 @@ runs:
       run: |
         kubectl version --client
 
+    - name: Setup Helm
+      uses: azure/setup-helm@v4
+      with:
+        version: latest
+
     - name: Checkout source
       uses: actions/checkout@v4
       with:
@@ -55,6 +60,11 @@ runs:
       with:
         go-version-file: go.mod
         cache: false
+
+    - name: Lint Helm chart
+      shell: bash
+      run: |
+        helm lint manifests/helm/kepler
 
     - name: Build image
       shell: bash
@@ -127,6 +137,55 @@ runs:
             exit 1
           fi
         done
+
+    - name: Remove existing Kepler deployment
+      shell: bash
+      run: |
+        echo "::group::Remove existing Kepler deployment before Helm test"
+        make undeploy
+        echo "::endgroup::"
+
+    - name: Test Helm deployment
+      shell: bash
+      run: |
+        echo "::group::Deploy Kepler using Helm"
+        # Update Helm chart to use the locally built image
+        sed -i 's|repository: quay.io/sustainable_computing_io/kepler|repository: localhost:5001/kepler|' manifests/helm/kepler/values.yaml
+        sed -i 's|tag: latest|tag: dev|' manifests/helm/kepler/values.yaml
+        sed -i '/fake-cpu-meter:/{n;s/enabled: false/enabled: true/}' manifests/helm/kepler/values.yaml
+
+        # Install using Helm
+        helm install kepler-helm-test manifests/helm/kepler --namespace kepler-helm --create-namespace --wait --timeout=5m
+        echo "::endgroup::"
+
+    - name: Verify Helm deployment
+      shell: bash
+      run: |
+        echo "::group::Verify Helm deployment"
+        kubectl rollout status daemonset/kepler-helm-test -n kepler-helm --timeout=5m
+        kubectl get pods -n kepler-helm
+        echo "::endgroup::"
+
+    - name: Validate Helm metrics endpoint
+      shell: bash
+      run: |
+        echo "::group::Test Helm deployment metrics"
+        kubectl port-forward service/kepler-helm-test 28283:28282 -n kepler-helm &
+        sleep 20
+
+        HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:28283/metrics)
+        [[ $HTTP_STATUS -ne 200 ]] && echo "Helm deployment HTTP status code is not 200" && exit 1
+
+        echo "Helm deployment metrics endpoint is working"
+        echo "::endgroup::"
+
+    - name: Cleanup Helm deployment
+      shell: bash
+      run: |
+        echo "::group::Cleanup Helm deployment"
+        helm uninstall kepler-helm-test -n kepler-helm
+        kubectl delete namespace kepler-helm
+        echo "::endgroup::"
 
     - name: Run must gather
       shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,11 @@ jobs:
           cache: true
           check-latest: true
 
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: latest
+
       - name: Login to Image Registry
         uses: docker/login-action@v2
         with:
@@ -53,6 +58,22 @@ jobs:
           TAG_NAME=${{ github.ref_name }}
           echo "version=$TAG_NAME" >> "$GITHUB_OUTPUT"
 
+      - name: Update Helm Chart Version
+        shell: bash
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          # Remove 'v' prefix from version
+          CHART_VERSION=${VERSION#v}
+          # Update Chart.yaml with the release version
+          sed -i "s/^version:.*/version: $CHART_VERSION/" manifests/helm/kepler/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"$VERSION\"/" manifests/helm/kepler/Chart.yaml
+
+      - name: Package Helm Chart
+        shell: bash
+        run: |
+          mkdir -p helm-releases
+          helm package manifests/helm/kepler -d helm-releases
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -61,6 +82,8 @@ jobs:
           generate_release_notes: true
           draft: false
           make_latest: true
+          files: |
+            helm-releases/*.tgz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
     rev: v1.37.0
     hooks:
       - id: yamllint
+        exclude: ^manifests/helm/.*/templates/.*\.yaml$
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.44.0
@@ -76,3 +77,13 @@ repos:
     hooks:
       - id: shellcheck
         args: [-x]
+
+  - repo: local
+    hooks:
+      - id: helm-lint
+        name: helm-lint
+        entry: helm lint
+        language: system
+        files: ^manifests/helm/[^/]+/(Chart\.yaml|values\.yaml|templates/.*)$
+        pass_filenames: false
+        args: [manifests/helm/kepler]

--- a/README.md
+++ b/README.md
@@ -110,7 +110,19 @@ docker-compose up -d
 
 ### 3️⃣ Running on Kubernetes 🐳
 
-Deploy Kepler to your Kubernetes cluster:
+Deploy Kepler to your Kubernetes cluster using Helm or Kustomize:
+
+#### Using Helm Chart (Recommended)
+
+```bash
+# Install using Helm
+helm install kepler manifests/helm/kepler/ \
+  --namespace kepler \
+  --create-namespace \
+  --set namespace.create=false
+```
+
+#### Using Kustomize
 
 ```bash
 # Set up a local development cluster with Kind
@@ -133,6 +145,10 @@ make deploy IMG_BASE=<your registry> VERSION=<your version>
 ```
 
 ## 📖 Documentation
+
+- **[Installation Guide](docs/user/installation.md)** - Detailed installation instructions for all deployment methods
+- **[Configuration Guide](docs/configuration/configuration.md)** - Configuration options and examples
+- **[Metrics Documentation](docs/metrics/metrics.md)** - Available metrics and their descriptions
 
 For more detailed documentation, please visit the [official Kepler documentation](https://sustainable-computing.io/kepler/).
 

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -1,0 +1,326 @@
+# Kepler Installation Guide
+
+This guide covers different methods to install and run Kepler (Kubernetes-based Efficient Power Level Exporter) for monitoring energy consumption metrics.
+
+## Prerequisites
+
+- **For Local Installation**: Go 1.21+ and sudo access for hardware sensor access
+- **For Kubernetes**: Kubernetes cluster (v1.20+) with kubectl configured
+- **For Helm**: Helm 3.0+ installed
+
+## Installation Methods
+
+### 1. Helm Chart Installation (Recommended for Kubernetes)
+
+#### Prerequisites for Helm
+
+- Helm 3.0+
+- Kubernetes cluster with kubectl configured
+
+#### Install from Source
+
+```bash
+# Clone the repository
+git clone https://github.com/sustainable-computing-io/kepler.git
+cd kepler
+
+# Install Kepler using Helm
+helm install kepler manifests/helm/kepler/ \
+  --namespace kepler \
+  --create-namespace \
+  --set namespace.create=false
+```
+
+#### Install from Release (Future)
+
+```bash
+# Add Kepler Helm repository (once published)
+helm repo add kepler https://sustainable-computing-io.github.io/kepler
+
+# Update repository
+helm repo update
+
+# Install Kepler
+helm install kepler kepler/kepler \
+  --namespace kepler \
+  --create-namespace
+```
+
+#### Customizing the Installation
+
+Create a `values.yaml` file to customize the installation:
+
+```yaml
+# values.yaml
+image:
+  repository: quay.io/sustainable_computing_io/kepler
+  tag: "v0.10.0"
+  pullPolicy: IfNotPresent
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 400Mi
+  requests:
+    cpu: 100m
+    memory: 200Mi
+
+tolerations:
+  - operator: Exists
+
+nodeSelector:
+  kubernetes.io/os: linux
+
+# Enable ServiceMonitor for Prometheus
+serviceMonitor:
+  enabled: true
+  interval: 30s
+```
+
+Install with custom values:
+
+```bash
+helm install kepler manifests/helm/kepler/ \
+  --namespace kepler \
+  --create-namespace \
+  --set namespace.create=false \
+  --values values.yaml
+```
+
+#### Helm Management Commands
+
+```bash
+# Check installation status
+helm status kepler -n kepler
+
+# List releases
+helm list -n kepler
+
+# Upgrade release
+helm upgrade kepler manifests/helm/kepler/ -n kepler
+
+# Uninstall
+helm uninstall kepler -n kepler
+```
+
+### 2. Local Installation
+
+#### Building from Source
+
+```bash
+# Clone the repository
+git clone https://github.com/sustainable-computing-io/kepler.git
+cd kepler
+
+# Build Kepler
+make build
+
+# Run Kepler (requires sudo for hardware access)
+sudo ./bin/kepler --config hack/config.yaml
+```
+
+#### Configuration
+
+Kepler can be configured using YAML files or CLI flags. The default configuration is in `hack/config.yaml`:
+
+```bash
+# Run with custom configuration
+sudo ./bin/kepler --config /path/to/your/config.yaml
+
+# Run with CLI flags
+sudo ./bin/kepler --log.level=debug --exporter.stdout
+```
+
+**Access Points:**
+
+- Metrics: <http://localhost:28282/metrics>
+
+### 3. Docker Compose (Recommended for Development)
+
+The Docker Compose setup provides a complete monitoring stack with Kepler, Prometheus, and Grafana:
+
+```bash
+cd compose/dev
+
+# Start the complete stack
+docker-compose up -d
+
+# View logs
+docker-compose logs -f kepler
+
+# Stop the stack
+docker-compose down
+```
+
+**Access Points:**
+
+- Kepler Metrics: <http://localhost:28283/metrics>
+- Prometheus: <http://localhost:29090>
+- Grafana: <http://localhost:23000> (admin/admin)
+
+### 4. Kubernetes with Kustomize
+
+#### Quick Setup with Kind
+
+```bash
+# Create a local cluster with monitoring stack
+make cluster-up
+
+# Deploy Kepler
+make deploy
+
+# Clean up
+make cluster-down
+```
+
+#### Manual Kubernetes Deployment
+
+```bash
+# Deploy using kustomize
+kubectl kustomize manifests/k8s | \
+  sed -e "s|<KEPLER_IMAGE>|quay.io/sustainable_computing_io/kepler:latest|g" | \
+  kubectl apply --server-side --force-conflicts -f -
+
+# Check deployment status
+kubectl get pods -n kepler
+
+# Access metrics (port-forward)
+kubectl port-forward -n kepler svc/kepler 28282:28282
+```
+
+#### Custom Image Deployment
+
+```bash
+# Build and push custom image
+make image push IMG_BASE=your-registry.com/yourorg VERSION=v1.0.0
+
+# Deploy with custom image
+make deploy IMG_BASE=your-registry.com/yourorg VERSION=v1.0.0
+```
+
+## Verification
+
+### Check Deployment Status
+
+```bash
+# Check pods
+kubectl get pods -n kepler
+
+# Check DaemonSet
+kubectl get daemonset -n kepler
+
+# Check services
+kubectl get svc -n kepler
+
+# View logs
+kubectl logs -n kepler -l app.kubernetes.io/name=kepler
+```
+
+### Access Metrics
+
+```bash
+# Port forward to access metrics locally
+kubectl port-forward -n kepler svc/kepler 28282:28282
+
+# Test metrics endpoint
+curl http://localhost:28282/metrics
+```
+
+### Verify Metrics Collection
+
+Look for key metrics like:
+
+- `kepler_node_cpu_watts`
+- `kepler_container_cpu_watts`
+- `kepler_process_cpu_watts`
+
+## Configuration Options
+
+### Helm Chart Values
+
+Key configuration options in `values.yaml`:
+
+```yaml
+# Image configuration
+image:
+  repository: quay.io/sustainable_computing_io/kepler
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+# DaemonSet configuration
+daemonset:
+  hostPID: true
+  securityContext:
+    privileged: true
+
+# Resource limits
+resources:
+  limits:
+    cpu: 100m
+    memory: 400Mi
+  requests:
+    cpu: 100m
+    memory: 200Mi
+
+# Node scheduling
+tolerations:
+  - operator: Exists
+
+nodeSelector:
+  kubernetes.io/os: linux
+
+# Monitoring
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  scrapeTimeout: 10s
+```
+
+### Environment-Specific Settings
+
+- **Development**: Use fake CPU meter when RAPL unavailable
+- **Production**: Ensure nodes have Intel RAPL support
+- **Cloud**: May need different privilege configurations
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Permission Denied**: Ensure privileged security context is enabled
+2. **No Metrics**: Check if nodes support Intel RAPL sensors
+3. **Pod Crashes**: Review logs for hardware access issues
+4. **ServiceMonitor Not Found**: Ensure Prometheus Operator is installed
+
+### Debug Commands
+
+```bash
+# Check pod logs
+kubectl logs -n kepler -l app.kubernetes.io/name=kepler
+
+# Describe pod for events
+kubectl describe pod -n kepler -l app.kubernetes.io/name=kepler
+
+# Check node hardware
+kubectl exec -n kepler -it <pod-name> -- ls /sys/class/powercap/intel-rapl
+
+# Test with fake meter (development)
+helm upgrade kepler manifests/helm/kepler/ -n kepler \
+  --set env.KEPLER_FAKE_CPU_METER=true
+```
+
+### Getting Help
+
+- **Documentation**: <https://sustainable-computing.io/kepler/>
+- **Issues**: <https://github.com/sustainable-computing-io/kepler/issues>
+- **Discussions**: <https://github.com/sustainable-computing-io/kepler/discussions>
+- **Slack**: [#kepler channel in CNCF Slack](https://cloud-native.slack.com/archives/C06HYDN4A01)
+
+## Next Steps
+
+After successful installation:
+
+1. **Set up Prometheus**: Configure scraping of Kepler metrics
+2. **Install Grafana**: Use pre-built dashboards for visualization
+3. **Configure Alerts**: Set up energy consumption alerts
+4. **Explore Metrics**: Learn about available energy metrics
+5. **Optimize Workloads**: Use insights to improve energy efficiency

--- a/manifests/helm/kepler/.helmignore
+++ b/manifests/helm/kepler/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/manifests/helm/kepler/Chart.yaml
+++ b/manifests/helm/kepler/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: kepler
+description: A Helm chart for Kepler - Kubernetes Efficient Power Level Exporter
+type: application
+version: 0.0.0-dev
+appVersion: latest
+home: https://github.com/sustainable-computing-io/kepler
+sources:
+  - https://github.com/sustainable-computing-io/kepler
+maintainers:
+  - name: Kepler Team
+    url: https://github.com/sustainable-computing-io/kepler
+keywords:
+  - energy
+  - power
+  - monitoring
+  - prometheus
+  - sustainability
+annotations:
+  category: Monitoring

--- a/manifests/helm/kepler/templates/_helpers.tpl
+++ b/manifests/helm/kepler/templates/_helpers.tpl
@@ -1,0 +1,77 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kepler.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kepler.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kepler.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kepler.labels" -}}
+helm.sh/chart: {{ include "kepler.chart" . }}
+{{ include "kepler.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: kepler
+{{- with .Values.labels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kepler.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kepler.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kepler.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kepler.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the namespace to use
+*/}}
+{{- define "kepler.namespace" -}}
+{{- if .Values.namespace.create }}
+{{- default (include "kepler.name" .) .Values.namespace.name }}
+{{- else }}
+{{- .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/manifests/helm/kepler/templates/configmap.yaml
+++ b/manifests/helm/kepler/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{include "kepler.fullname" .}}
+  namespace: {{include "kepler.namespace" .}}
+  labels:
+    {{- include "kepler.labels" . | nindent 4}}
+  {{- with .Values.annotations}}
+  annotations:
+    {{- toYaml . | nindent 4}}
+  {{- end}}
+data:
+  config.yaml: |
+    {{- toYaml .Values.config | nindent 4}}

--- a/manifests/helm/kepler/templates/daemonset.yaml
+++ b/manifests/helm/kepler/templates/daemonset.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{include "kepler.fullname" .}}
+  namespace: {{include "kepler.namespace" .}}
+  labels:
+    {{- include "kepler.labels" . | nindent 4}}
+  {{- with .Values.annotations}}
+  annotations:
+    {{- toYaml . | nindent 4}}
+  {{- end}}
+spec:
+  selector:
+    matchLabels:
+      {{- include "kepler.selectorLabels" . | nindent 6}}
+  template:
+    metadata:
+      labels:
+        {{- include "kepler.selectorLabels" . | nindent 8 }}
+        {{- with .Values.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "kepler.serviceAccountName" . }}
+      hostPID: {{ .Values.daemonset.hostPID }}
+      {{- with .Values.daemonset.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.daemonset.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.daemonset.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: kepler
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.daemonset.securityContext | nindent 12 }}
+          command:
+            - /usr/bin/kepler
+          args:
+            - --config.file=/etc/kepler/config.yaml
+            - --kube.enable
+            - --kube.node-name=$(NODE_NAME)
+          ports:
+            - name: http
+              containerPort: 28282
+              protocol: TCP
+          volumeMounts:
+            - name: sysfs
+              mountPath: /host/sys
+              readOnly: true
+            - name: procfs
+              mountPath: /host/proc
+              readOnly: true
+            - name: cfm
+              mountPath: /etc/kepler
+          {{- with .Values.daemonset.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.daemonset.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          {{- with .Values.daemonset.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: sysfs
+          hostPath:
+            path: /sys
+        - name: procfs
+          hostPath:
+            path: /proc
+        - name: cfm
+          configMap:
+            name: {{ include "kepler.fullname" . }}

--- a/manifests/helm/kepler/templates/namespace.yaml
+++ b/manifests/helm/kepler/templates/namespace.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.namespace.create}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{include "kepler.namespace" .}}
+  labels:
+    {{- include "kepler.labels" . | nindent 4}}
+  {{- with .Values.annotations}}
+  annotations:
+    {{- toYaml . | nindent 4}}
+  {{- end}}
+{{- end}}

--- a/manifests/helm/kepler/templates/rbac.yaml
+++ b/manifests/helm/kepler/templates/rbac.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.rbac.create}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{include "kepler.serviceAccountName" .}}
+  namespace: {{include "kepler.namespace" .}}
+  labels:
+    {{- include "kepler.labels" . | nindent 4}}
+  {{- with .Values.annotations}}
+  annotations:
+    {{- toYaml . | nindent 4}}
+  {{- end}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{include "kepler.fullname" .}}
+  labels:
+    {{- include "kepler.labels" . | nindent 4}}
+  {{- with .Values.annotations}}
+  annotations:
+    {{- toYaml . | nindent 4}}
+  {{- end}}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{include "kepler.fullname" .}}
+  labels:
+    {{- include "kepler.labels" . | nindent 4}}
+  {{- with .Values.annotations}}
+  annotations:
+    {{- toYaml . | nindent 4}}
+  {{- end}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{include "kepler.fullname" .}}
+subjects:
+  - kind: ServiceAccount
+    name: {{include "kepler.serviceAccountName" .}}
+    namespace: {{include "kepler.namespace" .}}
+{{- end}}

--- a/manifests/helm/kepler/templates/service.yaml
+++ b/manifests/helm/kepler/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{include "kepler.fullname" .}}
+  namespace: {{include "kepler.namespace" .}}
+  labels:
+    {{- include "kepler.labels" . | nindent 4}}
+  {{- with .Values.annotations}}
+  annotations:
+    {{- toYaml . | nindent 4}}
+  {{- end}}
+spec:
+  type: {{.Values.service.type}}
+  ports:
+  - name: http
+    port: {{.Values.service.port}}
+    targetPort: {{.Values.service.targetPort}}
+    protocol: {{.Values.service.protocol}}
+  selector:
+    {{- include "kepler.selectorLabels" . | nindent 4}}

--- a/manifests/helm/kepler/templates/servicemonitor.yaml
+++ b/manifests/helm/kepler/templates/servicemonitor.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{include "kepler.fullname" .}}
+  namespace: {{include "kepler.namespace" .}}
+  labels:
+    {{- include "kepler.labels" . | nindent 4}}
+  {{- with .Values.serviceMonitor.labels}}
+  {{- toYaml . | nindent 4}}
+  {{- end}}
+  {{- with .Values.serviceMonitor.annotations}}
+  annotations:
+    {{- toYaml . | nindent 4}}
+  {{- end}}
+spec:
+  selector:
+    matchLabels:
+      {{- include "kepler.selectorLabels" . | nindent 6}}
+  endpoints:
+    - port: http
+      interval: {{.Values.serviceMonitor.interval}}
+      path: {{.Values.serviceMonitor.path}}
+{{- end}}

--- a/manifests/helm/kepler/values.yaml
+++ b/manifests/helm/kepler/values.yaml
@@ -1,0 +1,113 @@
+# Default values for kepler.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: quay.io/sustainable_computing_io/kepler
+  pullPolicy: IfNotPresent
+  tag: latest
+
+nameOverride: ""
+fullnameOverride: ""
+
+namespace:
+  create: false
+  name: kepler
+
+serviceAccount:
+  create: true
+  name: kepler
+
+rbac:
+  create: true
+
+service:
+  type: ClusterIP
+  port: 28282
+  targetPort: http
+  protocol: TCP
+
+daemonset:
+  hostPID: true
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+
+  nodeSelector: {}
+  affinity: {}
+
+  securityContext:
+    privileged: true
+
+  resources:
+    {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  livenessProbe:
+    httpGet:
+      path: /metrics
+      port: http
+    initialDelaySeconds: 10
+    periodSeconds: 60
+
+  readinessProbe: {}
+
+config:
+  log:
+    level: debug
+    format: text
+  host:
+    sysfs: /host/sys
+    procfs: /host/proc
+  monitor:
+    interval: 5s
+    staleness: 500ms
+    maxTerminated: 100
+    minTerminatedEnergyThreshold: 10
+  rapl:
+    zones: []
+  exporter:
+    stdout:
+      enabled: false
+    prometheus:
+      enabled: true
+      debugCollectors:
+        - go
+  web:
+    configFile: ""
+    listenAddresses:
+      - :28282
+  debug:
+    pprof:
+      enabled: false
+  kube:
+    enabled: false
+    config: ""
+    nodeName: ""
+  dev:
+    fake-cpu-meter:
+      enabled: false
+      zones: []
+
+# ServiceMonitor for Prometheus Operator
+serviceMonitor:
+  enabled: false
+  interval: 5s
+  path: /metrics
+  labels: {}
+  annotations: {}
+
+# Additional labels to add to all resources
+labels: {}
+
+# Additional annotations to add to all resources
+annotations: {}


### PR DESCRIPTION

Enhancements include:

- Add complete Helm chart under manifests/helm/kepler/ with templates for all Kubernetes resources
- Integrate Helm chart packaging and release into GitHub Actions workflow
- Create comprehensive installation documentation with Helm, Docker Compose, and Kustomize methods
- Update README.md to highlight Helm as recommended Kubernetes deployment method
- Include ServiceMonitor, RBAC, ConfigMap, and DaemonSet templates with configurable values
- Add documentation links for installation, configuration, and metrics guides
- Automated chart versioning and GitHub release integration
