### PR TITLE
chore: add build args to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,19 @@
 # Build the binary
 FROM golang:1.23 AS builder
 
+ARG VERSION
+ARG GIT_COMMIT
+ARG GIT_BRANCH
+
 WORKDIR /workspace
 
 COPY . .
 
-RUN make build PRODUCTION=1
+RUN make build \
+  PRODUCTION=1 \
+  VERSION=${VERSION} \
+  GIT_COMMIT=${GIT_COMMIT} \
+  GIT_BRANCH=${GIT_BRANCH}
 
 FROM registry.access.redhat.com/ubi9:latest
 

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,19 @@ BUILD_TIME=$(shell date -u '+%Y-%m-%d_%H:%M:%S')
 GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null)
 
+ifeq ($(GIT_COMMIT),)
+$(error GIT_COMMIT cannot be empty)
+endif
+
+ifeq ($(GIT_BRANCH),)
+$(error GIT_BRANCH cannot be empty)
+endif
+
+ifeq ($(VERSION),)
+$(error VERSION cannot be empty)
+endif
+
+
 LD_VERSION_FLAGS=\
 	-X github.com/sustainable-computing-io/kepler/internal/version.version=$(VERSION) \
 	-X github.com/sustainable-computing-io/kepler/internal/version.buildTime=$(BUILD_TIME) \
@@ -155,6 +168,9 @@ deps: ## Dependencies management (tidy and verify)
 image: ## Docker image build
 	docker build -t \
 		$(KEPLER_IMAGE) \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
+		--build-arg GIT_BRANCH=$(GIT_BRANCH) \
 		--platform=linux/$(GOARCH) .
 	$(call docker_tag,$(KEPLER_IMAGE),$(ADDITIONAL_TAGS))
 


### PR DESCRIPTION
This commit modifies the Dockerfile to accept the following build args:

- VERSION
- GIT_BRANCH
- GIT_COMMIT

These args are defined in Makefile and are depend on Git to compute their values.