### PR TITLE
ci: ensure profiling job only runs on source code changes

### DIFF
--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -3,7 +3,26 @@ on:
   pull_request:
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      changes: ${{ steps.filter.outputs.changes }}
+    steps:
+      - name: checkout source
+        uses: actions/checkout@v5
+
+      - name: filter changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            changes:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
   profiling:
+    needs: check-changes
+    if: needs.check-changes.outputs.changes == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Install Graphviz
@@ -106,8 +125,9 @@ jobs:
           retention-days: 5 # Keep artifact for 5 days
 
   generate-comment-message:
+    needs: profiling
+    if: needs.profiling.outcome == 'success'
     runs-on: ubuntu-latest
-    needs: [profiling]
     steps:
       - name: Checkout source
         uses: actions/checkout@v4


### PR DESCRIPTION
This commit ensures that the profiling job only runs on source code changes only.