### PR TITLE
ci: extract pr-number from the artifact

### DIFF
--- a/.github/workflows/config-change.yaml
+++ b/.github/workflows/config-change.yaml
@@ -69,7 +69,7 @@ jobs:
               echo "- manifests/helm/kepler/values.yaml"
             fi
             echo "EOF"
-          } > /tmp/message.txt
+          } > /tmp/message-${{ github.event.pull_request.number }}.txt
 
       # NOTE: Uploading the message as an artifact so that PR Comment workflow can use it to
       # add comment on PR with the message.
@@ -77,5 +77,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: message
-          path: /tmp/message.txt
+          path: /tmp/message-${{ github.event.pull_request.number }}.txt
           retention-days: 1 # Keep artifact for 1 days

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -32,11 +32,18 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Comment on PR
+      - name: Extract PR number from filename
         if: steps.download-artifact.outcome == 'success'
+        id: extract-pr
+        run: |
+          echo "message-file=$(ls /tmp/message*.txt)" >> $GITHUB_OUTPUT
+          echo "pr-number=$(echo /tmp/message*.txt | sed -E 's/.*message-([0-9]+)\.txt/\1/')" >> $GITHUB_OUTPUT
+
+      - name: Comment on PR
+        if: steps.download-artifact.outcome == 'success' && steps.extract-pr.outputs.pr-number != ''
         uses: thollander/actions-comment-pull-request@v3
         with:
-          file-path: /tmp/message.txt
+          file-path: ${{ steps.extract-pr.outputs.message-file }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          pr-number: ${{ steps.extract-pr.outputs.pr-number }}
           reactions: eyes, rocket

--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -141,12 +141,12 @@ jobs:
             echo "gh run download ${{ github.run_id }} -n profile-artifacts-${{ github.event.pull_request.number }}"
             echo "\`\`\`"
             echo ""
-          } > /tmp/message.txt
+          } > /tmp/message-${{ github.event.pull_request.number }}.txt
       # NOTE: Uploading the message as an artifact so that PR Comment workflow can use it to
       # add comment on PR with the message.
       - name: Upload message
         uses: actions/upload-artifact@v4
         with:
           name: message
-          path: /tmp/message.txt
+          path: /tmp/message-${{ github.event.pull_request.number }}.txt
           retention-days: 1 # Keep artifact for 1 days


### PR DESCRIPTION
This commit fixes the issue where the pr-number required by the PR comment workflow was not being passed due to GitHub restricting the `github.event.workflow_run.pull_requests` array for security reasons, which causes it to be empty when PRs are created from forks