### PR TITLE
ci: publish Kepler binary on releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,23 @@ jobs:
         shell: bash
         run: |
           mkdir -p helm-releases
+          VERSION=${{ steps.version.outputs.version }}
+          # Remove 'v' prefix from version
+          CHART_VERSION=${VERSION#v}
           helm package manifests/helm/kepler -d helm-releases
+          # Rename the helm chart to include 'helm' identifier
+          mv helm-releases/kepler-${CHART_VERSION}.tgz helm-releases/kepler-helm-${CHART_VERSION}.tgz
+
+      - name: Build Kepler binary
+        shell: bash
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          # Remove 'v' prefix from version
+          VERSION=${VERSION#v}
+          make build PRODUCTION=1
+          mv bin/kepler-release bin/kepler
+          # Currently the binary is built for linux-amd64 only
+          tar -czvf bin/kepler-${VERSION}.linux-amd64.tar.gz bin/kepler
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -84,6 +100,7 @@ jobs:
           make_latest: true
           files: |
             helm-releases/*.tgz
+            bin/*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This commit updates the release workflow to publish the Kepler binary when release is created.
Currently we only publish the binary for Linux-amd64. Once we have multi-arch support, we can publish the binary for other platforms as well and update the workflow accordingly.