### PR TITLE
feat(redfish):  add redfish support

### DIFF
--- a/compose/default/kepler/etc/kepler/config.yaml
+++ b/compose/default/kepler/etc/kepler/config.yaml
@@ -70,3 +70,12 @@ dev:
   fake-cpu-meter:
     enabled: false
     zones: [] # zones to be enabled, empty enables all default zones
+
+# EXPERIMENTAL FEATURES - These features are experimental and may be unstable
+# and are disabled by default
+experimental:
+  platform:
+    redfish:
+      enabled: false # Enable experimental Redfish BMC power monitoring
+      configFile: /etc/kepler/redfish.yaml # Path to Redfish BMC configuration file
+      nodeName: "" # Node name to use (overrides Kubernetes node name and hostname fallback)

--- a/compose/default/kepler/etc/kepler/config.yaml
+++ b/compose/default/kepler/etc/kepler/config.yaml
@@ -79,3 +79,4 @@ experimental:
       enabled: false # Enable experimental Redfish BMC power monitoring
       configFile: /etc/kepler/redfish.yaml # Path to Redfish BMC configuration file
       nodeName: "" # Node name to use (overrides Kubernetes node name and hostname fallback)
+      httpTimeout: 5s # HTTP client timeout for BMC requests (default: 5s)

--- a/compose/dev/kepler-dev/etc/kepler/config.yaml
+++ b/compose/dev/kepler-dev/etc/kepler/config.yaml
@@ -70,3 +70,12 @@ dev:
   fake-cpu-meter:
     enabled: false
     zones: [] # zones to be enabled, empty enables all default zones
+
+# EXPERIMENTAL FEATURES - These features are experimental and may be unstable
+# and are disabled by default
+experimental:
+  platform:
+    redfish:
+      enabled: false # Enable experimental Redfish BMC power monitoring
+      configFile: /etc/kepler/redfish.yaml # Path to Redfish BMC configuration file
+      nodeName: "" # Node name to use (overrides Kubernetes node name and hostname fallback)

--- a/compose/dev/kepler-dev/etc/kepler/config.yaml
+++ b/compose/dev/kepler-dev/etc/kepler/config.yaml
@@ -79,3 +79,4 @@ experimental:
       enabled: false # Enable experimental Redfish BMC power monitoring
       configFile: /etc/kepler/redfish.yaml # Path to Redfish BMC configuration file
       nodeName: "" # Node name to use (overrides Kubernetes node name and hostname fallback)
+      httpTimeout: 5s # HTTP client timeout for BMC requests (default: 5s)

--- a/config/redfish/config.go
+++ b/config/redfish/config.go
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package redfish
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// BMCConfig represents the configuration structure for BMC connections
+type BMCConfig struct {
+	Nodes map[string]string    `yaml:"nodes"` // Node name -> BMC ID mapping
+	BMCs  map[string]BMCDetail `yaml:"bmcs"`  // BMC ID -> BMC connection details
+}
+
+// BMCDetail contains the connection details for a specific BMC
+type BMCDetail struct {
+	Endpoint string `yaml:"endpoint"` // BMC endpoint URL
+	Username string `yaml:"username"` // BMC username
+	Password string `yaml:"password"` // BMC password
+	Insecure bool   `yaml:"insecure"` // Skip TLS verification
+}
+
+// Load loads and parses the BMC configuration file
+func Load(configPath string) (*BMCConfig, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read BMC config file %s: %w", configPath, err)
+	}
+
+	var config BMCConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse BMC config file %s: %w", configPath, err)
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid BMC configuration: %w", err)
+	}
+
+	return &config, nil
+}
+
+// Validate validates the BMC configuration
+func (c *BMCConfig) Validate() error {
+	if len(c.Nodes) == 0 {
+		return fmt.Errorf("no nodes configured")
+	}
+
+	if len(c.BMCs) == 0 {
+		return fmt.Errorf("no BMCs configured")
+	}
+
+	// Validate that all node mappings point to valid BMCs
+	for node, bmcID := range c.Nodes {
+		if _, exists := c.BMCs[bmcID]; !exists {
+			return fmt.Errorf("node %s references non-existent BMC %s", node, bmcID)
+		}
+	}
+
+	// Validate BMC configurations
+	for bmcID, bmc := range c.BMCs {
+		if err := bmc.Validate(); err != nil {
+			return fmt.Errorf("BMC %s configuration invalid: %w", bmcID, err)
+		}
+	}
+
+	return nil
+}
+
+// Validate validates a BMC detail configuration
+func (b *BMCDetail) Validate() error {
+	if strings.TrimSpace(b.Endpoint) == "" {
+		return fmt.Errorf("endpoint is required")
+	}
+
+	// Validate credentials - if one is provided, both must be provided
+	hasUsername := strings.TrimSpace(b.Username) != ""
+	hasPassword := strings.TrimSpace(b.Password) != ""
+
+	if hasUsername && !hasPassword {
+		return fmt.Errorf("password is required when username is provided")
+	}
+
+	if !hasUsername && hasPassword {
+		return fmt.Errorf("username is required when password is provided")
+	}
+
+	return nil
+}
+
+// BMCForNode returns the BMC details for a given node name
+func (c *BMCConfig) BMCForNode(nodeName string) (*BMCDetail, error) {
+	bmcID, exists := c.Nodes[nodeName]
+	if !exists {
+		return nil, fmt.Errorf("node %s not found in BMC configuration", nodeName)
+	}
+
+	bmc, exists := c.BMCs[bmcID]
+	if !exists {
+		return nil, fmt.Errorf("BMC %s not found in BMC configuration", bmcID)
+	}
+
+	return &bmc, nil
+}
+
+// BMCIDForNode returns the BMC ID for a given node name
+func (c *BMCConfig) BMCIDForNode(nodeName string) (string, error) {
+	bmcID, exists := c.Nodes[nodeName]
+	if !exists {
+		return "", fmt.Errorf("node %s not found in BMC configuration", nodeName)
+	}
+
+	_, exists = c.BMCs[bmcID]
+	if !exists {
+		return "", fmt.Errorf("BMC %s not found in BMC configuration", bmcID)
+	}
+
+	return bmcID, nil
+}

--- a/config/redfish/config_test.go
+++ b/config/redfish/config_test.go
@@ -1,0 +1,264 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package redfish
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadAndValidate(t *testing.T) {
+	tt := []struct {
+		name          string
+		configContent string
+		expectError   bool
+		errorContains string
+	}{{
+		name: "Valid configuration",
+		configContent: `
+nodes:
+  node1: bmc1
+  node2: bmc2
+bmcs:
+  bmc1:
+    endpoint: "https://bmc1.example.com"
+    username: "admin"
+    password: "secret"
+  bmc2:
+    endpoint: "https://bmc2.example.com"
+    insecure: true
+`,
+		expectError: false,
+	}, {
+		name: "No credentials",
+		configContent: `
+nodes:
+  node1: bmc1
+bmcs:
+  bmc1:
+    endpoint: "https://bmc1.example.com"
+`,
+		expectError: false,
+	}, {
+		name: "Username without password",
+		configContent: `
+nodes:
+  node1: bmc1
+bmcs:
+  bmc1:
+    endpoint: "https://bmc1.example.com"
+    username: "admin"
+`,
+		expectError:   true,
+		errorContains: "password is required when username is provided",
+	}, {
+		name: "Password without username",
+		configContent: `
+nodes:
+  node1: bmc1
+bmcs:
+  bmc1:
+    endpoint: "https://bmc1.example.com"
+    password: "secret"
+`,
+		expectError:   true,
+		errorContains: "username is required when password is provided",
+	}, {
+		name: "Missing endpoint",
+		configContent: `
+nodes:
+  node1: bmc1
+bmcs:
+  bmc1:
+    username: "admin"
+    password: "secret"
+`,
+		expectError:   true,
+		errorContains: "endpoint is required",
+	}, {
+		name: "Node references non-existent BMC",
+		configContent: `
+nodes:
+  node1: bmc1
+  node2: nonexistent
+bmcs:
+  bmc1:
+    endpoint: "https://bmc1.example.com"
+`,
+		expectError:   true,
+		errorContains: "node node2 references non-existent BMC nonexistent",
+	}, {
+		name: "No nodes configured",
+		configContent: `
+bmcs:
+  bmc1:
+    endpoint: "https://bmc1.example.com"
+`,
+		expectError:   true,
+		errorContains: "no nodes configured",
+	}, {
+		name: "No BMCs configured",
+		configContent: `
+nodes:
+  node1: bmc1
+`,
+		expectError:   true,
+		errorContains: "no BMCs configured",
+	}}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "config_test")
+			require.NoError(t, err)
+			defer func() { _ = os.RemoveAll(tmpDir) }()
+
+			configFile := filepath.Join(tmpDir, "config.yaml")
+			err = os.WriteFile(configFile, []byte(tc.configContent), 0644)
+			require.NoError(t, err)
+
+			config, err := Load(configFile)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains)
+				}
+				assert.Nil(t, config)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, config)
+			}
+		})
+	}
+}
+
+func TestBMCIDForNodeSuccess(t *testing.T) {
+	// Create temporary config file
+	tmpDir, err := os.MkdirTemp("", "config_test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	configContent := `
+nodes:
+  node1: bmc1
+  node2: bmc2
+bmcs:
+  bmc1:
+    endpoint: "https://bmc1.example.com"
+  bmc2:
+    endpoint: "https://bmc2.example.com"
+`
+
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	err = os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	config, err := Load(configFile)
+	require.NoError(t, err)
+
+	tt := []struct {
+		name     string
+		nodeID   string
+		expected string
+		wantErr  bool
+	}{{
+		name:     "Valid node1",
+		nodeID:   "node1",
+		expected: "bmc1",
+		wantErr:  false,
+	}, {
+		name:     "Valid node2",
+		nodeID:   "node2",
+		expected: "bmc2",
+		wantErr:  false,
+	}, {
+		name:    "Non-existent node",
+		nodeID:  "node3",
+		wantErr: true,
+	}, {
+		name:    "Empty node ID",
+		nodeID:  "",
+		wantErr: true,
+	}}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := config.BMCIDForNode(tc.nodeID)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestBMCForNodeEdgeCases(t *testing.T) {
+	// Create temporary config with edge cases
+	tmpDir, err := os.MkdirTemp("", "config_edge_test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	configContent := `
+nodes:
+  node1: bmc1
+  node2: nonexistent-bmc  # BMC that doesn't exist in bmcs section
+bmcs:
+  bmc1:
+    endpoint: "https://bmc1.example.com"
+    username: "admin"
+    password: "secret"
+    insecure: true
+`
+
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	err = os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	_, err = Load(configFile)
+	require.Error(t, err) // Should fail validation due to nonexistent-bmc
+
+	// Test manually created config for edge cases
+	config := &BMCConfig{
+		Nodes: map[string]string{
+			"node1": "bmc1",
+		},
+		BMCs: map[string]BMCDetail{
+			"bmc1": {
+				Endpoint: "https://bmc1.example.com",
+				Username: "admin",
+				Password: "secret",
+				Insecure: true,
+			},
+		},
+	}
+
+	tt := []struct {
+		name    string
+		nodeID  string
+		wantErr bool
+	}{{
+		name:    "Valid node",
+		nodeID:  "node1",
+		wantErr: false,
+	}}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := config.BMCForNode(tc.nodeID)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/config/redfish/config_test.go
+++ b/config/redfish/config_test.go
@@ -163,32 +163,32 @@ bmcs:
 
 	tt := []struct {
 		name     string
-		nodeID   string
+		nodeName string
 		expected string
 		wantErr  bool
 	}{{
 		name:     "Valid node1",
-		nodeID:   "node1",
+		nodeName: "node1",
 		expected: "bmc1",
 		wantErr:  false,
 	}, {
 		name:     "Valid node2",
-		nodeID:   "node2",
+		nodeName: "node2",
 		expected: "bmc2",
 		wantErr:  false,
 	}, {
-		name:    "Non-existent node",
-		nodeID:  "node3",
-		wantErr: true,
+		name:     "Non-existent node",
+		nodeName: "node3",
+		wantErr:  true,
 	}, {
-		name:    "Empty node ID",
-		nodeID:  "",
-		wantErr: true,
+		name:     "Empty node ID",
+		nodeName: "",
+		wantErr:  true,
 	}}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := config.BMCIDForNode(tc.nodeID)
+			result, err := config.BMCIDForNode(tc.nodeName)
 
 			if tc.wantErr {
 				assert.Error(t, err)
@@ -241,18 +241,18 @@ bmcs:
 	}
 
 	tt := []struct {
-		name    string
-		nodeID  string
-		wantErr bool
+		name     string
+		nodeName string
+		wantErr  bool
 	}{{
-		name:    "Valid node",
-		nodeID:  "node1",
-		wantErr: false,
+		name:     "Valid node",
+		nodeName: "node1",
+		wantErr:  false,
 	}}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := config.BMCForNode(tc.nodeID)
+			_, err := config.BMCForNode(tc.nodeName)
 
 			if tc.wantErr {
 				assert.Error(t, err)

--- a/docs/developer/proposal/EP_001-redfish-support.md
+++ b/docs/developer/proposal/EP_001-redfish-support.md
@@ -1,14 +1,16 @@
 # EP-001: Redfish Power Monitoring Support
 
-- **Status**: Draft
+- **Status**: Implemented
+- **Maturity**: Experimental
 - **Author**: Sunil Thaha
 - **Created**: 2025-08-14
+- **Updated**: 2025-08-28
 
 ## Summary
 
-Add Redfish BMC power monitoring to Kepler for platform-level power consumption data,
-complementing existing RAPL CPU monitoring to provide comprehensive server power
-visibility.
+Redfish BMC power monitoring has been added to Kepler as an experimental feature, providing
+platform-level power consumption data that complements existing RAPL CPU monitoring
+for complete server power visibility.
 
 ## Problem
 
@@ -65,21 +67,29 @@ C4Container
 
 ## Node Identification
 
-Nodes identified via `--platform.redfish.node-id` flag or `platform.redfish.nodeID` config,
-matching identifiers in BMC configuration file. E.g.
+Nodes are automatically identified using the following priority:
+
+1. **CLI flag**: `--experimental.platform.redfish.node-id=worker-1`
+2. **Configuration**: `experimental.platform.redfish.nodeID` in config.yaml
+3. **Kubernetes node name**: Automatically detected when Kubernetes is enabled
+4. **Hostname fallback**: System hostname used if no explicit identifier provided
 
 ```bash
-kepler --platform.redfish.node-id=worker-1
+# Explicit node ID
+kepler --experimental.platform.redfish.node-id=worker-1
+
+# Or automatic resolution from Kubernetes node name
+kepler --kube.enable --kube.node-name=worker-1
 ```
 
-1. **Configuration**: `platform.redfish.nodeID` as below
+**Configuration Example:**
 
 ```yaml
 # config.yaml
-
+experimental:
   platform:
     redfish:
-      nodeID: worker-1
+      nodeID: worker-1  # Optional - will auto-resolve if not provided
 ```
 
 ```mermaid
@@ -109,9 +119,22 @@ graph TD
 
 Implements standard Kepler patterns:
 
-- `service.Initializer`: Configuration and connection setup
-- `service.Runner`: Periodic power collection with context
-- `service.Shutdowner`: Clean resource release
+- `service.Initializer`: Configuration and BMC connection setup
+- `service.Shutdowner`: Clean resource release and client disconnection
+
+### Implementation Details
+
+**Simplified On-Demand Architecture with Caching:**
+
+- `Power()`: synchronous method returning detailed PowerControl readings from all chassis
+- Simple staleness-based caching to reduce BMC API calls
+- Individual PowerControl entry exposure with detailed labeling (chassis_id, power_control_id, power_control_name)
+- BMC API calls only when cached data is stale or unavailable
+
+**Service Lifecycle:**
+
+- `Init()`: Establishes BMC connection, validates credentials
+- `Shutdown()`:  Disconnects from BMC
 
 ### Configuration
 
@@ -123,18 +146,21 @@ type Platform struct {
 }
 
 type Redfish struct {
-    Enabled    *bool  `yaml:"enabled"`
-    NodeID     string `yaml:"nodeID"`
-    ConfigFile string `yaml:"configFile"`
+    Enabled     *bool         `yaml:"enabled"`
+    NodeID      string        `yaml:"nodeID"`
+    ConfigFile  string        `yaml:"configFile"`
+    Staleness   time.Duration `yaml:"staleness"`   // Max age before forcing new collection (simplified caching)
+    HTTPTimeout time.Duration `yaml:"httpTimeout"` // HTTP client timeout for BMC requests
 }
 ```
 
 **CLI Flags:**
 
 ```bash
---platform.redfish.enabled=true
---platform.redfish.node-id=worker-1
---platform.redfish.config=/etc/kepler/redfish.yaml
+--experimental.platform.redfish.enabled=true
+--experimental.platform.redfish.node-id=worker-1
+--experimental.platform.redfish.config=/etc/kepler/redfish.yaml
+# Note: staleness and httpTimeout are configuration-only (not exposed as CLI flags)
 ```
 
 **Main Configuration (`hack/config.yaml`):**
@@ -142,11 +168,14 @@ type Redfish struct {
 ```yaml
 # ... existing config sections ...
 
-platform:
-  redfish:
-    enabled: true
-    nodeID: "worker-1"  # Node identifier for BMC mapping
-    configFile: "/etc/kepler/redfish.yaml"
+experimental:
+  platform:
+    redfish:
+      enabled: true
+      nodeID: "worker-1"  # Node identifier for BMC mapping
+      configFile: "/etc/kepler/redfish.yaml"
+      staleness: 30s      # Cache readings for 30 seconds
+      httpTimeout: 5s     # HTTP client timeout for BMC requests
 ```
 
 **BMC Configuration (`/etc/kepler/redfish.yaml`):**
@@ -185,27 +214,60 @@ bmcs:
 
 ```
 
+## Collection Strategy
+
+The Redfish service implements a **on-demand collection with caching**:
+
+### On Demand Collection Mode with Caching
+
+- No background collection or periodic polling
+- Direct BMC API calls during Prometheus scrape via `Power()`
+- Implements simple caching with configurable staleness (default 30 seconds) to
+ support multiple Prometheus scrapes in a short period (High Availability)
+- Returns cached data if available and fresh, otherwise collects fresh data
+- Returns all chassis with detailed PowerControl readings in a single call
+- Each PowerControl entry identified by `chassis_id`, `power_control_id`, and `power_control_name` for granular metric labeling
+
+### Multiple Chassis and PowerControl Support
+
+- `Power()` method returns `*PowerReading` (single reading containing multiple chassis with detailed PowerControl data)
+- `PowerReading` struct contains `[]Chassis` slice, each with `ID` and `[]Reading` for individual PowerControl entries
+- Iterates through all available chassis on the BMC and their PowerControl arrays
+- Filters and returns only PowerControl entries with valid power readings
+- Each reading includes `ControlID`, `Name`, and `Power` for granular power domain monitoring
+- Exposes individual PowerControl entries as separate metrics (e.g., Server Power Control, CPU Sub-system Power, Memory Power)
+
 ## Metrics
 
 Platform-level metrics are introduced as a separate metric namespace to distinguish from
 node-level power attribution. While Kepler's existing metrics attribute power consumption
-to workloads running on a node, platform metrics represent the total power consumed by
+to workloads running on a node, platform metrics represent individual power domains from
 the underlying bare metal server (via BMC), regardless of whether Kepler runs on bare
-metal or within a VM. This separation enables:
+metal or within a VM.
+
+**PowerControl Granularity**: Each PowerControl entry from the BMC's PowerControl array is
+exposed as an individual metric with detailed labels. This approach avoids making assumptions
+about power topology (whether PowerControl entries should be summed or represent independent
+power domains) and allows users to understand their specific hardware's power structure.
+
+This separation enables:
 
 - Multiple VMs on the same bare metal to report the same platform power
-- Clear distinction between attributed workload power and total platform power
-- Aggregation by BMC ID to get actual bare metal consumption: `max by(bmc) (kepler_platform_watts)`
+- Clear distinction between attributed workload power and platform power domains
+- Granular monitoring of power subsystems (CPU, memory, storage, etc.)
+- Flexible aggregation based on understanding of specific hardware topology
 
 **Important**: This implementation uses a **power-only (Watts) approach**.
 Energy counters (`kepler_platform_joules_total`) are not supported because:
 
 - Redfish does not provide native energy counters
-- BMC polling is intermittent (every 10 seconds) vs continuous monitoring
+- Collection frequency varies based on demand and configuration
 
 ```prometheus
-# Platform power metrics (bare metal power consumption)
-kepler_platform_watts{source="redfish",node_name="worker-1",bmc="bmc-1",chassis_id="System.Embedded.1"} 450.5
+# Platform power metrics (bare metal power consumption) - individual PowerControl entries exposed
+kepler_platform_watts{source="redfish",node_name="worker-1",bmc_id="bmc-1",chassis_id="System.Embedded.1",power_control_id="PC1",power_control_name="Server Power Control"} 450.5
+kepler_platform_watts{source="redfish",node_name="worker-1",bmc_id="bmc-1",chassis_id="System.Embedded.1",power_control_id="PC2",power_control_name="CPU Sub-system Power"} 85.2
+kepler_platform_watts{source="redfish",node_name="worker-1",bmc_id="bmc-1",chassis_id="Enclosure.Internal.0-1",power_control_id="PC1",power_control_name="Enclosure Power Control"} 125.3
 
 # Existing node metrics unchanged (workload attribution)
 kepler_node_cpu_watts{zone="package",node_name="worker-1"} 125.2
@@ -215,7 +277,8 @@ kepler_node_cpu_watts{zone="package",node_name="worker-1"} 125.2
 
 - Connection failures: Log errors and continue to run (instead of terminating)
 - Authentication errors: Retry once, then disable for node
-- Timeouts: 30-second context timeout for BMC requests
+- Timeouts: Configurable HTTP client timeout for BMC requests (default 5 seconds)
+- Individual chassis failures: Skip failed chassis and continue with available ones
 - Graceful degradation when BMCs unavailable
 
 ## Security
@@ -224,19 +287,58 @@ kepler_node_cpu_watts{zone="package",node_name="worker-1"} 125.2
 - No credential logging
 - Require explicit opt-in via configuration
 
+## Implementation Status
+
+**✅ Implemented and Available (Experimental):**
+
+1. **Core**: Full Gofish integration with simplified on-demand power collection and service interfaces
+2. **Metrics**: Platform collector integrated with Prometheus exporter
+3. **Configuration**: CLI flags and YAML configuration with automatic node ID resolution
+4. **Testing**: Unit tests with mock server covering multiple vendor scenarios
+5. **Caching**: Staleness-based caching to reduce BMC API calls
+6. **Multiple Chassis and PowerControl**: Support for collecting detailed power data from all chassis and individual PowerControl entries
+
+**Current State:**
+
+- Feature is **experimental** and requires explicit opt-in via configuration
+- All described functionality is implemented and tested
+- Available for use in controlled environments
+- Simplified architecture reduces complexity while providing core functionality
+
 ## Implementation Phases
 
-1. **Foundation**: Dependencies, service structure, config parsing
-2. **Core**: Gofish integration, power collection, service interface
-3. **Metrics**: Platform collector, Prometheus registration
-4. **Testing**: Unit, integration, multi-vendor validation
-5. **Release**: Documentation, migration guides
+1. **Core**: Gofish integration, power collection, service interface ✅
+2. **Metrics**: Platform collector, Prometheus registration ✅
+3. **Testing**: Unit, integration, multi-vendor validation ✅
+4. **Release**: Documentation, migration guides ✅
 
 ## Testing Strategy
 
-- Unit tests with mocked Redfish responses
-- Integration tests with Redfish simulator
-- Performance impact validation (<2% overhead target compared to base kepler)
+**Implemented Testing:**
+
+- **Unit tests**: Full test coverage with mocked Redfish responses
+- **Mock server**: HTTP server simulating BMC Redfish API endpoints for different vendors
+- **Multi-vendor scenarios**: Dell, HPE, Lenovo, and Generic response variations
+- **Error conditions**: Connection failures, authentication errors, timeouts, missing chassis
+- **Concurrency testing**: Race detection and thread safety validation
+- **Caching behavior**: Staleness-based caching and cache expiry testing
+- **Service lifecycle**: Complete Init, ChassisPower, and Shutdown testing
+
+**Testing Infrastructure:**
+
+- Mock Redfish server with configurable response scenarios and error injection
+- Test data validation helpers and assertion functions
+- Race condition testing with `go test -race`
+- Service lifecycle testing covering all service interfaces
+- Configuration validation and error handling tests
+- BMC configuration file loading and node mapping tests
+
+**Performance Validation:**
+
+- On-demand collection with caching reduces BMC load
+- Simplified architecture minimizes overhead
+- Multiple chassis data collected in single BMC interaction
+- Configurable staleness for different performance requirements
 
 ## Migration
 
@@ -253,14 +355,45 @@ kepler_node_cpu_watts{zone="package",node_name="worker-1"} 125.2
 | Performance impact   | <2% overhead validation                 |
 | Security             | Secure credential handling, TLS default |
 
+## Experimental Maturity
+
+**Why Experimental:**
+
+- First implementation of BMC integration in Kepler
+- Multi-vendor compatibility needs broader testing
+- Performance impact requires real-world validation
+- Configuration patterns may evolve based on user feedback
+
+**Path to Stable:**
+
+1. **Field Testing**: Deploy in controlled environments
+2. **Vendor Validation**: Test with additional BMC implementations
+3. **Performance Analysis**: Measure production impact and optimization
+4. **Community Feedback**: Iterate based on user experience
+5. **API Stabilization**: Finalize configuration and metric structures
+
+**Current Limitations:**
+
+- Power-only metrics (no energy counters due to intermittent BMC polling)
+- Basic staleness-based caching (more advanced cache management could be added)
+- BMC calls during Prometheus scrape when cache is stale (mitigated by configurable staleness)
+- Tested with mock servers (Dell, HPE, Lenovo, Generic scenarios)
+
 ## Future Enhancements
 
-- Circuit breaker patterns
-- Exponential backoff strategies
-- External secret integration
-- Chassis sub-component power zones
+- Background collection with better caching for improved performance
+- Enhanced staleness management and retry logic
+- Circuit breaker patterns for BMC failure handling
+- External secret integration (Kubernetes, Vault)
+- Chassis sub-component power zones (PSU, fans, storage)
+- Energy counter derivation for long-term monitoring
+- Additional BMC authentication methods
 
 ## Open Questions
 
-1. Multi-chassis server handling?
-2. Sub-component power exposure (PSU, fans)?
+1. ~~Multi-chassis server handling for complex hardware?~~ **Addressed**: `ChassisPower()` returns all chassis with power readings
+2. ~~Need for caching layer in future versions?~~ **Partially Addressed**: Simple staleness-based caching implemented
+3. Sub-component power exposure (PSU, fans) priority?
+4. Integration with other platform monitoring tools?
+5. Performance impact of BMC calls during Prometheus scrape (mitigated by caching)?
+6. Better cache management strategies for high-frequency monitoring?

--- a/docs/user/metrics.md
+++ b/docs/user/metrics.md
@@ -237,24 +237,6 @@ These metrics provide energy and power information for pods.
 - **Constant Labels**:
   - `node_name`
 
-### Platform Metrics
-
-These metrics provide hardware-level power information from platform management controllers (e.g., BMC via Redfish).
-
-#### kepler_platform_watts
-
-- **Type**: GAUGE
-- **Description**: Current platform power consumption in watts from BMC PowerControl entries
-- **Labels**:
-  - `source`: Platform monitoring source (e.g., "redfish")
-  - `node_name`: Node identifier
-  - `bmc_id`: BMC identifier
-  - `chassis_id`: Chassis identifier from BMC
-  - `power_control_id`: PowerControl entry identifier (e.g., "PC1", "PC2")
-  - `power_control_name`: Human-readable PowerControl name (e.g., "Server Power Control", "CPU Sub-system Power")
-
-**Note**: Each PowerControl entry from the BMC is exposed as an individual metric with unique labels. This allows monitoring of different power domains (server, CPU subsystem, memory, etc.) without making assumptions about power topology.
-
 ### Other Metrics
 
 Additional metrics provided by Kepler.
@@ -269,6 +251,26 @@ Additional metrics provided by Kepler.
   - `revision`
   - `version`
   - `goversion`
+
+## Experimental Metrics
+
+⚠️ **Warning**: The following metrics are experimental and may change or be removed in future versions. They are provided for early testing and feedback purposes.
+
+### Platform Power Metrics
+
+These experimental metrics provide platform-level power information from BMC sources (e.g., Redfish). Enable the experimental Redfish feature to collect these metrics.
+
+#### kepler_platform_watts
+
+- **Type**: GAUGE
+- **Description**: Current platform power consumption in watts from BMC PowerControl entries
+- **Labels**:
+  - `source`
+  - `node_name`
+  - `bmc_id`
+  - `chassis_id`
+  - `power_control_id`
+  - `power_control_name`
 
 ---
 

--- a/docs/user/metrics.md
+++ b/docs/user/metrics.md
@@ -237,6 +237,24 @@ These metrics provide energy and power information for pods.
 - **Constant Labels**:
   - `node_name`
 
+### Platform Metrics
+
+These metrics provide hardware-level power information from platform management controllers (e.g., BMC via Redfish).
+
+#### kepler_platform_watts
+
+- **Type**: GAUGE
+- **Description**: Current platform power consumption in watts from BMC PowerControl entries
+- **Labels**:
+  - `source`: Platform monitoring source (e.g., "redfish")
+  - `node_name`: Node identifier
+  - `bmc_id`: BMC identifier
+  - `chassis_id`: Chassis identifier from BMC
+  - `power_control_id`: PowerControl entry identifier (e.g., "PC1", "PC2")
+  - `power_control_name`: Human-readable PowerControl name (e.g., "Server Power Control", "CPU Sub-system Power")
+
+**Note**: Each PowerControl entry from the BMC is exposed as an individual metric with unique labels. This allows monitoring of different power domains (server, CPU subsystem, memory, etc.) without making assumptions about power topology.
+
 ### Other Metrics
 
 Additional metrics provided by Kepler.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/exporter-toolkit v0.14.0
 	github.com/prometheus/procfs v0.15.1
+	github.com/stmcginnis/gofish v0.15.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/sync v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stmcginnis/gofish v0.15.0 h1:8TG41+lvJk/0Nf8CIIYErxbMlQUy80W0JFRZP3Ld82A=
+github.com/stmcginnis/gofish v0.15.0/go.mod h1:BLDSFTp8pDlf/xDbLZa+F7f7eW0E/CHCboggsu8CznI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -79,3 +79,4 @@ experimental:
       enabled: false # Enable experimental Redfish BMC power monitoring
       configFile: hack/redfish.yaml # Path to Redfish BMC configuration file
       nodeName: "" # Node name to use (overrides Kubernetes node name and hostname fallback)
+      httpTimeout: 5s # HTTP client timeout for BMC requests (default: 5s)

--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -70,3 +70,12 @@ dev:
   fake-cpu-meter:
     enabled: false
     zones: [] # zones to be enabled, empty enables all default zones
+
+# EXPERIMENTAL FEATURES - These features are experimental and may be unstable
+# and are disabled by default
+experimental:
+  platform:
+    redfish:
+      enabled: false # Enable experimental Redfish BMC power monitoring
+      configFile: hack/redfish.yaml # Path to Redfish BMC configuration file
+      nodeName: "" # Node name to use (overrides Kubernetes node name and hostname fallback)

--- a/hack/redfish-production.yaml
+++ b/hack/redfish-production.yaml
@@ -1,0 +1,111 @@
+# Production Redfish BMC Configuration Example
+# This file demonstrates production-ready BMC configurations for Redfish power monitoring
+#
+# IMPORTANT: This is an experimental feature with no stability guarantees
+#
+# Production Best Practices:
+# - Use TLS certificates (insecure: false)
+# - Secure credential management
+# - Network segmentation for BMC access
+# - Regular credential rotation
+# - Monitoring and alerting for BMC connectivity
+
+# Node to BMC mapping
+# Production environments typically have dedicated BMCs per physical server
+# or shared BMCs for blade servers in chassis
+nodes:
+  # Kubernetes cluster nodes mapped to their respective BMCs
+  k8s-master-01: hpe-proliant-dl380-001
+  k8s-master-02: hpe-proliant-dl380-002
+  k8s-master-03: hpe-proliant-dl380-003
+
+  # Worker nodes on Dell PowerEdge servers
+  k8s-worker-01: dell-poweredge-r650-001
+  k8s-worker-02: dell-poweredge-r650-002
+  k8s-worker-03: dell-poweredge-r650-003
+  k8s-worker-04: dell-poweredge-r650-004
+
+  # Blade servers sharing chassis BMC
+  blade-01: dell-chassis-m1000e-001
+  blade-02: dell-chassis-m1000e-001
+  blade-03: dell-chassis-m1000e-001
+  blade-04: dell-chassis-m1000e-001
+
+  # GPU compute nodes
+  gpu-worker-01: supermicro-sys-4029gp-001
+  gpu-worker-02: supermicro-sys-4029gp-002
+
+# BMC connection details for production environment
+bmcs:
+  # HPE ProLiant DL380 Gen10 Plus servers
+  hpe-proliant-dl380-001:
+    endpoint: https://bmc-master-01.datacenter.local
+    username: monitoring_user
+    password: hpe_master_01_secure_pass
+    insecure: false # Use valid TLS certificates in production
+
+  hpe-proliant-dl380-002:
+    endpoint: https://bmc-master-02.datacenter.local:8443 # <- different port
+    username: monitoring_user
+    password: hpe_master_02_secure_pass
+    insecure: false
+
+  hpe-proliant-dl380-003:
+    endpoint: https://bmc-master-03.datacenter.local
+    username: monitoring_user
+    password: hpe_master_03_secure_pass
+    insecure: false
+
+  # Dell PowerEdge R650 servers
+  dell-poweredge-r650-001:
+    endpoint: http://idrac-worker-01.mgmt.datacenter.local # <- HTTP
+    username: keplermon
+    password: dell_worker_01_secure_pass
+    insecure: false
+
+  dell-poweredge-r650-002:
+    endpoint: https://idrac-worker-02.mgmt.datacenter.local
+    username: keplermon
+    password: dell_worker_02_secure_pass
+    insecure: false
+
+  dell-poweredge-r650-003:
+    endpoint: https://idrac-worker-03.mgmt.datacenter.local
+    username: keplermon
+    password: dell_worker_03_secure_pass
+    insecure: false
+
+  dell-poweredge-r650-004:
+    endpoint: https://idrac-worker-04.mgmt.datacenter.local
+    username: keplermon
+    password: dell_worker_04_secure_pass
+    insecure: false
+
+  # Dell PowerEdge M1000e Blade Chassis BMC
+  # Multiple blade servers share the same chassis management controller
+  dell-chassis-m1000e-001:
+    endpoint: https://cmc-chassis-01.mgmt.datacenter.local
+    username: keplermon
+    password: dell_chassis_01_secure_pass
+    insecure: false
+
+  # Supermicro GPU servers
+  supermicro-sys-4029gp-001:
+    endpoint: https://ipmi-gpu-01.mgmt.datacenter.local
+    username: ADMIN
+    password: supermicro_gpu_01_secure_pass
+    insecure: false
+
+  supermicro-sys-4029gp-002:
+    endpoint: https://ipmi-gpu-02.mgmt.datacenter.local
+    username: ADMIN
+    password: supermicro_gpu_02_secure_pass
+    insecure: false
+# Production Collection Configuration (in main config.yaml):
+# experimental:
+#   platform:
+#     redfish:
+#       enabled: true
+#       configFile: /etc/kepler/redfish.yaml
+#       nodeID: ""  # Auto-resolve from Kubernetes node name
+#       staleness: 2s   # Reasonable balance of freshness vs BMC load

--- a/hack/redfish-production.yaml
+++ b/hack/redfish-production.yaml
@@ -102,10 +102,11 @@ bmcs:
     password: supermicro_gpu_02_secure_pass
     insecure: false
 # Production Collection Configuration (in main config.yaml):
+#
 # experimental:
 #   platform:
 #     redfish:
 #       enabled: true
 #       configFile: /etc/kepler/redfish.yaml
-#       nodeID: ""  # Auto-resolve from Kubernetes node name
-#       staleness: 2s   # Reasonable balance of freshness vs BMC load
+#       nodeName: ""  # Auto-resolve from Kubernetes node name
+#       httpTimeout: 5s   # Reasonable balance of freshness vs BMC load

--- a/hack/redfish.yaml
+++ b/hack/redfish.yaml
@@ -1,0 +1,20 @@
+# IMPORTANT: This is an experimental feature with no stability guarantees
+#
+# Example Redfish BMC Configuration for Development using Sushy tool
+#
+# Configuration structure:
+# - nodes: Maps node names/IDs to BMC identifiers
+# - bmcs: Contains connection details for each BMC
+
+# Node to BMC mapping
+# Key: Node identifier (Kubernetes node name, hostname, or custom ID)
+# Value: BMC identifier that references an entry in the 'bmcs' section
+nodes:
+  fedora: sushy-static # development environment; use hostname as the node name
+
+bmcs:
+  sushy-static:
+    endpoint: http://127.0.0.1:8000
+    username: ""
+    password: ""
+    insecure: true

--- a/hack/redfish/README.md
+++ b/hack/redfish/README.md
@@ -1,0 +1,256 @@
+# Redfish BMC Test Data Capture Tools
+
+This directory contains utilities for capturing real BMC test data to improve Kepler's Redfish power monitoring capabilities.
+
+## 🎯 Quick Start
+
+```bash
+# Capture from single BMC
+go run hack/redfish/capture-bmc-testdata.go \
+    -endpoint https://192.168.1.100 \
+    -username admin \
+    -password yourpassword \
+    -vendor dell
+
+# Capture using config file
+go run hack/redfish/capture-bmc-testdata.go \
+    -config hack/redfish/bmc-config.yaml \
+    -node worker-node-1
+```
+
+## 📁 Files Overview
+
+### `capture-bmc-testdata.go`
+
+**🌟 Main capture utility** - Use this for all test data capture needs.
+
+**Features:**
+
+- ✅ Config file support for multiple BMCs
+- ✅ Automatic data sanitization
+- ✅ Test-ready JSON fixtures
+- ✅ Copy-paste ready code snippets
+- ✅ Comprehensive error handling
+- ✅ Security-conscious design
+
+**Usage:**
+
+```bash
+# Command line flags
+go run hack/redfish/capture-bmc-testdata.go [options]
+
+# Config file (recommended)
+go run hack/redfish/capture-bmc-testdata.go -config bmc-config.yaml -node worker-1
+```
+
+### `bmc-config.yaml`
+
+**Configuration template** for managing multiple BMCs.
+
+**Format:**
+
+```yaml
+nodes:
+  worker-node-1: bmc-1
+  worker-node-2: bmc-2
+bmcs:
+  bmc-1:
+    endpoint: https://192.168.1.100
+    username: admin
+    password: secret123
+    insecure: true
+```
+
+## 🚀 Integration Workflow
+
+1. **Capture BMC data**:
+
+   ```bash
+   go run hack/redfish/capture-bmc-testdata.go -endpoint ... -vendor dell
+   ```
+
+2. **Review sanitized output**:
+   - Check that sensitive data is removed
+   - Verify power readings are reasonable
+   - Ensure vendor-specific formats are captured
+
+3. **Integrate with test fixtures**:
+   - Save fixture as JSON file in `internal/platform/redfish/testdata/fixtures/`
+   - Use the fixture name in your tests (automatically loaded by testdata package)
+   - Add vendor constants if needed
+
+4. **Test integration**:
+
+   ```bash
+   # Test fixture loading and validation
+   go test ./internal/platform/redfish/testdata -v
+
+   # Test power reader functionality
+   go test ./internal/platform/redfish -run TestPowerReader -v
+   ```
+
+## 🛠️ Supported Hardware
+
+### To Capture BMC Vendors
+
+- [x] **Generic Redfish** (Standard implementations using [sushy tool](https://docs.openstack.org/sushy-tools/latest/index.html))
+- [ ] **Dell iDRAC** (iDRAC9, iDRAC8)
+- [ ] **HPE iLO** (iLO5, iLO6)
+- [ ] **Lenovo XCC** (XClarity Controller)
+
+### Power Monitoring Features
+
+- ✅ System-level power consumption
+- ✅ Real-time power readings
+- ✅ Chassis power information
+- ✅ Power control data structures
+
+## 🔒 Security Features
+
+### Automatic Sanitization
+
+The capture script automatically removes/replaces:
+
+- **IP Addresses** → `192.0.2.1` (RFC5737 test range)
+- **Serial Numbers** → `TEST-SERIAL-123456`
+- **UUIDs** → `12345678-1234-1234-1234-123456789012`
+- **MAC Addresses** → `00:11:22:33:44:55`
+- **Asset Tags** → `TEST-ASSET-TAG`
+- **Service Tags** → `TEST-SERVICE-TAG`
+
+### Manual Review Checklist
+
+Before contributing captured data:
+
+- [ ] No real IP addresses remain
+- [ ] No actual serial numbers or UUIDs
+- [ ] No company-specific model numbers
+- [ ] Power readings are anonymized
+- [ ] No internal network information
+
+## 📊 Output Examples
+
+### Power Response Fixture (JSON File)
+
+Save as `internal/platform/redfish/testdata/fixtures/dell_power_275w.json`:
+
+```json
+{
+    "@odata.context": "/redfish/v1/$metadata#Power.Power",
+    "@odata.type": "#Power.v1_5_0.Power",
+    "@odata.id": "/redfish/v1/Chassis/1/Power",
+    "Id": "Power",
+    "Name": "Power",
+    "PowerControl": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Power#/PowerControl/0",
+            "Name": "System Power Control",
+            "PowerConsumedWatts": 275.0
+        }
+    ]
+}
+```
+
+### Using the Fixture in Tests
+
+Reference the fixture by name in your tests:
+
+```go
+// The fixture will be automatically loaded from dell_power_275w.json
+response := CreateSuccessResponse("dell_power_275w")
+powerReader := NewTestPowerReader(t, map[string]*http.Response{
+    "/redfish/v1/Chassis/1/Power": response,
+})
+
+reading, err := powerReader.ReadPower(context.Background())
+AssertPowerReading(t, 275.0, reading)
+```
+
+## 🧪 Testing & Validation
+
+After integration, run comprehensive tests:
+
+```bash
+# Test fixture loading and validation
+go test ./internal/platform/redfish/testdata -v
+
+# Test power reader functionality
+go test ./internal/platform/redfish -run TestPowerReader -v
+
+# Test service integration
+go test ./internal/platform/redfish -run TestServiceIntegrationWithDifferentVendors -v
+
+# Full test suite with race detection
+go test ./internal/platform/redfish/... -race
+```
+
+## 🐛 Troubleshooting
+
+### Common Issues
+
+> Add common issues here
+
+## 🤝 Contributing
+
+### Test Data Contributions Welcome
+
+We need test data for:
+
+- BMC vendors
+- Different power ranges (idle, normal, peak)
+- Various server models
+- Error scenarios
+
+### Contribution Process
+
+1. Capture data using the script
+2. Review security sanitization
+3. Test integration locally
+4. Create pull request with hardware details
+
+### Pull Request Template
+
+```markdown
+feat(redfish): add Dell PowerEdge R750 BMC test data
+
+- Server: Dell PowerEdge R750
+- BMC: iDRAC9 firmware 6.10.30.00
+- Power: 275.0 watts
+- Security: All sensitive data sanitized
+```
+
+## 📚 Documentation
+
+- **Full Guide**: [internal/platform/redfish/testdata/HOW_TO_UPDATE_TESTDATA.md](../../internal/platform/redfish/testdata/HOW_TO_UPDATE_TESTDATA.md)
+- **Test Fixtures**: [internal/platform/redfish/testdata/fixtures/](../../internal/platform/redfish/testdata/fixtures/)
+- **Kepler Configuration**: [hack/config.yaml](../config.yaml)
+
+## ⚡ Advanced Usage
+
+### Batch Processing
+
+```bash
+# Capture multiple BMCs
+for node in node1 node2 node3; do
+    go run hack/redfish/capture-bmc-testdata.go \
+        -config bmc-config.yaml -node $node > "capture-$node.txt"
+done
+```
+
+### Custom Sanitization
+
+Modify `sanitizeJSON()` function for additional sanitization rules.
+
+### Integration Testing
+
+```bash
+# Build and test with new fixtures
+make build
+sudo ./bin/kepler --config hack/config.yaml --dev.fake-cpu-meter.enabled
+```
+
+---
+
+**🎉 Thank you for contributing to Kepler's BMC compatibility!**
+
+Your test data helps ensure reliable power monitoring across diverse hardware environments.

--- a/hack/redfish/bmc-config.yaml
+++ b/hack/redfish/bmc-config.yaml
@@ -1,0 +1,14 @@
+nodes:
+  worker-node-1: bmc-1
+  worker-node-2: bmc-2
+bmcs:
+  bmc-1:
+    endpoint: http://localhost:8000
+    username: admin
+    password: password
+    insecure: true
+  bmc-2:
+    endpoint: https://192.168.1.101
+    username: admin
+    password: secret456
+    insecure: true

--- a/hack/redfish/capture-bmc-testdata.go
+++ b/hack/redfish/capture-bmc-testdata.go
@@ -1,0 +1,515 @@
+//go:build ignore
+
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// capture-bmc-testdata.go - A utility to capture test data from real BMCs
+//
+// Usage:
+//   go run hack/redfish/capture-bmc-testdata.go -endpoint https://192.168.1.100 -username admin -password secret -vendor dell
+//
+// Or with config file:
+//   go run hack/redfish/capture-bmc-testdata.go -config hack/redfish/bmc-config.yaml -node worker-node-1
+//
+// This script will:
+// 1. Connect to your BMC safely
+// 2. Capture relevant power monitoring data
+// 3. Automatically sanitize sensitive information
+// 4. Generate test fixtures compatible with mock server infrastructure
+// 5. Output ready-to-use Go code for integration
+
+package main
+
+// TODO: support only -config file
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/stmcginnis/gofish"
+	"github.com/stmcginnis/gofish/redfish"
+	"gopkg.in/yaml.v3"
+)
+
+type BMCConfig struct {
+	Endpoint string
+	Username string
+	Password string
+	Vendor   string
+	Insecure bool
+	Timeout  time.Duration
+
+	// Config file support
+	ConfigFile string
+	NodeName   string
+}
+
+// BMCNodeConfig represents the YAML config file format
+type BMCNodeConfig struct {
+	Nodes map[string]string `yaml:"nodes"`
+	BMCs  map[string]struct {
+		Endpoint string `yaml:"endpoint"`
+		Username string `yaml:"username"`
+		Password string `yaml:"password"`
+		Insecure bool   `yaml:"insecure"`
+	} `yaml:"bmcs"`
+}
+
+type CapturedFixtures struct {
+	ServiceRoot       string
+	ChassisCollection string
+	Chassis           string
+	Power             string
+	PowerWatts        float64
+	BMCModel          string
+	ServerModel       string
+	VendorType        string
+}
+
+// MockServerConfig represents the format needed by our mock server
+type MockServerConfig struct {
+	Name       string  `json:"name"`
+	Vendor     string  `json:"vendor"`
+	PowerWatts float64 `json:"powerWatts"`
+	Fixtures   struct {
+		ServiceRoot string `json:"serviceRoot"`
+		Chassis     string `json:"chassis"`
+		Power       string `json:"power"`
+	} `json:"fixtures"`
+}
+
+func main() {
+	config := parseFlags()
+
+	fmt.Printf("🔌 Kepler BMC Test Data Capture Utility\n")
+	fmt.Printf("========================================\n\n")
+
+	if err := validateConfig(config); err != nil {
+		log.Fatalf("❌ Configuration error: %v", err)
+	}
+
+	fmt.Printf("📡 Connecting to BMC: %s\n", config.Endpoint)
+	fmt.Printf("👤 Username: %s\n", config.Username)
+	fmt.Printf("🏭 Vendor: %s\n", config.Vendor)
+	fmt.Printf("⏰ Timeout: %v\n\n", config.Timeout)
+
+	fixtures, err := captureBMCData(config)
+	if err != nil {
+		log.Fatalf("❌ Failed to capture BMC data: %v", err)
+	}
+
+	// Set vendor type for fixtures
+	fixtures.VendorType = config.Vendor
+
+	outputResults(fixtures, config)
+}
+
+func parseFlags() BMCConfig {
+	config := BMCConfig{}
+
+	flag.StringVar(&config.Endpoint, "endpoint", "", "BMC endpoint URL")
+	flag.StringVar(&config.Username, "username", "", "BMC username")
+	flag.StringVar(&config.Password, "password", "", "BMC password")
+	flag.StringVar(&config.Vendor, "vendor", "generic", "BMC vendor: dell, hpe, lenovo, or generic")
+	flag.BoolVar(&config.Insecure, "insecure", true, "Skip TLS verification (recommended for testing)")
+	flag.DurationVar(&config.Timeout, "timeout", 30*time.Second, "Connection timeout")
+
+	// Config file support
+	flag.StringVar(&config.ConfigFile, "config", "", "Path to BMC configuration YAML file")
+	flag.StringVar(&config.NodeName, "node", "", "Node name to capture (when using config file)")
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, ` Usage: %s [options]
+
+Capture test data from Redfish BMCs for Kepler development.
+
+Options:
+
+Examples:
+
+  # Direct connection:
+
+		go run hack/redfish/capture-bmc-testdata.go \
+			 -endpoint https://192.168.1.100 \
+			-username admin -password secret -vendor dell
+
+  # Using config file:
+		go run hack/redfish/capture-bmc-testdata.go \
+			-config hack/redfish/bmc-config.yaml \
+			-node worker-node-1
+
+`, os.Args[0])
+	}
+
+	flag.Parse()
+
+	// Load from config file if specified
+	if config.ConfigFile != "" {
+		if err := loadConfigFromFile(&config); err != nil {
+			log.Fatalf("❌ Failed to load config file: %v", err)
+		}
+	}
+
+	return config
+}
+
+// loadConfigFromFile loads BMC configuration from YAML file
+func loadConfigFromFile(config *BMCConfig) error {
+	if config.NodeName == "" {
+		return fmt.Errorf("node name is required when using config file")
+	}
+
+	data, err := os.ReadFile(config.ConfigFile)
+	if err != nil {
+		return fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	var nodeConfig BMCNodeConfig
+	if err := yaml.Unmarshal(data, &nodeConfig); err != nil {
+		return fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	// Find the BMC for the specified node
+	bmcName, exists := nodeConfig.Nodes[config.NodeName]
+	if !exists {
+		return fmt.Errorf("node '%s' not found in config file", config.NodeName)
+	}
+
+	bmcConfig, exists := nodeConfig.BMCs[bmcName]
+	if !exists {
+		return fmt.Errorf("BMC '%s' not found in config file", bmcName)
+	}
+
+	// Override config with values from file (only if not already set via flags/env)
+	if config.Endpoint == "" {
+		config.Endpoint = bmcConfig.Endpoint
+	}
+	if config.Username == "" {
+		config.Username = bmcConfig.Username
+	}
+	if config.Password == "" {
+		config.Password = bmcConfig.Password
+	}
+	config.Insecure = bmcConfig.Insecure
+
+	return nil
+}
+
+func validateConfig(config BMCConfig) error {
+	if config.Endpoint == "" {
+		return fmt.Errorf("BMC endpoint is required")
+	}
+	if config.Username == "" {
+		return fmt.Errorf("BMC username is required")
+	}
+	if config.Password == "" {
+		return fmt.Errorf("BMC password is required")
+	}
+
+	validVendors := map[string]bool{
+		"dell": true, "hpe": true, "lenovo": true, "generic": true,
+	}
+	if !validVendors[config.Vendor] {
+		return fmt.Errorf("invalid vendor '%s', must be one of: dell, hpe, lenovo, generic", config.Vendor)
+	}
+
+	return nil
+}
+
+func captureBMCData(config BMCConfig) (*CapturedFixtures, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
+	defer cancel()
+
+	// Connect to BMC
+	clientConfig := gofish.ClientConfig{
+		Endpoint:  config.Endpoint,
+		Username:  config.Username,
+		Password:  config.Password,
+		Insecure:  config.Insecure,
+		BasicAuth: true,
+	}
+
+	client, err := gofish.ConnectContext(ctx, clientConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to BMC: %w", err)
+	}
+	defer client.Logout()
+
+	fixtures := &CapturedFixtures{}
+
+	// Capture service root
+	fmt.Printf("📋 Capturing service root...\n")
+	if data, err := marshalAndSanitize(client.Service); err == nil {
+		fixtures.ServiceRoot = data
+	} else {
+		fmt.Printf("⚠️  Warning: failed to capture service root: %v\n", err)
+	}
+
+	// Get chassis information
+	fmt.Printf("🏗️  Capturing chassis information...\n")
+	chassis, err := client.Service.Chassis()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get chassis: %w", err)
+	}
+
+	if len(chassis) == 0 {
+		return nil, fmt.Errorf("no chassis found")
+	}
+
+	// Capture first chassis
+	firstChassis := chassis[0]
+	if data, err := marshalAndSanitize(firstChassis); err == nil {
+		fixtures.Chassis = data
+		fixtures.ServerModel = extractServerModel(firstChassis)
+	}
+
+	// Capture power information
+	fmt.Printf("⚡ Capturing power information...\n")
+	power, err := firstChassis.Power()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get power data: %w", err)
+	}
+
+	if data, err := marshalAndSanitize(power); err == nil {
+		fixtures.Power = data
+		fixtures.PowerWatts = extractPowerWatts(power)
+	}
+
+	// Try to get BMC model information
+	fmt.Printf("🖥️  Capturing BMC model information...\n")
+	if managers, err := client.Service.Managers(); err == nil && len(managers) > 0 {
+		fixtures.BMCModel = extractBMCModel(managers[0])
+	}
+
+	fmt.Printf("✅ Data capture completed successfully!\n\n")
+	return fixtures, nil
+}
+
+func marshalAndSanitize(obj any) (string, error) {
+	data, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	jsonStr := string(data)
+	return sanitizeJSON(jsonStr), nil
+}
+
+func sanitizeJSON(jsonStr string) string {
+	// Replace UUIDs with test UUID
+	uuidRegex := regexp.MustCompile(`"UUID":\s*"[a-fA-F0-9-]{36}"`)
+	jsonStr = uuidRegex.ReplaceAllString(jsonStr, `"UUID": "12345678-1234-1234-1234-123456789012"`)
+
+	// Replace serial numbers
+	serialRegex := regexp.MustCompile(`"SerialNumber":\s*"[^"]*"`)
+	jsonStr = serialRegex.ReplaceAllString(jsonStr, `"SerialNumber": "TEST-SERIAL-123456"`)
+
+	// Replace asset tags
+	assetRegex := regexp.MustCompile(`"AssetTag":\s*"[^"]*"`)
+	jsonStr = assetRegex.ReplaceAllString(jsonStr, `"AssetTag": "TEST-ASSET-TAG"`)
+
+	// Replace service tags (Dell specific)
+	serviceTagRegex := regexp.MustCompile(`"ServiceTag":\s*"[^"]*"`)
+	jsonStr = serviceTagRegex.ReplaceAllString(jsonStr, `"ServiceTag": "TEST-SERVICE-TAG"`)
+
+	// Replace MAC addresses
+	macRegex := regexp.MustCompile(`"([0-9a-fA-F]{2}[:-]){5}[0-9a-fA-F]{2}"`)
+	jsonStr = macRegex.ReplaceAllString(jsonStr, `"00:11:22:33:44:55"`)
+
+	// Replace IP addresses with test IPs
+	ipRegex := regexp.MustCompile(`"(\d{1,3}\.){3}\d{1,3}"`)
+	jsonStr = ipRegex.ReplaceAllString(jsonStr, `"192.0.2.1"`)
+
+	return jsonStr
+}
+
+func extractPowerWatts(power *redfish.Power) float64 {
+	if len(power.PowerControl) > 0 {
+		return float64(power.PowerControl[0].PowerConsumedWatts)
+	}
+	return 0.0
+}
+
+func extractServerModel(chassis *redfish.Chassis) string {
+	if chassis.Model != "" {
+		return chassis.Model
+	}
+	if chassis.Name != "" {
+		return chassis.Name
+	}
+	return "Unknown Server Model"
+}
+
+func extractBMCModel(manager *redfish.Manager) string {
+	model := ""
+	if manager.Model != "" {
+		model = manager.Model
+	}
+	if manager.FirmwareVersion != "" {
+		if model != "" {
+			model += " (FW: " + manager.FirmwareVersion + ")"
+		} else {
+			model = "FW: " + manager.FirmwareVersion
+		}
+	}
+	if model == "" {
+		return "Unknown BMC Model"
+	}
+	return model
+}
+
+func outputResults(fixtures *CapturedFixtures, config BMCConfig) {
+	fmt.Printf("📊 Capture Results Summary\n")
+	fmt.Printf("==========================\n")
+	fmt.Printf("🏭 Vendor: %s\n", config.Vendor)
+	fmt.Printf("🖥️  BMC Model: %s\n", fixtures.BMCModel)
+	fmt.Printf("🏗️  Server Model: %s\n", fixtures.ServerModel)
+	fmt.Printf("⚡ Power Consumption: %.1f watts\n\n", fixtures.PowerWatts)
+
+	// Generate names based on vendor and power
+	fixtureName := fmt.Sprintf("%s_power_%.0fw", strings.ToLower(config.Vendor), fixtures.PowerWatts)
+	scenarioName := fmt.Sprintf("%s%.0fW", strings.Title(config.Vendor), fixtures.PowerWatts)
+
+	fmt.Printf("📝 Generated Mock Server Integration\n")
+	fmt.Printf("====================================\n\n")
+
+	// 1. Power response fixture for power_responses.go
+	fmt.Printf("// 1. Add this to internal/platform/redfish/mock/power_responses.go:\n")
+	fmt.Printf("// In the PowerResponseFixtures map:\n")
+	fmt.Printf(`"%s": `+"`%s`"+",\n\n", fixtureName, fixtures.Power)
+
+	// 2. Success scenario for scenarios.go
+	fmt.Printf("// 2. Add this to GetSuccessScenarios() in internal/platform/redfish/mock/scenarios.go:\n")
+	fmt.Printf("{\n")
+	fmt.Printf("\tName: \"%s\",\n", scenarioName)
+	fmt.Printf("\tConfig: ServerConfig{\n")
+	fmt.Printf("\t\tVendor:     Vendor%s,\n", strings.Title(config.Vendor))
+	fmt.Printf("\t\tUsername:   \"admin\",\n")
+	fmt.Printf("\t\tPassword:   \"password\",\n")
+	fmt.Printf("\t\tPowerWatts: %.1f,\n", fixtures.PowerWatts)
+	fmt.Printf("\t\tEnableAuth: true,\n")
+	fmt.Printf("\t},\n")
+	fmt.Printf("\tPowerWatts: %.1f,\n", fixtures.PowerWatts)
+	fmt.Printf("},\n\n")
+
+	// 3. Vendor constant (if new)
+	if isNewVendor(config.Vendor) {
+		fmt.Printf("// 3. Add this vendor constant to internal/platform/redfish/mock/server.go:\n")
+		fmt.Printf("Vendor%s VendorType = \"%s\"\n\n", strings.Title(config.Vendor), config.Vendor)
+	}
+
+	// 4. Test scenario for power reader tests
+	fmt.Printf("// 4. This will automatically work with existing tests once integrated.\n")
+	fmt.Printf("// The mock server will serve the captured power data for vendor: %s\n\n", config.Vendor)
+
+	// 5. Create complete files to copy-paste
+	outputMockServerFiles(fixtures, config, fixtureName, scenarioName)
+
+	// Validation commands
+	fmt.Printf("🧪 Validation Commands\n")
+	fmt.Printf("======================\n")
+	fmt.Printf("# After integration, run these commands:\n")
+	fmt.Printf("go test ./internal/platform/redfish/mock -v\n")
+	fmt.Printf("go test ./internal/platform/redfish -run TestPowerReader\n")
+	fmt.Printf("go test ./internal/platform/redfish -run TestServiceIntegrationWithDifferentVendors\n\n")
+
+	// Security and contribution notes
+	outputSecurityAndContributionNotes(config, fixtures)
+}
+
+// outputMockServerFiles creates complete file snippets for easy integration
+func outputMockServerFiles(fixtures *CapturedFixtures, config BMCConfig, fixtureName, scenarioName string) {
+	fmt.Printf("📄 Complete File Snippets for Copy-Paste Integration\n")
+	fmt.Printf("=====================================================\n\n")
+
+	// Complete power_responses.go addition
+	fmt.Printf("// File: internal/platform/redfish/mock/power_responses.go\n")
+	fmt.Printf("// Add to PowerResponseFixtures map:\n")
+	fmt.Printf("var PowerResponseFixtures = map[string]string{\n")
+	fmt.Printf("\t// ... existing fixtures ...\n")
+	fmt.Printf(`	"%s": `+"`%s`"+",\n", fixtureName, fixtures.Power)
+	fmt.Printf("}\n\n")
+
+	// Complete scenario addition
+	fmt.Printf("// File: internal/platform/redfish/mock/scenarios.go\n")
+	fmt.Printf("// Add to GetSuccessScenarios() return slice:\n")
+	fmt.Printf("return []TestScenario{\n")
+	fmt.Printf("\t// ... existing scenarios ...\n")
+	fmt.Printf("\t{\n")
+	fmt.Printf("\t\tName: \"%s\",\n", scenarioName)
+	fmt.Printf("\t\tConfig: ServerConfig{\n")
+	fmt.Printf("\t\t\tVendor:     Vendor%s,\n", strings.Title(config.Vendor))
+	fmt.Printf("\t\t\tUsername:   baseConfig.Username,\n")
+	fmt.Printf("\t\t\tPassword:   baseConfig.Password,\n")
+	fmt.Printf("\t\t\tPowerWatts: %.1f,\n", fixtures.PowerWatts)
+	fmt.Printf("\t\t\tEnableAuth: baseConfig.EnableAuth,\n")
+	fmt.Printf("\t\t},\n")
+	fmt.Printf("\t\tPowerWatts: %.1f,\n", fixtures.PowerWatts)
+	fmt.Printf("\t},\n")
+	fmt.Printf("}\n\n")
+}
+
+// outputSecurityAndContributionNotes provides security and contribution guidance
+func outputSecurityAndContributionNotes(config BMCConfig, fixtures *CapturedFixtures) {
+	fmt.Printf("🔒 Security Verification\n")
+	fmt.Printf("========================\n")
+	fmt.Printf("✅ IP addresses sanitized (192.0.2.x)\n")
+	fmt.Printf("✅ Serial numbers replaced with TEST-SERIAL-*\n")
+	fmt.Printf("✅ UUIDs replaced with test UUID\n")
+	fmt.Printf("✅ MAC addresses anonymized\n")
+	fmt.Printf("✅ No credentials or tokens included\n")
+	fmt.Printf("✅ Safe for public repository sharing\n\n")
+
+	fmt.Printf("🤝 Integration Steps\n")
+	fmt.Printf("====================\n")
+	fmt.Printf("1. Copy power response fixture to internal/platform/redfish/mock/power_responses.go\n")
+	fmt.Printf("2. Add success scenario to internal/platform/redfish/mock/scenarios.go\n")
+	if isNewVendor(config.Vendor) {
+		fmt.Printf("3. Add vendor constant to internal/platform/redfish/mock/server.go\n")
+		fmt.Printf("4. Update vendor lists in tests if needed\n")
+		fmt.Printf("5. Run tests to verify integration\n")
+	} else {
+		fmt.Printf("3. Run tests to verify integration\n")
+	}
+	fmt.Printf("\n")
+
+	fmt.Printf("🚀 Creating Pull Request\n")
+	fmt.Printf("========================\n")
+	fmt.Printf("Title: feat(redfish): add %s %s BMC test data\n", strings.Title(config.Vendor), fixtures.ServerModel)
+	fmt.Printf("\nDescription template:\n")
+	fmt.Printf("```\n")
+	fmt.Printf("Add real BMC test data for %s systems.\n\n", strings.Title(config.Vendor))
+	fmt.Printf("**Hardware Details:**\n")
+	fmt.Printf("- Server: %s\n", fixtures.ServerModel)
+	fmt.Printf("- BMC: %s\n", fixtures.BMCModel)
+	fmt.Printf("- Power Reading: %.1f watts\n\n", fixtures.PowerWatts)
+	fmt.Printf("**Test Coverage:**\n")
+	fmt.Printf("- Power monitoring via Redfish\n")
+	fmt.Printf("- Vendor-specific response format\n")
+	fmt.Printf("- Authentication and connection handling\n\n")
+	fmt.Printf("**Security:**\n")
+	fmt.Printf("- All sensitive data sanitized\n")
+	fmt.Printf("- No real IP addresses, serials, or UUIDs\n")
+	fmt.Printf("```\n\n")
+
+	fmt.Printf("Thank you for contributing to Kepler! 🎉\n")
+}
+
+// isNewVendor checks if this is a vendor we haven't seen before
+func isNewVendor(vendor string) bool {
+	knownVendors := []string{"dell", "hpe", "lenovo", "generic"}
+	vendor = strings.ToLower(vendor)
+	for _, known := range knownVendors {
+		if vendor == known {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/exporter/prometheus/collector/platform_collector.go
+++ b/internal/exporter/prometheus/collector/platform_collector.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package collector
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sustainable-computing-io/kepler/internal/platform/redfish"
+)
+
+const (
+	// Prometheus namespace for Kepler platform metrics
+	platformSubsystem = "platform"
+)
+
+// RedfishDataProvider defines the interface for getting platform power data
+type RedfishDataProvider interface {
+	Power() (*redfish.PowerReading, error) // On-demand method for all chassis
+	NodeName() string                      // Node name
+	BMCID() string                         // BMC identifier
+}
+
+// PlatformCollector collects platform power metrics from Redfish BMC
+type PlatformCollector struct {
+	logger  *slog.Logger
+	redfish RedfishDataProvider
+
+	// Static metadata
+	nodeName string // Node identifier
+	bmcID    string // BMC identifier
+
+	// Metric descriptors
+	wattsDesc *prometheus.Desc
+}
+
+// NewRedfishCollector creates a new platform collector
+func NewRedfishCollector(redfish RedfishDataProvider, logger *slog.Logger) *PlatformCollector {
+	if redfish == nil {
+		panic("RedfishDataProvider cannot be nil - platform collector requires a data provider to function")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &PlatformCollector{
+		logger:   logger,
+		redfish:  redfish,
+		nodeName: redfish.NodeName(),
+		bmcID:    redfish.BMCID(),
+		wattsDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(keplerNS, platformSubsystem, "watts"),
+			"Current platform power consumption in watts from BMC PowerControl entries",
+			[]string{"source", "node_name", "bmc_id", "chassis_id", "power_control_id", "power_control_name"},
+			nil,
+		),
+	}
+}
+
+// Describe sends the descriptors of platform metrics to the provided channel
+func (c *PlatformCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.wattsDesc
+}
+
+// Collect gathers platform power metrics and sends them to the provided channel
+func (c *PlatformCollector) Collect(ch chan<- prometheus.Metric) {
+	// Get all chassis power readings using the new simplified interface
+	powerReading, err := c.redfish.Power()
+	if err != nil {
+		c.logger.Error("Failed to get chassis power readings", "error", err)
+		return
+	}
+
+	// If no power reading is available, don't emit metrics
+	if powerReading == nil || len(powerReading.Chassis) == 0 {
+		c.logger.Debug("No platform power readings available")
+		return
+	}
+
+	// Emit metrics for each PowerControl reading in each chassis
+	for _, chassis := range powerReading.Chassis {
+		for _, reading := range chassis.Readings {
+			// Label order must match the descriptor: source, node_name, bmc_id, chassis_id, power_control_id, power_control_name
+			labels := []string{"redfish", c.nodeName, c.bmcID, chassis.ID, reading.ControlID, reading.Name}
+
+			// Emit current power consumption metric (power-only approach)
+			ch <- prometheus.MustNewConstMetric(
+				c.wattsDesc,
+				prometheus.GaugeValue,
+				float64(reading.Power.Watts()),
+				labels...,
+			)
+
+			c.logger.Debug("Collected platform power metrics",
+				"node.name", c.nodeName,
+				"bmc.id", c.bmcID,
+				"chassis.id", chassis.ID,
+				"power_control.id", reading.ControlID,
+				"power_control.name", reading.Name,
+				"power.watts", reading.Power,
+				"age", time.Since(powerReading.Timestamp).Seconds())
+		}
+	}
+}

--- a/internal/exporter/prometheus/collector/platform_collector_test.go
+++ b/internal/exporter/prometheus/collector/platform_collector_test.go
@@ -1,0 +1,527 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package collector
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/sustainable-computing-io/kepler/internal/device"
+	"github.com/sustainable-computing-io/kepler/internal/platform/redfish"
+)
+
+// mockRedfishDataProvider implements RedfishDataProvider for testing
+type mockRedfishDataProvider struct {
+	nodeName     string
+	bmcID        string
+	powerReading *redfish.PowerReading
+	err          error
+	callCount    int
+	mu           sync.Mutex
+}
+
+func (m *mockRedfishDataProvider) Power() (*redfish.PowerReading, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.callCount++
+
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.powerReading, nil
+}
+
+func (m *mockRedfishDataProvider) NodeName() string {
+	return m.nodeName
+}
+
+func (m *mockRedfishDataProvider) BMCID() string {
+	return m.bmcID
+}
+
+func (m *mockRedfishDataProvider) getCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.callCount
+}
+
+// Helper function to find metric value by labels
+func findMetricValue(t *testing.T, metricFamily *dto.MetricFamily, expectedLabels map[string]string) float64 {
+	for _, metric := range metricFamily.GetMetric() {
+		allLabelsMatch := true
+		for expectedName, expectedValue := range expectedLabels {
+			found := false
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == expectedName && label.GetValue() == expectedValue {
+					found = true
+					break
+				}
+			}
+			if !found {
+				allLabelsMatch = false
+				break
+			}
+		}
+
+		if allLabelsMatch {
+			if metric.GetGauge() != nil {
+				return metric.GetGauge().GetValue()
+			} else if metric.GetCounter() != nil {
+				return metric.GetCounter().GetValue()
+			}
+		}
+	}
+	t.Errorf("Metric with labels %v not found", expectedLabels)
+	return 0
+}
+
+func TestNewRedfishCollector(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	mockProvider := &mockRedfishDataProvider{
+		nodeName: "test-node",
+		bmcID:    "test-bmc",
+	}
+
+	collector := NewRedfishCollector(mockProvider, logger)
+
+	require.NotNil(t, collector)
+	assert.Equal(t, "test-node", collector.nodeName)
+	assert.Equal(t, "test-bmc", collector.bmcID)
+	assert.NotNil(t, collector.wattsDesc)
+	assert.Equal(t, logger, collector.logger)
+	assert.Equal(t, mockProvider, collector.redfish)
+}
+
+func TestNewRedfishCollector_ValidationPanics(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	t.Run("Nil data provider panics", func(t *testing.T) {
+		assert.Panics(t, func() {
+			NewRedfishCollector(nil, logger)
+		}, "Should panic when RedfishDataProvider is nil")
+	})
+
+	t.Run("Nil logger uses default", func(t *testing.T) {
+		mockProvider := &mockRedfishDataProvider{
+			nodeName: "test-node",
+			bmcID:    "test-bmc",
+		}
+
+		collector := NewRedfishCollector(mockProvider, nil)
+		require.NotNil(t, collector)
+		assert.NotNil(t, collector.logger, "Should use default logger when nil is passed")
+	})
+}
+
+func TestPlatformCollector_Describe(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	mockProvider := &mockRedfishDataProvider{
+		nodeName: "test-node",
+		bmcID:    "test-bmc",
+	}
+
+	collector := NewRedfishCollector(mockProvider, logger)
+
+	// Create a channel to collect descriptors
+	ch := make(chan *prometheus.Desc, 10)
+
+	// Test Describe method
+	collector.Describe(ch)
+	close(ch)
+
+	// Verify we got exactly one descriptor
+	descriptors := make([]*prometheus.Desc, 0)
+	for desc := range ch {
+		descriptors = append(descriptors, desc)
+	}
+
+	require.Len(t, descriptors, 1)
+	assert.Equal(t, collector.wattsDesc, descriptors[0])
+
+	// Verify descriptor properties
+	desc := descriptors[0]
+	assert.Contains(t, desc.String(), "kepler_platform_watts")
+	assert.Contains(t, desc.String(), "source")
+	assert.Contains(t, desc.String(), "node_name")
+	assert.Contains(t, desc.String(), "bmc")
+	assert.Contains(t, desc.String(), "chassis_id")
+}
+
+func TestPlatformCollector_Collect_Success(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Create mock power reading with multiple chassis and multiple PowerControl entries
+	powerReading := &redfish.PowerReading{
+		Timestamp: time.Now(),
+		Chassis: []redfish.Chassis{
+			{
+				ID: "System.Embedded.1",
+				Readings: []redfish.Reading{
+					{
+						ControlID: "PC1",
+						Name:      "Server Power Control",
+						Power:     450.5 * device.Watt,
+					},
+					{
+						ControlID: "PC2",
+						Name:      "CPU Sub-system Power",
+						Power:     85.2 * device.Watt,
+					},
+				},
+			},
+			{
+				ID: "Enclosure.Internal.0-1",
+				Readings: []redfish.Reading{
+					{
+						ControlID: "PC1",
+						Name:      "Enclosure Power Control",
+						Power:     125.3 * device.Watt,
+					},
+				},
+			},
+		},
+	}
+
+	mockProvider := &mockRedfishDataProvider{
+		nodeName:     "worker-1",
+		bmcID:        "bmc-1",
+		powerReading: powerReading,
+	}
+
+	collector := NewRedfishCollector(mockProvider, logger)
+
+	// Create registry and register collector
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+
+	// Gather metrics
+	metrics, err := registry.Gather()
+	require.NoError(t, err)
+
+	// Verify we have the platform metric
+	require.Len(t, metrics, 1)
+	platformMetric := metrics[0]
+	assert.Equal(t, "kepler_platform_watts", platformMetric.GetName())
+	assert.Equal(t, dto.MetricType_GAUGE, platformMetric.GetType())
+
+	// Verify we have metrics for all PowerControl entries (3 total: 2 from first chassis, 1 from second)
+	require.Len(t, platformMetric.GetMetric(), 3)
+
+	// Verify first chassis, first PowerControl metric
+	chassis1PC1Value := findMetricValue(t, platformMetric, map[string]string{
+		"source":             "redfish",
+		"node_name":          "worker-1",
+		"bmc_id":             "bmc-1",
+		"chassis_id":         "System.Embedded.1",
+		"power_control_id":   "PC1",
+		"power_control_name": "Server Power Control",
+	})
+	assert.Equal(t, 450.5, chassis1PC1Value)
+
+	// Verify first chassis, second PowerControl metric
+	chassis1PC2Value := findMetricValue(t, platformMetric, map[string]string{
+		"source":             "redfish",
+		"node_name":          "worker-1",
+		"bmc_id":             "bmc-1",
+		"chassis_id":         "System.Embedded.1",
+		"power_control_id":   "PC2",
+		"power_control_name": "CPU Sub-system Power",
+	})
+	assert.Equal(t, 85.2, chassis1PC2Value)
+
+	// Verify second chassis metric
+	chassis2Value := findMetricValue(t, platformMetric, map[string]string{
+		"source":             "redfish",
+		"node_name":          "worker-1",
+		"bmc_id":             "bmc-1",
+		"chassis_id":         "Enclosure.Internal.0-1",
+		"power_control_id":   "PC1",
+		"power_control_name": "Enclosure Power Control",
+	})
+	assert.Equal(t, 125.3, chassis2Value)
+}
+
+func TestPlatformCollector_Collect_Error(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	mockProvider := &mockRedfishDataProvider{
+		nodeName: "test-node",
+		bmcID:    "test-bmc",
+		err:      errors.New("BMC connection failed"),
+	}
+
+	collector := NewRedfishCollector(mockProvider, logger)
+
+	// Create registry and register collector
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+
+	// Gather metrics
+	metrics, err := registry.Gather()
+	require.NoError(t, err)
+
+	// Verify no metrics were emitted on error
+	assert.Len(t, metrics, 0)
+}
+
+func TestPlatformCollector_Collect_NilReading(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	mockProvider := &mockRedfishDataProvider{
+		nodeName:     "test-node",
+		bmcID:        "test-bmc",
+		powerReading: nil, // nil reading
+	}
+
+	collector := NewRedfishCollector(mockProvider, logger)
+
+	// Create registry and register collector
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+
+	// Gather metrics
+	metrics, err := registry.Gather()
+	require.NoError(t, err)
+
+	// Verify no metrics were emitted with nil reading
+	assert.Len(t, metrics, 0)
+}
+
+func TestPlatformCollector_Collect_EmptyReadings(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Create empty power reading
+	powerReading := &redfish.PowerReading{
+		Timestamp: time.Now(),
+		Chassis:   []redfish.Chassis{}, // empty chassis
+	}
+
+	mockProvider := &mockRedfishDataProvider{
+		nodeName:     "test-node",
+		bmcID:        "test-bmc",
+		powerReading: powerReading,
+	}
+
+	collector := NewRedfishCollector(mockProvider, logger)
+
+	// Create registry and register collector
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+
+	// Gather metrics
+	metrics, err := registry.Gather()
+	require.NoError(t, err)
+
+	// Verify no metrics were emitted with empty readings
+	assert.Len(t, metrics, 0)
+}
+
+func TestPlatformCollector_Collect_SingleChassis(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Create power reading with single chassis
+	powerReading := &redfish.PowerReading{
+		Timestamp: time.Now(),
+		Chassis: []redfish.Chassis{
+			{
+				ID: "System.Embedded.1",
+				Readings: []redfish.Reading{
+					{
+						ControlID: "PC1",
+						Name:      "Server Power Control",
+						Power:     300.0 * device.Watt,
+					},
+				},
+			},
+		},
+	}
+
+	mockProvider := &mockRedfishDataProvider{
+		nodeName:     "single-node",
+		bmcID:        "single-bmc",
+		powerReading: powerReading,
+	}
+
+	collector := NewRedfishCollector(mockProvider, logger)
+
+	// Create registry and register collector
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+
+	// Gather metrics
+	metrics, err := registry.Gather()
+	require.NoError(t, err)
+
+	// Verify we got exactly one metric family with one metric
+	require.Len(t, metrics, 1)
+	platformMetric := metrics[0]
+	require.Len(t, platformMetric.GetMetric(), 1)
+
+	// Verify the metric value
+	chassisValue := findMetricValue(t, platformMetric, map[string]string{
+		"source":     "redfish",
+		"node_name":  "single-node",
+		"bmc_id":     "single-bmc",
+		"chassis_id": "System.Embedded.1",
+	})
+	assert.Equal(t, 300.0, chassisValue)
+}
+
+func TestPlatformCollector_Collect_ParallelCollection(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Create power reading
+	powerReading := &redfish.PowerReading{
+		Timestamp: time.Now(),
+		Chassis: []redfish.Chassis{
+			{
+				ID: "System.Embedded.1",
+				Readings: []redfish.Reading{
+					{
+						ControlID: "PC1",
+						Name:      "Server Power Control",
+						Power:     200.0 * device.Watt,
+					},
+				},
+			},
+		},
+	}
+
+	mockProvider := &mockRedfishDataProvider{
+		nodeName:     "parallel-node",
+		bmcID:        "parallel-bmc",
+		powerReading: powerReading,
+	}
+
+	collector := NewRedfishCollector(mockProvider, logger)
+
+	// Create registry and register collector
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+
+	// Test parallel collection
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			// Gather metrics
+			metrics, err := registry.Gather()
+			assert.NoError(t, err)
+
+			if len(metrics) > 0 {
+				// Verify metric structure is consistent
+				platformMetric := metrics[0]
+				assert.Equal(t, "kepler_platform_watts", platformMetric.GetName())
+				assert.Len(t, platformMetric.GetMetric(), 1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify the mock provider was called multiple times
+	assert.Greater(t, mockProvider.getCallCount(), 1)
+}
+
+func TestPlatformCollector_Collect_MetricLabelsValidation(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	testCases := []struct {
+		name      string
+		nodeName  string
+		bmcID     string
+		chassisID string
+		power     device.Power
+	}{
+		{
+			name:      "Standard Dell System",
+			nodeName:  "dell-worker-01",
+			bmcID:     "dell-bmc-01",
+			chassisID: "System.Embedded.1",
+			power:     428.5 * device.Watt,
+		},
+		{
+			name:      "HPE System with Special Characters",
+			nodeName:  "hpe-node_with-dashes",
+			bmcID:     "hpe-bmc.domain.local",
+			chassisID: "Chassis.Internal-0",
+			power:     523.1 * device.Watt,
+		},
+		{
+			name:      "Generic System",
+			nodeName:  "generic-node",
+			bmcID:     "generic-bmc",
+			chassisID: "chassis-0",
+			power:     350.0 * device.Watt,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			powerReading := &redfish.PowerReading{
+				Timestamp: time.Now(),
+				Chassis: []redfish.Chassis{
+					{
+						ID: tc.chassisID,
+						Readings: []redfish.Reading{
+							{
+								ControlID: "PC1",
+								Name:      "Server Power Control",
+								Power:     tc.power,
+							},
+						},
+					},
+				},
+			}
+
+			mockProvider := &mockRedfishDataProvider{
+				nodeName:     tc.nodeName,
+				bmcID:        tc.bmcID,
+				powerReading: powerReading,
+			}
+
+			collector := NewRedfishCollector(mockProvider, logger)
+
+			// Create registry and register collector
+			registry := prometheus.NewRegistry()
+			registry.MustRegister(collector)
+
+			// Gather metrics
+			metrics, err := registry.Gather()
+			require.NoError(t, err)
+			require.Len(t, metrics, 1)
+
+			platformMetric := metrics[0]
+			require.Len(t, platformMetric.GetMetric(), 1)
+
+			// Verify all labels are present and correct
+			metric := platformMetric.GetMetric()[0]
+			labels := make(map[string]string)
+			for _, label := range metric.GetLabel() {
+				labels[label.GetName()] = label.GetValue()
+			}
+
+			assert.Equal(t, "redfish", labels["source"])
+			assert.Equal(t, tc.nodeName, labels["node_name"])
+			assert.Equal(t, tc.bmcID, labels["bmc_id"])
+			assert.Equal(t, tc.chassisID, labels["chassis_id"])
+
+			// Verify power value
+			assert.Equal(t, tc.power.Watts(), metric.GetGauge().GetValue())
+		})
+	}
+}

--- a/internal/platform/redfish/helpers.go
+++ b/internal/platform/redfish/helpers.go
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package redfish
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stmcginnis/gofish"
+	"github.com/stmcginnis/gofish/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sustainable-computing-io/kepler/internal/platform/redfish/testdata"
+)
+
+// CreateMockResponse creates an HTTP response from a fixture
+func CreateMockResponse(fixture string, statusCode int) *http.Response {
+	body := io.NopCloser(strings.NewReader(testdata.GetFixture(fixture)))
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       body,
+		Header:     make(http.Header),
+	}
+}
+
+// CreateSuccessResponse creates a successful HTTP response from a fixture
+func CreateSuccessResponse(fixture string) *http.Response {
+	return CreateMockResponse(fixture, http.StatusOK)
+}
+
+// CreateErrorResponse creates an error HTTP response from a fixture
+func CreateErrorResponse(fixture string, statusCode int) *http.Response {
+	return CreateMockResponse(fixture, statusCode)
+}
+
+// NewTestPowerReader creates a PowerReader with a mock gofish client
+func NewTestPowerReader(t *testing.T, responses map[string]*http.Response) *PowerReader {
+	testClient := &common.TestClient{}
+
+	// Convert responses map to the slice format expected by gofish TestClient
+	var getResponses []interface{}
+	for _, response := range responses {
+		getResponses = append(getResponses, response)
+	}
+
+	testClient.CustomReturnForActions = map[string][]interface{}{
+		"GET": getResponses,
+	}
+
+	// Create a gofish API client with the test client
+	apiClient := &gofish.APIClient{}
+
+	// Create mock service to avoid connecting
+	service := &gofish.Service{
+		Entity: common.Entity{
+			ODataID: "/redfish/v1/",
+		},
+	}
+	apiClient.Service = service
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	powerReader := NewPowerReader(logger)
+	powerReader.SetClient(apiClient)
+
+	return powerReader
+}
+
+// PowerReadingScenario represents a test scenario for power readings
+type PowerReadingScenario struct {
+	Name          string
+	Fixture       string
+	ExpectedWatts float64
+	ExpectError   bool
+}
+
+// GetPowerReadingScenarios returns predefined test scenarios
+func GetPowerReadingScenarios() []PowerReadingScenario {
+	return []PowerReadingScenario{
+		{
+			Name:          "DellPowerSuccess",
+			Fixture:       "dell_power_245w",
+			ExpectedWatts: 245.0,
+			ExpectError:   false,
+		},
+		{
+			Name:          "HPEPowerSuccess",
+			Fixture:       "hpe_power_189w",
+			ExpectedWatts: 189.5,
+			ExpectError:   false,
+		},
+		{
+			Name:          "LenovoPowerSuccess",
+			Fixture:       "lenovo_power_167w",
+			ExpectedWatts: 167.8,
+			ExpectError:   false,
+		},
+		{
+			Name:          "GenericPowerSuccess",
+			Fixture:       "generic_power_200w",
+			ExpectedWatts: 200.0,
+			ExpectError:   false,
+		},
+		{
+			Name:          "Generic590WFromJSON",
+			Fixture:       "generic_power_590w",
+			ExpectedWatts: 590.0,
+			ExpectError:   false,
+		},
+		{
+			Name:          "ZeroPowerReading",
+			Fixture:       "zero_power",
+			ExpectedWatts: 0.0,
+			ExpectError:   false,
+		},
+	}
+}
+
+// GetErrorScenarios returns predefined error test scenarios
+func GetErrorScenarios() []PowerReadingScenario {
+	return []PowerReadingScenario{
+		{
+			Name:        "EmptyPowerControl",
+			Fixture:     "empty_power_control",
+			ExpectError: true,
+		},
+		{
+			Name:        "ResourceNotFound",
+			Fixture:     "error_not_found",
+			ExpectError: true,
+		},
+		{
+			Name:        "AuthenticationFailed",
+			Fixture:     "error_auth_failed",
+			ExpectError: true,
+		},
+	}
+}
+
+// AssertPowerReading validates a power reading with single chassis
+func AssertPowerReading(t *testing.T, expected float64, actual *PowerReading) {
+	require.NotNil(t, actual)
+	require.False(t, actual.Timestamp.IsZero())
+	require.NotEmpty(t, actual.Chassis, "PowerReading should contain at least one chassis")
+	require.NotEmpty(t, actual.Chassis[0].Readings, "Chassis should contain at least one reading")
+
+	// Check the first reading for backward compatibility with existing tests
+	require.InDelta(t, expected, actual.Chassis[0].Readings[0].Power.Watts(), 0.001)
+}

--- a/internal/platform/redfish/helpers_test.go
+++ b/internal/platform/redfish/helpers_test.go
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package redfish
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/sustainable-computing-io/kepler/internal/device"
+)
+
+func TestCreateMockResponse(t *testing.T) {
+	response := CreateMockResponse("dell_power_245w", 200)
+
+	assert.NotNil(t, response)
+	assert.Equal(t, 200, response.StatusCode)
+	assert.NotNil(t, response.Body)
+	assert.NotNil(t, response.Header)
+}
+
+func TestCreateSuccessResponse(t *testing.T) {
+	response := CreateSuccessResponse("generic_power_200w")
+
+	assert.NotNil(t, response)
+	assert.Equal(t, 200, response.StatusCode)
+	assert.NotNil(t, response.Body)
+}
+
+func TestCreateErrorResponse(t *testing.T) {
+	response := CreateErrorResponse("error_not_found", 404)
+
+	assert.NotNil(t, response)
+	assert.Equal(t, 404, response.StatusCode)
+	assert.NotNil(t, response.Body)
+}
+
+func TestNewTestPowerReader(t *testing.T) {
+	mockResponses := map[string]*http.Response{
+		"test": CreateMockResponse("dell_power_245w", 200),
+	}
+
+	reader := NewTestPowerReader(t, mockResponses)
+
+	assert.NotNil(t, reader)
+}
+
+func TestGetPowerReadingScenarios(t *testing.T) {
+	scenarios := GetPowerReadingScenarios()
+
+	assert.NotEmpty(t, scenarios)
+
+	// Verify each scenario has required fields
+	for _, scenario := range scenarios {
+		assert.NotEmpty(t, scenario.Name)
+		assert.NotEmpty(t, scenario.Fixture)
+		assert.GreaterOrEqual(t, scenario.ExpectedWatts, 0.0)
+	}
+}
+
+func TestGetErrorScenarios(t *testing.T) {
+	scenarios := GetErrorScenarios()
+
+	assert.NotEmpty(t, scenarios)
+
+	// Verify each scenario has required fields
+	for _, scenario := range scenarios {
+		assert.NotEmpty(t, scenario.Name)
+		assert.NotEmpty(t, scenario.Fixture)
+		assert.True(t, scenario.ExpectError)
+	}
+}
+
+func TestAssertPowerReading(t *testing.T) {
+	// Test successful assertion
+	reading := &PowerReading{
+		Timestamp: time.Now(),
+		Chassis: []Chassis{
+			{
+				ID: "1",
+				Readings: []Reading{
+					{
+						ControlID: "PC1",
+						Name:      "Server Power Control",
+						Power:     150.0 * device.Watt,
+					},
+				},
+			},
+		},
+	}
+
+	// This should not panic
+	assert.NotPanics(t, func() {
+		AssertPowerReading(t, 150.0, reading)
+	})
+}
+
+func TestAssertPowerReadingNil(t *testing.T) {
+	// Test with nil reading - this should panic due to require.NotNil
+	// We expect AssertPowerReading to panic, so we don't actually call it
+	// Instead just test that it would panic by checking the function behavior
+	reading := (*PowerReading)(nil)
+	assert.Nil(t, reading)
+}

--- a/internal/platform/redfish/mock/fixtures_test.go
+++ b/internal/platform/redfish/mock/fixtures_test.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPowerResponseFixtures(t *testing.T) {
+	t.Run("Dynamic_Power_Response_Generation", func(t *testing.T) {
+		// Test that the mock server can generate dynamic responses
+		response := PowerResponse(590.0)
+		assert.NotEmpty(t, response, "should generate dynamic response")
+		assert.Equal(t, "Power", response["Id"], "should have correct ID")
+		assert.Equal(t, "Power", response["Name"], "should have correct Name")
+
+		// Verify PowerControl structure
+		powerControl, ok := response["PowerControl"].([]map[string]any)
+		require.True(t, ok, "PowerControl should be array")
+		require.Len(t, powerControl, 1, "Should have one PowerControl entry")
+
+		// Verify dynamic power value
+		powerConsumed, ok := powerControl[0]["PowerConsumedWatts"].(float64)
+		require.True(t, ok, "PowerConsumedWatts should be float64")
+		assert.Equal(t, 590.0, powerConsumed, "Power consumption should be 590W")
+	})
+}
+
+func TestGeneric590WScenario(t *testing.T) {
+	scenarios := SuccessScenarios()
+
+	// Find our scenario
+	var generic590WScenario *TestScenario
+	for _, scenario := range scenarios {
+		if scenario.Name == "Generic590W" {
+			generic590WScenario = &scenario
+			break
+		}
+	}
+
+	require.NotNil(t, generic590WScenario, "Generic590W scenario should exist")
+	assert.Equal(t, 590.0, generic590WScenario.Config.PowerWatts)
+	assert.Equal(t, 590.0, generic590WScenario.PowerWatts)
+}

--- a/internal/platform/redfish/mock/power_responses.go
+++ b/internal/platform/redfish/mock/power_responses.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mock
+
+// NOTE: all static fixtures should be placed  in testdata/fixtures/
+
+// PowerResponse returns a power response structure
+func PowerResponse(powerWatts float64) map[string]any {
+	baseResponse := map[string]any{
+		"@odata.context": "/redfish/v1/$metadata#Power.Power",
+		"@odata.type":    "#Power.v1_5_0.Power",
+		"@odata.id":      "/redfish/v1/Chassis/1/Power",
+		"Id":             "Power",
+		"Name":           "Power",
+		"PowerControl": []map[string]any{
+			{
+				"@odata.id":           "/redfish/v1/Chassis/1/Power#/PowerControl/0",
+				"MemberId":            "0",
+				"Name":                "System Power Control",
+				"PowerConsumedWatts":  powerWatts,
+				"PowerRequestedWatts": powerWatts,
+				"PowerAvailableWatts": 600.0,
+				"PowerCapacityWatts":  750.0,
+				"PowerMetrics": map[string]any{
+					"IntervalInMin":        1,
+					"MinConsumedWatts":     powerWatts * 0.8,
+					"MaxConsumedWatts":     powerWatts * 1.2,
+					"AverageConsumedWatts": powerWatts,
+				},
+				"PowerLimit": map[string]any{
+					"LimitInWatts":   500.0,
+					"LimitException": "NoAction",
+				},
+			},
+		},
+	}
+
+	return baseResponse
+}

--- a/internal/platform/redfish/mock/scenarios.go
+++ b/internal/platform/redfish/mock/scenarios.go
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mock
+
+import "time"
+
+// TestScenario represents a test scenario configuration
+type TestScenario struct {
+	Name       string
+	Config     ServerConfig
+	PowerWatts float64 // For backward compatibility
+}
+
+// SuccessScenarios returns predefined success test scenarios
+func SuccessScenarios() []TestScenario {
+	baseConfig := ServerConfig{
+		Username:   "admin",
+		Password:   "password",
+		EnableAuth: true,
+		PowerWatts: 150.0,
+	}
+
+	return []TestScenario{{
+		Name: "BasicAuth",
+		Config: ServerConfig{
+			Username:   baseConfig.Username,
+			Password:   baseConfig.Password,
+			PowerWatts: baseConfig.PowerWatts,
+			EnableAuth: baseConfig.EnableAuth,
+		},
+		PowerWatts: baseConfig.PowerWatts,
+	}, {
+		Name: "NoAuthentication",
+		Config: ServerConfig{
+			Username:   "",
+			Password:   "",
+			PowerWatts: 100.0,
+			EnableAuth: false,
+		},
+		PowerWatts: 100.0,
+	}, {
+		Name: "TLSEnabled",
+		Config: ServerConfig{
+			Username:   baseConfig.Username,
+			Password:   baseConfig.Password,
+			PowerWatts: baseConfig.PowerWatts,
+			EnableAuth: baseConfig.EnableAuth,
+			EnableTLS:  true,
+		},
+		PowerWatts: baseConfig.PowerWatts,
+	}, {
+		Name: "Generic590W",
+		Config: ServerConfig{
+			Username:   baseConfig.Username,
+			Password:   baseConfig.Password,
+			PowerWatts: 590.0,
+			EnableAuth: baseConfig.EnableAuth,
+		},
+		PowerWatts: 590.0,
+	}}
+}
+
+// ErrorScenarios returns predefined error test scenarios
+func ErrorScenarios() []TestScenario {
+	baseConfig := ServerConfig{
+		Username:   "admin",
+		Password:   "password",
+		PowerWatts: 150.0,
+		EnableAuth: true,
+	}
+
+	return []TestScenario{{
+		Name: "ConnectionError",
+		Config: ServerConfig{
+			Username:   baseConfig.Username,
+			Password:   baseConfig.Password,
+			PowerWatts: baseConfig.PowerWatts,
+			EnableAuth: baseConfig.EnableAuth,
+			ForceError: ErrorConnection,
+		},
+	}, {
+		Name: "AuthenticationError",
+		Config: ServerConfig{
+			Username:   "wrong",
+			Password:   "wrong",
+			PowerWatts: baseConfig.PowerWatts,
+			EnableAuth: baseConfig.EnableAuth,
+			ForceError: ErrorAuth,
+		},
+	}, {
+		Name: "TimeoutError",
+		Config: ServerConfig{
+			Username:   baseConfig.Username,
+			Password:   baseConfig.Password,
+			PowerWatts: baseConfig.PowerWatts,
+			EnableAuth: baseConfig.EnableAuth,
+			ForceError: ErrorTimeout,
+		},
+	}, {
+		Name: "MissingChassis",
+		Config: ServerConfig{
+			Username:   baseConfig.Username,
+			Password:   baseConfig.Password,
+			PowerWatts: baseConfig.PowerWatts,
+			EnableAuth: baseConfig.EnableAuth,
+			ForceError: ErrorMissingChassis,
+		},
+	}, {
+		Name: "MissingPowerInfo",
+		Config: ServerConfig{
+			Username:   baseConfig.Username,
+			Password:   baseConfig.Password,
+			PowerWatts: baseConfig.PowerWatts,
+			EnableAuth: baseConfig.EnableAuth,
+			ForceError: ErrorMissingPower,
+		},
+	}, {
+		Name: "InternalServerError",
+		Config: ServerConfig{
+			Username:   baseConfig.Username,
+			Password:   baseConfig.Password,
+			PowerWatts: baseConfig.PowerWatts,
+			EnableAuth: baseConfig.EnableAuth,
+			ForceError: ErrorInternalServer,
+		},
+	}, {
+		Name: "BadJSONResponse",
+		Config: ServerConfig{
+			Username:   baseConfig.Username,
+			Password:   baseConfig.Password,
+			PowerWatts: baseConfig.PowerWatts,
+			EnableAuth: baseConfig.EnableAuth,
+			ForceError: ErrorBadJSON,
+		},
+	}, {
+		Name: "SlowResponse",
+		Config: ServerConfig{
+			Username:             baseConfig.Username,
+			Password:             baseConfig.Password,
+			PowerWatts:           baseConfig.PowerWatts,
+			EnableAuth:           baseConfig.EnableAuth,
+			SimulateSlowResponse: true,
+			ResponseDelay:        1 * time.Second,
+		},
+	}}
+}
+
+// CreateScenarioServer creates a mock server for a given test scenario
+func CreateScenarioServer(scenario TestScenario) *Server {
+	// Use PowerWatts from scenario config, fallback to scenario PowerWatts for backward compatibility
+	if scenario.Config.PowerWatts == 0 && scenario.PowerWatts != 0 {
+		scenario.Config.PowerWatts = scenario.PowerWatts
+	}
+	return NewServer(scenario.Config)
+}

--- a/internal/platform/redfish/mock/scenarios_test.go
+++ b/internal/platform/redfish/mock/scenarios_test.go
@@ -1,0 +1,686 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mock
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateScenarioServer(t *testing.T) {
+	scenario := TestScenario{
+		Name: "BasicGeneric",
+		Config: ServerConfig{
+			Username:   "admin",
+			Password:   "password",
+			PowerWatts: 150.0,
+			EnableAuth: true,
+		},
+	}
+
+	server := CreateScenarioServer(scenario)
+	defer server.Close()
+
+	assert.NotNil(t, server)
+	assert.NotEmpty(t, server.URL())
+	assert.True(t, strings.HasPrefix(server.URL(), "http"))
+}
+
+func TestServerServiceRoot(t *testing.T) {
+	config := ServerConfig{
+		Username: "admin",
+		Password: "password",
+	}
+
+	server := NewServer(config)
+	defer server.Close()
+
+	// Test service root endpoint
+	resp, err := http.Get(server.URL() + "/redfish/v1/")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	var serviceRoot map[string]any
+	err = json.NewDecoder(resp.Body).Decode(&serviceRoot)
+	require.NoError(t, err)
+
+	// Verify required fields
+	assert.Equal(t, "/redfish/v1/", serviceRoot["@odata.id"])
+	assert.Equal(t, "RootService", serviceRoot["Id"])
+	assert.Equal(t, "1.6.1", serviceRoot["RedfishVersion"])
+	assert.NotNil(t, serviceRoot["Chassis"])
+}
+
+func TestServerChassisCollection(t *testing.T) {
+	config := ServerConfig{
+		Username: "admin",
+		Password: "password",
+	}
+
+	server := NewServer(config)
+	defer server.Close()
+
+	// Test chassis collection endpoint
+	resp, err := http.Get(server.URL() + "/redfish/v1/Chassis")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var collection map[string]any
+	err = json.NewDecoder(resp.Body).Decode(&collection)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/redfish/v1/Chassis", collection["@odata.id"])
+	assert.Equal(t, "Chassis Collection", collection["Name"])
+
+	members, ok := collection["Members"].([]any)
+	require.True(t, ok)
+	assert.Len(t, members, 1)
+}
+
+func TestServerChassis(t *testing.T) {
+	config := ServerConfig{
+		Username: "admin",
+		Password: "password",
+	}
+
+	server := NewServer(config)
+	defer server.Close()
+
+	// Test individual chassis endpoint
+	resp, err := http.Get(server.URL() + "/redfish/v1/Chassis/1")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var chassis map[string]any
+	err = json.NewDecoder(resp.Body).Decode(&chassis)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/redfish/v1/Chassis/1", chassis["@odata.id"])
+	assert.Equal(t, "1", chassis["Id"])
+	assert.Equal(t, "Computer System Chassis", chassis["Name"])
+	assert.Equal(t, "generic", chassis["Manufacturer"])
+	assert.NotNil(t, chassis["Power"])
+}
+
+func TestServerPowerEndpoint(t *testing.T) {
+	powerWatts := 175.5
+	config := ServerConfig{
+		Username:   "admin",
+		Password:   "password",
+		PowerWatts: powerWatts,
+	}
+
+	server := NewServer(config)
+	defer server.Close()
+
+	// Test power endpoint
+	resp, err := http.Get(server.URL() + "/redfish/v1/Chassis/1/Power")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var power map[string]any
+	err = json.NewDecoder(resp.Body).Decode(&power)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/redfish/v1/Chassis/1/Power", power["@odata.id"])
+	assert.Equal(t, "Power", power["Name"])
+
+	// Check power control information
+	powerControl, ok := power["PowerControl"].([]any)
+	require.True(t, ok)
+	require.Len(t, powerControl, 1)
+
+	control := powerControl[0].(map[string]any)
+	assert.InDelta(t, powerWatts, control["PowerConsumedWatts"].(float64), 0.001)
+}
+
+func TestServerPowerResponse(t *testing.T) {
+	powerWatts := 200.0
+	config := ServerConfig{
+		Username:   "admin",
+		Password:   "password",
+		PowerWatts: powerWatts,
+	}
+
+	server := NewServer(config)
+	defer server.Close()
+
+	// Test power endpoint response
+	resp, err := http.Get(server.URL() + "/redfish/v1/Chassis/1/Power")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var power map[string]any
+	err = json.NewDecoder(resp.Body).Decode(&power)
+	require.NoError(t, err)
+
+	// Verify power structure
+	powerControl, ok := power["PowerControl"].([]any)
+	require.True(t, ok)
+	require.Len(t, powerControl, 1)
+
+	control := powerControl[0].(map[string]any)
+	assert.InDelta(t, powerWatts, control["PowerConsumedWatts"].(float64), 0.001)
+}
+
+func TestServerAuthenticationEnabled(t *testing.T) {
+	config := ServerConfig{
+		Username:   "admin",
+		Password:   "password",
+		EnableAuth: true,
+	}
+
+	server := NewServer(config)
+	defer server.Close()
+
+	// Test session creation
+	sessionData := map[string]string{
+		"UserName": "admin",
+		"Password": "password",
+	}
+	body, _ := json.Marshal(sessionData)
+
+	resp, err := http.Post(server.URL()+"/redfish/v1/SessionService/Sessions",
+		"application/json", strings.NewReader(string(body)))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.NotEmpty(t, resp.Header.Get("X-Auth-Token"))
+	assert.NotEmpty(t, resp.Header.Get("Location"))
+
+	var session map[string]any
+	err = json.NewDecoder(resp.Body).Decode(&session)
+	require.NoError(t, err)
+
+	assert.Equal(t, "admin", session["UserName"])
+	assert.NotEmpty(t, session["Id"])
+}
+
+func TestServerAuthenticationDisabled(t *testing.T) {
+	config := ServerConfig{
+		Username:   "admin",
+		Password:   "password",
+		EnableAuth: false,
+	}
+
+	server := NewServer(config)
+	defer server.Close()
+
+	// Test session creation without credentials
+	resp, err := http.Post(server.URL()+"/redfish/v1/SessionService/Sessions",
+		"application/json", strings.NewReader("{}"))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.NotEmpty(t, resp.Header.Get("X-Auth-Token"))
+}
+
+func TestServerErrorScenarios(t *testing.T) {
+	errorTests := []struct {
+		name         string
+		errorType    ErrorType
+		endpoint     string
+		expectedCode int
+	}{
+		{
+			name:         "MissingChassis",
+			errorType:    ErrorMissingChassis,
+			endpoint:     "/redfish/v1/Chassis",
+			expectedCode: http.StatusNotFound,
+		},
+		{
+			name:         "MissingPower",
+			errorType:    ErrorMissingPower,
+			endpoint:     "/redfish/v1/Chassis/1/Power",
+			expectedCode: http.StatusNotFound,
+		},
+		{
+			name:         "InternalServerError",
+			errorType:    ErrorInternalServer,
+			endpoint:     "/redfish/v1/",
+			expectedCode: http.StatusInternalServerError,
+		},
+		{
+			name:         "AuthError",
+			errorType:    ErrorAuth,
+			endpoint:     "/redfish/v1/SessionService/Sessions",
+			expectedCode: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range errorTests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := ServerConfig{
+				Username:   "admin",
+				Password:   "password",
+				EnableAuth: true,
+				ForceError: tt.errorType,
+			}
+
+			server := NewServer(config)
+			defer server.Close()
+
+			var resp *http.Response
+			var err error
+
+			if tt.errorType == ErrorAuth {
+				// Test with invalid credentials
+				sessionData := map[string]string{
+					"UserName": "wrong",
+					"Password": "wrong",
+				}
+				body, _ := json.Marshal(sessionData)
+				resp, err = http.Post(server.URL()+tt.endpoint,
+					"application/json", strings.NewReader(string(body)))
+			} else {
+				resp, err = http.Get(server.URL() + tt.endpoint)
+			}
+
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+
+			assert.Equal(t, tt.expectedCode, resp.StatusCode)
+		})
+	}
+}
+
+func TestServerSlowResponse(t *testing.T) {
+	responseDelay := 200 * time.Millisecond
+	config := ServerConfig{
+		Username:             "admin",
+		Password:             "password",
+		PowerWatts:           150.0,
+		SimulateSlowResponse: true,
+		ResponseDelay:        responseDelay,
+	}
+
+	server := NewServer(config)
+	defer server.Close()
+
+	start := time.Now()
+	resp, err := http.Get(server.URL() + "/redfish/v1/")
+	duration := time.Since(start)
+
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, duration >= responseDelay,
+		"Response should take at least %v, took %v", responseDelay, duration)
+}
+
+func TestServerTimeoutHandling(t *testing.T) {
+	config := ServerConfig{
+		Username:   "admin",
+		Password:   "password",
+		ForceError: ErrorTimeout,
+	}
+
+	server := NewServer(config)
+	defer server.Close()
+
+	// Create request with short timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", server.URL()+"/redfish/v1/", nil)
+	require.NoError(t, err)
+
+	client := &http.Client{}
+	_, err = client.Do(req)
+
+	// Should get context deadline exceeded or connection reset
+	assert.Error(t, err)
+}
+
+func TestServerDynamicPowerChanges(t *testing.T) {
+	config := ServerConfig{
+		Username:   "admin",
+		Password:   "password",
+		PowerWatts: 100.0,
+	}
+
+	server := NewServer(config)
+	defer server.Close()
+
+	// Test initial power reading
+	resp, err := http.Get(server.URL() + "/redfish/v1/Chassis/1/Power")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	var power1 map[string]any
+	err = json.NewDecoder(resp.Body).Decode(&power1)
+	require.NoError(t, err)
+
+	powerControl1 := power1["PowerControl"].([]any)[0].(map[string]any)
+	assert.InDelta(t, 100.0, powerControl1["PowerConsumedWatts"].(float64), 0.001)
+
+	// Change power dynamically
+	server.SetPowerWatts(250.0)
+
+	// Test updated power reading
+	resp2, err := http.Get(server.URL() + "/redfish/v1/Chassis/1/Power")
+	require.NoError(t, err)
+	defer func() { _ = resp2.Body.Close() }()
+
+	var power2 map[string]any
+	err = json.NewDecoder(resp2.Body).Decode(&power2)
+	require.NoError(t, err)
+
+	powerControl2 := power2["PowerControl"].([]any)[0].(map[string]any)
+	assert.InDelta(t, 250.0, powerControl2["PowerConsumedWatts"].(float64), 0.001)
+}
+
+func TestServerConcurrentRequests(t *testing.T) {
+	config := ServerConfig{
+		Username:   "admin",
+		Password:   "password",
+		PowerWatts: 150.0,
+	}
+
+	server := NewServer(config)
+	defer server.Close()
+
+	const numRequests = 10
+	results := make(chan error, numRequests)
+
+	// Make concurrent requests
+	for i := 0; i < numRequests; i++ {
+		go func() {
+			resp, err := http.Get(server.URL() + "/redfish/v1/")
+			if err != nil {
+				results <- err
+				return
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				results <- fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+				return
+			}
+
+			results <- nil
+		}()
+	}
+
+	// Check all results
+	for i := 0; i < numRequests; i++ {
+		err := <-results
+		assert.NoError(t, err, "Concurrent request %d failed", i)
+	}
+}
+
+func TestServerMethodNotAllowed(t *testing.T) {
+	config := ServerConfig{
+		Username: "admin",
+		Password: "password",
+	}
+
+	server := NewServer(config)
+	defer server.Close()
+
+	endpoints := []string{
+		"/redfish/v1/",
+		"/redfish/v1/Chassis",
+		"/redfish/v1/Chassis/1",
+		"/redfish/v1/Chassis/1/Power",
+	}
+
+	for _, endpoint := range endpoints {
+		// Test POST on GET-only endpoints
+		resp, err := http.Post(server.URL()+endpoint, "application/json", strings.NewReader("{}"))
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		if endpoint == "/redfish/v1/SessionService/Sessions" {
+			// This endpoint accepts POST
+			continue
+		}
+
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode,
+			"Endpoint %s should not allow POST", endpoint)
+	}
+}
+
+func TestServerNotFoundEndpoints(t *testing.T) {
+	config := ServerConfig{
+		Username: "admin",
+		Password: "password",
+	}
+
+	server := NewServer(config)
+	defer server.Close()
+
+	notFoundEndpoints := []string{
+		"/redfish/v1/NonExistent",
+		"/redfish/v1/Chassis/999",
+		"/redfish/v1/Chassis/1/NonExistent",
+		"/completely/wrong/path",
+	}
+
+	for _, endpoint := range notFoundEndpoints {
+		resp, err := http.Get(server.URL() + endpoint)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode,
+			"Endpoint %s should return 404", endpoint)
+	}
+}
+
+func TestServerSessionManagement(t *testing.T) {
+	config := ServerConfig{
+		Username:   "admin",
+		Password:   "password",
+		EnableAuth: true,
+	}
+
+	server := NewServer(config)
+	defer server.Close()
+
+	// Create session
+	sessionData := map[string]string{
+		"UserName": "admin",
+		"Password": "password",
+	}
+	body, _ := json.Marshal(sessionData)
+
+	resp, err := http.Post(server.URL()+"/redfish/v1/SessionService/Sessions",
+		"application/json", strings.NewReader(string(body)))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	sessionLocation := resp.Header.Get("Location")
+	assert.NotEmpty(t, sessionLocation)
+
+	// Get session
+	resp2, err := http.Get(server.URL() + sessionLocation)
+	require.NoError(t, err)
+	defer func() { _ = resp2.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp2.StatusCode)
+
+	// Delete session
+	req, _ := http.NewRequest("DELETE", server.URL()+sessionLocation, nil)
+	resp3, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp3.Body.Close() }()
+
+	assert.Equal(t, http.StatusNoContent, resp3.StatusCode)
+
+	// Verify session is gone
+	resp4, err := http.Get(server.URL() + sessionLocation)
+	require.NoError(t, err)
+	defer func() { _ = resp4.Body.Close() }()
+
+	assert.Equal(t, http.StatusNotFound, resp4.StatusCode)
+}
+
+func TestServerSetError(t *testing.T) {
+	server := NewServer(ServerConfig{
+		Username:   "admin",
+		Password:   "password",
+		PowerWatts: 100.0,
+		EnableAuth: false,
+	})
+	defer server.Close()
+
+	// Test setting different error types
+	testCases := []struct {
+		name      string
+		errorType ErrorType
+	}{
+		{"Connection Error", ErrorConnection},
+		{"Auth Error", ErrorAuth},
+		{"Timeout Error", ErrorTimeout},
+		{"Missing Chassis", ErrorMissingChassis},
+		{"Missing Power", ErrorMissingPower},
+		{"Internal Server Error", ErrorInternalServer},
+		{"Bad JSON", ErrorBadJSON},
+		{"No Error", ErrorNone},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set the error type
+			server.SetError(tc.errorType)
+
+			// Make a request to verify the error behavior
+			resp, err := http.Get(server.URL() + "/redfish/v1/")
+			assert.NoError(t, err)
+			defer func() { assert.NoError(t, resp.Body.Close()) }()
+
+			// Verify response based on error type
+			switch tc.errorType {
+			case ErrorNone:
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+			case ErrorInternalServer:
+				assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+			case ErrorBadJSON:
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				// Should have malformed JSON - verify by trying to parse
+				body, readErr := io.ReadAll(resp.Body)
+				assert.NoError(t, readErr)
+				var jsonData any
+				parseErr := json.Unmarshal(body, &jsonData)
+				assert.Error(t, parseErr) // Should fail to parse
+			default:
+				// Most error types still return 200 but with error content
+				assert.True(t, resp.StatusCode >= 200)
+			}
+		})
+	}
+}
+
+func TestServerGetTLSCertificate(t *testing.T) {
+	// Test with TLS enabled
+	server := NewServer(ServerConfig{
+		EnableTLS: true,
+	})
+	defer server.Close()
+
+	cert := server.GetTLSCertificate()
+	assert.NotNil(t, cert)
+	assert.NotEmpty(t, cert.Certificate)
+}
+
+func TestServerGetTLSCertificateWithoutTLS(t *testing.T) {
+	// Test with TLS disabled
+	server := NewServer(ServerConfig{
+		EnableTLS: false,
+	})
+	defer server.Close()
+
+	cert := server.GetTLSCertificate()
+	assert.Nil(t, cert)
+}
+
+func TestServerListSessions(t *testing.T) {
+	server := NewServer(ServerConfig{
+		Username:   "admin",
+		Password:   "password",
+		EnableAuth: true,
+	})
+	defer server.Close()
+
+	// Create a session first
+	sessionBody := `{"UserName":"admin","Password":"password"}`
+	resp, err := http.Post(server.URL()+"/redfish/v1/SessionService/Sessions",
+		"application/json", strings.NewReader(sessionBody))
+	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	// List sessions
+	resp, err = http.Get(server.URL() + "/redfish/v1/SessionService/Sessions")
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, resp.Body.Close()) }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	var sessions map[string]any
+	err = json.Unmarshal(body, &sessions)
+	assert.NoError(t, err)
+
+	// Should contain session information
+	assert.Contains(t, sessions, "Members")
+}
+
+func TestSuccessScenarios(t *testing.T) {
+	scenarios := SuccessScenarios()
+
+	assert.NotEmpty(t, scenarios)
+
+	// Verify all scenarios have valid configurations
+	for _, scenario := range scenarios {
+		assert.NotEmpty(t, scenario.Name)
+		// Note: Username/Password can be empty for no-auth scenarios
+		if scenario.Config.EnableAuth {
+			assert.NotEmpty(t, scenario.Config.Username)
+			assert.NotEmpty(t, scenario.Config.Password)
+		}
+		assert.Equal(t, ErrorNone, scenario.Config.ForceError)
+	}
+}
+
+func TestErrorScenarios(t *testing.T) {
+	scenarios := ErrorScenarios()
+
+	assert.NotEmpty(t, scenarios)
+
+	// Verify all scenarios have error conditions or special configurations
+	for _, scenario := range scenarios {
+		assert.NotEmpty(t, scenario.Name)
+		// Error scenarios either have ForceError set OR have special conditions like slow response
+		hasError := scenario.Config.ForceError != ErrorNone
+		hasSpecialCondition := scenario.Config.SimulateSlowResponse
+		assert.True(t, hasError || hasSpecialCondition,
+			"Scenario %s should have either an error condition or special behavior", scenario.Name)
+	}
+}

--- a/internal/platform/redfish/mock/server.go
+++ b/internal/platform/redfish/mock/server.go
@@ -1,0 +1,444 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mock
+
+import (
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ServerConfig holds configuration for the mock server
+type ServerConfig struct {
+	Username             string
+	Password             string
+	PowerWatts           float64
+	EnableAuth           bool
+	EnableTLS            bool
+	SimulateSlowResponse bool
+	ResponseDelay        time.Duration
+	ForceError           ErrorType
+	SessionTimeout       time.Duration
+}
+
+// ErrorType represents different error scenarios
+type ErrorType string
+
+const (
+	ErrorNone           ErrorType = ""
+	ErrorConnection     ErrorType = "connection"
+	ErrorAuth           ErrorType = "auth"
+	ErrorTimeout        ErrorType = "timeout"
+	ErrorMissingChassis ErrorType = "missing_chassis"
+	ErrorMissingPower   ErrorType = "missing_power"
+	ErrorInternalServer ErrorType = "internal_server"
+	ErrorBadJSON        ErrorType = "bad_json"
+)
+
+// Server represents a mock Redfish BMC server
+type Server struct {
+	server *httptest.Server
+	config ServerConfig
+
+	mutex    sync.RWMutex
+	sessions map[string]time.Time // Track active sessions
+}
+
+// NewServer creates a new mock Redfish server
+func NewServer(config ServerConfig) *Server {
+	// Set defaults
+	if config.Username == "" {
+		config.Username = "admin"
+	}
+	if config.Password == "" {
+		config.Password = "password"
+	}
+	// Don't set default PowerWatts - tests should explicitly set the value they want
+	// This allows testing zero power consumption scenarios
+	if config.SessionTimeout == 0 {
+		config.SessionTimeout = 30 * time.Minute
+	}
+
+	s := &Server{
+		config:   config,
+		sessions: make(map[string]time.Time),
+	}
+
+	// Create HTTP server with custom handler
+	if config.EnableTLS {
+		s.server = httptest.NewTLSServer(http.HandlerFunc(s.handler))
+	} else {
+		s.server = httptest.NewServer(http.HandlerFunc(s.handler))
+	}
+
+	return s
+}
+
+// URL returns the server's URL
+func (s *Server) URL() string {
+	return s.server.URL
+}
+
+// Close shuts down the mock server
+func (s *Server) Close() {
+	s.server.Close()
+}
+
+// SetPowerWatts dynamically sets the power reading for testing
+func (s *Server) SetPowerWatts(watts float64) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.config.PowerWatts = watts
+}
+
+// SetError forces a specific error scenario
+func (s *Server) SetError(errorType ErrorType) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.config.ForceError = errorType
+}
+
+// GetTLSCertificate returns the server's TLS certificate (for testing TLS scenarios)
+func (s *Server) GetTLSCertificate() *tls.Certificate {
+	if s.server.TLS != nil && len(s.server.TLS.Certificates) > 0 {
+		return &s.server.TLS.Certificates[0]
+	}
+	return nil
+}
+
+// handler is the main HTTP handler for the mock server
+func (s *Server) handler(w http.ResponseWriter, r *http.Request) {
+	// Debug logging (remove in production)
+	fmt.Printf("[MockServer] %s %s - Auth: %s\n", r.Method, r.URL.Path, r.Header.Get("Authorization"))
+
+	// Simulate slow response if configured
+	if s.config.SimulateSlowResponse {
+		select {
+		case <-r.Context().Done():
+			return // Client cancelled, exit immediately
+		case <-time.After(s.config.ResponseDelay):
+			// Continue with normal processing
+		}
+	}
+
+	// Handle forced errors
+	s.mutex.RLock()
+	forceError := s.config.ForceError
+	s.mutex.RUnlock()
+
+	switch forceError {
+	case ErrorConnection:
+		// Simulate connection error by closing connection
+		return
+	case ErrorTimeout:
+		// Force timeout by sleeping longer than client timeout
+		select {
+		case <-r.Context().Done():
+			return // Client cancelled, exit immediately
+		case <-time.After(2 * time.Second):
+			return // Force timeout
+		}
+	case ErrorInternalServer:
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	// Set common headers
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("OData-Version", "4.0")
+
+	// Route requests to appropriate handlers
+	switch r.URL.Path {
+	case "/redfish/v1/", "/redfish/v1":
+		s.handleServiceRoot(w, r)
+	case "/redfish/v1/SessionService/Sessions":
+		s.handleSessionService(w, r)
+	case "/redfish/v1/Chassis":
+		s.handleChassisCollection(w, r)
+	case "/redfish/v1/Chassis/1":
+		s.handleChassis(w, r)
+	case "/redfish/v1/Chassis/1/Power":
+		s.handlePower(w, r)
+	default:
+		if strings.HasPrefix(r.URL.Path, "/redfish/v1/SessionService/Sessions/") {
+			// Handle individual session endpoints
+			s.handleSession(w, r)
+		} else {
+			http.NotFound(w, r)
+		}
+	}
+}
+
+// handleServiceRoot handles the Redfish service root endpoint
+func (s *Server) handleServiceRoot(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if s.config.ForceError == ErrorBadJSON {
+		_, _ = w.Write([]byte("{invalid json"))
+		return
+	}
+
+	response := map[string]any{
+		"@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
+		"@odata.type":    "#ServiceRoot.v1_5_0.ServiceRoot",
+		"@odata.id":      "/redfish/v1/",
+		"Id":             "RootService",
+		"Name":           "Root Service",
+		"RedfishVersion": "1.6.1",
+		"UUID":           "12345678-1234-1234-1234-123456789012",
+		"Chassis": map[string]any{
+			"@odata.id": "/redfish/v1/Chassis",
+		},
+		"SessionService": map[string]any{
+			"@odata.id": "/redfish/v1/SessionService",
+		},
+		"Links": map[string]any{
+			"Sessions": map[string]any{
+				"@odata.id": "/redfish/v1/SessionService/Sessions",
+			},
+		},
+	}
+
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// handleChassisCollection handles the chassis collection endpoint
+func (s *Server) handleChassisCollection(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if s.config.ForceError == ErrorMissingChassis {
+		http.NotFound(w, r)
+		return
+	}
+
+	response := map[string]any{
+		"@odata.context":      "/redfish/v1/$metadata#ChassisCollection.ChassisCollection",
+		"@odata.type":         "#ChassisCollection.ChassisCollection",
+		"@odata.id":           "/redfish/v1/Chassis",
+		"Name":                "Chassis Collection",
+		"Members@odata.count": 1,
+		"Members": []map[string]any{
+			{
+				"@odata.id": "/redfish/v1/Chassis/1",
+			},
+		},
+	}
+
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// handleChassis handles individual chassis endpoint
+func (s *Server) handleChassis(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	response := map[string]any{
+		"@odata.context": "/redfish/v1/$metadata#Chassis.Chassis",
+		"@odata.type":    "#Chassis.v1_10_0.Chassis",
+		"@odata.id":      "/redfish/v1/Chassis/1",
+		"Id":             "1",
+		"Name":           "Computer System Chassis",
+		"ChassisType":    "RackMount",
+		"Manufacturer":   "generic",
+		"PowerState":     "On",
+		"Status": map[string]any{
+			"State":  "Enabled",
+			"Health": "OK",
+		},
+		"Power": map[string]any{
+			"@odata.id": "/redfish/v1/Chassis/1/Power",
+		},
+	}
+
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// handlePower handles power endpoint for chassis
+func (s *Server) handlePower(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if s.config.ForceError == ErrorMissingPower {
+		http.NotFound(w, r)
+		return
+	}
+
+	if s.config.ForceError == ErrorBadJSON {
+		_, _ = w.Write([]byte("{invalid json"))
+		return
+	}
+
+	s.mutex.RLock()
+	powerWatts := s.config.PowerWatts
+	s.mutex.RUnlock()
+
+	response := PowerResponse(powerWatts)
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// handleSessionService handles session management
+func (s *Server) handleSessionService(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		s.createSession(w, r)
+	case http.MethodGet:
+		s.listSessions(w, r)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// createSession creates a new authentication session
+func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
+	if !s.config.EnableAuth {
+		// Skip authentication if disabled
+		sessionID := fmt.Sprintf("session_%d", time.Now().Unix())
+		response := map[string]any{
+			"@odata.context": "/redfish/v1/$metadata#Session.Session",
+			"@odata.type":    "#Session.v1_1_0.Session",
+			"@odata.id":      fmt.Sprintf("/redfish/v1/SessionService/Sessions/%s", sessionID),
+			"Id":             sessionID,
+			"Name":           "Session",
+			"UserName":       "admin",
+		}
+		w.Header().Set("X-Auth-Token", "dummy-token-12345")
+		w.Header().Set("Location", fmt.Sprintf("/redfish/v1/SessionService/Sessions/%s", sessionID))
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(response)
+		return
+	}
+
+	if s.config.ForceError == ErrorAuth {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Parse request body for credentials
+	var creds struct {
+		UserName string `json:"UserName"`
+		Password string `json:"Password"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&creds); err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	// Validate credentials
+	if creds.UserName == "" || creds.Password == "" ||
+		creds.UserName != s.config.Username || creds.Password != s.config.Password {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Create session
+	sessionID := fmt.Sprintf("session_%d", time.Now().Unix())
+	s.mutex.Lock()
+	s.sessions[sessionID] = time.Now().Add(s.config.SessionTimeout)
+	s.mutex.Unlock()
+
+	response := map[string]any{
+		"@odata.context": "/redfish/v1/$metadata#Session.Session",
+		"@odata.type":    "#Session.v1_1_0.Session",
+		"@odata.id":      fmt.Sprintf("/redfish/v1/SessionService/Sessions/%s", sessionID),
+		"Id":             sessionID,
+		"Name":           "Session",
+		"UserName":       creds.UserName,
+	}
+
+	w.Header().Set("X-Auth-Token", base64.StdEncoding.EncodeToString([]byte(sessionID)))
+	w.Header().Set("Location", fmt.Sprintf("/redfish/v1/SessionService/Sessions/%s", sessionID))
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// listSessions lists active sessions
+func (s *Server) listSessions(w http.ResponseWriter, r *http.Request) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	var members []map[string]any
+	for sessionID := range s.sessions {
+		members = append(members, map[string]any{
+			"@odata.id": fmt.Sprintf("/redfish/v1/SessionService/Sessions/%s", sessionID),
+		})
+	}
+
+	response := map[string]any{
+		"@odata.context":      "/redfish/v1/$metadata#SessionCollection.SessionCollection",
+		"@odata.type":         "#SessionCollection.SessionCollection",
+		"@odata.id":           "/redfish/v1/SessionService/Sessions",
+		"Name":                "Session Collection",
+		"Members@odata.count": len(members),
+		"Members":             members,
+	}
+
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// handleSession handles individual session operations
+func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
+	sessionID := strings.TrimPrefix(r.URL.Path, "/redfish/v1/SessionService/Sessions/")
+
+	switch r.Method {
+	case http.MethodGet:
+		s.getSession(w, r, sessionID)
+	case http.MethodDelete:
+		s.deleteSession(w, r, sessionID)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// getSession retrieves session information
+func (s *Server) getSession(w http.ResponseWriter, r *http.Request, sessionID string) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	if _, exists := s.sessions[sessionID]; !exists {
+		http.NotFound(w, r)
+		return
+	}
+
+	response := map[string]any{
+		"@odata.context": "/redfish/v1/$metadata#Session.Session",
+		"@odata.type":    "#Session.v1_1_0.Session",
+		"@odata.id":      fmt.Sprintf("/redfish/v1/SessionService/Sessions/%s", sessionID),
+		"Id":             sessionID,
+		"Name":           "Session",
+		"UserName":       s.config.Username,
+	}
+
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// deleteSession removes a session
+func (s *Server) deleteSession(w http.ResponseWriter, r *http.Request, sessionID string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if _, exists := s.sessions[sessionID]; !exists {
+		http.NotFound(w, r)
+		return
+	}
+
+	delete(s.sessions, sessionID)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/platform/redfish/power_reader.go
+++ b/internal/platform/redfish/power_reader.go
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package redfish
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/stmcginnis/gofish"
+	"github.com/sustainable-computing-io/kepler/internal/device"
+)
+
+// PowerReader handles reading power data from Redfish BMC
+type PowerReader struct {
+	logger   *slog.Logger
+	client   *gofish.APIClient
+	endpoint string // Store endpoint for logging
+}
+
+// NewPowerReader creates a new PowerReader with the given client
+func NewPowerReader(logger *slog.Logger) *PowerReader {
+	return &PowerReader{
+		logger: logger,
+	}
+}
+
+// SetClient sets the gofish client and endpoint for the power reader
+func (pr *PowerReader) SetClient(client *gofish.APIClient) {
+	pr.client = client
+	if client != nil && client.Service != nil {
+		pr.endpoint = client.Service.ODataID
+	}
+}
+
+// ReadAll reads power consumption from all chassis with power data
+func (pr *PowerReader) ReadAll() ([]Chassis, error) {
+	if pr.client == nil {
+		return nil, fmt.Errorf("BMC client is not connected")
+	}
+
+	service := pr.client.Service
+	if service == nil {
+		return nil, fmt.Errorf("BMC service is not available")
+	}
+
+	// Get chassis collection
+	chassis, err := service.Chassis()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get chassis collection: %w", err)
+	}
+
+	if len(chassis) == 0 {
+		return nil, fmt.Errorf("no chassis found in BMC")
+	}
+
+	var chassisList []Chassis
+	totalReadings := 0
+
+	// Iterate
+	for i, ch := range chassis {
+		if ch == nil {
+			pr.logger.Warn("Skipping nil chassis", "index", i)
+			continue
+		}
+
+		// Extract chassis ID for metrics labeling
+		chassisID := ch.ID
+		if chassisID == "" {
+			chassisID = fmt.Sprintf("chassis-%d", i)
+		}
+
+		power, err := ch.Power()
+		if err != nil {
+			pr.logger.Warn("Failed to get power information from chassis",
+				"chassis_id", chassisID, "error", err)
+			continue
+		}
+
+		if power == nil || len(power.PowerControl) == 0 {
+			pr.logger.Debug("No power control information available for chassis",
+				"chassis_id", chassisID)
+			continue
+		}
+
+		// Collect all PowerControl entries for this chassis
+		var readings []Reading
+		for j, powerControl := range power.PowerControl {
+			// Skip entries with zero power consumption
+			if powerControl.PowerConsumedWatts == 0 {
+				pr.logger.Debug("Power consumption reading is zero for PowerControl entry",
+					"chassis_id", chassisID, "power_control_index", j, "member_id", powerControl.MemberID)
+				continue
+			}
+
+			reading := Reading{
+				ControlID: powerControl.MemberID,
+				Name:      powerControl.Name,
+				Power:     Power(powerControl.PowerConsumedWatts) * device.Watt,
+			}
+
+			readings = append(readings, reading)
+
+			pr.logger.Debug("Successfully read power from PowerControl entry",
+				"endpoint", pr.endpoint,
+				"chassis_id", chassisID,
+				"power_control_index", j,
+				"member_id", powerControl.MemberID,
+				"name", powerControl.Name,
+				"physical_context", powerControl.PhysicalContext,
+				"power_watts", powerControl.PowerConsumedWatts)
+		}
+
+		// Only add chassis if it has valid PowerControl readings
+		if len(readings) > 0 {
+			chassisData := Chassis{
+				ID:       chassisID,
+				Readings: readings,
+			}
+			chassisList = append(chassisList, chassisData)
+			totalReadings += len(readings)
+		}
+	}
+
+	if len(chassisList) == 0 {
+		return nil, fmt.Errorf("no chassis with valid power readings found")
+	}
+
+	pr.logger.Info("Successfully collected PowerControl readings",
+		"endpoint", pr.endpoint, "chassis_count", len(chassisList),
+		"total_readings", totalReadings)
+
+	return chassisList, nil
+}

--- a/internal/platform/redfish/power_reader_test.go
+++ b/internal/platform/redfish/power_reader_test.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package redfish
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPowerReader(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	powerReader := NewPowerReader(logger)
+
+	assert.NotNil(t, powerReader)
+	assert.Equal(t, logger, powerReader.logger)
+	assert.Nil(t, powerReader.client) // Should be nil initially
+}
+
+func TestPowerReaderSetClient(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	powerReader := NewPowerReader(logger)
+
+	// Test with nil client
+	powerReader.SetClient(nil)
+	assert.Nil(t, powerReader.client)
+	assert.Empty(t, powerReader.endpoint)
+}
+
+func TestPowerReaderReadAllNotConnected(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	powerReader := NewPowerReader(logger)
+
+	readings, err := powerReader.ReadAll()
+	assert.Error(t, err)
+	assert.Nil(t, readings)
+	assert.Contains(t, err.Error(), "not connected")
+}

--- a/internal/platform/redfish/service.go
+++ b/internal/platform/redfish/service.go
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package redfish
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/stmcginnis/gofish"
+	"github.com/sustainable-computing-io/kepler/config"
+	"github.com/sustainable-computing-io/kepler/config/redfish"
+	"github.com/sustainable-computing-io/kepler/internal/service"
+)
+
+// Service implements the Redfish power monitoring service
+type Service struct {
+	logger *slog.Logger
+	bmc    *redfish.BMCDetail // Store BMC configuration
+	client *gofish.APIClient  // Direct gofish client
+
+	powerReader *PowerReader
+	nodeName    string
+	bmcID       string // Store BMC ID for metrics
+
+	staleness   time.Duration // Max age before forcing new collection
+	httpTimeout time.Duration // HTTP client timeout for BMC requests
+
+	// Simplified caching for staleness support
+	mu            sync.RWMutex  // Protects cached readings
+	cachedReading *PowerReading // Last reading from all chassis
+}
+
+// Ensure Service implements the required interfaces
+var (
+	_ service.Initializer = (*Service)(nil)
+	_ service.Shutdowner  = (*Service)(nil) // To logout
+)
+
+// OptionFn is a functional option for configuring the Redfish service
+type OptionFn func(*Service)
+
+// WithStaleness sets the staleness duration for cached power readings
+func WithStaleness(staleness time.Duration) OptionFn {
+	return func(s *Service) {
+		s.staleness = staleness
+	}
+}
+
+// NewService creates a new Redfish service
+func NewService(cfg config.Redfish, logger *slog.Logger, opts ...OptionFn) (*Service, error) {
+	// Log experimental feature warning
+	logger = logger.With(slog.String("service", "experimental.redfish"))
+	logger.Warn("Using EXPERIMENTAL Redfish power monitoring feature", "feature", "redfish")
+
+	// NodeName is already resolved in config processing
+	nodeName := cfg.NodeName
+	if nodeName == "" {
+		return nil, fmt.Errorf("NodeName is empty - ensure Redfish is enabled and configured properly")
+	}
+
+	logger.Info("Using resolved node name", "node_name", nodeName)
+
+	// Load BMC configuration using redfishCfg.ConfigFile
+	bmcCfg, err := redfish.Load(cfg.ConfigFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load BMC configuration: %w", err)
+	}
+
+	// Get BMC details and ID for this node
+	bmcDetail, err := bmcCfg.BMCForNode(nodeName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get BMC configuration for node %s: %w", nodeName, err)
+	}
+
+	bmcID, err := bmcCfg.BMCIDForNode(nodeName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get BMC ID for node %s: %w", nodeName, err)
+	}
+
+	logger.Info("BMC configuration loaded", "node_name", nodeName, "bmc_id", bmcID, "endpoint", bmcDetail.Endpoint)
+
+	// Create power reader (will be initialized in Init())
+	reader := NewPowerReader(logger)
+
+	service := &Service{
+		logger:      logger,
+		bmc:         bmcDetail,
+		powerReader: reader,
+		nodeName:    nodeName,
+		bmcID:       bmcID,
+		staleness:   500 * time.Millisecond, // Default staleness
+		httpTimeout: cfg.HTTPTimeout,
+		// Initialize cache fields
+		cachedReading: nil,
+	}
+
+	// Apply functional options
+	for _, opt := range opts {
+		opt(service)
+	}
+
+	return service, nil
+}
+
+// Name returns the service name
+func (s *Service) Name() string {
+	return "platform.redfish"
+}
+
+// Init initializes the service by connecting to the BMC
+func (s *Service) Init() error {
+	s.logger.Info("Initializing Redfish power monitoring service",
+		"node_name", s.nodeName,
+		"bmc_endpoint", s.bmc.Endpoint)
+
+	// Configure HTTP client with timeout and TLS configuration
+	httpClient := &http.Client{
+		Timeout: s.httpTimeout,
+	}
+
+	if s.bmc.Insecure {
+		httpClient.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	}
+
+	//  Gofish client
+	gofishConfig := gofish.ClientConfig{
+		Endpoint:   s.bmc.Endpoint,
+		Username:   s.bmc.Username,
+		Password:   s.bmc.Password,
+		HTTPClient: httpClient,
+	}
+
+	// NOTE: Use Background() for client connection since gofish stores this context
+	// and uses it for all subsequent HTTP requests. A timeout context causes
+	// "context canceled" errors on later requests when the timeout expires.
+	client, err := gofish.ConnectContext(context.Background(), gofishConfig)
+	if err != nil {
+		// Don't log credentials in error messages
+		return fmt.Errorf("failed to connect to BMC at %s for node %s: %w", s.bmc.Endpoint, s.nodeName, err)
+	}
+
+	s.client = client
+
+	// Initialize power reader with the connected client
+	s.powerReader.SetClient(client)
+
+	// NOTE: Do not validate power reading capability during Init()
+	// to allow the service to start even if power data is temporarily unavailable.
+	// Power reading errors will be handled during actual data collection.
+
+	s.logger.Info("Successfully connected to BMC", "node_name", s.nodeName)
+	return nil
+}
+
+// Shutdown cleanly shuts down the service
+func (s *Service) Shutdown() error {
+	s.logger.Info("Shutting down Redfish power monitoring service")
+	defer s.logger.Info("Redfish power monitoring service shutdown complete")
+
+	// Disconnect gofish client if connected
+	if s.client == nil {
+		return nil
+	}
+	s.client.Logout()
+	s.client = nil
+
+	return nil
+}
+
+// NodeName returns the node name
+func (s *Service) NodeName() string {
+	return s.nodeName
+}
+
+// BMCID returns the BMC identifier
+func (s *Service) BMCID() string {
+	return s.bmcID
+}
+
+// isFresh checks if the cached reading is still within the staleness threshold
+func (s *Service) isFresh() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.cachedReading == nil || s.cachedReading.Timestamp.IsZero() {
+		return false
+	}
+
+	age := time.Since(s.cachedReading.Timestamp)
+	return age <= s.staleness
+}
+
+// Power returns power readings from all chassis with power data
+func (s *Service) Power() (*PowerReading, error) {
+	if s.powerReader == nil {
+		return nil, fmt.Errorf("power reader is not initialized")
+	}
+
+	// Check if we have fresh cached data
+	if s.isFresh() {
+		s.mu.RLock()
+		cached := s.cachedReading.Clone()
+		cacheAge := time.Since(s.cachedReading.Timestamp)
+		s.mu.RUnlock()
+
+		s.logger.Debug("Returning cached chassis power readings",
+			"chassis.count", len(cached.Chassis),
+			"cache.age", cacheAge,
+			"staleness", s.staleness)
+		return cached, nil
+	}
+
+	// Need fresh data - collect from BMC
+	readings, err := s.powerReader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect power data from BMC: %w", err)
+	}
+
+	// Assemble PowerReading with timestamp
+	newReading := &PowerReading{
+		Timestamp: time.Now(),
+		Chassis:   readings,
+	}
+
+	// Update the cache with the new reading
+	s.mu.Lock()
+	s.cachedReading = newReading.Clone() // Clone for safe storage
+	s.mu.Unlock()
+
+	s.logger.Debug("Collected and cached fresh chassis power readings",
+		"chassis.count", len(newReading.Chassis),
+		"staleness", s.staleness)
+
+	return newReading, nil
+}

--- a/internal/platform/redfish/service_test.go
+++ b/internal/platform/redfish/service_test.go
@@ -1,0 +1,740 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package redfish
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sustainable-computing-io/kepler/config"
+	"github.com/sustainable-computing-io/kepler/internal/device"
+	"github.com/sustainable-computing-io/kepler/internal/platform/redfish/mock"
+)
+
+const testMonitorStaleness = 30 * time.Second // Test monitor staleness duration
+
+// defaultRedfishConfig returns a default redfish config for testing
+func defaultRedfishConfig(configFile string, nodeName string) config.Redfish {
+	return config.Redfish{
+		NodeName:    nodeName, // Pre-resolved NodeName
+		ConfigFile:  configFile,
+		HTTPTimeout: 5 * time.Second, // Use 5s HTTP timeout for testing
+	}
+}
+
+func TestNewService(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	tt := []struct {
+		name          string
+		configContent string
+		nodeName      string
+		kubeNodeName  string
+		expectError   bool
+	}{{
+		name: "ValidConfiguration",
+		configContent: `
+nodes:
+  test-node: test-bmc
+bmcs:
+  test-bmc:
+    endpoint: "https://192.168.1.100"
+    username: "admin"
+    password: "password"
+    insecure: true
+`,
+		nodeName:     "test-node",
+		kubeNodeName: "",
+		expectError:  false,
+	}, {
+		name: "NodeNotFound",
+		configContent: `
+nodes:
+  other-node: test-bmc
+bmcs:
+  test-bmc:
+    endpoint: "https://192.168.1.100"
+    username: "admin"
+    password: "password"
+    insecure: true
+`,
+		nodeName:     "missing-node",
+		kubeNodeName: "",
+		expectError:  true,
+	}, {
+		name: "InvalidConfigFile",
+		configContent: `
+invalid: yaml: content
+`,
+		nodeName:     "test-node",
+		kubeNodeName: "",
+		expectError:  true,
+	}, {
+		name: "HostnameFallback",
+		configContent: func() string {
+			hostname, _ := os.Hostname()
+			return `
+nodes:
+  ` + hostname + `: test-bmc
+bmcs:
+  test-bmc:
+    endpoint: "https://192.168.1.100"
+    username: "admin"
+    password: "password"
+    insecure: true
+`
+		}(),
+		nodeName:     "",
+		kubeNodeName: "",
+		expectError:  false, // Should succeed with hostname fallback
+	}}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create temporary config file
+			tmpDir, err := os.MkdirTemp("", "service_test")
+			require.NoError(t, err)
+			defer func() { _ = os.RemoveAll(tmpDir) }()
+
+			configFile := filepath.Join(tmpDir, "config.yaml")
+			err = os.WriteFile(configFile, []byte(tc.configContent), 0644)
+			require.NoError(t, err)
+
+			// Create service with resolved NodeName
+			// In the real implementation, NodeName would be resolved during config processing
+			resolvedNodeName := tc.nodeName
+			if resolvedNodeName == "" {
+				// Simulate hostname fallback for test
+				hostname, _ := os.Hostname()
+				resolvedNodeName = hostname
+			}
+			redfishCfg := defaultRedfishConfig(configFile, resolvedNodeName)
+			service, err := NewService(redfishCfg, logger, WithStaleness(testMonitorStaleness))
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, service)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, service)
+
+			// Verify service properties
+			assert.Equal(t, "platform.redfish", service.Name())
+			assert.Nil(t, service.client) // Client is created during Init()
+			assert.NotNil(t, service.powerReader)
+			// Verify configuration
+			assert.Equal(t, testMonitorStaleness, service.staleness)
+			assert.Equal(t, 5*time.Second, service.httpTimeout)
+
+			// Verify resolved node name
+			if tc.nodeName != "" {
+				// For explicit nodeName, should match exactly
+				assert.Equal(t, tc.nodeName, service.nodeName)
+			} else {
+				// For empty nodeName, should fall back to hostname
+				hostname, _ := os.Hostname()
+				assert.Equal(t, hostname, service.nodeName)
+			}
+		})
+	}
+}
+
+func TestNewServiceNonExistentConfig(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	redfishCfg := defaultRedfishConfig("/non/existent/config.yaml", "test-node")
+	service, err := NewService(redfishCfg, logger, WithStaleness(testMonitorStaleness))
+	assert.Error(t, err)
+	assert.Nil(t, service)
+	assert.Contains(t, err.Error(), "failed to load BMC configuration")
+}
+
+func TestServiceInitSuccess(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	scenario := mock.TestScenario{
+		Config: mock.ServerConfig{
+			Username:   "admin",
+			Password:   "password",
+			PowerWatts: 150.0,
+			EnableAuth: true,
+		},
+	}
+
+	server := mock.CreateScenarioServer(scenario)
+	defer server.Close()
+
+	// Create service with mock server
+	service := createTestService(t, server, logger)
+
+	// Test initialization
+	err := service.Init()
+	assert.NoError(t, err)
+	assert.NotNil(t, service.client)
+
+	// Cleanup
+	err = service.Shutdown()
+	assert.NoError(t, err)
+}
+
+func TestServiceInitConnectionFailure(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	scenario := mock.TestScenario{
+		Config: mock.ServerConfig{
+			Username:   "admin",
+			Password:   "password",
+			PowerWatts: 150.0,
+			EnableAuth: true,
+			ForceError: mock.ErrorAuth,
+		},
+	}
+
+	server := mock.CreateScenarioServer(scenario)
+	defer server.Close()
+
+	// Create service with failing mock server
+	service := createTestService(t, server, logger)
+
+	// Test initialization failure
+	err := service.Init()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to connect to BMC")
+	assert.Nil(t, service.client)
+}
+
+func TestServicePowerDataCollection(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	initialPower := 150.0
+	scenario := mock.TestScenario{
+		Config: mock.ServerConfig{
+			Username:   "admin",
+			Password:   "password",
+			PowerWatts: initialPower,
+			EnableAuth: true,
+		},
+	}
+
+	server := mock.CreateScenarioServer(scenario)
+	defer server.Close()
+
+	// Create and initialize service with short staleness for testing
+	service := createTestService(t, server, logger)
+	service.staleness = 50 * time.Millisecond // Short staleness for testing
+	err := service.Init()
+	require.NoError(t, err)
+
+	// Test ChassisPower() can collect data on-demand (even before Run())
+	readings, err := service.Power()
+	require.NoError(t, err)
+	require.NotNil(t, readings)
+	require.NotEmpty(t, readings.Chassis)
+	require.NotEmpty(t, readings.Chassis[0].Readings)
+
+	expectedPower := Power(initialPower) * device.Watt
+	assert.Equal(t, expectedPower, readings.Chassis[0].Readings[0].Power)
+
+	// Test ChassisPower() on-demand collection again (should return cached value)
+	readings, err = service.Power()
+	require.NoError(t, err)
+	require.NotNil(t, readings)
+	require.NotEmpty(t, readings.Chassis)
+	require.NotEmpty(t, readings.Chassis[0].Readings)
+
+	// Check first reading (should be same as the on-demand reading above)
+	assert.Equal(t, expectedPower, readings.Chassis[0].Readings[0].Power)
+
+	// Change power and wait for staleness to expire
+	newPower := 250.0
+	server.SetPowerWatts(newPower)
+
+	// Wait for staleness to expire
+	time.Sleep(100 * time.Millisecond)
+
+	// Test on-demand collection again after power change
+	readings, err = service.Power()
+	require.NoError(t, err)
+	require.NotNil(t, readings)
+	require.NotEmpty(t, readings.Chassis)
+	require.NotEmpty(t, readings.Chassis[0].Readings)
+
+	// Check second reading (should get fresh data from BMC)
+	expectedNewPower := Power(newPower) * device.Watt
+	assert.Equal(t, expectedNewPower, readings.Chassis[0].Readings[0].Power)
+
+	// Cleanup
+	err = service.Shutdown()
+	assert.NoError(t, err)
+}
+
+func TestServiceCollectionErrors(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	scenario := mock.TestScenario{
+		Config: mock.ServerConfig{
+			Username:   "admin",
+			Password:   "password",
+			PowerWatts: 150.0,
+			EnableAuth: true,
+			ForceError: mock.ErrorMissingChassis,
+		},
+	}
+
+	server := mock.CreateScenarioServer(scenario)
+	defer server.Close()
+
+	// Create and initialize service (should succeed)
+	service := createTestService(t, server, logger)
+	err := service.Init()
+	require.NoError(t, err)
+
+	// Try to collect power data (should fail)
+	readings, err := service.Power()
+	assert.Error(t, err)
+	assert.Nil(t, readings)
+
+	// Verify subsequent calls also fail
+	readings, err = service.Power()
+	assert.Error(t, err)
+	assert.Nil(t, readings)
+
+	// Cleanup
+	err = service.Shutdown()
+	assert.NoError(t, err)
+}
+
+func TestServiceConcurrentAccess(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	scenario := mock.TestScenario{
+		Config: mock.ServerConfig{
+			Username:   "admin",
+			Password:   "password",
+			PowerWatts: 180.0,
+			EnableAuth: true,
+		},
+	}
+
+	server := mock.CreateScenarioServer(scenario)
+	defer server.Close()
+
+	// Create and initialize service
+	service := createTestService(t, server, logger)
+	err := service.Init()
+	require.NoError(t, err)
+
+	// Test that we can collect data on-demand
+	readings, err := service.Power()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, readings)
+
+	// Test concurrent reads using ChassisPower
+	const numReaders = 10
+	var wg sync.WaitGroup
+
+	for range numReaders {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				readings, err := service.Power()
+				if err == nil && readings != nil && len(readings.Chassis) > 0 && len(readings.Chassis[0].Readings) > 0 {
+					expectedPower := 180 * device.Watt
+					assert.Equal(t, expectedPower, readings.Chassis[0].Readings[0].Power)
+				}
+			}
+		}()
+	}
+
+	// Concurrent data collection using ChassisPower()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 10 {
+			_, _ = service.Power()
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	wg.Wait()
+
+	// Cleanup
+	err = service.Shutdown()
+	assert.NoError(t, err)
+}
+
+func TestServiceStalenessCache(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	// Create a mock server with initial power reading
+	config := mock.ServerConfig{
+		Username:   "admin",
+		Password:   "secret",
+		PowerWatts: 200.0,
+	}
+	server := mock.NewServer(config)
+	defer server.Close()
+
+	// Create service using helper with short staleness for testing
+	service := createTestService(t, server, logger)
+
+	// Override staleness for testing
+	service.staleness = 100 * time.Millisecond // Very short staleness for testing
+
+	err := service.Init()
+	require.NoError(t, err)
+	defer func() {
+		err := service.Shutdown()
+		require.NoError(t, err)
+	}()
+
+	// First call should hit the BMC
+	readings1, err := service.Power()
+	require.NoError(t, err)
+	require.NotEmpty(t, readings1)
+	assert.Equal(t, 200.0*device.Watt, readings1.Chassis[0].Readings[0].Power)
+
+	// Change power on server
+	server.SetPowerWatts(300.0)
+
+	// Immediate second call should return cached data (same power)
+	readings2, err := service.Power()
+	require.NoError(t, err)
+	require.NotEmpty(t, readings2)
+	assert.Equal(t, 200.0*device.Watt, readings2.Chassis[0].Readings[0].Power) // Still cached value
+
+	// Wait for staleness to expire
+	time.Sleep(150 * time.Millisecond)
+
+	// Third call should hit BMC again and get new power
+	readings3, err := service.Power()
+	require.NoError(t, err)
+	require.NotEmpty(t, readings3)
+	assert.Equal(t, 300.0*device.Watt, readings3.Chassis[0].Readings[0].Power) // New value from BMC
+
+	// Fourth immediate call should return new cached data
+	readings4, err := service.Power()
+	require.NoError(t, err)
+	require.NotEmpty(t, readings4)
+	assert.Equal(t, 300.0*device.Watt, readings4.Chassis[0].Readings[0].Power) // Cached new value
+}
+
+func TestServiceShutdownIdempotent(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	scenario := mock.TestScenario{
+		Config: mock.ServerConfig{
+			Username:   "admin",
+			Password:   "password",
+			PowerWatts: 150.0,
+			EnableAuth: true,
+		},
+	}
+
+	server := mock.CreateScenarioServer(scenario)
+	defer server.Close()
+
+	// Create and initialize service
+	service := createTestService(t, server, logger)
+	err := service.Init()
+	require.NoError(t, err)
+
+	// First shutdown
+	err = service.Shutdown()
+	assert.NoError(t, err)
+
+	// Second shutdown should be safe
+	err = service.Shutdown()
+	assert.NoError(t, err)
+
+	// Third shutdown should also be safe
+	err = service.Shutdown()
+	assert.NoError(t, err)
+}
+
+func TestServiceIntegrationBasic(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	scenario := mock.TestScenario{
+		Config: mock.ServerConfig{
+			Username:   "admin",
+			Password:   "password",
+			PowerWatts: 165.5,
+			EnableAuth: true,
+		},
+	}
+
+	server := mock.CreateScenarioServer(scenario)
+	defer server.Close()
+
+	// Create and test service
+	service := createTestService(t, server, logger)
+
+	// Init
+	err := service.Init()
+	require.NoError(t, err)
+
+	// Test on-demand collection
+	readings, err := service.Power()
+	assert.NoError(t, err)
+	require.NotNil(t, readings)
+	require.NotEmpty(t, readings.Chassis)
+	require.NotEmpty(t, readings.Chassis[0].Readings)
+
+	// Create expected power value using the same pattern as in PowerReader
+	expectedPower := 165.5 * device.Watt
+	assert.Equal(t, expectedPower, readings.Chassis[0].Readings[0].Power)
+
+	// Cleanup
+	err = service.Shutdown()
+	assert.NoError(t, err)
+}
+
+func TestServiceInterfaceCompliance(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	scenario := mock.TestScenario{
+		Config: mock.ServerConfig{
+			Username:   "admin",
+			Password:   "password",
+			PowerWatts: 150.0,
+			EnableAuth: true,
+		},
+	}
+
+	server := mock.CreateScenarioServer(scenario)
+	defer server.Close()
+
+	service := createTestService(t, server, logger)
+
+	// Test Service interface
+	assert.Equal(t, "platform.redfish", service.Name())
+
+	// Test Initializer interface
+	err := service.Init()
+	assert.NoError(t, err)
+
+	// Test Shutdowner interface
+	err = service.Shutdown()
+	assert.NoError(t, err)
+}
+
+func TestServiceInitCredentialValidation(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	testCases := []struct {
+		name     string
+		username string
+		password string
+		wantErr  bool
+	}{
+		{
+			name:     "Both username and password provided",
+			username: "admin",
+			password: "secret",
+			wantErr:  false,
+		},
+		{
+			name:     "Both username and password empty",
+			username: "",
+			password: "",
+			wantErr:  false,
+		},
+		{
+			name:     "Username without password",
+			username: "admin",
+			password: "",
+			wantErr:  true,
+		},
+		{
+			name:     "Password without username",
+			username: "",
+			password: "secret",
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create temporary config file with specific credentials
+			tmpDir, err := os.MkdirTemp("", "credential_test")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+			configContent := fmt.Sprintf(`
+nodes:
+  test-node: test-bmc
+bmcs:
+  test-bmc:
+    endpoint: "https://192.168.1.100"
+    username: "%s"
+    password: "%s"
+    insecure: true
+`, tc.username, tc.password)
+
+			configFile := filepath.Join(tmpDir, "config.yaml")
+			err = os.WriteFile(configFile, []byte(configContent), 0644)
+			require.NoError(t, err)
+
+			// Create service - this should now fail for invalid credentials
+			redfishCfg := defaultRedfishConfig(configFile, "test-node")
+			service, err := NewService(redfishCfg, logger, WithStaleness(testMonitorStaleness))
+
+			if tc.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid BMC configuration")
+				assert.Nil(t, service)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, service)
+
+				// Test initialization - may fail due to connection issues, but not credential validation
+				err = service.Init()
+				if err != nil {
+					assert.NotContains(t, err.Error(), "both username and password must be provided")
+				}
+			}
+		})
+	}
+}
+
+// Helper function to create a test service with mock server
+func createTestService(t *testing.T, server *mock.Server, logger *slog.Logger) *Service {
+	// Create temporary config file
+	tmpDir, err := os.MkdirTemp("", "service_test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	configContent := `
+nodes:
+  test-node: test-bmc
+bmcs:
+  test-bmc:
+    endpoint: "` + server.URL() + `"
+    username: "admin"
+    password: "password"
+    insecure: true
+`
+
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	err = os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	// Create service
+	redfishCfg := defaultRedfishConfig(configFile, "test-node")
+	service, err := NewService(redfishCfg, logger, WithStaleness(testMonitorStaleness))
+	require.NoError(t, err)
+
+	return service
+}
+
+func TestServiceNodeNameAndBMCID(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	// Create temporary config file
+	tmpDir, err := os.MkdirTemp("", "service_test")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	configContent := `
+nodes:
+  test-worker-1: test-bmc-1
+bmcs:
+  test-bmc-1:
+    endpoint: "https://192.168.1.100"
+    username: "admin"
+    password: "password"
+    insecure: true
+`
+
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	err = os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	// Create service
+	redfishCfg := defaultRedfishConfig(configFile, "test-worker-1")
+	service, err := NewService(redfishCfg, logger, WithStaleness(testMonitorStaleness))
+	require.NoError(t, err)
+	require.NotNil(t, service)
+
+	// Test NodeName method
+	nodeName := service.NodeName()
+	assert.Equal(t, "test-worker-1", nodeName)
+
+	// Test BMCID method
+	bmcID := service.BMCID()
+	assert.Equal(t, "test-bmc-1", bmcID)
+}
+
+func TestServiceIsFresh(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	// Create temporary config file
+	tmpDir, err := os.MkdirTemp("", "service_test")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	configContent := `
+nodes:
+  test-node: test-bmc
+bmcs:
+  test-bmc:
+    endpoint: "https://192.168.1.100"
+    username: "admin"
+    password: "password"
+    insecure: true
+`
+
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	err = os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	// Create service with short staleness for testing
+	redfishCfg := defaultRedfishConfig(configFile, "test-node")
+	service, err := NewService(redfishCfg, logger, WithStaleness(100*time.Millisecond)) // Short staleness for testing
+	require.NoError(t, err)
+	require.NotNil(t, service)
+
+	// Test 1: No cached data - should not be fresh
+	assert.False(t, service.isFresh())
+
+	// Test 2: Add cached data with current timestamp - should be fresh
+	service.cachedReading = &PowerReading{
+		Timestamp: time.Now(),
+		Chassis: []Chassis{
+			{
+				ID: "test",
+				Readings: []Reading{
+					{ControlID: "PC1", Name: "Test Power Control", Power: 100 * device.Watt},
+				},
+			},
+		},
+	}
+	assert.True(t, service.isFresh())
+
+	// Test 3: Wait for staleness to expire - should not be fresh
+	time.Sleep(150 * time.Millisecond) // Wait longer than staleness threshold
+	assert.False(t, service.isFresh())
+
+	// Test 4: Cached data with zero timestamp - should not be fresh
+	service.cachedReading = &PowerReading{
+		Timestamp: time.Time{}, // Zero timestamp
+		Chassis: []Chassis{
+			{
+				ID: "test",
+				Readings: []Reading{
+					{ControlID: "PC1", Name: "Test Power Control", Power: 100 * device.Watt},
+				},
+			},
+		},
+	}
+	assert.False(t, service.isFresh())
+
+	// Test 5: Nil cached data - should not be fresh
+	service.cachedReading = nil
+	assert.False(t, service.isFresh())
+}

--- a/internal/platform/redfish/testdata/HOW_TO_UPDATE_TESTDATA.md
+++ b/internal/platform/redfish/testdata/HOW_TO_UPDATE_TESTDATA.md
@@ -1,0 +1,112 @@
+# Updating Redfish Test Fixtures
+
+This guide explains how to update test fixtures for the Kepler Redfish power monitoring feature.
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Integration Process](#integration-process)
+- [Testing and Validation](#testing-and-validation)
+- [Security Guidelines](#security-guidelines)
+
+## Quick Start
+
+### Prerequisites
+
+- Go 1.23 or later
+- For new test data: Access to a Redfish BMC and credentials
+
+### 1. Capture BMC Data (for new fixtures)
+
+Use the capture tool in `hack/redfish/` - see [hack/redfish/README.md](../../../../hack/redfish/README.md) for detailed instructions:
+
+```bash
+# Capture from BMC
+go run hack/redfish/capture-bmc-testdata.go \
+    -endpoint https://192.168.1.100 \
+    -username admin \
+    -password yourpassword \
+    -vendor dell
+```
+
+### 2. Integration Process
+
+The capture script generates ready-to-integrate JSON fixtures and code snippets for immediate use.
+
+## Integration Process
+
+### Step 1: Save JSON Fixture
+
+Save the captured JSON data as a fixture file:
+
+```bash
+# Create fixture file in fixtures/ directory
+echo '{...captured BMC response...}' > fixtures/dell_power_275w.json
+```
+
+### Step 2: Use Fixture in Tests
+
+The fixture will be automatically loaded by the testdata package:
+
+```go
+// Reference fixture by filename (without .json extension)
+response := CreateSuccessResponse("dell_power_275w")
+powerReader := NewTestPowerReader(t, map[string]*http.Response{
+    "/redfish/v1/Chassis/1/Power": response,
+})
+
+reading, err := powerReader.ReadPower(context.Background())
+AssertPowerReading(t, 275.0, reading)
+```
+
+### Step 3: Add Test Scenario (Optional)
+
+For comprehensive testing, add scenario to mock server in `internal/platform/redfish/mock/scenarios.go`:
+
+```go
+{
+    Name: "Dell275W",
+    Config: ServerConfig{
+        Vendor:     VendorDell,
+        PowerWatts: 275.0,
+        EnableAuth: true,
+    },
+    PowerWatts: 275.0,
+},
+```
+
+## Testing and Validation
+
+### Run Validation Tests
+
+After adding fixtures, verify they work:
+
+```bash
+# Test fixture loading
+go test ./internal/platform/redfish/testdata -v
+
+# Test power reader with new fixtures
+go test ./internal/platform/redfish -run TestPowerReader -v
+
+# Run all Redfish tests
+go test ./internal/platform/redfish/... -race
+```
+
+## Security Guidelines
+
+### Automatic Sanitization
+
+The capture script (see [hack/redfish/README.md](../../../../hack/redfish/README.md)) automatically sanitizes sensitive data.
+
+### Security Checklist
+
+Before contributing fixtures:
+
+- [ ] No real IP addresses, serial numbers, or UUIDs
+- [ ] No credentials or authentication tokens
+- [ ] No company-specific identifying information
+- [ ] Power readings are realistic but anonymized
+
+---
+
+**For capturing new BMC test data, see [hack/redfish/README.md](../../../../hack/redfish/README.md)**

--- a/internal/platform/redfish/testdata/README.md
+++ b/internal/platform/redfish/testdata/README.md
@@ -1,0 +1,120 @@
+# Redfish Test Data
+
+This package contains test fixtures and validation utilities for Redfish BMC testing.
+
+## Test Data Sources and Validation
+
+### How We Ensure Test Data Correctness
+
+1. **Schema Validation**: All fixtures are validated against official gofish structs
+2. **Real BMC Capture**: Fixtures are derived from real BMC responses
+3. **Automated Validation**: CI runs validation tests on all fixtures
+4. **Vendor Testing**: Fixtures cover major BMC vendors (Dell, HPE, Lenovo)
+
+### Fixture Categories
+
+#### Power Response Fixtures
+
+- `dell_power_245w` - Dell iDRAC power response (245W consumption)
+- `hpe_power_189w` - HPE iLO power response (189.5W consumption)
+- `lenovo_power_167w` - Lenovo XCC power response (167.8W consumption)
+- `generic_power_200w` - Generic Redfish-compliant response (200W)
+- `zero_power` - Zero power consumption scenario
+- `empty_power_control` - Missing PowerControl array
+
+#### Infrastructure Fixtures
+
+- `service_root` - Redfish service root response
+- `chassis_collection` - Chassis collection response
+- `chassis` - Individual chassis response
+
+#### Error Fixtures
+
+- `error_not_found` - HTTP 404 resource not found
+- `error_auth_failed` - Authentication failure
+
+### Validation Process
+
+```bash
+# Run fixture validation tests
+go test ./internal/platform/redfish/testdata -v
+
+# Validate individual fixture
+go test -run TestIndividualFixtures/DellPower
+```
+
+### Capturing Real BMC Data
+
+For development purposes, you can capture real BMC responses:
+
+```bash
+# Build with manual tag to include real capture utilities
+go test -tags=manual ./internal/platform/redfish/testdata -run TestCapture
+```
+
+**Security Note**: Real capture utilities sanitize sensitive data (UUIDs, serial numbers, IPs) before creating fixtures.
+
+### Adding New Fixtures
+
+1. **From Real BMC**: Use `real_capture.go` utilities to capture authentic responses
+2. **Manual Creation**: Create JSON following Redfish schema patterns
+3. **Validation**: Ensure new fixtures pass `ValidateFixture()` tests
+4. **Testing**: Add test scenarios using the new fixture
+
+### Fixture Structure Guidelines
+
+#### Power Fixtures Must Include
+
+- `@odata.type`: Redfish Power schema type
+- `Id`: Resource identifier
+- `PowerControl`: Array with at least one power control object
+- `PowerConsumedWatts`: Current power consumption value
+
+#### Error Fixtures Must Include
+
+- `error`: Object with error details
+- `code`: Redfish error code
+- `message`: Human-readable error message
+
+### API Evolution Strategy
+
+When Redfish API changes:
+
+1. **Schema Updates**: Update gofish dependency to latest version
+2. **Fixture Migration**: Use validation tests to identify incompatible fixtures
+3. **Real Data Refresh**: Re-capture from updated BMCs when possible
+4. **Backward Compatibility**: Maintain old fixtures for testing legacy scenarios
+
+### Best Practices
+
+- **Minimal Fixtures**: Include only necessary fields for test scenarios
+- **Vendor Diversity**: Test against multiple BMC vendor formats
+- **Error Coverage**: Include various error conditions
+- **Real-World Data**: Base fixtures on actual BMC responses when possible
+- **Security**: Never include real credentials, serial numbers, or network details
+
+### Running Validation
+
+Validation is automatically run in CI, but you can run it locally:
+
+```bash
+# Validate all fixtures
+go test ./internal/platform/redfish/testdata -run TestFixtureValidation
+
+# Validate specific vendor fixtures
+go test ./internal/platform/redfish/testdata -run TestIndividualFixtures/Dell
+
+# Check for JSON syntax errors
+go test ./internal/platform/redfish/testdata -run TestErrorFixtures
+```
+
+### Integration with Gofish
+
+Our fixtures leverage gofish's approach:
+
+- **Struct Compatibility**: All fixtures validate against gofish structs
+- **Error Handling**: Use gofish's error response patterns
+- **Schema Compliance**: Follow DMTF Redfish schema standards
+- **Vendor Support**: Cover vendor-specific response variations
+
+This ensures our tests accurately represent real-world BMC behavior while maintaining reliability and maintainability.

--- a/internal/platform/redfish/testdata/fixtures/chassis.json
+++ b/internal/platform/redfish/testdata/fixtures/chassis.json
@@ -1,0 +1,12 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#Chassis.Chassis",
+  "@odata.type": "#Chassis.v1_10_0.Chassis",
+  "@odata.id": "/redfish/v1/Chassis/1",
+  "Id": "1",
+  "Name": "Computer System Chassis",
+  "ChassisType": "RackMount",
+  "PowerState": "On",
+  "Power": {
+    "@odata.id": "/redfish/v1/Chassis/1/Power"
+  }
+}

--- a/internal/platform/redfish/testdata/fixtures/chassis_collection.json
+++ b/internal/platform/redfish/testdata/fixtures/chassis_collection.json
@@ -1,0 +1,12 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#ChassisCollection.ChassisCollection",
+  "@odata.type": "#ChassisCollection.ChassisCollection",
+  "@odata.id": "/redfish/v1/Chassis",
+  "Name": "Chassis Collection",
+  "Members@odata.count": 1,
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/1"
+    }
+  ]
+}

--- a/internal/platform/redfish/testdata/fixtures/dell_power_245w.json
+++ b/internal/platform/redfish/testdata/fixtures/dell_power_245w.json
@@ -1,0 +1,22 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#Power.Power",
+  "@odata.type": "#Power.v1_5_0.Power",
+  "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Power",
+  "Id": "Power",
+  "Name": "Power",
+  "PowerControl": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Power#/PowerControl/0",
+      "Name": "System Power Control",
+      "PowerConsumedWatts": 245.0,
+      "PowerRequestedWatts": 295.0,
+      "PowerCapacityWatts": 750.0,
+      "PowerMetrics": {
+        "IntervalInMin": 60,
+        "MinConsumedWatts": 235.0,
+        "MaxConsumedWatts": 265.0,
+        "AverageConsumedWatts": 250.0
+      }
+    }
+  ]
+}

--- a/internal/platform/redfish/testdata/fixtures/empty_power_control.json
+++ b/internal/platform/redfish/testdata/fixtures/empty_power_control.json
@@ -1,0 +1,8 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#Power.Power",
+  "@odata.type": "#Power.v1_5_0.Power",
+  "@odata.id": "/redfish/v1/Chassis/1/Power",
+  "Id": "Power",
+  "Name": "Power",
+  "PowerControl": []
+}

--- a/internal/platform/redfish/testdata/fixtures/error_auth_failed.json
+++ b/internal/platform/redfish/testdata/fixtures/error_auth_failed.json
@@ -1,0 +1,14 @@
+{
+  "error": {
+    "code": "Base.1.0.GeneralError",
+    "message": "Authentication failed",
+    "@Message.ExtendedInfo": [
+      {
+        "MessageId": "Base.1.0.SessionLimitExceeded",
+        "Message": "The session establishment failed due to authentication failure.",
+        "Severity": "Critical",
+        "Resolution": "Log in with proper credentials."
+      }
+    ]
+  }
+}

--- a/internal/platform/redfish/testdata/fixtures/error_not_found.json
+++ b/internal/platform/redfish/testdata/fixtures/error_not_found.json
@@ -1,0 +1,14 @@
+{
+  "error": {
+    "code": "Base.1.0.ResourceNotFound",
+    "message": "The requested resource was not found.",
+    "@Message.ExtendedInfo": [
+      {
+        "MessageId": "Base.1.0.ResourceNotFound",
+        "Message": "The requested resource of type Power was not found.",
+        "Severity": "Critical",
+        "Resolution": "Check the URI and resubmit the request."
+      }
+    ]
+  }
+}

--- a/internal/platform/redfish/testdata/fixtures/generic_power_200w.json
+++ b/internal/platform/redfish/testdata/fixtures/generic_power_200w.json
@@ -1,0 +1,15 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#Power.Power",
+  "@odata.type": "#Power.v1_5_0.Power",
+  "@odata.id": "/redfish/v1/Chassis/System/Power",
+  "Id": "Power",
+  "Name": "Power",
+  "PowerControl": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/System/Power#/PowerControl/0",
+      "Name": "System Power Control",
+      "PowerConsumedWatts": 200.0,
+      "PowerCapacityWatts": 650.0
+    }
+  ]
+}

--- a/internal/platform/redfish/testdata/fixtures/generic_power_590w.json
+++ b/internal/platform/redfish/testdata/fixtures/generic_power_590w.json
@@ -1,0 +1,196 @@
+{
+  "@odata.id": "/redfish/v1/Chassis/1U/Power",
+  "Id": "Power",
+  "Name": "Power",
+  "@odata.context": "/redfish/v1/$metadata#Power.Power",
+  "@odata.type": "#Power.v1_1_0.Power",
+  "Description": "",
+  "IndicatorLED": "",
+  "PowerControl": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/1U/Power#/PowerControl/0",
+      "Id": "",
+      "Name": "Server Power Control",
+      "MemberId": "0",
+      "PhysicalContext": "",
+      "PowerAllocatedWatts": 800,
+      "PowerAvailableWatts": 0,
+      "PowerCapacityWatts": 800,
+      "PowerConsumedWatts": 590,
+      "PowerLimit": {
+        "CorrectionInMs": 50,
+        "LimitException": "LogEventOnly",
+        "LimitInWatts": 500
+      },
+      "PowerMetrics": {
+        "AverageConsumedWatts": 581,
+        "IntervalInMin": 30,
+        "MaxConsumedWatts": 600,
+        "MinConsumedWatts": 200
+      },
+      "PowerRequestedWatts": 800,
+      "Status": {
+        "Health": "OK",
+        "HealthRollup": "",
+        "State": "Enabled"
+      }
+    }
+  ],
+  "PowerControl@odata.count": 0,
+  "PowerSupplies": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/1U/Power#/PowerSupplies/0",
+      "Id": "",
+      "Name": "Power Supply Bay",
+      "EfficiencyPercent": 0,
+      "FirmwareVersion": "1.00",
+      "HotPluggable": false,
+      "IndicatorLED": "",
+      "InputRanges": [
+        {
+          "InputType": "AC",
+          "MaximumFrequencyHz": 0,
+          "MaximumVoltage": 120,
+          "MinimumFrequencyHz": 0,
+          "MinimumVoltage": 100,
+          "OutputWattage": 800
+        },
+        {
+          "InputType": "AC",
+          "MaximumFrequencyHz": 0,
+          "MaximumVoltage": 240,
+          "MinimumFrequencyHz": 0,
+          "MinimumVoltage": 200,
+          "OutputWattage": 1300
+        }
+      ],
+      "LastPowerOutputWatts": 590,
+      "LineInputVoltage": 120,
+      "LineInputVoltageType": "ACWideRange",
+      "Location": {
+        "AltitudeMeters": 0,
+        "Contacts": null,
+        "Info": "",
+        "InfoFormat": "",
+        "Latitude": 0,
+        "Longitude": 0,
+        "PartLocation": {
+          "LocationOrdinalValue": 0,
+          "LocationType": "",
+          "Orientation": "",
+          "Reference": "",
+          "ServiceLabel": ""
+        },
+        "Placement": {
+          "AdditionalInfo": "",
+          "Rack": "",
+          "RackOffset": 0,
+          "RackOffsetUnits": "",
+          "Row": ""
+        },
+        "PostalAddress": {
+          "AdditionalCode": "",
+          "AdditionalInfo": "",
+          "Building": "",
+          "City": "",
+          "Community": "",
+          "Country": "",
+          "District": "",
+          "Division": "",
+          "Floor": "",
+          "GPSCoords": "",
+          "HouseNumber": 0,
+          "HouseNumberSuffix": "",
+          "Landmark": "",
+          "LeadingStreetDirection": "",
+          "Location": "",
+          "Name": "",
+          "Neighborhood": "",
+          "POBox": "",
+          "PlaceType": "",
+          "PostalCode": "",
+          "Road": "",
+          "RoadBranch": "",
+          "RoadPostModifier": "",
+          "RoadPreModifier": "",
+          "RoadSection": "",
+          "RoadSubBranch": "",
+          "Room": "",
+          "Seat": "",
+          "Street": "",
+          "StreetSuffix": "",
+          "Territory": "",
+          "TrailingStreetSuffix": "",
+          "Unit": ""
+        }
+      },
+      "Manufacturer": "ManufacturerName",
+      "MemberId": "0",
+      "Model": "499253-B21",
+      "PartNumber": "0000001A3A",
+      "PowerCapacityWatts": 800,
+      "PowerInputWatts": 0,
+      "PowerOutputWatts": 0,
+      "PowerSupplyType": "AC",
+      "Redundancy": null,
+      "Redundancy@odata.count": 0,
+      "SerialNumber": "TEST-SERIAL-123456",
+      "SparePartNumber": "0000001A3A",
+      "Status": {
+        "Health": "Warning",
+        "HealthRollup": "",
+        "State": "Enabled"
+      }
+    }
+  ],
+  "PowerSupplies@odata.count": 0,
+  "Redundancy": null,
+  "Redundancy@odata.count": 0,
+  "Voltages": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/1U/Power#/Voltages/0",
+      "Id": "",
+      "Name": "VRM1 Voltage",
+      "LowerThresholdCritical": 11,
+      "LowerThresholdFatal": 10,
+      "LowerThresholdNonCritical": 11.5,
+      "MaxReadingRange": 20,
+      "MemberId": "0",
+      "MinReadingRange": 0,
+      "PhysicalContext": "VoltageRegulator",
+      "ReadingVolts": 12,
+      "SensorNumber": 11,
+      "Status": {
+        "Health": "OK",
+        "HealthRollup": "",
+        "State": "Enabled"
+      },
+      "UpperThresholdCritical": 13,
+      "UpperThresholdFatal": 15,
+      "UpperThresholdNonCritical": 12.5
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/1U/Power#/Voltages/1",
+      "Id": "",
+      "Name": "VRM2 Voltage",
+      "LowerThresholdCritical": 4.5,
+      "LowerThresholdFatal": 0,
+      "LowerThresholdNonCritical": 4.75,
+      "MaxReadingRange": 20,
+      "MemberId": "1",
+      "MinReadingRange": 0,
+      "PhysicalContext": "VoltageRegulator",
+      "ReadingVolts": 5,
+      "SensorNumber": 12,
+      "Status": {
+        "Health": "OK",
+        "HealthRollup": "",
+        "State": "Enabled"
+      },
+      "UpperThresholdCritical": 7,
+      "UpperThresholdFatal": 0,
+      "UpperThresholdNonCritical": 5.5
+    }
+  ],
+  "Voltages@odata.count": 0
+}

--- a/internal/platform/redfish/testdata/fixtures/hpe_power_189w.json
+++ b/internal/platform/redfish/testdata/fixtures/hpe_power_189w.json
@@ -1,0 +1,17 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#Power.Power",
+  "@odata.type": "#Power.v1_5_0.Power",
+  "@odata.id": "/redfish/v1/Chassis/1/Power",
+  "Id": "Power",
+  "Name": "Power",
+  "PowerControl": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/1/Power#/PowerControl/0",
+      "Name": "Server Power Control",
+      "PowerConsumedWatts": 189.5,
+      "PowerRequestedWatts": 214.5,
+      "PowerAvailableWatts": 800.0,
+      "PowerAllocatedWatts": 289.5
+    }
+  ]
+}

--- a/internal/platform/redfish/testdata/fixtures/lenovo_power_167w.json
+++ b/internal/platform/redfish/testdata/fixtures/lenovo_power_167w.json
@@ -1,0 +1,15 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#Power.Power",
+  "@odata.type": "#Power.v1_5_0.Power",
+  "@odata.id": "/redfish/v1/Chassis/1/Power",
+  "Id": "Power",
+  "Name": "Power",
+  "PowerControl": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/1/Power#/PowerControl/0",
+      "Name": "Node Power Control",
+      "PowerConsumedWatts": 167.8,
+      "PowerCapacityWatts": 550.0
+    }
+  ]
+}

--- a/internal/platform/redfish/testdata/fixtures/service_root.json
+++ b/internal/platform/redfish/testdata/fixtures/service_root.json
@@ -1,0 +1,12 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
+  "@odata.type": "#ServiceRoot.v1_5_0.ServiceRoot",
+  "@odata.id": "/redfish/v1/",
+  "Id": "RootService",
+  "Name": "Root Service",
+  "RedfishVersion": "1.6.1",
+  "UUID": "12345678-1234-1234-1234-123456789012",
+  "Chassis": {
+    "@odata.id": "/redfish/v1/Chassis"
+  }
+}

--- a/internal/platform/redfish/testdata/fixtures/zero_power.json
+++ b/internal/platform/redfish/testdata/fixtures/zero_power.json
@@ -1,0 +1,15 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#Power.Power",
+  "@odata.type": "#Power.v1_5_0.Power",
+  "@odata.id": "/redfish/v1/Chassis/1/Power",
+  "Id": "Power",
+  "Name": "Power",
+  "PowerControl": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/1/Power#/PowerControl/0",
+      "Name": "System Power Control",
+      "PowerConsumedWatts": 0.0,
+      "PowerCapacityWatts": 650.0
+    }
+  ]
+}

--- a/internal/platform/redfish/testdata/json_fixtures_test.go
+++ b/internal/platform/redfish/testdata/json_fixtures_test.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package testdata
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONFixtureLoading(t *testing.T) {
+	t.Run("LoadGeneric590W_FromJSON", func(t *testing.T) {
+		fixture := GetFixture("generic_power_590w")
+		assert.NotEmpty(t, fixture, "fixture should not be empty")
+
+		// Verify it's valid JSON
+		var powerData map[string]interface{}
+		err := json.Unmarshal([]byte(fixture), &powerData)
+		assert.NoError(t, err, "fixture should be valid JSON")
+		assert.NotEmpty(t, powerData, "parsed JSON should not be empty")
+
+		// Verify structure
+		assert.Equal(t, "Power", powerData["Id"])
+		assert.Equal(t, "Power", powerData["Name"])
+
+		// Check power value
+		powerControl, ok := powerData["PowerControl"].([]interface{})
+		require.True(t, ok, "PowerControl should be array")
+		require.Len(t, powerControl, 1, "Should have one PowerControl entry")
+
+		control, ok := powerControl[0].(map[string]interface{})
+		require.True(t, ok, "PowerControl[0] should be object")
+
+		powerConsumed, ok := control["PowerConsumedWatts"].(float64)
+		require.True(t, ok, "PowerConsumedWatts should be float64")
+		assert.Equal(t, 590.0, powerConsumed, "Power consumption should be 590W")
+	})
+
+	t.Run("GetFixtureFromJSON_Direct", func(t *testing.T) {
+		fixture, err := GetFixtureFromJSON("generic_power_590w")
+		assert.NoError(t, err, "should load JSON fixture successfully")
+		assert.NotEmpty(t, fixture, "fixture should not be empty")
+
+		// Verify it's valid JSON
+		var powerData map[string]interface{}
+		err = json.Unmarshal([]byte(fixture), &powerData)
+		assert.NoError(t, err, "fixture should be valid JSON")
+	})
+
+	t.Run("ListJSONFixtures", func(t *testing.T) {
+		fixtures, err := ListJSONFixtures()
+		assert.NoError(t, err, "should list fixtures successfully")
+		assert.NotEmpty(t, fixtures, "should have at least one fixture")
+		assert.Contains(t, fixtures, "generic_power_590w", "should contain our fixture")
+	})
+
+	t.Run("GetFixture_Fallback_To_Embedded", func(t *testing.T) {
+		// This should work for existing embedded fixtures
+		fixture := GetFixture("service_root")
+		assert.NotEmpty(t, fixture, "should fallback to embedded fixtures")
+
+		var data map[string]interface{}
+		err := json.Unmarshal([]byte(fixture), &data)
+		assert.NoError(t, err, "embedded fixture should be valid JSON")
+	})
+}
+
+func TestJSONFixtureErrors(t *testing.T) {
+	t.Run("GetFixtureFromJSON_NotFound", func(t *testing.T) {
+		_, err := GetFixtureFromJSON("nonexistent_fixture")
+		assert.Error(t, err, "should return error for missing fixture")
+	})
+
+	t.Run("GetFixture_NotFound", func(t *testing.T) {
+		assert.Panics(t, func() {
+			GetFixture("totally_nonexistent_fixture")
+		}, "should panic for missing fixture")
+	})
+}

--- a/internal/platform/redfish/testdata/power_responses.go
+++ b/internal/platform/redfish/testdata/power_responses.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package testdata
+
+import (
+	"embed"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+//go:embed fixtures/*.json
+var fixturesFS embed.FS
+
+// PowerResponseFixtures contains JSON fixtures for different power response scenarios
+// NOTE: Most fixtures are now loaded from JSON files in the fixtures/ directory.
+// This map serves as a fallback for backward compatibility.
+var PowerResponseFixtures = map[string]string{
+	// All fixtures have been migrated to JSON files in fixtures/ directory
+	// This map is kept for backward compatibility and will load from JSON files first
+}
+
+// GetFixture returns a fixture by name, loading from JSON files first, then fallback to embedded strings
+func GetFixture(name string) string {
+	// First try to load from JSON file
+	jsonFilename := name + ".json"
+	if data, err := fixturesFS.ReadFile(filepath.Join("fixtures", jsonFilename)); err == nil {
+		return string(data)
+	}
+
+	// Fallback to embedded string fixtures
+	fixture, exists := PowerResponseFixtures[name]
+	if !exists {
+		panic(fmt.Sprintf("fixture not found: %s (tried JSON file %s and embedded fixtures)", name, jsonFilename))
+	}
+	return fixture
+}
+
+// GetFixtureFromJSON loads a fixture directly from a JSON file
+func GetFixtureFromJSON(filename string) (string, error) {
+	if !strings.HasSuffix(filename, ".json") {
+		filename += ".json"
+	}
+
+	data, err := fixturesFS.ReadFile(filepath.Join("fixtures", filename))
+	if err != nil {
+		return "", fmt.Errorf("failed to load JSON fixture %s: %w", filename, err)
+	}
+
+	return string(data), nil
+}
+
+// ListJSONFixtures returns a list of available JSON fixture files
+func ListJSONFixtures() ([]string, error) {
+	entries, err := fixturesFS.ReadDir("fixtures")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read fixtures directory: %w", err)
+	}
+
+	var fixtures []string
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".json") {
+			// Return name without .json extension to match GetFixture convention
+			name := strings.TrimSuffix(entry.Name(), ".json")
+			fixtures = append(fixtures, name)
+		}
+	}
+
+	return fixtures, nil
+}

--- a/internal/platform/redfish/testdata/validation.go
+++ b/internal/platform/redfish/testdata/validation.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package testdata
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/stmcginnis/gofish/redfish"
+)
+
+// ValidateFixture validates a test fixture against gofish structs
+func ValidateFixture(fixtureName string) error {
+	fixture := GetFixture(fixtureName)
+
+	// Parse as generic JSON first
+	var jsonData map[string]interface{}
+	if err := json.Unmarshal([]byte(fixture), &jsonData); err != nil {
+		return fmt.Errorf("invalid JSON in fixture %s: %w", fixtureName, err)
+	}
+
+	// Check OData fields that are required for Redfish
+	if strings.Contains(fixtureName, "power") {
+		return validatePowerFixture(fixture)
+	}
+
+	if strings.Contains(fixtureName, "chassis") {
+		return validateChassisFixture(fixture)
+	}
+
+	return nil
+}
+
+// validatePowerFixture validates power-related fixtures
+func validatePowerFixture(fixture string) error {
+	var power redfish.Power
+	if err := json.Unmarshal([]byte(fixture), &power); err != nil {
+		return fmt.Errorf("power fixture doesn't match gofish Power struct: %w", err)
+	}
+
+	// Validate required fields
+	if power.ID == "" {
+		return fmt.Errorf("power fixture missing required ID field")
+	}
+
+	if power.ODataType == "" {
+		return fmt.Errorf("power fixture missing required @odata.type field")
+	}
+
+	// Validate PowerControl structure
+	if len(power.PowerControl) > 0 {
+		pc := power.PowerControl[0]
+		if pc.PowerConsumedWatts < 0 {
+			return fmt.Errorf("power fixture has negative PowerConsumedWatts")
+		}
+	}
+
+	return nil
+}
+
+// validateChassisFixture validates chassis-related fixtures
+func validateChassisFixture(fixture string) error {
+	// // For chassis collection
+	// if strings.Contains(fixture, "Collection") {
+	// 	var chassisCollection redfish.ChassisCollection
+	// 	if err := json.Unmarshal([]byte(fixture), &chassisCollection); err != nil {
+	// 		return fmt.Errorf("chassis collection fixture doesn't match gofish struct: %w", err)
+	// 	}
+	// 	return nil
+	// }
+	//
+	// // For individual chassis
+	// var chassis redfish.Chassis
+	// if err := json.Unmarshal([]byte(fixture), &chassis); err != nil {
+	// 	return fmt.Errorf("chassis fixture doesn't match gofish Chassis struct: %w", err)
+	// }
+
+	return nil
+}
+
+// CreateMockResponseFromRealBMC creates a fixture from a real BMC response
+// This would be used during development to capture real responses
+func CreateMockResponseFromRealBMC(endpoint, username, password string) (map[string]string, error) {
+	// This function would connect to a real BMC and capture responses
+	// to create validated fixtures. Implementation would:
+	// 1. Connect to real BMC
+	// 2. Fetch actual responses
+	// 3. Validate against gofish structs
+	// 4. Sanitize sensitive data
+	// 5. Return as fixture data
+
+	return nil, fmt.Errorf("not implemented - use this for capturing real BMC responses")
+}
+
+// ValidateAllFixtures validates all fixtures in the package
+func ValidateAllFixtures() []error {
+	var errors []error
+
+	for name := range PowerResponseFixtures {
+		if err := ValidateFixture(name); err != nil {
+			errors = append(errors, fmt.Errorf("fixture %s: %w", name, err))
+		}
+	}
+
+	return errors
+}

--- a/internal/platform/redfish/testdata/validation_test.go
+++ b/internal/platform/redfish/testdata/validation_test.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package testdata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFixtureValidation ensures all our test fixtures are valid
+func TestFixtureValidation(t *testing.T) {
+	errors := ValidateAllFixtures()
+
+	for _, err := range errors {
+		t.Errorf("Fixture validation failed: %v", err)
+	}
+
+	assert.Empty(t, errors, "All fixtures should be valid")
+}
+
+// TestIndividualFixtures tests each fixture type
+func TestIndividualFixtures(t *testing.T) {
+	tests := []struct {
+		name        string
+		fixtureName string
+	}{
+		{"ServiceRoot", "service_root"},
+		{"ChassisCollection", "chassis_collection"},
+		{"Chassis", "chassis"},
+		{"DellPower", "dell_power_245w"},
+		{"HPEPower", "hpe_power_189w"},
+		{"LenovoPower", "lenovo_power_167w"},
+		{"GenericPower", "generic_power_200w"},
+		{"ZeroPower", "zero_power"},
+		{"EmptyPowerControl", "empty_power_control"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateFixture(tt.fixtureName)
+			assert.NoError(t, err, "Fixture %s should be valid", tt.fixtureName)
+		})
+	}
+}
+
+// TestErrorFixtures ensures error fixtures are proper JSON
+func TestErrorFixtures(t *testing.T) {
+	errorFixtures := []string{
+		"error_not_found",
+		"error_auth_failed",
+	}
+
+	for _, fixtureName := range errorFixtures {
+		t.Run(fixtureName, func(t *testing.T) {
+			// Error fixtures should be valid JSON but won't match gofish structs
+			err := ValidateFixture(fixtureName)
+			// We expect validation to pass for JSON structure
+			assert.NoError(t, err, "Error fixture %s should have valid JSON", fixtureName)
+		})
+	}
+}

--- a/internal/platform/redfish/types.go
+++ b/internal/platform/redfish/types.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package redfish
+
+import (
+	"time"
+
+	"github.com/sustainable-computing-io/kepler/internal/device"
+)
+
+type (
+	Energy = device.Energy
+	Power  = device.Power
+)
+
+// Reading represents a single PowerControl entry measurement
+type Reading struct {
+	ControlID string // PowerControl MemberID
+	Name      string // PowerControl Name (optional)
+	Power     Power  // Current power consumption in watts
+}
+
+// Chassis represents a single chassis with its PowerControl readings
+type Chassis struct {
+	ID       string    // Chassis ID for identification
+	Readings []Reading // PowerControl readings from this chassis
+}
+
+// PowerReading represents a collection of chassis with their power measurements and a single timestamp
+type PowerReading struct {
+	Timestamp time.Time // When the readings were taken
+	Chassis   []Chassis // Chassis with their PowerControl readings
+}
+
+// Clone creates a deep copy of PowerReading for safe concurrent usage
+func (pr *PowerReading) Clone() *PowerReading {
+	if pr == nil {
+		return nil
+	}
+
+	// Copy all non-pointer fields at once (Timestamp)
+	ret := *pr
+
+	// Deep copy the chassis slice and their readings
+	ret.Chassis = make([]Chassis, len(pr.Chassis))
+	for i, chassis := range pr.Chassis {
+		ret.Chassis[i] = Chassis{
+			ID:       chassis.ID,
+			Readings: make([]Reading, len(chassis.Readings)),
+		}
+		// Deep copy the readings slice
+		copy(ret.Chassis[i].Readings, chassis.Readings)
+	}
+
+	return &ret
+}

--- a/internal/platform/redfish/types_test.go
+++ b/internal/platform/redfish/types_test.go
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package redfish
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/sustainable-computing-io/kepler/internal/device"
+)
+
+func TestPowerReadingCloneNil(t *testing.T) {
+	var pr *PowerReading = nil
+
+	result := pr.Clone()
+
+	assert.Nil(t, result)
+}
+
+func TestPowerReadingCloneSuccess(t *testing.T) {
+	timestamp := time.Now()
+	original := &PowerReading{
+		Timestamp: timestamp,
+		Chassis: []Chassis{
+			{
+				ID: "chassis-1",
+				Readings: []Reading{
+					{
+						ControlID: "PC1",
+						Name:      "Chassis 1 Power Control",
+						Power:     100.5 * device.Watt,
+					},
+				},
+			},
+			{
+				ID: "chassis-2",
+				Readings: []Reading{
+					{
+						ControlID: "PC1",
+						Name:      "Chassis 2 Power Control",
+						Power:     200.3 * device.Watt,
+					},
+				},
+			},
+		},
+	}
+
+	cloned := original.Clone()
+
+	// Verify cloned is not nil and is a different instance
+	assert.NotNil(t, cloned)
+	assert.NotSame(t, original, cloned)
+
+	// Verify timestamp is copied correctly
+	assert.Equal(t, timestamp, cloned.Timestamp)
+
+	// Verify chassis slice is copied correctly
+	assert.Len(t, cloned.Chassis, 2)
+	assert.Equal(t, original.Chassis[0].ID, cloned.Chassis[0].ID)
+	assert.Equal(t, original.Chassis[0].Readings[0].Power, cloned.Chassis[0].Readings[0].Power)
+	assert.Equal(t, original.Chassis[0].Readings[0].ControlID, cloned.Chassis[0].Readings[0].ControlID)
+	assert.Equal(t, original.Chassis[1].Readings[0].Power, cloned.Chassis[1].Readings[0].Power)
+	assert.Equal(t, original.Chassis[1].Readings[0].ControlID, cloned.Chassis[1].Readings[0].ControlID)
+
+	// Verify it's a deep copy - modifying original shouldn't affect clone
+	original.Chassis[0].Readings[0].Power = 999 * device.Watt
+	original.Chassis[0].Readings[0].ControlID = "modified"
+
+	assert.Equal(t, 100.5*device.Watt, cloned.Chassis[0].Readings[0].Power)
+	assert.Equal(t, "PC1", cloned.Chassis[0].Readings[0].ControlID)
+}
+
+func TestPowerReadingCloneEmpty(t *testing.T) {
+	timestamp := time.Now()
+	original := &PowerReading{
+		Timestamp: timestamp,
+		Chassis:   []Chassis{}, // empty slice
+	}
+
+	cloned := original.Clone()
+
+	// Verify cloned is not nil and is a different instance
+	assert.NotNil(t, cloned)
+	assert.NotSame(t, original, cloned)
+
+	// Verify timestamp is copied correctly
+	assert.Equal(t, timestamp, cloned.Timestamp)
+
+	// Verify empty chassis slice is handled correctly
+	assert.NotNil(t, cloned.Chassis)
+	assert.Len(t, cloned.Chassis, 0)
+}

--- a/manifests/helm/kepler/values.yaml
+++ b/manifests/helm/kepler/values.yaml
@@ -97,6 +97,14 @@ config:
     fake-cpu-meter:
       enabled: false
       zones: []
+  # EXPERIMENTAL FEATURES - These features are experimental and may be unstable
+  # and are disabled by default
+  experimental:
+    platform:
+      redfish:
+        enabled: false  # Enable experimental Redfish BMC power monitoring
+        configFile: /etc/kepler/redfish.yaml  # Path to Redfish BMC configuration file
+        nodeName: ""  # Node name to use (overrides Kubernetes node name and hostname fallback)
 
 # ServiceMonitor for Prometheus Operator
 serviceMonitor:

--- a/manifests/k8s/configmap.yaml
+++ b/manifests/k8s/configmap.yaml
@@ -43,3 +43,11 @@ data:
       fake-cpu-meter:
         enabled: false
         zones: []
+    # EXPERIMENTAL FEATURES - These features are experimental and may be unstable
+    # and are disabled by default
+    experimental:
+      platform:
+        redfish:
+          enabled: false  # Enable experimental Redfish BMC power monitoring
+          configFile: "/etc/kepler/redfish.yaml"  # Path to Redfish BMC configuration file
+          nodeName: ""  # Node name to use (overrides Kubernetes node name and hostname fallback)

--- a/manifests/k8s/configmap.yaml
+++ b/manifests/k8s/configmap.yaml
@@ -51,3 +51,4 @@ data:
           enabled: false  # Enable experimental Redfish BMC power monitoring
           configFile: "/etc/kepler/redfish.yaml"  # Path to Redfish BMC configuration file
           nodeName: ""  # Node name to use (overrides Kubernetes node name and hostname fallback)
+          httpTimeout: 5s  # HTTP client timeout for BMC requests (default: 5s)


### PR DESCRIPTION
This PR adds **experimental** Redfish support for collecting platform-level 
power metrics directly from BMC interfaces.

## Features

- **Multi-BMC Support**: Configure multiple BMCs with node-to-BMC mappings
- **Thread-Safe**: Concurrent access with caching (configurable staleness)
- **Robust Error Handling**: Graceful degradation when BMCs unavailable

## Metrics Exposed

```
kepler_platform_watts{source="redfish", node_name="worker-1", bmc="192.168.1.100", chassis_id="1", power_control_id="0",power_control_name="Server Power Control"} 275.0

```

## Configuration

### CLI Flags
```bash
--experimental.platform.redfish.enabled=true
--experimental.platform.redfish.config=/path/to/redfish-config.yaml
--experimental.platform.redfish.node-id=worker-node-1  # optional: auto-resolved
```

### BMC Config File
```yaml
nodes:
  worker-node-1: bmc-dell-r750
bmcs:
  bmc-dell-r750:
    endpoint: https://192.168.1.100
    username: admin
    password: secret123
    insecure: true
```


Addresses #2078 

### Verified 

* using BMC: 

```
$ http :28282/metrics | grep platform
# HELP kepler_platform_watts Current platform power consumption in watts from BMC
# TYPE kepler_platform_watts gauge
kepler_platform_watts{bmc="bmc",chassis_id="System.Embedded.1",node_name="dev",source="redfish"} 140
```

* Using Sushy - https://docs.openstack.org/sushy-tools/latest/


```text
kepler_platform_watts{bmc="hpe-bmc-01", chassis_id="1U", instance="host.docker.internal:28282", job="host", node_name="master", source="redfish"}
```

<img width="1674" height="1083" alt="image" src="https://github.com/user-attachments/assets/f1b81ba5-ba9a-406e-ba7c-ebfdb488505e" />
