### PR TITLE
ci: add simple install test for the new helm chart

### DIFF
--- a/.github/workflows/helm-deploy-test.yaml
+++ b/.github/workflows/helm-deploy-test.yaml
@@ -1,0 +1,27 @@
+name: Deploy Kepler with Helm on a k8s Kind cluster
+
+on:
+  pull_request:
+
+jobs:
+  install-kepler-on-kind:
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@v3
+      # https://github.com/marketplace/actions/kind-cluster
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1
+      # https://github.com/Azure/setup-helm
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.3.1
+      # Install the Kepler Helm chart to the previously deployed Kind cluster
+      - name: Install the Helm chart
+        run: helm install kepler ./ --namespace kepler --create-namespace
+        working-directory: ./manifests/helm/kepler
+      # Verify Kepler is up and running and show all resources in the namespace
+      - name: Wait for rollout status of daemonset/kepler to be completed
+        run: kubectl -n kepler rollout status daemonset/kepler
+      - name: Show all Kubernetes resources from the kepler namespace
+        run: kubectl -n kepler get all


### PR DESCRIPTION
* to allow a minimal verification if the helm chart can be installed, this commit adds a corresponding GitHub workflow
* the workflow
  * is triggered on pull_requests to ensure that those do not break the deployment of Kepler via the helm chart
  * installs a simple KinD cluster, utilizing the GitHub action from https://github.com/marketplace/actions/kind-cluster
  * installs helm using the GitHub action from https://github.com/Azure/setup-helm
  * installs the helm chart directly from the current git checkout to the KinD cluster
  * waits for the rollout of the kepler daemonset to finish
  * shows all deployed kubernetes resources in the kepler namespace
* ideally this minimal test can be expanded in the future by exposing the service and checking if the /metrics endpoint is reachable as intended