### PR TITLE
Use precommit hook for helm lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,12 +78,9 @@ repos:
       - id: shellcheck
         args: [-x]
 
-  - repo: local
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: v0.1.30
     hooks:
-      - id: helm-lint
+      - id: helmlint
         name: helm-lint
-        entry: helm lint
-        language: system
         files: ^manifests/helm/[^/]+/(Chart\.yaml|values\.yaml|templates/.*)$
-        pass_filenames: false
-        args: [manifests/helm/kepler]


### PR DESCRIPTION
Use https://github.com/gruntwork-io/pre-commit/blob/master/hooks/helmlint.sh to pre commit hook for helm lint so that developers don't need to install helm in their hosts for pre-commit.

https://github.com/sustainable-computing-io/kepler/issues/2225