### PR TITLE
No default namespace for grafana dashboard

### DIFF
--- a/compose/default/grafana/dashboards/latest/dashboard.json
+++ b/compose/default/grafana/dashboards/latest/dashboard.json
@@ -2154,9 +2154,8 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": false,
-          "text": "local-path-storage",
-          "value": "local-path-storage"
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": {
           "type": "prometheus",


### PR DESCRIPTION
The example grafana dashboard defaulted to a static namespace `local-path-storage`.  This not a great default as not all clusters will have this namespace.