### PR TITLE
[docs] Add Gen AI policy in readme and contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,10 @@ Kepler is a Go-based project focused on sustainable computing. Before contributi
 - Familiarize yourself with the project structure by exploring the repository
 - Read our [GOVERNANCE.md](GOVERNANCE.md) and [MAINTAINERS.md](MAINTAINERS.md) documents
 
+## Gen AI policy
+
+Our project adheres to the Linux Foundation's Generative AI Policy, which can be viewed at [https://www.linuxfoundation.org/legal/generative-ai](https://www.linuxfoundation.org/legal/generative-ai).
+
 ## How Do I Start Contributing? 🚀
 
 1. Fork the repository on GitHub

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ For more detailed documentation, please visit the [official Kepler documentation
 
 Contributions are welcome! Please feel free to submit a Pull Request. For more detailed information about contributing to this project, please refer to our [CONTRIBUTING.md](CONTRIBUTING.md) file.
 
+### Gen AI policy
+
+Our project adheres to the Linux Foundation's Generative AI Policy, which can be viewed at [https://www.linuxfoundation.org/legal/generative-ai](https://www.linuxfoundation.org/legal/generative-ai).
+
 ## 📝 License
 
 This project is licensed under the Apache License 2.0 - see the [LICENSES](LICENSES) for details.


### PR DESCRIPTION
pre our discussion on community session, just start this PR for our Gen AI policy discussion.
IMO, I suppose as CNCF "under" LF, and kepler is CNCF project, hence we should follow LF Gen AI policy by default.
I am not been aware of any reason today(2025-07-16) we should have our own community Gen AI policy.
If there any good lesson and learn to build a detail, community specific Gen AI policy with case study, please free to add comments in this PR and I am happy to learn from the case study.