### PR TITLE
ci: remove EOF from the config change message

### DIFF
--- a/.github/workflows/assign-labels.yaml
+++ b/.github/workflows/assign-labels.yaml
@@ -1,6 +1,6 @@
 name: Assign Labels
 
-on:
+on: # yamllint disable-line rule:truthy
   pull_request_target:
 
 jobs:

--- a/.github/workflows/check-x-crypto-deps.yaml
+++ b/.github/workflows/check-x-crypto-deps.yaml
@@ -1,6 +1,6 @@
 name: Check x/crypto
 
-on:
+on: # yamllint disable-line rule:truthy
   pull_request:
 
 jobs:

--- a/.github/workflows/config-change.yaml
+++ b/.github/workflows/config-change.yaml
@@ -1,6 +1,6 @@
 name: Check Config Changes
 
-on: #yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
   pull_request:
 
 jobs:
@@ -38,14 +38,14 @@ jobs:
   generate-comment-message:
     needs: check-changes
     if: >-
-        needs.check-changes.outputs.changes == 'true' &&
-        (
-          needs.check-changes.outputs.doc_changes != 'true' ||
-          needs.check-changes.outputs.compose_changes != 'true' ||
-          needs.check-changes.outputs.hack_changes != 'true' ||
-          needs.check-changes.outputs.manifest_changes != 'true' ||
-          needs.check-changes.outputs.helm_changes != 'true'
-        )
+      needs.check-changes.outputs.changes == 'true' &&
+      (
+        needs.check-changes.outputs.doc_changes != 'true' ||
+        needs.check-changes.outputs.compose_changes != 'true' ||
+        needs.check-changes.outputs.hack_changes != 'true' ||
+        needs.check-changes.outputs.manifest_changes != 'true' ||
+        needs.check-changes.outputs.helm_changes != 'true'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Generate comment message
@@ -68,7 +68,6 @@ jobs:
             if [[ "${{ needs.check-changes.outputs.helm_changes }}" != "true" ]]; then
               echo "- manifests/helm/kepler/values.yaml"
             fi
-            echo "EOF"
           } > /tmp/message-${{ github.event.pull_request.number }}.txt
 
       # NOTE: Uploading the message as an artifact so that PR Comment workflow can use it to

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -2,7 +2,7 @@
 # Triggered when specified workflows complete successfully
 name: PR Comment
 
-on:
+on: # yamllint disable-line rule:truthy
   workflow_run:
     # NOTE: Add any workflow that needs to comment on PRs to this list
     workflows:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,6 @@
 name: Release
 
-on: #yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+

--- a/.github/workflows/test-and-codecov.yaml
+++ b/.github/workflows/test-and-codecov.yaml
@@ -1,6 +1,6 @@
 name: Test and Upload Coverage
 
-on:
+on: # yamllint disable-line rule:truthy
   workflow_call:
     secrets:
       CODECOV_TOKEN:


### PR DESCRIPTION
This commit fixes the issue where the config change message was ending with an EOF.

It also updates the rest of the workflows to include `yamllint disable rule` for `truly` values