### PR TITLE
docs: keep the formatting for tables consistent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,18 @@ default_install_hook_types:
   - pre-commit
   - commit-msg
 repos:
-  # This hook lints commit messages within a specified range, ideal for validating all commits in a PR.
+  # NOTE: This hook formats the tables in markdown files ensuring consistent formatting
+  - repo: local
+    hooks:
+      - id: markdown-table-format
+        name: markdown-table-format
+        language: node
+        additional_dependencies:
+          - markdown-table-formatter
+        pass_filenames: false
+        entry: bash -c "markdown-table-formatter"
+
+  # NOTE: This hook lints commit messages within a specified range, ideal for validating all commits in a PR.
   # Environment variables $FROM (start of range) and $TO (end of range) are set in PR Checks workflow.
   - repo: local
     hooks:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -39,10 +39,10 @@ support, and collaboration.
 
 Active maintainer will be reviewed on a 6-month cycle.
 
-| **Cycle** | **Active Period**         | **Nomination / Review Period**       |
-|-----------|---------------------------|--------------------------------------|
-| **Fall**  | October 1 – March 31      | August 1 – September 30              |
-| **Spring**| April 1 – September 30    | February 1 – March 31                |
+| **Cycle**  | **Active Period**      | **Nomination / Review Period** |
+|------------|------------------------|--------------------------------|
+| **Fall**   | October 1 – March 31   | August 1 – September 30        |
+| **Spring** | April 1 – September 30 | February 1 – March 31          |
 
 - Active maintainers are expected to maintain engagement during each cycle by providing tangible contributions in accordance with the [Active Engagement Expectations](#active-engagement-expectations).
 - A designated person responsible for maintaining the maintainer list will create an issue during each review period to propose changes based on observed activity. This issue will remain open throughout the window, giving maintainers the opportunity to review and confirm their status.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,34 +1,30 @@
 # Maintainers
 
-<!-- markdownlint-disable  MD013 -->
-<!-- Teporarily disable MD013 - Line length to keep the table formatting  -->
-
 (As of August, 18, 2025) <!-- For every PR that modifies this file, please update the PR creation date here accordingly -->
 
-| Name                  | Company    | Github ID      | Email                            | Role              | Last sign up |
-| --------------------- | ---------- | -------------- | -------------------------------- | ----------------- | ------------ |
-| Sunil Thaha           | Red Hat    | sthaha         | <sthaha@redhat.com>              | Project Lead      | 16/07/2025   |
-| Huamin Chen           | Red Hat    | rootfs         | <hchen@redhat.com>               |                   |              |
-| Ji Chen               | IBM        | jichenjc       | <jichenjc@cn.ibm.com>            |                   |              |
-| Parul Singh           | Red Hat    | husky-parul    | <parsingh@redhat.com>            |                   |              |
-| Kaiyi Liu             | Red Hat    | KaiyiLiu1234   | <kaliu@redhat.com>               |                   |              |
-| Peng Hui Jiang        | IBM        | jiangphcn      | <jiangph@cn.ibm.com>             |                   |              |
-| William Caban         | Red Hat    | williamcaban   | <wcabanba@redhat.com>            |                   |              |
-| Yi Yuan               |         | SamYuan1990    | <yy19902439@126.com>             |    Community Engagement   |01/08/2025              |
-| Qi Feng Huo           | IBM        | huoqifeng      | <huoqif@cn.ibm.com>              |                   |              |
-| Ken Lu                | Intel      | kenplusplus    | <ken.lu@intel.com>               |                   |              |
-| Marcelo Amaral        | IBM        | marceloamaral  | <marcelo.amaral1@ibm.com>        |                   |              |
-| Niki Manoledaki       | Grafana Labs | nikimanoledaki | <niki.manoledaki@grafana.com>  |                   |              |
-| Brad McCoy            | Basiq      | bradmccoydev   | <bradmccoydev@gmail.com>         |                   |              |
-| Sunyanan Choochotkaew | IBM        | sunya-ch       | <sunyanan.choochotkaew1@ibm.com> | Community Engagement|01/08/2025  |
-| Ruomeng Hao           | Intel      | ruomengh       | <ruomengh@intel.com>             |                   |              |
-| Chen Wang             | IBM        | wangchen615    | <chen.wang1@ibm.com>             |                   |              |
-| Jie Ren               | Intel      | jiere          | <jie.ren@intel.com>              |                   |              |
-| Vibhu Prashar         | Red Hat    | vprashar2929   | <vibhu.sharma2929@gmail.com>     | Maintainer        |              |
-| Vimal Kumar           | Red Hat    | vimalk78       | <vimal78@gmail.com>              |                   |              |
-| Dave Tucker           | Red Hat    | dave-tucker    | <datucker@redhat.com>            |                   |              |
-| Maryam Tahhan         | Red Hat    | maryamtahhan   | <mtahhan@redhat.com>             |                   |              |
-<!-- markdownlint-enable  MD013 -->
+| Name                  | Company      | Github ID      | Email                            | Role                 | Last sign up |
+|-----------------------|--------------|----------------|----------------------------------|----------------------|--------------|
+| Sunil Thaha           | Red Hat      | sthaha         | <sthaha@redhat.com>              | Project Lead         | 16/07/2025   |
+| Huamin Chen           | Red Hat      | rootfs         | <hchen@redhat.com>               |                      |              |
+| Ji Chen               | IBM          | jichenjc       | <jichenjc@cn.ibm.com>            |                      |              |
+| Parul Singh           | Red Hat      | husky-parul    | <parsingh@redhat.com>            |                      |              |
+| Kaiyi Liu             | Red Hat      | KaiyiLiu1234   | <kaliu@redhat.com>               |                      |              |
+| Peng Hui Jiang        | IBM          | jiangphcn      | <jiangph@cn.ibm.com>             |                      |              |
+| William Caban         | Red Hat      | williamcaban   | <wcabanba@redhat.com>            |                      |              |
+| Yi Yuan               |              | SamYuan1990    | <yy19902439@126.com>             | Community Engagement | 01/08/2025   |
+| Qi Feng Huo           | IBM          | huoqifeng      | <huoqif@cn.ibm.com>              |                      |              |
+| Ken Lu                | Intel        | kenplusplus    | <ken.lu@intel.com>               |                      |              |
+| Marcelo Amaral        | IBM          | marceloamaral  | <marcelo.amaral1@ibm.com>        |                      |              |
+| Niki Manoledaki       | Grafana Labs | nikimanoledaki | <niki.manoledaki@grafana.com>    |                      |              |
+| Brad McCoy            | Basiq        | bradmccoydev   | <bradmccoydev@gmail.com>         |                      |              |
+| Sunyanan Choochotkaew | IBM          | sunya-ch       | <sunyanan.choochotkaew1@ibm.com> | Community Engagement | 01/08/2025   |
+| Ruomeng Hao           | Intel        | ruomengh       | <ruomengh@intel.com>             |                      |              |
+| Chen Wang             | IBM          | wangchen615    | <chen.wang1@ibm.com>             |                      |              |
+| Jie Ren               | Intel        | jiere          | <jie.ren@intel.com>              |                      |              |
+| Vibhu Prashar         | Red Hat      | vprashar2929   | <vibhu.sharma2929@gmail.com>     | Maintainer           | 18/08/2025   |
+| Vimal Kumar           | Red Hat      | vimalk78       | <vimal78@gmail.com>              |                      |              |
+| Dave Tucker           | Red Hat      | dave-tucker    | <datucker@redhat.com>            |                      |              |
+| Maryam Tahhan         | Red Hat      | maryamtahhan   | <mtahhan@redhat.com>             |                      |              |
 
 This list must be kept in sync with the
 [CNCF Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv).

--- a/docs/developer/design/architecture/concurrency.md
+++ b/docs/developer/design/architecture/concurrency.md
@@ -12,14 +12,14 @@ Kepler's architecture ensures that concurrent access never produces different re
 
 ### Component-Level Thread Safety
 
-| Component | Thread Safety | Access Pattern | Notes |
-|-----------|---------------|----------------|-------|
-| **PowerMonitor** (public methods) | ✅ Thread-safe | Multiple readers, single writer | Except `Init()` |
-| **Device Layer** | ❌ Not required | Single goroutine access | Called only from monitor |
-| **Resource Layer** | ❌ Not required | Single goroutine access | Called only from monitor |
-| **Snapshot** | ✅ Immutable | Multiple readers | Copy-on-write semantics |
-| **Exporters** | ✅ Thread-safe | Multiple concurrent exports | Independent collection |
-| **Service Framework** | ✅ Thread-safe | Concurrent lifecycle management | Coordinated shutdown |
+| Component                         | Thread Safety  | Access Pattern                  | Notes                    |
+|-----------------------------------|----------------|---------------------------------|--------------------------|
+| **PowerMonitor** (public methods) | ✅ Thread-safe  | Multiple readers, single writer | Except `Init()`          |
+| **Device Layer**                  | ❌ Not required | Single goroutine access         | Called only from monitor |
+| **Resource Layer**                | ❌ Not required | Single goroutine access         | Called only from monitor |
+| **Snapshot**                      | ✅ Immutable    | Multiple readers                | Copy-on-write semantics  |
+| **Exporters**                     | ✅ Thread-safe  | Multiple concurrent exports     | Independent collection   |
+| **Service Framework**             | ✅ Thread-safe  | Concurrent lifecycle management | Coordinated shutdown     |
 
 ### PowerMonitor Thread Safety
 

--- a/docs/developer/design/architecture/data-flow.md
+++ b/docs/developer/design/architecture/data-flow.md
@@ -77,13 +77,13 @@ func calculateEnergyDelta(current, previous, maxEnergy Energy) Energy {
 
 ### Energy Zone Types
 
-| Zone | Description | Coverage | Priority |
-|------|-------------|----------|----------|
-| **psys** | Platform system energy | CPU + Memory + I/O | Highest |
-| **package** | CPU package energy | Cores + Uncore + Cache | High |
-| **core** | CPU cores only | Processing units | Medium |
-| **dram** | Memory energy | System memory | Medium |
-| **uncore** | Uncore energy | Cache, memory controller | Low |
+| Zone        | Description            | Coverage                 | Priority |
+|-------------|------------------------|--------------------------|----------|
+| **psys**    | Platform system energy | CPU + Memory + I/O       | Highest  |
+| **package** | CPU package energy     | Cores + Uncore + Cache   | High     |
+| **core**    | CPU cores only         | Processing units         | Medium   |
+| **dram**    | Memory energy          | System memory            | Medium   |
+| **uncore**  | Uncore energy          | Cache, memory controller | Low      |
 
 ## Phase 2: Node Energy Breakdown
 

--- a/docs/developer/design/architecture/index.md
+++ b/docs/developer/design/architecture/index.md
@@ -19,19 +19,19 @@ This section provides comprehensive documentation of Kepler's architecture, desi
 
 ### Core Architecture
 
-| Document | Description |
-|----------|-------------|
-| **[Design Principles](principles.md)** | The fundamental principles that drive all architectural decisions |
-| **[System Components](components.md)** | Deep dive into each architectural layer and component |
-| **[Data Flow & Attribution](data-flow.md)** | Power attribution algorithm and data flow patterns |
-| **[Concurrency & Thread Safety](concurrency.md)** | Thread safety guarantees and concurrent processing |
+| Document                                          | Description                                                       |
+|---------------------------------------------------|-------------------------------------------------------------------|
+| **[Design Principles](principles.md)**            | The fundamental principles that drive all architectural decisions |
+| **[System Components](components.md)**            | Deep dive into each architectural layer and component             |
+| **[Data Flow & Attribution](data-flow.md)**       | Power attribution algorithm and data flow patterns                |
+| **[Concurrency & Thread Safety](concurrency.md)** | Thread safety guarantees and concurrent processing                |
 
 ### Implementation Details
 
-| Document | Description |
-|----------|-------------|
-| **[Interfaces & Contracts](interfaces.md)** | Key interfaces, service contracts, and API boundaries |
-| **[Configuration System](configuration.md)** | Hierarchical configuration and option management |
+| Document                                     | Description                                           |
+|----------------------------------------------|-------------------------------------------------------|
+| **[Interfaces & Contracts](interfaces.md)**  | Key interfaces, service contracts, and API boundaries |
+| **[Configuration System](configuration.md)** | Hierarchical configuration and option management      |
 
 ## Quick Reference
 

--- a/docs/developer/design/architecture/principles.md
+++ b/docs/developer/design/architecture/principles.md
@@ -181,14 +181,14 @@ go test -race ./...
 
 ### Well-Maintained Dependencies
 
-| Area | Package | Benefit |
-|------|---------|---------|
-| Service Management | `oklog/run` | Coordinated lifecycle management |
-| Metrics | `prometheus/client_golang` | Standard Prometheus exposition |
-| Concurrency | `golang.org/x/sync/singleflight` | Proven deduplication patterns |
-| Kubernetes | `k8s.io/client-go` | Native Kubernetes API integration |
-| Configuration | `alecthomas/kingpin/v2` | Battle-tested CLI parsing |
-| Logging | `log/slog` | Standard structured logging |
+| Area               | Package                          | Benefit                           |
+|--------------------|----------------------------------|-----------------------------------|
+| Service Management | `oklog/run`                      | Coordinated lifecycle management  |
+| Metrics            | `prometheus/client_golang`       | Standard Prometheus exposition    |
+| Concurrency        | `golang.org/x/sync/singleflight` | Proven deduplication patterns     |
+| Kubernetes         | `k8s.io/client-go`               | Native Kubernetes API integration |
+| Configuration      | `alecthomas/kingpin/v2`          | Battle-tested CLI parsing         |
+| Logging            | `log/slog`                       | Standard structured logging       |
 
 ### Package Reuse Benefits
 
@@ -223,13 +223,13 @@ exporter:
 
 ### Current Support Matrix
 
-| Level | Status | Metrics | Benefits |
-|-------|--------|---------|----------|
-| **Node** | ✅ | `kepler_node_cpu_watts{zone="package"}` | System-level monitoring |
-| **Process** | 🔄 | `kepler_process_cpu_watts{pid="1234"}` | Fine-grained analysis |
-| **Container** | 🔄 | `kepler_container_cpu_watts{id="abc123"}` | Container-level billing |
-| **VM** | 🔄 | `kepler_vm_cpu_watts{id="vm-123"}` | Virtualization monitoring |
-| **Pod** | ✅ | `kepler_pod_cpu_watts{pod="webapp"}` | Kubernetes workload monitoring |
+| Level         | Status | Metrics                                   | Benefits                       |
+|---------------|--------|-------------------------------------------|--------------------------------|
+| **Node**      | ✅      | `kepler_node_cpu_watts{zone="package"}`   | System-level monitoring        |
+| **Process**   | 🔄     | `kepler_process_cpu_watts{pid="1234"}`    | Fine-grained analysis          |
+| **Container** | 🔄     | `kepler_container_cpu_watts{id="abc123"}` | Container-level billing        |
+| **VM**        | 🔄     | `kepler_vm_cpu_watts{id="vm-123"}`        | Virtualization monitoring      |
+| **Pod**       | ✅      | `kepler_pod_cpu_watts{pod="webapp"}`      | Kubernetes workload monitoring |
 
 ### Configuration Benefits
 
@@ -270,11 +270,11 @@ type Informer interface {
 
 ### Current and Future Implementations
 
-| Layer | Current | Future | Abstraction Benefit |
-|-------|---------|--------|-------------------|
-| **Hardware** | RAPL sysfs | eBPF perf counters | Pluggable energy sources |
-| **Resource Tracking** | procfs reader | eBPF tracer | Different collection methods |
-| **Export** | Prometheus, stdout | OpenTelemetry | Multiple presentation formats |
+| Layer                 | Current            | Future             | Abstraction Benefit           |
+|-----------------------|--------------------|--------------------|-------------------------------|
+| **Hardware**          | RAPL sysfs         | eBPF perf counters | Pluggable energy sources      |
+| **Resource Tracking** | procfs reader      | eBPF tracer        | Different collection methods  |
+| **Export**            | Prometheus, stdout | OpenTelemetry      | Multiple presentation formats |
 
 ### Design Benefits
 
@@ -322,17 +322,17 @@ kepler --config=production.yaml --log.level=debug --monitor.interval=5s
 
 These principles directly influenced major architectural decisions:
 
-| Principle | Architectural Impact | Implementation |
-|-----------|---------------------|----------------|
-| Fair Allocation | Terminated workload tracking system | `TerminatedResourceTracker` with priority queues |
-| Mathematical Integrity | Atomic snapshots + energy conservation | Immutable `Snapshot` with validation |
-| M/V Separation | PowerDataProvider interface + pluggable exporters | Interface-based exporter system |
-| Data Freshness | Staleness control + singleflight pattern | `isFresh()` checks + automatic refresh |
-| Deterministic Processing | Thread-safe design + immutable snapshots | Single writer, multiple readers |
-| Package Reuse | Minimal custom implementations + proven libraries | Strategic dependency selection |
-| Configurable Exposure | Metrics level system + zone filtering | `config.Level` + filtering logic |
-| Implementation Abstraction | Interface-based layers + dependency injection | Clean interface boundaries |
-| Simple Configuration | Hierarchical config + CLI/YAML sync | `kingpin` + YAML parsing |
+| Principle                  | Architectural Impact                              | Implementation                                   |
+|----------------------------|---------------------------------------------------|--------------------------------------------------|
+| Fair Allocation            | Terminated workload tracking system               | `TerminatedResourceTracker` with priority queues |
+| Mathematical Integrity     | Atomic snapshots + energy conservation            | Immutable `Snapshot` with validation             |
+| M/V Separation             | PowerDataProvider interface + pluggable exporters | Interface-based exporter system                  |
+| Data Freshness             | Staleness control + singleflight pattern          | `isFresh()` checks + automatic refresh           |
+| Deterministic Processing   | Thread-safe design + immutable snapshots          | Single writer, multiple readers                  |
+| Package Reuse              | Minimal custom implementations + proven libraries | Strategic dependency selection                   |
+| Configurable Exposure      | Metrics level system + zone filtering             | `config.Level` + filtering logic                 |
+| Implementation Abstraction | Interface-based layers + dependency injection     | Clean interface boundaries                       |
+| Simple Configuration       | Hierarchical config + CLI/YAML sync               | `kingpin` + YAML parsing                         |
 
 ---
 

--- a/docs/developer/proposal/index.md
+++ b/docs/developer/proposal/index.md
@@ -4,10 +4,10 @@ This directory contains Enhancement Proposals (EPs) for major features and chang
 
 ## Active Proposals
 
-| ID | Title | Status | Author | Created |
-|----|-------|--------|--------|---------|
-| [EP-000](EP_TEMPLATE.md) | Enhancement Proposal Template | Accepted | Sunil Thaha | 2025-01-18 |
-| [EP-002](EP-002-MSR-Fallback-Power-Meter.md) | MSR Fallback for CPU Power Meter | Draft | Kepler Development Team | 2025-08-12 |
+| ID                                           | Title                            | Status   | Author                  | Created    |
+|----------------------------------------------|----------------------------------|----------|-------------------------|------------|
+| [EP-000](EP_TEMPLATE.md)                     | Enhancement Proposal Template    | Accepted | Sunil Thaha             | 2025-01-18 |
+| [EP-002](EP-002-MSR-Fallback-Power-Meter.md) | MSR Fallback for CPU Power Meter | Draft    | Kepler Development Team | 2025-08-12 |
 
 ## Proposal Status
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -15,24 +15,24 @@ Kepler supports two primary methods for configuration:
 
 You can configure Kepler by passing flags when starting the service. The following flags are available:
 
-| Flag | Description | Default | Values |
-|------|-------------|---------|--------|
-| `--config.file` | Path to YAML configuration file | | Any valid file path |
-| `--log.level` | Logging level | `info` | `debug`, `info`, `warn`, `error` |
-| `--log.format` | Output format for logs | `text` | `text`, `json` |
-| `--host.sysfs` | Path to sysfs filesystem | `/sys` | Any valid directory path |
-| `--host.procfs` | Path to procfs filesystem | `/proc` | Any valid directory path |
-| `--monitor.interval` | Monitor refresh interval | `5s` | Any valid duration |
-| `--monitor.max-terminated` | Maximum number of terminated workloads to keep in memory until exported | `500` | Negative number indicates `unlimited` and `0` disables the feature |
-| `--web.config-file` | Path to TLS server config file | `""` | Any valid file path |
-| `--web.listen-address` | Web server listen addresses (can be specified multiple times) | `:28282` | Any valid host:port or :port format |
-| `--debug.pprof` | Enable pprof debugging endpoints | `false` | `true`, `false` |
-| `--exporter.stdout` | Enable stdout exporter | `false` | `true`, `false` |
-| `--exporter.prometheus` | Enable Prometheus exporter | `true` | `true`, `false` |
-| `--metrics` | Metrics levels to export (can be specified multiple times) | `node,process,container,vm,pod` | `node`, `process`, `container`, `vm`, `pod` |
-| `--kube.enable` | Monitor kubernetes | `false` | `true`, `false` |
-| `--kube.config` | Path to a kubeconfig file | `""` | Any valid file path |
-| `--kube.node-name` | Name of kubernetes node on which kepler is running | `""` | Any valid node name |
+| Flag                       | Description                                                             | Default                         | Values                                                             |
+|----------------------------|-------------------------------------------------------------------------|---------------------------------|--------------------------------------------------------------------|
+| `--config.file`            | Path to YAML configuration file                                         |                                 | Any valid file path                                                |
+| `--log.level`              | Logging level                                                           | `info`                          | `debug`, `info`, `warn`, `error`                                   |
+| `--log.format`             | Output format for logs                                                  | `text`                          | `text`, `json`                                                     |
+| `--host.sysfs`             | Path to sysfs filesystem                                                | `/sys`                          | Any valid directory path                                           |
+| `--host.procfs`            | Path to procfs filesystem                                               | `/proc`                         | Any valid directory path                                           |
+| `--monitor.interval`       | Monitor refresh interval                                                | `5s`                            | Any valid duration                                                 |
+| `--monitor.max-terminated` | Maximum number of terminated workloads to keep in memory until exported | `500`                           | Negative number indicates `unlimited` and `0` disables the feature |
+| `--web.config-file`        | Path to TLS server config file                                          | `""`                            | Any valid file path                                                |
+| `--web.listen-address`     | Web server listen addresses (can be specified multiple times)           | `:28282`                        | Any valid host:port or :port format                                |
+| `--debug.pprof`            | Enable pprof debugging endpoints                                        | `false`                         | `true`, `false`                                                    |
+| `--exporter.stdout`        | Enable stdout exporter                                                  | `false`                         | `true`, `false`                                                    |
+| `--exporter.prometheus`    | Enable Prometheus exporter                                              | `true`                          | `true`, `false`                                                    |
+| `--metrics`                | Metrics levels to export (can be specified multiple times)              | `node,process,container,vm,pod` | `node`, `process`, `container`, `vm`, `pod`                        |
+| `--kube.enable`            | Monitor kubernetes                                                      | `false`                         | `true`, `false`                                                    |
+| `--kube.config`            | Path to a kubeconfig file                                               | `""`                            | Any valid file path                                                |
+| `--kube.node-name`         | Name of kubernetes node on which kepler is running                      | `""`                            | Any valid node name                                                |
 
 ### 💡 Examples
 


### PR DESCRIPTION
This commit adds a new precommit hook which runs the formatter on the tables in the markdown files. This ensures that the tables are formatted consistently.