### PR TITLE
feat(Dockerfile): use FROM scratch container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN make build \
   GIT_COMMIT=${GIT_COMMIT} \
   GIT_BRANCH=${GIT_BRANCH}
 
-FROM registry.access.redhat.com/ubi9:latest
-
+FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /workspace/bin/kepler-release /usr/bin/kepler
-
 ENTRYPOINT ["/usr/bin/kepler"]


### PR DESCRIPTION
We seem to be using an ubi9 container instead of a smaller base, this leads to having a lot more vulnerabilities without much need considering kepler is technically the only thing you need to run it like that. If the base container is really necessary, I would instead recommend using alpine or debian-slim as a base considering how many vulnerabilities get reported by grype with the current image



<details>

<summary>UBI9 image</summary>

```
grype quay.io/sustainable_computing_io/kepler:latest@sha256:9afc1feeb1115d87de9d52889f3d6fd1628861aeb25d99ff574dea5b6a3d0037
```
```
NAME                         INSTALLED            FIXED IN     TYPE       VULNERABILITY        SEVERITY    EPSS           RISK   
tar                          2:1.34-7.el9         (won't fix)  rpm        CVE-2005-2541        Medium      3.7% (87th)    2.2    
shadow-utils                 2:4.9-12.el9                      rpm        CVE-2024-56433       Medium      2.8% (85th)    1.2    
curl-minimal                 7.76.1-31.el9                     rpm        CVE-2024-7264        Low         2.6% (84th)    1.1    
libcurl-minimal              7.76.1-31.el9                     rpm        CVE-2024-7264        Low         2.6% (84th)    1.1    
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2182        Low         1.4% (79th)    0.8    
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-1619        Low         0.7% (71st)    0.4    
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2183        Low         1.1% (76th)    0.3    
vim-minimal                  2:8.2.2637-22.el9_6  (won't fix)  rpm        CVE-2022-1720        Low         0.6% (68th)    0.3    
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-4292        Low         0.3% (54th)    0.2    
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2845        Low         0.5% (63rd)    0.1    
python3                      3.9.21-2.el9_6.1                  rpm        CVE-2024-7592        Low         0.3% (54th)    0.1    
python3-libs                 3.9.21-2.el9_6.1                  rpm        CVE-2024-7592        Low         0.3% (54th)    0.1    
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2021-4187        Low         0.2% (47th)    0.1    
curl-minimal                 7.76.1-31.el9                     rpm        CVE-2024-9681        Low         0.3% (56th)    0.1    
libcurl-minimal              7.76.1-31.el9                     rpm        CVE-2024-9681        Low         0.3% (56th)    0.1    
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2021-4166        Low         0.2% (45th)    0.1    
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2021-4173        Low         0.2% (41st)    0.1    
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2024-22667       Low         0.2% (39th)    0.1    
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2021-3973        Low         0.2% (41st)    0.1    
curl-minimal                 7.76.1-31.el9                     rpm        CVE-2024-11053       Low         0.2% (44th)    < 0.1  
libcurl-minimal              7.76.1-31.el9                     rpm        CVE-2024-11053       Low         0.2% (44th)    < 0.1  
golang.org/x/crypto          v0.32.0              0.35.0       go-module  GHSA-hcg3-q754-cr77  High        0.1% (32nd)    < 0.1  
python3                      3.9.21-2.el9_6.1                  rpm        CVE-2024-0397        Low         0.2% (46th)    < 0.1  
python3-libs                 3.9.21-2.el9_6.1                  rpm        CVE-2024-0397        Low         0.2% (46th)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2285        Low         0.2% (39th)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2021-3968        Low         0.3% (53rd)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-3705        Low         0.2% (40th)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2284        Low         0.2% (38th)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2286        Low         0.2% (38th)    < 0.1  
python3-pip-wheel            21.3.1-1.el9                      rpm        CVE-2021-3572        Low         0.2% (47th)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-0213        Low         0.2% (40th)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2021-3927        Low         0.2% (37th)    < 0.1  
glib2                        2.68.4-16.el9_6.2                 rpm        CVE-2023-32636       Low         0.2% (39th)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2021-4136        Low         0.2% (36th)    < 0.1  
openssl                      1:3.2.2-6.el9_5.1    (won't fix)  rpm        CVE-2024-41996       Low         0.2% (38th)    < 0.1  
openssl-libs                 1:3.2.2-6.el9_5.1    (won't fix)  rpm        CVE-2024-41996       Low         0.2% (38th)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2124        Low         0.1% (33rd)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2126        Low         0.1% (33rd)    < 0.1  
libxml2                      2.9.13-10.el9_6                   rpm        CVE-2024-34459       Low         0.2% (37th)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2042        Low         0.1% (32nd)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-1620        Low         0.1% (31st)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2129        Low         0.1% (31st)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-1616        Low         0.1% (31st)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2210        Low         0.1% (31st)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2207        Low         0.1% (30th)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2257        Low         0.1% (30th)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2125        Low         0.1% (30th)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2175        Low         0.1% (29th)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2206        Low         0.1% (29th)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2021-3974        Low         0.2% (41st)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2343        Low         0.1% (29th)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-4293        Low         0.1% (33rd)    < 0.1  
gdb-gdbserver                14.2-4.1.el9_6                    rpm        CVE-2025-1153        Low         0.2% (40th)    < 0.1  
libbpf                       2:1.5.0-1.el9        (won't fix)  rpm        CVE-2021-45941       Medium      0.1% (31st)    < 0.1  
golang.org/x/oauth2          v0.24.0              0.27.0       go-module  GHSA-6v2p-p543-phr9  High        < 0.1% (20th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-1674        Low         0.1% (30th)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2862        Low         < 0.1% (25th)  < 0.1  
libbpf                       2:1.5.0-1.el9        (won't fix)  rpm        CVE-2021-45940       Low         0.1% (31st)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2025-29768       Medium      < 0.1% (27th)  < 0.1  
python3                      3.9.21-2.el9_6.1                  rpm        CVE-2025-1795        Low         0.1% (34th)    < 0.1  
python3-libs                 3.9.21-2.el9_6.1                  rpm        CVE-2025-1795        Low         0.1% (34th)    < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2304        Low         < 0.1% (21st)  < 0.1  
python3                      3.9.21-2.el9_6.1                  rpm        CVE-2025-6069        Medium      < 0.1% (23rd)  < 0.1  
python3-libs                 3.9.21-2.el9_6.1                  rpm        CVE-2025-6069        Medium      < 0.1% (23rd)  < 0.1  
sqlite-libs                  3.34.1-7.el9_3                    rpm        CVE-2025-6965        High        < 0.1% (14th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2024-45306       Low         < 0.1% (27th)  < 0.1  
libxml2                      2.9.13-10.el9_6                   rpm        CVE-2023-45322       Low         < 0.1% (24th)  < 0.1  
gnutls                       3.8.3-6.el9                       rpm        CVE-2025-32990       Medium      < 0.1% (18th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-48706       Low         < 0.1% (26th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2208        Low         0.1% (29th)    < 0.1  
gnutls                       3.8.3-6.el9                       rpm        CVE-2025-6395        Medium      < 0.1% (16th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-3297        Low         < 0.1% (17th)  < 0.1  
gnutls                       3.8.3-6.el9                       rpm        CVE-2025-32988       Medium      < 0.1% (16th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-3099        Low         < 0.1% (16th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-3256        Low         < 0.1% (16th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2021-3928        Low         < 0.1% (17th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-3234        Low         < 0.1% (16th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-3296        Low         < 0.1% (16th)  < 0.1  
libarchive                   3.5.3-5.el9_6                     rpm        CVE-2025-1632        Low         < 0.1% (26th)  < 0.1  
openssl                      1:3.2.2-6.el9_5.1                 rpm        CVE-2024-13176       Low         < 0.1% (22nd)  < 0.1  
openssl-libs                 1:3.2.2-6.el9_5.1                 rpm        CVE-2024-13176       Low         < 0.1% (22nd)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2287        Low         < 0.1% (16th)  < 0.1  
glib2                        2.68.4-16.el9_6.2                 rpm        CVE-2025-3360        Low         < 0.1% (24th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-3235        Low         < 0.1% (15th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-5344        Low         < 0.1% (19th)  < 0.1  
pcre2                        10.40-6.el9                       rpm        CVE-2022-41409       Low         < 0.1% (19th)  < 0.1  
pcre2-syntax                 10.40-6.el9                       rpm        CVE-2022-41409       Low         < 0.1% (19th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2982        Low         < 0.1% (13th)  < 0.1  
gdb-gdbserver                14.2-4.1.el9_6                    rpm        CVE-2025-1150        Low         < 0.1% (24th)  < 0.1  
gdb-gdbserver                14.2-4.1.el9_6                    rpm        CVE-2025-1152        Low         < 0.1% (24th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-3324        Low         < 0.1% (13th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-4751        Low         < 0.1% (13th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2817        Low         < 0.1% (12th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-3037        Low         < 0.1% (12th)  < 0.1  
ncurses-base                 6.2-10.20210508.el9               rpm        CVE-2023-50495       Low         < 0.1% (15th)  < 0.1  
ncurses-libs                 6.2-10.20210508.el9               rpm        CVE-2023-50495       Low         < 0.1% (15th)  < 0.1  
gdb-gdbserver                14.2-4.1.el9_6                    rpm        CVE-2025-1151        Low         < 0.1% (23rd)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2344        Low         < 0.1% (11th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-3134        Low         < 0.1% (11th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-4738        Low         < 0.1% (11th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2889        Low         < 0.1% (11th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-3016        Low         < 0.1% (11th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-1725        Low         < 0.1% (15th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-1170        Low         < 0.1% (15th)  < 0.1  
tpm2-tss                     3.2.3-1.el9                       rpm        CVE-2024-29040       Medium      < 0.1% (13th)  < 0.1  
elfutils-default-yama-scope  0.192-6.el9_6                     rpm        CVE-2025-1377        Low         < 0.1% (20th)  < 0.1  
elfutils-libelf              0.192-6.el9_6                     rpm        CVE-2025-1377        Low         < 0.1% (20th)  < 0.1  
elfutils-libs                0.192-6.el9_6                     rpm        CVE-2025-1377        Low         < 0.1% (20th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2345        Low         < 0.1% (9th)   < 0.1  
libgcc                       11.5.0-5.el9_5                    rpm        CVE-2022-27943       Low         < 0.1% (14th)  < 0.1  
libgomp                      11.5.0-5.el9_5                    rpm        CVE-2022-27943       Low         < 0.1% (14th)  < 0.1  
libstdc++                    11.5.0-5.el9_5                    rpm        CVE-2022-27943       Low         < 0.1% (14th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-4734        Low         < 0.1% (9th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-48232       Low         < 0.1% (16th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-48233       Low         < 0.1% (16th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-48237       Low         < 0.1% (16th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-48231       Low         < 0.1% (16th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2024-43802       Low         < 0.1% (15th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2980        Low         < 0.1% (11th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2522        Low         < 0.1% (7th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-0351        Low         < 0.1% (8th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-1127        Low         < 0.1% (7th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-0288        Low         < 0.1% (7th)   < 0.1  
libxml2                      2.9.13-10.el9_6                   rpm        CVE-2025-32415       Medium      < 0.1% (5th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2819        Low         < 0.1% (7th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-4781        Low         < 0.1% (6th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2946        Low         < 0.1% (6th)   < 0.1  
golang.org/x/net             v0.33.0              0.38.0       go-module  GHSA-vvgc-356p-c3xw  Medium      < 0.1% (7th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-3153        Low         < 0.1% (8th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-3278        Low         < 0.1% (10th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-48235       Low         < 0.1% (12th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2874        Low         < 0.1% (8th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2025-24014       Low         < 0.1% (11th)  < 0.1  
libxml2                      2.9.13-10.el9_6                   rpm        CVE-2025-27113       Low         < 0.1% (14th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-48236       Low         < 0.1% (10th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-48234       Low         < 0.1% (10th)  < 0.1  
gawk                         5.1.0-6.el9                       rpm        CVE-2023-4156        Low         < 0.1% (7th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-4735        Low         < 0.1% (5th)   < 0.1  
libarchive                   3.5.3-5.el9_6                     rpm        CVE-2025-5914        Low         < 0.1% (10th)  < 0.1  
elfutils-default-yama-scope  0.192-6.el9_6                     rpm        CVE-2025-1376        Low         < 0.1% (14th)  < 0.1  
elfutils-libelf              0.192-6.el9_6                     rpm        CVE-2025-1376        Low         < 0.1% (14th)  < 0.1  
elfutils-libs                0.192-6.el9_6                     rpm        CVE-2025-1376        Low         < 0.1% (14th)  < 0.1  
ncurses-base                 6.2-10.20210508.el9               rpm        CVE-2022-29458       Low         < 0.1% (6th)   < 0.1  
ncurses-libs                 6.2-10.20210508.el9               rpm        CVE-2022-29458       Low         < 0.1% (6th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-1175        Low         < 0.1% (6th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-4141        Low         < 0.1% (4th)   < 0.1  
tar                          2:1.34-7.el9                      rpm        CVE-2025-45582       Medium      < 0.1% (4th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2849        Low         < 0.1% (11th)  < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-3352        Low         < 0.1% (3rd)   < 0.1  
tar                          2:1.34-7.el9                      rpm        CVE-2023-39804       Low         < 0.1% (8th)   < 0.1  
gnutls                       3.8.3-6.el9                       rpm        CVE-2025-32989       Medium      < 0.1% (3rd)   < 0.1  
python3                      3.9.21-2.el9_6.1                  rpm        CVE-2025-4516        Medium      < 0.1% (3rd)   < 0.1  
python3-libs                 3.9.21-2.el9_6.1                  rpm        CVE-2025-4516        Medium      < 0.1% (3rd)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-0051        Low         < 0.1% (2nd)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2025-1215        Low         < 0.1% (7th)   < 0.1  
elfutils-default-yama-scope  0.192-6.el9_6                     rpm        CVE-2025-1371        Low         < 0.1% (6th)   < 0.1  
elfutils-libelf              0.192-6.el9_6                     rpm        CVE-2025-1371        Low         < 0.1% (6th)   < 0.1  
elfutils-libs                0.192-6.el9_6                     rpm        CVE-2025-1371        Low         < 0.1% (6th)   < 0.1  
libxml2                      2.9.13-10.el9_6                   rpm        CVE-2025-32414       Medium      < 0.1% (2nd)   < 0.1  
gdb-gdbserver                14.2-4.1.el9_6                    rpm        CVE-2024-57360       Low         < 0.1% (4th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-0049        Low         < 0.1% (2nd)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-0433        Low         < 0.1% (2nd)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-0054        Low         < 0.1% (2nd)   < 0.1  
gdb-gdbserver                14.2-4.1.el9_6                    rpm        CVE-2025-5245        Medium      < 0.1% (3rd)   < 0.1  
libarchive                   3.5.3-5.el9_6        (won't fix)  rpm        CVE-2023-30571       Medium      < 0.1% (2nd)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-1264        Low         < 0.1% (3rd)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-5441        Low         < 0.1% (3rd)   < 0.1  
elfutils-default-yama-scope  0.192-6.el9_6                     rpm        CVE-2024-25260       Low         < 0.1% (3rd)   < 0.1  
elfutils-libelf              0.192-6.el9_6                     rpm        CVE-2024-25260       Low         < 0.1% (3rd)   < 0.1  
elfutils-libs                0.192-6.el9_6                     rpm        CVE-2024-25260       Low         < 0.1% (3rd)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6  (won't fix)  rpm        CVE-2023-5535        Low         < 0.1% (4th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2024-43374       Low         < 0.1% (4th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2022-2923        Low         < 0.1% (2nd)   < 0.1  
coreutils-single             8.32-39.el9                       rpm        CVE-2025-5278        Medium      < 0.1% (1st)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-0512        Low         < 0.1% (1st)   < 0.1  
sqlite-libs                  3.34.1-7.el9_3                    rpm        CVE-2024-0232        Low         < 0.1% (2nd)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2025-26603       Low         < 0.1% (3rd)   < 0.1  
python3-pip-wheel            21.3.1-1.el9                      rpm        CVE-2025-50181       Medium      < 0.1% (1st)   < 0.1  
golang.org/x/net             v0.33.0              0.36.0       go-module  GHSA-qxp5-gwg8-xv66  Medium      < 0.1% (1st)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2024-47814       Low         < 0.1% (3rd)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2024-41965       Low         < 0.1% (2nd)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2024-41957       Low         < 0.1% (2nd)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-2610        Low         < 0.1% (1st)   < 0.1  
gdb-gdbserver                14.2-4.1.el9_6                    rpm        CVE-2022-47007       Low         < 0.1% (1st)   < 0.1  
gdb-gdbserver                14.2-4.1.el9_6                    rpm        CVE-2022-47010       Low         < 0.1% (1st)   < 0.1  
gdb-gdbserver                14.2-4.1.el9_6                    rpm        CVE-2022-47011       Low         < 0.1% (1st)   < 0.1  
libarchive                   3.5.3-5.el9_6                     rpm        CVE-2025-5916        Low         < 0.1% (2nd)   < 0.1  
libarchive                   3.5.3-5.el9_6                     rpm        CVE-2025-5918        Low         < 0.1% (2nd)   < 0.1  
python3-pip-wheel            21.3.1-1.el9                      rpm        CVE-2025-50182       Medium      < 0.1% (1st)   < 0.1  
gnupg2                       2.3.3-4.el9                       rpm        CVE-2022-3219        Low         < 0.1% (1st)   < 0.1  
systemd                      252-51.el9_6.1                    rpm        CVE-2025-4598        Medium      < 0.1% (0th)   < 0.1  
systemd-libs                 252-51.el9_6.1                    rpm        CVE-2025-4598        Medium      < 0.1% (0th)   < 0.1  
systemd-pam                  252-51.el9_6.1                    rpm        CVE-2025-4598        Medium      < 0.1% (0th)   < 0.1  
systemd-rpm-macros           252-51.el9_6.1                    rpm        CVE-2025-4598        Medium      < 0.1% (0th)   < 0.1  
libarchive                   3.5.3-5.el9_6                     rpm        CVE-2025-5915        Low         < 0.1% (1st)   < 0.1  
gnupg2                       2.3.3-4.el9                       rpm        CVE-2025-30258       Low         < 0.1% (2nd)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2023-2609        Low         < 0.1% (1st)   < 0.1  
gdb-gdbserver                14.2-4.1.el9_6                    rpm        CVE-2025-3198        Low         < 0.1% (2nd)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6  (won't fix)  rpm        CVE-2023-46246       Low         < 0.1% (1st)   < 0.1  
libxml2                      2.9.13-10.el9_6                   rpm        CVE-2025-6170        Low         < 0.1% (2nd)   < 0.1  
libarchive                   3.5.3-5.el9_6                     rpm        CVE-2025-5917        Low         < 0.1% (1st)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2025-22134       Low         < 0.1% (0th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2025-53905       Medium      < 0.1% (0th)   < 0.1  
vim-minimal                  2:8.2.2637-22.el9_6               rpm        CVE-2025-53906       Medium      < 0.1% (0th)   < 0.1  
libbpf                       2:1.5.0-1.el9        (won't fix)  rpm        CVE-2022-3606        Low         < 0.1% (0th)   < 0.1  
gdb-gdbserver                14.2-4.1.el9_6                    rpm        CVE-2023-2222        Negligible  N/A            N/A
```
</details>

<details>
<summary>FROM scratch image</summary>

```
NAME                 INSTALLED  FIXED IN  TYPE       VULNERABILITY        SEVERITY  EPSS           RISK   
golang.org/x/crypto  v0.32.0    0.35.0    go-module  GHSA-hcg3-q754-cr77  High      0.1% (32nd)    < 0.1  
golang.org/x/oauth2  v0.24.0    0.27.0    go-module  GHSA-6v2p-p543-phr9  High      < 0.1% (20th)  < 0.1  
golang.org/x/net     v0.33.0    0.38.0    go-module  GHSA-vvgc-356p-c3xw  Medium    < 0.1% (7th)   < 0.1  
golang.org/x/net     v0.33.0    0.36.0    go-module  GHSA-qxp5-gwg8-xv66  Medium    < 0.1% (1st)   < 0.1
```

</details>