### PR TITLE
ci: add workflow to profile Kepler versions

### DIFF
--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -1,0 +1,157 @@
+name: Profiling Report
+on:
+  pull_request_target:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  profiling:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Graphviz
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz
+
+      - name: Install Docker
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list
+          sudo apt-get update
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+          sudo usermod -aG docker $USER
+
+      - name: Verify Docker installation
+        shell: bash
+        run: |
+          docker ps
+          docker --version
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Install pprof
+        run: go install github.com/google/pprof@latest
+
+      - name: Enable fake cpu meter
+        shell: bash
+        run: |
+          sed -i '/fake-cpu-meter:/{n;s/enabled: false/enabled: true/}' \
+            compose/dev/kepler-dev/etc/kepler/config.yaml \
+            compose/dev/kepler-latest/etc/kepler/config.yaml
+
+      - name: Run Docker Compose services
+        shell: bash
+        working-directory: compose/dev
+        run: |
+          # Build and start kepler-dev and kepler-latest services in detach mode
+          docker compose up kepler-dev kepler-latest --build -d --wait --wait-timeout 300
+
+      - name: Run must gather
+        if: always()
+        shell: bash
+        working-directory: compose/dev
+        run: |
+          echo "::group::Get Docker ps output"
+          docker ps || true
+          echo "::endgroup::"
+
+          echo "::group::Get Docker compose ps output"
+          docker compose ps || true
+          echo "::endgroup::"
+
+          services=$(docker compose config --services)
+          for service in $services; do
+            echo "::group::Get logs for $service service"
+            docker compose logs $service || true
+            echo "::endgroup::"
+          done
+
+          echo "::group::Fetch metrics from kepler-dev service"
+          curl -s http://localhost:28283/metrics || true
+          echo "::endgroup::"
+
+          echo "::group::Fetch metrics from kepler-latest service"
+          curl -s http://localhost:28284/metrics || true
+          echo "::endgroup::"
+
+      - name: Sleeping for 10 seconds
+        shell: bash
+        run: |
+          sleep 10
+
+      - name: Capture CPU and Memory profiling for Kepler
+        run: |
+          # NOTE: Setting the duration to 60 seconds
+          ./hack/reports/profiling.sh capture --duration 60
+
+      - name: Compare profiling results
+        run: |
+          ./hack/reports/profiling.sh compare
+
+      - name: Upload profiling artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: profile-artifacts-${{ github.event.pull_request.number }}
+          path: ./tmp/*
+          retention-days: 5 # Keep artifact for 5 days
+
+  comment_on_pr:
+    runs-on: ubuntu-latest
+    needs: [profiling]
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Install pprof
+        run: go install github.com/google/pprof@latest
+
+      - name: Download profiling artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: profile-artifacts-${{ github.event.pull_request.number }}
+          path: ./tmp
+
+      - name: Generate comment messages
+        id: generate_message
+        run: |
+          {
+            echo "message<<EOF"
+            ./hack/reports/profiling.sh output
+            echo ""
+            echo "⬇️ Download the Profiling artifacts from the [Actions Summary page](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            echo ""
+            echo "📦 Artifact name: \`profile-artifacts-${{ github.event.pull_request.number }}\`"
+            echo ""
+            echo "🔧 Or use GitHub CLI to download artifacts:"
+            echo "\`\`\`bash"
+            echo "gh run download ${{ github.run_id }} -n profile-artifacts-${{ github.event.pull_request.number }}"
+            echo "\`\`\`"
+            echo ""
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Create PR Comment with report links
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: ${{ steps.generate_message.outputs.message }}
+          reactions: eyes, rocket

--- a/hack/reports/profiling.sh
+++ b/hack/reports/profiling.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+
+# config
+declare DURATION=${DURATION:-30}
+declare KEPLER_DEV_PORT=${KEPLER_DEV_PORT:-28283}
+declare KEPLER_LATEST_PORT=${KEPLER_LATEST_PORT:-28284}
+declare SHOW_HELP=false
+
+# constants
+declare -r PROJECT_ROOT
+declare -r TMP_DIR="$PROJECT_ROOT/tmp"
+declare -r CPU_PROFILE_DIR="$TMP_DIR/cpu-profile"
+declare -r MEM_PROFILE_DIR="$TMP_DIR/mem-profile"
+declare -r COMPARE_DIR="$TMP_DIR/compare"
+
+source "$PROJECT_ROOT/hack/utils.bash"
+
+validate() {
+	header "Validating"
+	command -v pprof >/dev/null 2>&1 || {
+		fail "No pprof command found in PATH"
+		info "Please install pprof"
+		cat <<-EOF
+			go install github.com/google/pprof@latest
+		EOF
+		# NOTE: do not proceed without pprof installed
+		return 1
+	}
+}
+
+parse_args() {
+	### while there are args parse them
+	while [[ -n "${1+xxx}" ]]; do
+		case $1 in
+		--help | -h)
+			shift
+			SHOW_HELP=true
+			return 0
+			;;
+		--dev-port)
+			shift
+			KEPLER_DEV_PORT="$1"
+			shift
+			;;
+		--latest-port)
+			shift
+			KEPLER_LATEST_PORT="$1"
+			shift
+			;;
+		--duration)
+			shift
+			DURATION="$1"
+			shift
+			;;
+		*) return 1 ;; # show usage on everything else
+		esac
+	done
+	return 0
+}
+
+print_usage() {
+	local scr
+	scr="$(basename "$0")"
+
+	read -r -d '' help <<-EOF_HELP || true
+		  🔆 Usage:
+			  $scr <command> [OPTIONS]
+			  $scr  -h | --help
+
+		    📋 Commands:
+		      capture        Captures CPU and Memory profile from the Kepler dev and latest compose services
+		      compare        Compares two profiles and prints out the top cumulative samples
+		      output         Generates formatted profiling report output for GitHub workflow
+
+		    💡 Examples:
+		      →  $scr capture --duration 30 --dev-port 28283 --latest-port 28284
+
+		      →  $scr compare
+
+		      →  $scr output
+
+			⚙️ Options:
+		      -h | --help             Show this help message
+		      --duration              Duration of the profiling session in seconds (default: 30)
+		      --dev-port              Port of the kepler dev compose service  (default: 28283)
+		      --latest-port           Port of the kepler latest compose service (default: 28284)
+	EOF_HELP
+
+	echo -e "$help"
+	return 0
+}
+
+profile_capture() {
+	header "Running CPU Profiling"
+	mkdir -p "$CPU_PROFILE_DIR"
+
+	local http_dev_status=0
+	local http_latest_status=0
+
+	http_dev_status=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$KEPLER_DEV_PORT/debug/pprof/")
+	http_latest_status=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$KEPLER_LATEST_PORT/debug/pprof/")
+
+	[[ $http_dev_status -ne 200 || $http_latest_status -ne 200 ]] && {
+		fail "Unable to connect to kepler-dev or kepler-latest compose service"
+		info "Make sure that kepler-dev and kepler-latest compose services are running"
+		return 1
+	}
+
+	run pprof -proto -seconds "$DURATION" \
+		-output "$CPU_PROFILE_DIR"/profile-dev.pb.gz \
+		"http://localhost:$KEPLER_DEV_PORT/debug/pprof/profile" &
+
+	run pprof -proto -seconds "$DURATION" \
+		-output "$CPU_PROFILE_DIR"/profile-latest.pb.gz \
+		"http://localhost:$KEPLER_LATEST_PORT/debug/pprof/profile" &
+
+	# NOTE: Simulate Prometheus scraping by querying metrics endpoints
+	# to capture realistic operational behavior during profiling
+	(
+		sleep 5
+		for i in {1..5}; do
+			info "Querying metric endpoints [$i/5]"
+			curl -s "http://localhost:$KEPLER_LATEST_PORT/metrics" >/dev/null &
+			curl -s "http://localhost:$KEPLER_DEV_PORT/metrics" >/dev/null &
+			wait
+			sleep 5
+			curl -s "http://localhost:$KEPLER_DEV_PORT/metrics" >/dev/null &
+			curl -s "http://localhost:$KEPLER_LATEST_PORT/metrics" >/dev/null &
+			wait
+			sleep 5
+		done
+	) &
+	wait
+
+	header "Running Memory Profiling"
+
+	mkdir -p "$MEM_PROFILE_DIR"
+
+	run pprof -proto -seconds "$DURATION" \
+		-output "$MEM_PROFILE_DIR"/profile-dev.pb.gz \
+		"http://localhost:$KEPLER_DEV_PORT/debug/pprof/heap" &
+
+	run pprof -proto -seconds "$DURATION" \
+		-output "$MEM_PROFILE_DIR"/profile-latest.pb.gz \
+		"http://localhost:$KEPLER_LATEST_PORT/debug/pprof/heap" &
+
+	# NOTE: Simulate Prometheus scraping by querying metrics endpoints to
+	# capture realistic operational behavior during profiling
+	(
+		sleep 5
+		for i in {1..5}; do
+			info "Querying metric endpoints [$i/5]"
+			curl -s "http://localhost:$KEPLER_LATEST_PORT/metrics" >/dev/null &
+			curl -s "http://localhost:$KEPLER_DEV_PORT/metrics" >/dev/null &
+			wait
+			sleep 5
+			curl -s "http://localhost:$KEPLER_DEV_PORT/metrics" >/dev/null &
+			curl -s "http://localhost:$KEPLER_LATEST_PORT/metrics" >/dev/null &
+			wait
+			sleep 5
+		done
+	) &
+	wait
+
+	return 0
+}
+
+profile_compare() {
+	header "Comparing CPU Profiles"
+
+	mkdir -p "$COMPARE_DIR"
+	info "Fetching top cumulative samples"
+	run pprof -top -cum -show "github.com/sustainable-computing-io" -base \
+		"$CPU_PROFILE_DIR"/profile-latest.pb.gz "$CPU_PROFILE_DIR"/profile-dev.pb.gz |
+		tee "$COMPARE_DIR/top-cpu.txt"
+
+	header "Comparing Memory Profiles"
+
+	info "Fetching top cumulative samples for inuse memory"
+	run pprof -top -cum -show "github.com/sustainable-computing-io" -base \
+		"$MEM_PROFILE_DIR"/profile-latest.pb.gz "$MEM_PROFILE_DIR"/profile-dev.pb.gz |
+		tee "$COMPARE_DIR/top-mem-inuse.txt"
+
+	info "Fetching top cumulative samples for alloc memory"
+	run pprof -top -cum -alloc_space -show "github.com/sustainable-computing-io" -base \
+		"$MEM_PROFILE_DIR"/profile-latest.pb.gz "$MEM_PROFILE_DIR"/profile-dev.pb.gz |
+		tee "$COMPARE_DIR/top-mem-alloc.txt"
+
+	return 0
+}
+
+profile_output() {
+	# NOTE: Generate the formatted message in Markdown format
+	echo "📊 Profiling reports are ready to be viewed"
+	echo ""
+	echo "⚠️ ***Variability in pprof CPU and Memory profiles***"
+	echo "***When comparing pprof profiles of Kepler versions, expect variability in CPU and memory. Focus only on significant, consistent differences.***"
+	echo ""
+
+	# CPU Comparison section
+	echo "<details>"
+	echo "<summary>💻 CPU Comparison with base Kepler</summary>"
+	echo ""
+	echo "\`\`\`"
+	if [[ -f "$COMPARE_DIR/top-cpu.txt" ]]; then
+		cat "$COMPARE_DIR/top-cpu.txt"
+	else
+		echo "❌ CPU comparison data not available"
+	fi
+	echo "\`\`\`"
+	echo "</details>"
+	echo ""
+
+	# Memory Comparison (Inuse) section
+	echo "<details>"
+	echo "<summary>💾 Memory Comparison with base Kepler (Inuse)</summary>"
+	echo ""
+	echo "\`\`\`"
+	if [[ -f "$COMPARE_DIR/top-mem-inuse.txt" ]]; then
+		cat "$COMPARE_DIR/top-mem-inuse.txt"
+	else
+		echo "❌ Memory comparison data not available"
+	fi
+	echo "\`\`\`"
+	echo "</details>"
+	echo ""
+
+	# Memory Comparison (Alloc) section
+	echo "<details>"
+	echo "<summary>💾 Memory Comparison with base Kepler (Alloc)</summary>"
+	echo ""
+	echo "\`\`\`"
+	if [[ -f "$COMPARE_DIR/top-mem-alloc.txt" ]]; then
+		cat "$COMPARE_DIR/top-mem-alloc.txt"
+	else
+		echo "❌ Memory comparison data not available"
+	fi
+	echo "\`\`\`"
+	echo "</details>"
+	echo ""
+
+	return 0
+}
+
+main() {
+	local fn=${1:-''}
+	shift
+
+	parse_args "$@" || die "failed to parse args"
+
+	$SHOW_HELP && {
+		print_usage
+		exit 0
+	}
+
+	cd "$PROJECT_ROOT"
+
+	local cmd_fn="profile_$fn"
+	if ! is_fn "$cmd_fn"; then
+		fail "unknown command: $fn"
+		print_usage
+		return 1
+	fi
+
+	validate || return 1
+
+	$cmd_fn "$@" || return 1
+
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
This commit adds a workflow and script to profile `kepler-dev` and `kepler-latest` using Docker compose

The script requires both services to be active, captures CPU/Memory profiles, compare then and generate top cumulative diff. The workflow uses this to comment on the PR.

Steps include:
1. Deploy kepler-dev and kepler-latest via Docker compose
2. Use fake CPU power meter (runs on VM; BM machine post-merge)
3. Run profiling script to collect profiling data
4. Compare CPU/Memory profiles and generate PR comment