### PR TITLE
ci: track workflow and profiling script as part of change

### DIFF
--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -20,6 +20,9 @@ jobs:
               - '**/*.go'
               - 'go.mod'
               - 'go.sum'
+              - '.github/workflows/profiling.yaml'
+              - 'hack/reports/profiling.sh'
+
   profiling:
     needs: check-changes
     if: needs.check-changes.outputs.changes == 'true'


### PR DESCRIPTION
This commit updates the profiling workflow's check-change job to also track the workflow and the profiling script as part of the change. This ensures that if the PR makes changes to the script or workflow and not specifically the code base the workflow will still run.