### PR TITLE
ci: use valid version of scorecard action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.2
         with:
           results_file: scorecard-results.sarif
           results_format: sarif


### PR DESCRIPTION
This commit updates the invalid version of the scorecard action used in the workflow. Now it uses the latest version of the action.

Ref: https://github.com/ossf/scorecard-action/releases