### PR TITLE
chore(compose): add support for deploying redfish using sushy tool

### DIFF
--- a/compose/dev/compose.yaml
+++ b/compose/dev/compose.yaml
@@ -44,8 +44,12 @@ services:
     command:
       - --config.file=/etc/kepler/config.yaml
 
+    depends_on:
+      - sushy-static
+
     networks:
       - kepler-dev
+      - sushy-network
       # - kind  # NOTE: uncomment to use kind
 
   scaphandre:
@@ -100,10 +104,30 @@ services:
     networks:
       - node-exporter-network
 
+  sushy-static:
+    image: quay.io/metal3-io/sushy-tools:latest
+    ports:
+      - 28001:8001
+    volumes:
+      - type: bind
+        source: ./mockups
+        target: /mockups
+    command:
+      - sushy-static
+      - -m
+      - /mockups/public-rackmount
+      - -i
+      - 0.0.0.0
+      - -p
+      - "8001"
+    networks:
+      - sushy-network
+
 networks:
   kepler-dev:
   scaph-network:
   node-exporter-network:
+  sushy-network:
   # NOTE: uncomment to use kind
   # kind:
   #   external: true

--- a/compose/dev/kepler-dev/etc/kepler/config.yaml
+++ b/compose/dev/kepler-dev/etc/kepler/config.yaml
@@ -76,7 +76,7 @@ dev:
 experimental:
   platform:
     redfish:
-      enabled: false # Enable experimental Redfish BMC power monitoring
+      enabled: true # Enable experimental Redfish BMC power monitoring
       configFile: /etc/kepler/redfish.yaml # Path to Redfish BMC configuration file
-      nodeName: "" # Node name to use (overrides Kubernetes node name and hostname fallback)
+      nodeName: kepler-dev # Node name to use (overrides Kubernetes node name and hostname fallback)
       httpTimeout: 5s # HTTP client timeout for BMC requests (default: 5s)

--- a/compose/dev/kepler-dev/etc/kepler/redfish.yaml
+++ b/compose/dev/kepler-dev/etc/kepler/redfish.yaml
@@ -1,0 +1,12 @@
+# Redfish BMC Configuration for Development Environment
+# This configuration connects to the sushy-static service running in Docker Compose
+
+nodes:
+  kepler-dev: sushy-static
+
+bmcs:
+  sushy-static:
+    endpoint: http://sushy-static:8001
+    username: ""
+    password: ""
+    insecure: true

--- a/compose/dev/mockups/public-rackmount/AccountService/Accounts/1/index.json
+++ b/compose/dev/mockups/public-rackmount/AccountService/Accounts/1/index.json
@@ -1,0 +1,19 @@
+{
+    "@odata.type": "#ManagerAccount.v1_0_2.ManagerAccount",
+    "Id": "1",
+    "Name": "User Account",
+    "Description": "User Account",
+    "Enabled": true,
+    "Password": null,
+    "UserName": "Administrator",
+    "RoleId": "Admin",
+    "Locked": false,
+    "Links": {
+        "Role": {
+            "@odata.id": "/redfish/v1/AccountService/Roles/Admin"
+        }
+    },
+    "@odata.context": "/redfish/v1/$metadata#ManagerAccount.ManagerAccount",
+    "@odata.id": "/redfish/v1/AccountService/Accounts/1",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/AccountService/Accounts/index.json
+++ b/compose/dev/mockups/public-rackmount/AccountService/Accounts/index.json
@@ -1,0 +1,13 @@
+{
+    "@odata.type": "#ManagerAccountCollection.ManagerAccountCollection",
+    "Name": "Accounts Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/AccountService/Accounts/1"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#ManagerAccountCollection.ManagerAccountCollection",
+    "@odata.id": "/redfish/v1/AccountService/Accounts",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/AccountService/Roles/Admin/index.json
+++ b/compose/dev/mockups/public-rackmount/AccountService/Roles/Admin/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.type": "#Role.v1_0_2.Role",
+    "Id": "Admin",
+    "Name": "User Role",
+    "Description": "Admin User Role",
+    "IsPredefined": true,
+    "AssignedPrivileges": [
+        "Login",
+        "ConfigureManager",
+        "ConfigureUsers",
+        "ConfigureSelf",
+        "ConfigureComponents"
+    ],
+    "OEMPrivileges": [
+        "OemClearLog",
+        "OemPowerControl"
+    ],
+    "@odata.context": "/redfish/v1/$metadata#Role.Role",
+    "@odata.id": "/redfish/v1/AccountService/Roles/Admin",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/AccountService/Roles/Operator/index.json
+++ b/compose/dev/mockups/public-rackmount/AccountService/Roles/Operator/index.json
@@ -1,0 +1,16 @@
+{
+    "@odata.type": "#Role.v1_0_2.Role",
+    "Id": "Operator",
+    "Name": "User Role",
+    "Description": "Operator User Role",
+    "IsPredefined": true,
+    "AssignedPrivileges": [
+        "Login",
+        "ConfigureSelf",
+        "ConfigureComponents"
+    ],
+    "OEMPrivileges": [],
+    "@odata.context": "/redfish/v1/$metadata#Role.Role",
+    "@odata.id": "/redfish/v1/AccountService/Roles/Operator",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/AccountService/Roles/ReadOnlyUser/index.json
+++ b/compose/dev/mockups/public-rackmount/AccountService/Roles/ReadOnlyUser/index.json
@@ -1,0 +1,14 @@
+{
+    "@odata.type": "#Role.v1_0_2.Role",
+    "Id": "ReadOnlyUser",
+    "Name": "User Role",
+    "Description": "ReadOnlyUser User Role",
+    "IsPredefined": true,
+    "AssignedPrivileges": [
+        "Login"
+    ],
+    "OEMPrivileges": [],
+    "@odata.context": "/redfish/v1/$metadata#Role.Role",
+    "@odata.id": "/redfish/v1/AccountService/Roles/ReadOnlyUser",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/AccountService/Roles/index.json
+++ b/compose/dev/mockups/public-rackmount/AccountService/Roles/index.json
@@ -1,0 +1,19 @@
+{
+    "@odata.type": "#RoleCollection.RoleCollection",
+    "Name": "Roles Collection",
+    "Members@odata.count": 3,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/AccountService/Roles/Admin"
+        },
+        {
+            "@odata.id": "/redfish/v1/AccountService/Roles/Operator"
+        },
+        {
+            "@odata.id": "/redfish/v1/AccountService/Roles/ReadOnlyUser"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#Role.Role",
+    "@odata.id": "/redfish/v1/AccountService/Roles",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/AccountService/index.json
+++ b/compose/dev/mockups/public-rackmount/AccountService/index.json
@@ -1,0 +1,25 @@
+{
+    "@odata.type": "#AccountService.v1_0_2.AccountService",
+    "Id": "AccountService",
+    "Name": "Account Service",
+    "Description": "Account Service",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "ServiceEnabled": true,
+    "AuthFailureLoggingThreshold": 3,
+    "MinPasswordLength": 8,
+    "AccountLockoutThreshold": 5,
+    "AccountLockoutDuration": 30,
+    "AccountLockoutCounterResetAfter": 30,
+    "Accounts": {
+        "@odata.id": "/redfish/v1/AccountService/Accounts"
+    },
+    "Roles": {
+        "@odata.id": "/redfish/v1/AccountService/Roles"
+    },
+    "@odata.context": "/redfish/v1/$metadata#AccountService",
+    "@odata.id": "/redfish/v1/AccountService",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/1U/Power/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/1U/Power/index.json
@@ -1,0 +1,174 @@
+{
+    "@odata.type": "#Power.v1_1_0.Power",
+    "Id": "Power",
+    "Name": "Power",
+    "PowerControl": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/PowerControl/0",
+            "MemberId": "0",
+            "Name": "Server Power Control",
+            "PowerConsumedWatts": 344,
+            "PowerRequestedWatts": 800,
+            "PowerAvailableWatts": 0,
+            "PowerCapacityWatts": 800,
+            "PowerAllocatedWatts": 800,
+            "PowerMetrics": {
+                "IntervalInMin": 30,
+                "MinConsumedWatts": 271,
+                "MaxConsumedWatts": 489,
+                "AverageConsumedWatts": 319
+            },
+            "PowerLimit": {
+                "LimitInWatts": 500,
+                "LimitException": "LogEventOnly",
+                "CorrectionInMs": 50
+            },
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ],
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Oem": {}
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/PowerControl/1",
+            "MemberId": "1",
+            "Name": "Chassis Power Control",
+            "PowerConsumedWatts": 45,
+            "PowerRequestedWatts": 100,
+            "PowerAvailableWatts": 0,
+            "PowerCapacityWatts": 100,
+            "PowerAllocatedWatts": 100,
+            "PowerMetrics": {
+                "IntervalInMin": 30,
+                "MinConsumedWatts": 35,
+                "MaxConsumedWatts": 65,
+                "AverageConsumedWatts": 45
+            },
+            "PowerLimit": {
+                "LimitInWatts": 80,
+                "LimitException": "HardPowerOff",
+                "CorrectionInMs": 100
+            },
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ],
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Oem": {}
+        }
+    ],
+    "Voltages": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/Voltages/0",
+            "MemberId": "0",
+            "Name": "VRM1 Voltage",
+            "SensorNumber": 11,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingVolts": 12,
+            "UpperThresholdNonCritical": 12.5,
+            "UpperThresholdCritical": 13,
+            "UpperThresholdFatal": 15,
+            "LowerThresholdNonCritical": 11.5,
+            "LowerThresholdCritical": 11,
+            "LowerThresholdFatal": 10,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 20,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/Voltages/1",
+            "MemberId": "1",
+            "Name": "VRM2 Voltage",
+            "SensorNumber": 12,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingVolts": 5,
+            "UpperThresholdNonCritical": 5.5,
+            "UpperThresholdCritical": 7,
+            "LowerThresholdNonCritical": 4.75,
+            "LowerThresholdCritical": 4.5,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 20,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "PowerSupplies": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/PowerSupplies/0",
+            "MemberId": "0",
+            "Name": "Power Supply Bay",
+            "Status": {
+                "State": "Enabled",
+                "Health": "Warning"
+            },
+            "Oem": {},
+            "PowerSupplyType": "AC",
+            "LineInputVoltageType": "ACWideRange",
+            "LineInputVoltage": 120,
+            "PowerCapacityWatts": 800,
+            "LastPowerOutputWatts": 325,
+            "Model": "499253-B21",
+            "Manufacturer": "ManufacturerName",
+            "FirmwareVersion": "1.00",
+            "SerialNumber": "1Z0000001",
+            "PartNumber": "0000001A3A",
+            "SparePartNumber": "0000001A3A",
+            "InputRanges": [
+                {
+                    "InputType": "AC",
+                    "MinimumVoltage": 100,
+                    "MaximumVoltage": 120,
+                    "OutputWattage": 800
+                },
+                {
+                    "InputType": "AC",
+                    "MinimumVoltage": 200,
+                    "MaximumVoltage": 240,
+                    "OutputWattage": 1300
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Power.Power",
+    "@odata.id": "/redfish/v1/Chassis/1U/Power",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/1U/PowerSubsystem/PowerSupplies/PS1/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/1U/PowerSubsystem/PowerSupplies/PS1/index.json
@@ -1,0 +1,33 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#PowerSupply.PowerSupply",
+  "@odata.type": "#PowerSupply.v1_6_0.PowerSupply",
+  "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/PS1",
+  "Id": "PS1",
+  "Name": "Power Supply 1",
+  "MemberId": "PS1",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "PowerSupplyType": "AC",
+  "LineInputVoltageType": "ACMidLine",
+  "PowerCapacityWatts": 800.0,
+  "PowerOutputWatts": 245.0,
+  "PowerInputWatts": 268.0,
+  "EfficiencyPercent": 91.4,
+  "Manufacturer": "Dell Inc.",
+  "Model": "PWR SPLY,800W,RDNT,ARTESYN",
+  "SerialNumber": "CN0123456789",
+  "PartNumber": "0H3H50",
+  "FirmwareVersion": "1.2.3",
+  "Location": {
+    "PartLocation": {
+      "ServiceLabel": "PS1",
+      "LocationType": "Slot",
+      "LocationOrdinalValue": 1
+    }
+  },
+  "Metrics": {
+    "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/PS1/Metrics"
+  }
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/1U/PowerSubsystem/PowerSupplies/PS2/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/1U/PowerSubsystem/PowerSupplies/PS2/index.json
@@ -1,0 +1,33 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#PowerSupply.PowerSupply",
+  "@odata.type": "#PowerSupply.v1_6_0.PowerSupply",
+  "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/PS2",
+  "Id": "PS2",
+  "Name": "Power Supply 2",
+  "MemberId": "PS2",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "PowerSupplyType": "AC",
+  "LineInputVoltageType": "ACMidLine",
+  "PowerCapacityWatts": 800.0,
+  "PowerOutputWatts": 0.0,
+  "PowerInputWatts": 25.0,
+  "EfficiencyPercent": 0.0,
+  "Manufacturer": "Dell Inc.",
+  "Model": "PWR SPLY,800W,RDNT,ARTESYN",
+  "SerialNumber": "CN0987654321",
+  "PartNumber": "0H3H50",
+  "FirmwareVersion": "1.2.3",
+  "Location": {
+    "PartLocation": {
+      "ServiceLabel": "PS2",
+      "LocationType": "Slot",
+      "LocationOrdinalValue": 2
+    }
+  },
+  "Metrics": {
+    "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/PS2/Metrics"
+  }
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/1U/PowerSubsystem/PowerSupplies/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/1U/PowerSubsystem/PowerSupplies/index.json
@@ -1,0 +1,49 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#PowerSupplyCollection.PowerSupplyCollection",
+  "@odata.type": "#PowerSupplyCollection.PowerSupplyCollection",
+  "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies",
+  "Name": "Power Supply Collection",
+  "Members@odata.count": 2,
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/PS1",
+      "@odata.type": "#PowerSupply.v1_6_0.PowerSupply",
+      "Id": "PS1",
+      "Name": "Power Supply 1",
+      "MemberId": "PS1",
+      "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+      },
+      "PowerSupplyType": "AC",
+      "PowerCapacityWatts": 800.0,
+      "PowerOutputWatts": 245.0,
+      "PowerInputWatts": 268.0,
+      "EfficiencyPercent": 91.4,
+      "Manufacturer": "Dell Inc.",
+      "Model": "PWR SPLY,800W,RDNT,ARTESYN",
+      "SerialNumber": "CN0123456789",
+      "PartNumber": "0H3H50"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/PS2",
+      "@odata.type": "#PowerSupply.v1_6_0.PowerSupply",
+      "Id": "PS2",
+      "Name": "Power Supply 2",
+      "MemberId": "PS2",
+      "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+      },
+      "PowerSupplyType": "AC",
+      "PowerCapacityWatts": 800.0,
+      "PowerOutputWatts": 0.0,
+      "PowerInputWatts": 25.0,
+      "EfficiencyPercent": 0.0,
+      "Manufacturer": "Dell Inc.",
+      "Model": "PWR SPLY,800W,RDNT,ARTESYN",
+      "SerialNumber": "CN0987654321",
+      "PartNumber": "0H3H50"
+    }
+  ]
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/1U/PowerSubsystem/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/1U/PowerSubsystem/index.json
@@ -1,0 +1,33 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#PowerSubsystem.PowerSubsystem",
+  "@odata.type": "#PowerSubsystem.v1_1_0.PowerSubsystem",
+  "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem",
+  "Id": "PowerSubsystem",
+  "Name": "Power Subsystem",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "PowerSupplies": {
+    "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies"
+  },
+  "PowerSupplyRedundancy": [
+    {
+      "RedundancyGroup": [
+        {
+          "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/PS1"
+        },
+        {
+          "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/PS2"
+        }
+      ],
+      "Mode": "N+1",
+      "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+      },
+      "MinNumNeeded": 1,
+      "MaxNumSupported": 2
+    }
+  ]
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/1U/Thermal/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/1U/Thermal/index.json
@@ -1,0 +1,160 @@
+{
+    "@odata.type": "#Thermal.v1_0_2.Thermal",
+    "Id": "Thermal",
+    "Name": "Thermal",
+    "Temperatures": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/0",
+            "MemberId": "0",
+            "Name": "CPU1 Temp",
+            "SensorNumber": 5,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 41,
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 45,
+            "UpperThresholdFatal": 48,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/1",
+            "MemberId": "1",
+            "Name": "CPU2 Temp",
+            "SensorNumber": 6,
+            "Status": {
+                "State": "Disabled"
+            },
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 45,
+            "UpperThresholdFatal": 48,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU2"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/2",
+            "MemberId": "2",
+            "Name": "Chassis Intake Temp",
+            "SensorNumber": 9,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 25,
+            "UpperThresholdNonCritical": 30,
+            "UpperThresholdCritical": 40,
+            "UpperThresholdFatal": 50,
+            "LowerThresholdNonCritical": 10,
+            "LowerThresholdCritical": 5,
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 60,
+            "PhysicalContext": "Intake",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                }
+            ]
+        }
+    ],
+    "Fans": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fan",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2100,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/1",
+            "MemberId": "1",
+            "Name": "BaseBoard System Fan Backup",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2050,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "Redundancy": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fans",
+            "RedundancySet": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/0"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/1"
+                }
+            ],
+            "Mode": "N+m",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "MinNumNeeded": 1,
+            "MaxNumSupported": 2
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#Thermal.Thermal",
+    "@odata.id": "/redfish/v1/Chassis/1U/Thermal",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/1U/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/1U/index.json
@@ -1,0 +1,47 @@
+{
+    "@odata.type": "#Chassis.v1_2_0.Chassis",
+    "Id": "1U",
+    "Name": "Computer System Chassis",
+    "ChassisType": "RackMount",
+    "AssetTag": "Chicago-45Z-2381",
+    "Manufacturer": "Contoso",
+    "Model": "3500RX",
+    "SKU": "8675309",
+    "SerialNumber": "437XR1138R2",
+    "PartNumber": "224071-J23",
+    "PowerState": "On",
+    "IndicatorLED": "Lit",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Thermal": {
+        "@odata.id": "/redfish/v1/Chassis/1U/Thermal"
+    },
+    "Power": {
+        "@odata.id": "/redfish/v1/Chassis/1U/Power"
+    },
+    "PowerSubsystem": {
+        "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem"
+    },
+    "Links": {
+        "ComputerSystems": [
+            {
+                "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+            }
+        ],
+        "ManagedBy": [
+            {
+                "@odata.id": "/redfish/v1/Managers/BMC"
+            }
+        ],
+        "ManagersInChassis": [
+            {
+                "@odata.id": "/redfish/v1/Managers/BMC"
+            }
+        ]
+    },
+    "@odata.context": "/redfish/v1/$metadata#Chassis.Chassis",
+    "@odata.id": "/redfish/v1/Chassis/1U",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/2U/Power/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/2U/Power/index.json
@@ -1,0 +1,174 @@
+{
+    "@odata.type": "#Power.v1_1_0.Power",
+    "Id": "Power",
+    "Name": "Power",
+    "PowerControl": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/2U/Power#/PowerControl/0",
+            "MemberId": "0",
+            "Name": "Server Power Control",
+            "PowerConsumedWatts": 450,
+            "PowerRequestedWatts": 1000,
+            "PowerAvailableWatts": 0,
+            "PowerCapacityWatts": 1000,
+            "PowerAllocatedWatts": 1000,
+            "PowerMetrics": {
+                "IntervalInMin": 30,
+                "MinConsumedWatts": 350,
+                "MaxConsumedWatts": 550,
+                "AverageConsumedWatts": 420
+            },
+            "PowerLimit": {
+                "LimitInWatts": 600,
+                "LimitException": "LogEventOnly",
+                "CorrectionInMs": 50
+            },
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R3"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/2U"
+                }
+            ],
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Oem": {}
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/2U/Power#/PowerControl/1",
+            "MemberId": "1",
+            "Name": "Chassis Power Control",
+            "PowerConsumedWatts": 65,
+            "PowerRequestedWatts": 150,
+            "PowerAvailableWatts": 0,
+            "PowerCapacityWatts": 150,
+            "PowerAllocatedWatts": 150,
+            "PowerMetrics": {
+                "IntervalInMin": 30,
+                "MinConsumedWatts": 50,
+                "MaxConsumedWatts": 85,
+                "AverageConsumedWatts": 65
+            },
+            "PowerLimit": {
+                "LimitInWatts": 100,
+                "LimitException": "HardPowerOff",
+                "CorrectionInMs": 100
+            },
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/2U"
+                }
+            ],
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Oem": {}
+        }
+    ],
+    "Voltages": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/2U/Power#/Voltages/0",
+            "MemberId": "0",
+            "Name": "VRM1 Voltage",
+            "SensorNumber": 11,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingVolts": 12,
+            "UpperThresholdNonCritical": 12.5,
+            "UpperThresholdCritical": 13,
+            "UpperThresholdFatal": 15,
+            "LowerThresholdNonCritical": 11.5,
+            "LowerThresholdCritical": 11,
+            "LowerThresholdFatal": 10,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 20,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R3"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/2U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/2U/Power#/Voltages/1",
+            "MemberId": "1",
+            "Name": "VRM2 Voltage",
+            "SensorNumber": 12,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingVolts": 5,
+            "UpperThresholdNonCritical": 5.5,
+            "UpperThresholdCritical": 7,
+            "LowerThresholdNonCritical": 4.75,
+            "LowerThresholdCritical": 4.5,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 20,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R3"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/2U"
+                }
+            ]
+        }
+    ],
+    "PowerSupplies": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/2U/Power#/PowerSupplies/0",
+            "MemberId": "0",
+            "Name": "Power Supply Bay",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Oem": {},
+            "PowerSupplyType": "AC",
+            "LineInputVoltageType": "ACWideRange",
+            "LineInputVoltage": 120,
+            "PowerCapacityWatts": 1000,
+            "LastPowerOutputWatts": 425,
+            "Model": "499253-B22",
+            "Manufacturer": "ManufacturerName",
+            "FirmwareVersion": "1.00",
+            "SerialNumber": "2Z0000001",
+            "PartNumber": "0000002A3A",
+            "SparePartNumber": "0000002A3A",
+            "InputRanges": [
+                {
+                    "InputType": "AC",
+                    "MinimumVoltage": 100,
+                    "MaximumVoltage": 120,
+                    "OutputWattage": 1000
+                },
+                {
+                    "InputType": "AC",
+                    "MinimumVoltage": 200,
+                    "MaximumVoltage": 240,
+                    "OutputWattage": 1500
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/2U"
+                }
+            ]
+        }
+    ],
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Power.Power",
+    "@odata.id": "/redfish/v1/Chassis/2U/Power",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/2U/PowerSubsystem/PowerSupplies/PS1/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/2U/PowerSubsystem/PowerSupplies/PS1/index.json
@@ -1,0 +1,33 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#PowerSupply.PowerSupply",
+  "@odata.type": "#PowerSupply.v1_6_0.PowerSupply",
+  "@odata.id": "/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/PS1",
+  "Id": "PS1",
+  "Name": "Power Supply 1",
+  "MemberId": "PS1",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "PowerSupplyType": "AC",
+  "LineInputVoltageType": "ACMidLine",
+  "PowerCapacityWatts": 1200.0,
+  "PowerOutputWatts": 345.0,
+  "PowerInputWatts": 378.0,
+  "EfficiencyPercent": 91.3,
+  "Manufacturer": "Dell Inc.",
+  "Model": "PWR SPLY,1200W,RDNT,ARTESYN",
+  "SerialNumber": "CN0234567890",
+  "PartNumber": "0H4H60",
+  "FirmwareVersion": "1.2.3",
+  "Location": {
+    "PartLocation": {
+      "ServiceLabel": "PS1",
+      "LocationType": "Slot",
+      "LocationOrdinalValue": 1
+    }
+  },
+  "Metrics": {
+    "@odata.id": "/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/PS1/Metrics"
+  }
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/2U/PowerSubsystem/PowerSupplies/PS2/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/2U/PowerSubsystem/PowerSupplies/PS2/index.json
@@ -1,0 +1,33 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#PowerSupply.PowerSupply",
+  "@odata.type": "#PowerSupply.v1_6_0.PowerSupply",
+  "@odata.id": "/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/PS2",
+  "Id": "PS2",
+  "Name": "Power Supply 2",
+  "MemberId": "PS2",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "PowerSupplyType": "AC",
+  "LineInputVoltageType": "ACMidLine",
+  "PowerCapacityWatts": 1200.0,
+  "PowerOutputWatts": 0.0,
+  "PowerInputWatts": 25.0,
+  "EfficiencyPercent": 0.0,
+  "Manufacturer": "Dell Inc.",
+  "Model": "PWR SPLY,1200W,RDNT,ARTESYN",
+  "SerialNumber": "CN0098765432",
+  "PartNumber": "0H4H60",
+  "FirmwareVersion": "1.2.3",
+  "Location": {
+    "PartLocation": {
+      "ServiceLabel": "PS2",
+      "LocationType": "Slot",
+      "LocationOrdinalValue": 2
+    }
+  },
+  "Metrics": {
+    "@odata.id": "/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/PS2/Metrics"
+  }
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/2U/PowerSubsystem/PowerSupplies/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/2U/PowerSubsystem/PowerSupplies/index.json
@@ -1,0 +1,49 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#PowerSupplyCollection.PowerSupplyCollection",
+  "@odata.type": "#PowerSupplyCollection.PowerSupplyCollection",
+  "@odata.id": "/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies",
+  "Name": "Power Supply Collection",
+  "Members@odata.count": 2,
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/PS1",
+      "@odata.type": "#PowerSupply.v1_6_0.PowerSupply",
+      "Id": "PS1",
+      "Name": "Power Supply 1",
+      "MemberId": "PS1",
+      "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+      },
+      "PowerSupplyType": "AC",
+      "PowerCapacityWatts": 1200.0,
+      "PowerOutputWatts": 345.0,
+      "PowerInputWatts": 378.0,
+      "EfficiencyPercent": 91.3,
+      "Manufacturer": "Dell Inc.",
+      "Model": "PWR SPLY,1200W,RDNT,ARTESYN",
+      "SerialNumber": "CN0234567890",
+      "PartNumber": "0H4H60"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/PS2",
+      "@odata.type": "#PowerSupply.v1_6_0.PowerSupply",
+      "Id": "PS2",
+      "Name": "Power Supply 2",
+      "MemberId": "PS2",
+      "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+      },
+      "PowerSupplyType": "AC",
+      "PowerCapacityWatts": 1200.0,
+      "PowerOutputWatts": 0.0,
+      "PowerInputWatts": 25.0,
+      "EfficiencyPercent": 0.0,
+      "Manufacturer": "Dell Inc.",
+      "Model": "PWR SPLY,1200W,RDNT,ARTESYN",
+      "SerialNumber": "CN0098765432",
+      "PartNumber": "0H4H60"
+    }
+  ]
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/2U/PowerSubsystem/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/2U/PowerSubsystem/index.json
@@ -1,0 +1,33 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#PowerSubsystem.PowerSubsystem",
+  "@odata.type": "#PowerSubsystem.v1_1_0.PowerSubsystem",
+  "@odata.id": "/redfish/v1/Chassis/2U/PowerSubsystem",
+  "Id": "PowerSubsystem",
+  "Name": "Power Subsystem",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "PowerSupplies": {
+    "@odata.id": "/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies"
+  },
+  "PowerSupplyRedundancy": [
+    {
+      "RedundancyGroup": [
+        {
+          "@odata.id": "/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/PS1"
+        },
+        {
+          "@odata.id": "/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/PS2"
+        }
+      ],
+      "Mode": "N+1",
+      "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+      },
+      "MinNumNeeded": 1,
+      "MaxNumSupported": 2
+    }
+  ]
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/2U/Thermal/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/2U/Thermal/index.json
@@ -1,0 +1,162 @@
+{
+    "@odata.type": "#Thermal.v1_0_2.Thermal",
+    "Id": "Thermal",
+    "Name": "Thermal",
+    "Temperatures": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/2U/Thermal#/Temperatures/0",
+            "MemberId": "0",
+            "Name": "CPU1 Temp",
+            "SensorNumber": 5,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 42,
+            "UpperThresholdNonCritical": 43,
+            "UpperThresholdCritical": 46,
+            "UpperThresholdFatal": 49,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R3/Processors/CPU1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/2U/Thermal#/Temperatures/1",
+            "MemberId": "1",
+            "Name": "CPU2 Temp",
+            "SensorNumber": 6,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 39,
+            "UpperThresholdNonCritical": 43,
+            "UpperThresholdCritical": 46,
+            "UpperThresholdFatal": 49,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R3/Processors/CPU2"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/2U/Thermal#/Temperatures/2",
+            "MemberId": "2",
+            "Name": "Chassis Intake Temp",
+            "SensorNumber": 9,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 26,
+            "UpperThresholdNonCritical": 31,
+            "UpperThresholdCritical": 41,
+            "UpperThresholdFatal": 51,
+            "LowerThresholdNonCritical": 10,
+            "LowerThresholdCritical": 5,
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 60,
+            "PhysicalContext": "Intake",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/2U"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R3"
+                }
+            ]
+        }
+    ],
+    "Fans": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/2U/Thermal#/Fans/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fan",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2200,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/2U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R3"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/2U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/2U/Thermal#/Fans/1",
+            "MemberId": "1",
+            "Name": "BaseBoard System Fan Backup",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2150,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/2U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R3"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/2U"
+                }
+            ]
+        }
+    ],
+    "Redundancy": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/2U/Thermal#/Redundancy/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fans",
+            "RedundancySet": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/2U/Thermal#/Fans/0"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/2U/Thermal#/Fans/1"
+                }
+            ],
+            "Mode": "N+m",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "MinNumNeeded": 1,
+            "MaxNumSupported": 2
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#Thermal.Thermal",
+    "@odata.id": "/redfish/v1/Chassis/2U/Thermal",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/2U/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/2U/index.json
@@ -1,0 +1,47 @@
+{
+    "@odata.type": "#Chassis.v1_2_0.Chassis",
+    "Id": "2U",
+    "Name": "Computer System Chassis",
+    "ChassisType": "RackMount",
+    "AssetTag": "Chicago-45Z-2382",
+    "Manufacturer": "Contoso",
+    "Model": "4500RX",
+    "SKU": "8675310",
+    "SerialNumber": "437XR1138R3",
+    "PartNumber": "224071-J24",
+    "PowerState": "On",
+    "IndicatorLED": "Lit",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Thermal": {
+        "@odata.id": "/redfish/v1/Chassis/2U/Thermal"
+    },
+    "Power": {
+        "@odata.id": "/redfish/v1/Chassis/2U/Power"
+    },
+    "PowerSubsystem": {
+        "@odata.id": "/redfish/v1/Chassis/2U/PowerSubsystem"
+    },
+    "Links": {
+        "ComputerSystems": [
+            {
+                "@odata.id": "/redfish/v1/Systems/437XR1138R3"
+            }
+        ],
+        "ManagedBy": [
+            {
+                "@odata.id": "/redfish/v1/Managers/BMC"
+            }
+        ],
+        "ManagersInChassis": [
+            {
+                "@odata.id": "/redfish/v1/Managers/BMC"
+            }
+        ]
+    },
+    "@odata.context": "/redfish/v1/$metadata#Chassis.Chassis",
+    "@odata.id": "/redfish/v1/Chassis/2U",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/4U/Power/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/4U/Power/index.json
@@ -1,0 +1,174 @@
+{
+    "@odata.type": "#Power.v1_1_0.Power",
+    "Id": "Power",
+    "Name": "Power",
+    "PowerControl": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/4U/Power#/PowerControl/0",
+            "MemberId": "0",
+            "Name": "Server Power Control",
+            "PowerConsumedWatts": 750,
+            "PowerRequestedWatts": 1600,
+            "PowerAvailableWatts": 0,
+            "PowerCapacityWatts": 1600,
+            "PowerAllocatedWatts": 1600,
+            "PowerMetrics": {
+                "IntervalInMin": 30,
+                "MinConsumedWatts": 600,
+                "MaxConsumedWatts": 900,
+                "AverageConsumedWatts": 720
+            },
+            "PowerLimit": {
+                "LimitInWatts": 1000,
+                "LimitException": "LogEventOnly",
+                "CorrectionInMs": 50
+            },
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R4"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/4U"
+                }
+            ],
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Oem": {}
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/4U/Power#/PowerControl/1",
+            "MemberId": "1",
+            "Name": "Chassis Power Control",
+            "PowerConsumedWatts": 95,
+            "PowerRequestedWatts": 200,
+            "PowerAvailableWatts": 0,
+            "PowerCapacityWatts": 200,
+            "PowerAllocatedWatts": 200,
+            "PowerMetrics": {
+                "IntervalInMin": 30,
+                "MinConsumedWatts": 75,
+                "MaxConsumedWatts": 125,
+                "AverageConsumedWatts": 95
+            },
+            "PowerLimit": {
+                "LimitInWatts": 150,
+                "LimitException": "HardPowerOff",
+                "CorrectionInMs": 100
+            },
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/4U"
+                }
+            ],
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Oem": {}
+        }
+    ],
+    "Voltages": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/4U/Power#/Voltages/0",
+            "MemberId": "0",
+            "Name": "VRM1 Voltage",
+            "SensorNumber": 11,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingVolts": 12,
+            "UpperThresholdNonCritical": 12.5,
+            "UpperThresholdCritical": 13,
+            "UpperThresholdFatal": 15,
+            "LowerThresholdNonCritical": 11.5,
+            "LowerThresholdCritical": 11,
+            "LowerThresholdFatal": 10,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 20,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R4"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/4U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/4U/Power#/Voltages/1",
+            "MemberId": "1",
+            "Name": "VRM2 Voltage",
+            "SensorNumber": 12,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingVolts": 5,
+            "UpperThresholdNonCritical": 5.5,
+            "UpperThresholdCritical": 7,
+            "LowerThresholdNonCritical": 4.75,
+            "LowerThresholdCritical": 4.5,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 20,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R4"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/4U"
+                }
+            ]
+        }
+    ],
+    "PowerSupplies": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/4U/Power#/PowerSupplies/0",
+            "MemberId": "0",
+            "Name": "Power Supply Bay",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Oem": {},
+            "PowerSupplyType": "AC",
+            "LineInputVoltageType": "ACWideRange",
+            "LineInputVoltage": 120,
+            "PowerCapacityWatts": 1600,
+            "LastPowerOutputWatts": 725,
+            "Model": "499253-B24",
+            "Manufacturer": "ManufacturerName",
+            "FirmwareVersion": "1.00",
+            "SerialNumber": "4Z0000001",
+            "PartNumber": "0000004A3A",
+            "SparePartNumber": "0000004A3A",
+            "InputRanges": [
+                {
+                    "InputType": "AC",
+                    "MinimumVoltage": 100,
+                    "MaximumVoltage": 120,
+                    "OutputWattage": 1600
+                },
+                {
+                    "InputType": "AC",
+                    "MinimumVoltage": 200,
+                    "MaximumVoltage": 240,
+                    "OutputWattage": 2400
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/4U"
+                }
+            ]
+        }
+    ],
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Power.Power",
+    "@odata.id": "/redfish/v1/Chassis/4U/Power",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/4U/PowerSubsystem/PowerSupplies/PS1/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/4U/PowerSubsystem/PowerSupplies/PS1/index.json
@@ -1,0 +1,33 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#PowerSupply.PowerSupply",
+  "@odata.type": "#PowerSupply.v1_6_0.PowerSupply",
+  "@odata.id": "/redfish/v1/Chassis/4U/PowerSubsystem/PowerSupplies/PS1",
+  "Id": "PS1",
+  "Name": "Power Supply 1",
+  "MemberId": "PS1",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "PowerSupplyType": "AC",
+  "LineInputVoltageType": "ACMidLine",
+  "PowerCapacityWatts": 1600.0,
+  "PowerOutputWatts": 445.0,
+  "PowerInputWatts": 488.0,
+  "EfficiencyPercent": 91.2,
+  "Manufacturer": "Dell Inc.",
+  "Model": "PWR SPLY,1600W,RDNT,ARTESYN",
+  "SerialNumber": "CN0345678901",
+  "PartNumber": "0H5H70",
+  "FirmwareVersion": "1.2.3",
+  "Location": {
+    "PartLocation": {
+      "ServiceLabel": "PS1",
+      "LocationType": "Slot",
+      "LocationOrdinalValue": 1
+    }
+  },
+  "Metrics": {
+    "@odata.id": "/redfish/v1/Chassis/4U/PowerSubsystem/PowerSupplies/PS1/Metrics"
+  }
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/4U/PowerSubsystem/PowerSupplies/PS2/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/4U/PowerSubsystem/PowerSupplies/PS2/index.json
@@ -1,0 +1,33 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#PowerSupply.PowerSupply",
+  "@odata.type": "#PowerSupply.v1_6_0.PowerSupply",
+  "@odata.id": "/redfish/v1/Chassis/4U/PowerSubsystem/PowerSupplies/PS2",
+  "Id": "PS2",
+  "Name": "Power Supply 2",
+  "MemberId": "PS2",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "PowerSupplyType": "AC",
+  "LineInputVoltageType": "ACMidLine",
+  "PowerCapacityWatts": 1600.0,
+  "PowerOutputWatts": 0.0,
+  "PowerInputWatts": 25.0,
+  "EfficiencyPercent": 0.0,
+  "Manufacturer": "Dell Inc.",
+  "Model": "PWR SPLY,1600W,RDNT,ARTESYN",
+  "SerialNumber": "CN0109876543",
+  "PartNumber": "0H5H70",
+  "FirmwareVersion": "1.2.3",
+  "Location": {
+    "PartLocation": {
+      "ServiceLabel": "PS2",
+      "LocationType": "Slot",
+      "LocationOrdinalValue": 2
+    }
+  },
+  "Metrics": {
+    "@odata.id": "/redfish/v1/Chassis/4U/PowerSubsystem/PowerSupplies/PS2/Metrics"
+  }
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/4U/PowerSubsystem/PowerSupplies/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/4U/PowerSubsystem/PowerSupplies/index.json
@@ -1,0 +1,49 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#PowerSupplyCollection.PowerSupplyCollection",
+  "@odata.type": "#PowerSupplyCollection.PowerSupplyCollection",
+  "@odata.id": "/redfish/v1/Chassis/4U/PowerSubsystem/PowerSupplies",
+  "Name": "Power Supply Collection",
+  "Members@odata.count": 2,
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/4U/PowerSubsystem/PowerSupplies/PS1",
+      "@odata.type": "#PowerSupply.v1_6_0.PowerSupply",
+      "Id": "PS1",
+      "Name": "Power Supply 1",
+      "MemberId": "PS1",
+      "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+      },
+      "PowerSupplyType": "AC",
+      "PowerCapacityWatts": 1600.0,
+      "PowerOutputWatts": 445.0,
+      "PowerInputWatts": 488.0,
+      "EfficiencyPercent": 91.2,
+      "Manufacturer": "Dell Inc.",
+      "Model": "PWR SPLY,1600W,RDNT,ARTESYN",
+      "SerialNumber": "CN0345678901",
+      "PartNumber": "0H5H70"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/4U/PowerSubsystem/PowerSupplies/PS2",
+      "@odata.type": "#PowerSupply.v1_6_0.PowerSupply",
+      "Id": "PS2",
+      "Name": "Power Supply 2",
+      "MemberId": "PS2",
+      "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+      },
+      "PowerSupplyType": "AC",
+      "PowerCapacityWatts": 1600.0,
+      "PowerOutputWatts": 0.0,
+      "PowerInputWatts": 25.0,
+      "EfficiencyPercent": 0.0,
+      "Manufacturer": "Dell Inc.",
+      "Model": "PWR SPLY,1600W,RDNT,ARTESYN",
+      "SerialNumber": "CN0109876543",
+      "PartNumber": "0H5H70"
+    }
+  ]
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/4U/PowerSubsystem/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/4U/PowerSubsystem/index.json
@@ -1,0 +1,33 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#PowerSubsystem.PowerSubsystem",
+  "@odata.type": "#PowerSubsystem.v1_1_0.PowerSubsystem",
+  "@odata.id": "/redfish/v1/Chassis/4U/PowerSubsystem",
+  "Id": "PowerSubsystem",
+  "Name": "Power Subsystem",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "PowerSupplies": {
+    "@odata.id": "/redfish/v1/Chassis/4U/PowerSubsystem/PowerSupplies"
+  },
+  "PowerSupplyRedundancy": [
+    {
+      "RedundancyGroup": [
+        {
+          "@odata.id": "/redfish/v1/Chassis/4U/PowerSubsystem/PowerSupplies/PS1"
+        },
+        {
+          "@odata.id": "/redfish/v1/Chassis/4U/PowerSubsystem/PowerSupplies/PS2"
+        }
+      ],
+      "Mode": "N+1",
+      "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+      },
+      "MinNumNeeded": 1,
+      "MaxNumSupported": 2
+    }
+  ]
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/4U/Thermal/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/4U/Thermal/index.json
@@ -1,0 +1,207 @@
+{
+    "@odata.type": "#Thermal.v1_0_2.Thermal",
+    "Id": "Thermal",
+    "Name": "Thermal",
+    "Temperatures": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/4U/Thermal#/Temperatures/0",
+            "MemberId": "0",
+            "Name": "CPU1 Temp",
+            "SensorNumber": 5,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 43,
+            "UpperThresholdNonCritical": 44,
+            "UpperThresholdCritical": 47,
+            "UpperThresholdFatal": 50,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R4/Processors/CPU1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/4U/Thermal#/Temperatures/1",
+            "MemberId": "1",
+            "Name": "CPU2 Temp",
+            "SensorNumber": 6,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 40,
+            "UpperThresholdNonCritical": 44,
+            "UpperThresholdCritical": 47,
+            "UpperThresholdFatal": 50,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R4/Processors/CPU2"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/4U/Thermal#/Temperatures/2",
+            "MemberId": "2",
+            "Name": "Chassis Intake Temp",
+            "SensorNumber": 9,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 27,
+            "UpperThresholdNonCritical": 32,
+            "UpperThresholdCritical": 42,
+            "UpperThresholdFatal": 52,
+            "LowerThresholdNonCritical": 10,
+            "LowerThresholdCritical": 5,
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 60,
+            "PhysicalContext": "Intake",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/4U"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R4"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/4U/Thermal#/Temperatures/3",
+            "MemberId": "3",
+            "Name": "Chassis Exhaust Temp",
+            "SensorNumber": 10,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 35,
+            "UpperThresholdNonCritical": 40,
+            "UpperThresholdCritical": 50,
+            "UpperThresholdFatal": 60,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 70,
+            "PhysicalContext": "Exhaust",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/4U"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R4"
+                }
+            ]
+        }
+    ],
+    "Fans": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/4U/Thermal#/Fans/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fan 1",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2400,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/4U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R4"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/4U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/4U/Thermal#/Fans/1",
+            "MemberId": "1",
+            "Name": "BaseBoard System Fan 2",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2350,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/4U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R4"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/4U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/4U/Thermal#/Fans/2",
+            "MemberId": "2",
+            "Name": "Chassis Cooling Fan",
+            "PhysicalContext": "Chassis",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 1800,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 4000,
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/4U"
+                }
+            ]
+        }
+    ],
+    "Redundancy": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/4U/Thermal#/Redundancy/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fans",
+            "RedundancySet": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/4U/Thermal#/Fans/0"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/4U/Thermal#/Fans/1"
+                }
+            ],
+            "Mode": "N+m",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "MinNumNeeded": 1,
+            "MaxNumSupported": 2
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#Thermal.Thermal",
+    "@odata.id": "/redfish/v1/Chassis/4U/Thermal",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/4U/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/4U/index.json
@@ -1,0 +1,47 @@
+{
+    "@odata.type": "#Chassis.v1_2_0.Chassis",
+    "Id": "4U",
+    "Name": "Computer System Chassis",
+    "ChassisType": "RackMount",
+    "AssetTag": "Chicago-45Z-2384",
+    "Manufacturer": "Contoso",
+    "Model": "6500RX",
+    "SKU": "8675312",
+    "SerialNumber": "437XR1138R4",
+    "PartNumber": "224071-J26",
+    "PowerState": "On",
+    "IndicatorLED": "Lit",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Thermal": {
+        "@odata.id": "/redfish/v1/Chassis/4U/Thermal"
+    },
+    "Power": {
+        "@odata.id": "/redfish/v1/Chassis/4U/Power"
+    },
+    "PowerSubsystem": {
+        "@odata.id": "/redfish/v1/Chassis/4U/PowerSubsystem"
+    },
+    "Links": {
+        "ComputerSystems": [
+            {
+                "@odata.id": "/redfish/v1/Systems/437XR1138R4"
+            }
+        ],
+        "ManagedBy": [
+            {
+                "@odata.id": "/redfish/v1/Managers/BMC"
+            }
+        ],
+        "ManagersInChassis": [
+            {
+                "@odata.id": "/redfish/v1/Managers/BMC"
+            }
+        ]
+    },
+    "@odata.context": "/redfish/v1/$metadata#Chassis.Chassis",
+    "@odata.id": "/redfish/v1/Chassis/4U",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Chassis/index.json
+++ b/compose/dev/mockups/public-rackmount/Chassis/index.json
@@ -1,0 +1,19 @@
+{
+    "@odata.type": "#ChassisCollection.ChassisCollection",
+    "Name": "Chassis Collection",
+    "Members@odata.count": 3,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/2U"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/4U"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#ChassisCollection",
+    "@odata.id": "/redfish/v1/Chassis",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/EventService/Subscriptions/1/index.json
+++ b/compose/dev/mockups/public-rackmount/EventService/Subscriptions/1/index.json
@@ -1,0 +1,14 @@
+{
+    "@odata.type": "#EventDestination.v1_0_2.EventDestination",
+    "Id": "1",
+    "Name": "EventSubscription 1",
+    "Destination": "http://www.dnsname.com/Destination1",
+    "EventTypes": [
+        "Alert"
+    ],
+    "Context": "WebUser3",
+    "Protocol": "Redfish",
+    "@odata.context": "/redfish/v1/$metadata#EventDestination.EventDestination",
+    "@odata.id": "/redfish/v1/EventService/Subscriptions/1",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/EventService/Subscriptions/index.json
+++ b/compose/dev/mockups/public-rackmount/EventService/Subscriptions/index.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#EventDestinationCollection.EventDestinationCollection",
+    "Name": "Event Subscriptions Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/EventService/Subscriptions/1"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#EventDestinationCollection.EventDestinationCollection",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/EventService/index.json
+++ b/compose/dev/mockups/public-rackmount/EventService/index.json
@@ -1,0 +1,39 @@
+{
+    "@odata.type": "#EventService.v1_0_2.EventService",
+    "Id": "EventService",
+    "Name": "Event Service",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "ServiceEnabled": true,
+    "DeliveryRetryAttempts": 3,
+    "DeliveryRetryIntervalInSeconds": 60,
+    "EventTypesForSubscription": [
+        "StatusChange",
+        "ResourceUpdated",
+        "ResourceAdded",
+        "ResourceRemoved",
+        "Alert"
+    ],
+    "Subscriptions": {
+        "@odata.id": "/redfish/v1/EventService/Subscriptions"
+    },
+    "Actions": {
+        "#EventService.SubmitTestEvent": {
+            "target": "/redfish/v1/EventService/Actions/EventService.SubmitTestEvent",
+            "EventType@Redfish.AllowableValues": [
+                "StatusChange",
+                "ResourceUpdated",
+                "ResourceAdded",
+                "ResourceRemoved",
+                "Alert"
+            ]
+        },
+        "Oem": {}
+    },
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#EventService",
+    "@odata.id": "/redfish/v1/EventService",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Managers/BMC/LogServices/Log/Entries/1/index.json
+++ b/compose/dev/mockups/public-rackmount/Managers/BMC/LogServices/Log/Entries/1/index.json
@@ -1,0 +1,27 @@
+{
+    "@odata.type": "#LogEntry.v1_0_2.LogEntry",
+    "Id": "1",
+    "Name": "Log Entry 1",
+    "EntryType": "SEL",
+    "OEMRecordFormat": "Contoso",
+    "Severity": "Critical",
+    "Created": "2012-03-07T14:44",
+    "EntryCode": "Assert",
+    "SensorType": "Temperature",
+    "SensorNumber": 1,
+    "Message": "System May be Melting",
+    "MessageId": "Event.1.0.TempWayTooHot",
+    "MessageArgs": [
+        "88"
+    ],
+    "Links": {
+        "OriginOfCondition": {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal"
+        },
+        "Oem": {}
+    },
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/LogServices/Members/Log/Entries/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/LogServices/Log/Entries/1",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Managers/BMC/LogServices/Log/Entries/index.json
+++ b/compose/dev/mockups/public-rackmount/Managers/BMC/LogServices/Log/Entries/index.json
@@ -1,0 +1,36 @@
+{
+    "@odata.type": "#LogEntryCollection.LogEntryCollection",
+    "Name": "Log Service Collection",
+    "Description": "Collection of Logs for this System",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/BMC/LogServices/Log/Entries/1",
+            "@odata.type": "#LogEntry.v1_0_2.LogEntry",
+            "Id": "1",
+            "Name": "Log Entry 1",
+            "EntryType": "SEL",
+            "OEMRecordFormat": "Contoso",
+            "Severity": "Critical",
+            "Created": "2012-03-07T14:44",
+            "EntryCode": "Assert",
+            "SensorType": "Temperature",
+            "SensorNumber": 1,
+            "Message": "System May be Melting",
+            "MessageId": "Event.1.0.TempWayTooHot",
+            "MessageArgs": [
+                "88"
+            ],
+            "Links": {
+                "OriginOfCondition": {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal"
+                },
+                "Oem": {}
+            },
+            "Oem": {}
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/LogServices/Members/Log/Entries",
+    "@odata.id": "/redfish/v1/Managers/BMC/LogServices/Log/Entries",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Managers/BMC/LogServices/Log/index.json
+++ b/compose/dev/mockups/public-rackmount/Managers/BMC/LogServices/Log/index.json
@@ -1,0 +1,27 @@
+{
+    "@odata.type": "#LogService.v1_0_2.LogService",
+    "Id": "Log",
+    "Name": "System Log Service",
+    "MaxNumberOfRecords": 1000,
+    "OverWritePolicy": "WrapsWhenFull",
+    "DateTime": "2015-03-13T04:14:33+06:00",
+    "DateTimeLocalOffset": "+06:00",
+    "ServiceEnabled": true,
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Oem": {},
+    "Actions": {
+        "#LogService.ClearLog": {
+            "target": "/redfish/v1/Managers/BMC/LogServices/Log/Actions/LogService.Reset"
+        },
+        "Oem": {}
+    },
+    "Entries": {
+        "@odata.id": "/redfish/v1/Managers/BMC/LogServices/Log/Entries"
+    },
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/LogServices/Members/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/LogServices/Log",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Managers/BMC/LogServices/index.json
+++ b/compose/dev/mockups/public-rackmount/Managers/BMC/LogServices/index.json
@@ -1,0 +1,14 @@
+{
+    "@odata.type": "#LogServiceCollection.LogServiceCollection",
+    "Name": "Log Service Collection",
+    "Description": "Collection of Log Services for this Manager",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/BMC/LogServices/Log"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#LogServicesCollection.LogServicesCollection",
+    "@odata.id": "/redfish/v1/Managers/BMC/LogServices",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Managers/BMC/NICs/Dedicated/SD/index.json
+++ b/compose/dev/mockups/public-rackmount/Managers/BMC/NICs/Dedicated/SD/index.json
@@ -1,0 +1,79 @@
+{
+    "@odata.type": "#EthernetInterface.v1_0_2.EthernetInterface",
+    "Id": "SD",
+    "Name": "Manager Ethernet Interface",
+    "Description": "Management Network Interface",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "InterfaceEnabled": true,
+    "PermanentMACAddress": "23:11:8A:33:CF:EA",
+    "MACAddress": "23:11:8A:33:CF:EA",
+    "SpeedMbps": 100,
+    "AutoNeg": true,
+    "FullDuplex": true,
+    "MTUSize": 1500,
+    "HostName": "web483-bmc",
+    "FQDN": "web483-bmc.dmtf.org",
+    "MaxIPv6StaticAddresses": 1,
+    "VLAN": {
+        "VLANEnable": true,
+        "VLANId": 101
+    },
+    "IPv4Addresses": [
+        {
+            "Address": "192.168.0.10",
+            "SubnetMask": "255.255.252.0",
+            "AddressOrigin": "DHCP",
+            "Gateway": "192.168.0.1",
+            "Oem": {}
+        }
+    ],
+    "IPv6AddressPolicyTable": [
+        {
+            "Prefix": "::1/128",
+            "Precedence": 50,
+            "Label": 0
+        }
+    ],
+    "IPv6StaticAddresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e24",
+            "PrefixLength": 16
+        }
+    ],
+    "IPv6DefaultGateway": "fe80::1ec1:deff:fe6f:1e24",
+    "IPv6Addresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e24",
+            "PrefixLength": 64,
+            "AddressOrigin": "SLAAC",
+            "AddressState": "Preferred",
+            "Oem": {}
+        }
+    ],
+    "NameServers": [
+        "names.dmtf.org"
+    ],
+    "@Redfish.Settings": {
+        "@odata.type": "#Settings.v1_0_2.Settings",
+        "SettingsObject": {
+            "@odata.id": "/redfish/v1/Managers/BMC/NICs/Dedicated/SD"
+        },
+        "Time": "2012-03-07T14:44.30-05:00",
+        "ETag": "84ffcbb050ddc7fa9cddb59014546e59",
+        "Messages": [
+            {
+                "MessageId": "Base.1.0.SettingsFailed",
+                "RelatedProperties": [
+                    "#/IPv6Addresses/PrefixLength"
+                ]
+            }
+        ]
+    },
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/NICs/Members/Dedicated/Settings/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/NICs/Dedicated/SD",
+    "@Redfish.Copyright":"Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Managers/BMC/NICs/Dedicated/index.json
+++ b/compose/dev/mockups/public-rackmount/Managers/BMC/NICs/Dedicated/index.json
@@ -1,0 +1,79 @@
+{
+    "@odata.type": "#EthernetInterface.v1_0_2.EthernetInterface",
+    "Id": "Dedicated",
+    "Name": "Manager Ethernet Interface",
+    "Description": "Management Network Interface",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "InterfaceEnabled": true,
+    "PermanentMACAddress": "23:11:8A:33:CF:EA",
+    "MACAddress": "23:11:8A:33:CF:EA",
+    "SpeedMbps": 100,
+    "AutoNeg": true,
+    "FullDuplex": true,
+    "MTUSize": 1500,
+    "HostName": "web483-bmc",
+    "FQDN": "web483-bmc.dmtf.org",
+    "MaxIPv6StaticAddresses": 1,
+    "VLAN": {
+        "VLANEnable": true,
+        "VLANId": 101
+    },
+    "IPv4Addresses": [
+        {
+            "Address": "192.168.0.10",
+            "SubnetMask": "255.255.252.0",
+            "AddressOrigin": "DHCP",
+            "Gateway": "192.168.0.1",
+            "Oem": {}
+        }
+    ],
+    "IPv6AddressPolicyTable": [
+        {
+            "Prefix": "::1/128",
+            "Precedence": 50,
+            "Label": 0
+        }
+    ],
+    "IPv6StaticAddresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e24",
+            "PrefixLength": 16
+        }
+    ],
+    "IPv6DefaultGateway": "fe80::1ec1:deff:fe6f:1e24",
+    "IPv6Addresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e24",
+            "PrefixLength": 64,
+            "AddressOrigin": "SLAAC",
+            "AddressState": "Preferred",
+            "Oem": {}
+        }
+    ],
+    "NameServers": [
+        "names.dmtf.org"
+    ],
+    "@Redfish.Settings": {
+        "@odata.type": "#Settings.v1_0_2.Settings",
+        "SettingsObject": {
+            "@odata.id": "/redfish/v1/Managers/BMC/NICs/Dedicated/SD"
+        },
+        "Time": "2012-03-07T14:44.30-05:00",
+        "ETag": "84ffcbb050ddc7fa9cddb59014546e59",
+        "Messages": [
+            {
+                "MessageId": "Base.1.0.SettingsFailed",
+                "RelatedProperties": [
+                    "#/IPv6Addresses/PrefixLength"
+                ]
+            }
+        ]
+    },
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/NICs/Members/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/NICs/Dedicated",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Managers/BMC/NICs/index.json
+++ b/compose/dev/mockups/public-rackmount/Managers/BMC/NICs/index.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#EthernetInterfaceCollection.EthernetInterfaceCollection",
+    "Name": "Ethernet Network Interface Collection",
+    "Description": "Collection of EthernetInterfaces for this Manager",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/BMC/NICs/Dedicated"
+        }
+    ],
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/NICs/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/NICs",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Managers/BMC/NetworkProtocol/index.json
+++ b/compose/dev/mockups/public-rackmount/Managers/BMC/NetworkProtocol/index.json
@@ -1,0 +1,55 @@
+{
+    "@odata.type": "#ManagerNetworkProtocol.v1_0_2.ManagerNetworkProtocol",
+    "Id": "NetworkProtocol",
+    "Name": "Manager Network Protocol",
+    "Description": "Manager Network Service",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "HostName": "web483-bmc",
+    "FQDN": "web483-bmc.dmtf.org",
+    "HTTP": {
+        "ProtocolEnabled": true,
+        "Port": 80
+    },
+    "HTTPS": {
+        "ProtocolEnabled": true,
+        "Port": 443
+    },
+    "IPMI": {
+        "ProtocolEnabled": true,
+        "Port": 623
+    },
+    "SSH": {
+        "ProtocolEnabled": true,
+        "Port": 22
+    },
+    "SNMP": {
+        "ProtocolEnabled": true,
+        "Port": 161
+    },
+    "VirtualMedia": {
+        "ProtocolEnabled": true,
+        "Port": 17988
+    },
+    "SSDP": {
+        "ProtocolEnabled": true,
+        "Port": 1900,
+        "NotifyMulticastIntervalSeconds": 600,
+        "NotifyTTL": 5,
+        "NotifyIPv6Scope": "Site"
+    },
+    "Telnet": {
+        "ProtocolEnabled": true,
+        "Port": 23
+    },
+    "KVMIP": {
+        "ProtocolEnabled": true,
+        "Port": 5288
+    },
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/NetworkProtocol/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/NetworkProtocol",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Managers/BMC/SerialInterfaces/TTY0/index.json
+++ b/compose/dev/mockups/public-rackmount/Managers/BMC/SerialInterfaces/TTY0/index.json
@@ -1,0 +1,22 @@
+{
+    "@odata.type": "#SerialInterface.v1_0_2.SerialInterface",
+    "Id": "TTY0",
+    "Name": "Manager Serial Interface 1",
+    "Description": "Management for Serial Interface",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "InterfaceEnabled": true,
+    "SignalType": "Rs232",
+    "BitRate": "115200",
+    "Parity": "None",
+    "DataBits": "8",
+    "StopBits": "1",
+    "FlowControl": "None",
+    "ConnectorType": "RJ45",
+    "PinOut": "Cyclades",
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/SerialInterfaces/Members/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/SerialInterfaces/TTY0",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Managers/BMC/SerialInterfaces/index.json
+++ b/compose/dev/mockups/public-rackmount/Managers/BMC/SerialInterfaces/index.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#SerialInterfaceCollection.SerialInterfaceCollection",
+    "Name": "Serial Interface Collection",
+    "Description": "Collection of Serial Interfaces for this System",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/BMC/SerialInterfaces/TTY0"
+        }
+    ],
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Managers/BMC/SerialInterfaces/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/SerialInterfaces",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Managers/BMC/VirtualMedia/CD1/index.json
+++ b/compose/dev/mockups/public-rackmount/Managers/BMC/VirtualMedia/CD1/index.json
@@ -1,0 +1,17 @@
+{
+    "@odata.type": "#VirtualMedia.v1_0_2.VirtualMedia",
+    "Id": "CD1",
+    "Name": "Virtual CD",
+    "MediaTypes": [
+        "CD",
+        "DVD"
+    ],
+    "Image": "redfish.dmtf.org/freeImages/freeOS.1.1.iso",
+    "ImageName": "mymedia-read-only",
+    "ConnectedVia": "Applet",
+    "Inserted": true,
+    "WriteProtected": false,
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/VirtualMedia/Members/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/VirtualMedia/CD1",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Managers/BMC/VirtualMedia/Floppy1/index.json
+++ b/compose/dev/mockups/public-rackmount/Managers/BMC/VirtualMedia/Floppy1/index.json
@@ -1,0 +1,17 @@
+{
+    "@odata.type": "#VirtualMedia.v1_0_2.VirtualMedia",
+    "Id": "Floppy1",
+    "Name": "Virtual Removable Media",
+    "MediaTypes": [
+        "Floppy",
+        "USBStick"
+    ],
+    "Image": "https://www.dmtf.org/freeImages/Sardine.img",
+    "ImageName": "Sardine2.1.43.35.6a",
+    "ConnectedVia": "URI",
+    "Inserted": true,
+    "WriteProtected": false,
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/VirtualMedia/Members/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/VirtualMedia/Floppy1",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Managers/BMC/VirtualMedia/index.json
+++ b/compose/dev/mockups/public-rackmount/Managers/BMC/VirtualMedia/index.json
@@ -1,0 +1,18 @@
+{
+    "@odata.type": "#VirtualMediaCollection.VirtualMediaCollection",
+    "Name": "Virtual Media Services",
+    "Description": "Redfish-BMC Virtual Media Service Settings",
+    "Members@odata.count": 2,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/BMC/VirtualMedia/Floppy1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Managers/BMC/VirtualMedia/CD1"
+        }
+    ],
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/VirtualMedia/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/VirtualMedia",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Managers/BMC/index.json
+++ b/compose/dev/mockups/public-rackmount/Managers/BMC/index.json
@@ -1,0 +1,86 @@
+{
+  "@odata.type": "#Manager.v1_1_0.Manager",
+  "Id": "BMC",
+  "Name": "Manager",
+  "ManagerType": "BMC",
+  "Description": "Contoso BMC",
+  "ServiceEntryPointUUID": "92384634-2938-2342-8820-489239905423",
+  "UUID": "58893887-8974-2487-2389-841168418919",
+  "Model": "Janta 200",
+  "DateTime": "2015-03-13T04:14:33+06:00",
+  "DateTimeLocalOffset": "+06:00",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "GraphicalConsole": {
+    "ServiceEnabled": true,
+    "MaxConcurrentSessions": 2,
+    "ConnectTypesSupported": [
+      "KVMIP"
+    ]
+  },
+  "SerialConsole": {
+    "ServiceEnabled": true,
+    "MaxConcurrentSessions": 1,
+    "ConnectTypesSupported": [
+      "Telnet",
+      "SSH",
+      "IPMI"
+    ]
+  },
+  "CommandShell": {
+    "ServiceEnabled": true,
+    "MaxConcurrentSessions": 4,
+    "ConnectTypesSupported": [
+      "Telnet",
+      "SSH"
+    ]
+  },
+  "FirmwareVersion": "1.00",
+  "NetworkProtocol": {
+    "@odata.id": "/redfish/v1/Managers/BMC/NetworkProtocol"
+  },
+  "EthernetInterfaces": {
+    "@odata.id": "/redfish/v1/Managers/BMC/NICs"
+  },
+  "SerialInterfaces": {
+    "@odata.id": "/redfish/v1/Managers/BMC/SerialInterfaces"
+  },
+  "LogServices": {
+    "@odata.id": "/redfish/v1/Managers/BMC/LogServices"
+  },
+  "VirtualMedia": {
+    "@odata.id": "/redfish/v1/Managers/BMC/VirtualMedia"
+  },
+  "Links": {
+    "ManagerForServers": [
+      {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+      }
+    ],
+    "ManagerForChassis": [
+      {
+        "@odata.id": "/redfish/v1/Chassis/1U"
+      }
+    ],
+    "ManagerInChassis": {
+      "@odata.id": "/redfish/v1/Chassis/1U"
+    },
+    "Oem": {}
+  },
+  "Actions": {
+    "#Manager.Reset": {
+      "target": "/redfish/v1/Managers/BMC/Actions/Manager.Reset",
+      "ResetType@Redfish.AllowableValues": [
+        "ForceRestart",
+        "GracefulRestart"
+      ]
+    },
+    "Oem": {}
+  },
+  "Oem": {},
+  "@odata.context": "/redfish/v1/$metadata#Manager.Manager",
+  "@odata.id": "/redfish/v1/Managers/BMC",
+  "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Managers/index.json
+++ b/compose/dev/mockups/public-rackmount/Managers/index.json
@@ -1,0 +1,14 @@
+{
+    "@odata.type": "#ManagerCollection.ManagerCollection",
+    "Name": "Manager Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/BMC"
+        }
+    ],
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Managers",
+    "@odata.id": "/redfish/v1/Managers",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/SessionService/Sessions/1234567890ABCDEF/index.json
+++ b/compose/dev/mockups/public-rackmount/SessionService/Sessions/1234567890ABCDEF/index.json
@@ -1,0 +1,11 @@
+{
+    "@odata.type": "#Session.v1_0_2.Session",
+    "Id": "1234567890ABCDEF",
+    "Name": "User Session",
+    "Description": "Manager User Session",
+    "UserName": "Administrator",
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Session.Session",
+    "@odata.id": "/redfish/v1/SessionService/Sessions/1234567890ABCDEF",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/SessionService/Sessions/index.json
+++ b/compose/dev/mockups/public-rackmount/SessionService/Sessions/index.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#SessionCollection.SessionCollection",
+    "Name": "Session Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/SessionService/Sessions/1234567890ABCDEF"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#SessionService/Sessions/$entity",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/SessionService/index.json
+++ b/compose/dev/mockups/public-rackmount/SessionService/index.json
@@ -1,0 +1,18 @@
+{
+    "@odata.type": "#SessionService.v1_0_2.SessionService",
+    "Id": "SessionService",
+    "Name": "Session Service",
+    "Description": "Session Service",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "ServiceEnabled": true,
+    "SessionTimeout": 30,
+    "Sessions": {
+        "@odata.id": "/redfish/v1/SessionService/Sessions"
+    },
+    "@odata.context": "/redfish/v1/$metadata#SessionService",
+    "@odata.id": "/redfish/v1/SessionService",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/BIOS/Settings/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/BIOS/Settings/index.json
@@ -1,0 +1,21 @@
+{
+	"@odata.type": "#Bios.v1_0_0.Bios",
+	"Id": "Settings",
+	"Name": "BIOS Configuration Pending Settings",
+	"AttributeRegistry": "BiosAttributeRegistryP89.v1_0_0",
+	"Attributes": {
+		"AdminPhone": "(404) 555-1212",
+		"BootMode": "Uefi",
+		"EmbeddedSata": "Ahci",
+		"NicBoot1": "NetworkBoot",
+		"NicBoot2": "NetworkBoot",
+		"PowerProfile": "MaxPerf",
+		"ProcCoreDisable": 0,
+		"ProcHyperthreading": "Enabled",
+		"ProcTurboMode": "Disabled",
+		"UsbControl": "UsbEnabled"
+	},
+	"@odata.context": "/redfish/v1/$metadata#Bios.Bios",
+	"@odata.id": "/redfish/v1/Systems/437XR1138R2/BIOS/Settings",
+	"@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/BIOS/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/BIOS/index.json
@@ -1,0 +1,43 @@
+{
+	"@odata.type": "#Bios.v1_0_0.Bios",
+	"Id": "BIOS",
+	"Name": "BIOS Configuration Current Settings",
+	"AttributeRegistry": "BiosAttributeRegistryP89.v1_0_0",
+	"Attributes": {
+		"AdminPhone": "",
+		"BootMode": "Uefi",
+		"EmbeddedSata": "Raid",
+		"NicBoot1": "NetworkBoot",
+		"NicBoot2": "Disabled",
+		"PowerProfile": "MaxPerf",
+		"ProcCoreDisable": 0,
+		"ProcHyperthreading": "Enabled",
+		"ProcTurboMode": "Enabled",
+		"UsbControl": "UsbEnabled"
+	},
+	"@Redfish.Settings": {
+		"@odata.type": "#Settings.v1_0_0.Settings",
+		"ETag": "9234ac83b9700123cc32",
+		"Messages": [{
+			"MessageId": "Base.1.0.SettingsFailed",
+			"RelatedProperties": [
+				"#/Attributes/ProcTurboMode"
+			]
+		}],
+		"SettingsObject": {
+			"@odata.id": "/redfish/v1/Systems/437XR1138R2/BIOS/Settings"
+		},
+		"Time": "2016-03-07T14:44.30-05:00"
+	},
+	"Actions": {
+		"#Bios.ResetBios": {
+			"target": "/redfish/v1/Systems/437XR1138R2/BIOS/Actions/Bios.ResetBios"
+		},
+		"#Bios.ChangePassword": {
+			"target": "/redfish/v1/Systems/437XR1138R2/BIOS/Actions/Bios.ChangePassword"
+		}
+	},
+	"@odata.context": "/redfish/v1/$metadata#Bios.Bios",
+	"@odata.id": "/redfish/v1/Systems/437XR1138R2/BIOS",
+	"@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs/1/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs/1/index.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#VLanNetworkInterface.v1_0_2.VLanNetworkInterface",
+    "Id": "1",
+    "Name": "VLAN Network Interface",
+    "Description": "System NIC 1 VLAN",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "VLANEnable": true,
+    "VLANId": 101,
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/EthernetInterfaces/Members/12446A3B0411/VLANs/Members/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs/1",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs/2/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs/2/index.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#VLanNetworkInterface.v1_0_2.VLanNetworkInterface",
+    "Id": "2",
+    "Name": "VLAN Network Interface",
+    "Description": "System NIC 1 VLAN",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "VLANEnable": true,
+    "VLANId": 199,
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/EthernetInterfaces/Members/12446A3B0411/VLANs/Members/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs/2",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs/index.json
@@ -1,0 +1,16 @@
+{
+    "@odata.type": "#VLanNetworkInterfaceCollection.VLanNetworkInterfaceCollection",
+    "Name": "VLAN Network Interface Collection",
+    "Members@odata.count": 2,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs/1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs/2"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/EthernetInterfaces/Members/12446A3B0411/VLANs/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/index.json
@@ -1,0 +1,42 @@
+{
+    "@odata.type": "#EthernetInterface.v1_0_2.EthernetInterface",
+    "Id": "1",
+    "Name": "Ethernet Interface",
+    "Description": "System NIC 1",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "FactoryMacAddress": "12:44:6A:3B:04:11",
+    "MacAddress": "12:44:6A:3B:04:11",
+    "SpeedMbps": 1000,
+    "FullDuplex": true,
+    "HostName": "web483",
+    "FQDN": "web483.contoso.com",
+    "IPv6DefaultGateway": "fe80::3ed9:2bff:fe34:600",
+    "NameServers": [
+        "names.contoso.com"
+    ],
+    "IPv4Addresses": [
+        {
+            "Address": "192.168.0.10",
+            "SubnetMask": "255.255.252.0",
+            "AddressOrigin": "Static",
+            "Gateway": "192.168.0.1"
+        }
+    ],
+    "IPv6Addresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e24",
+            "PrefixLength": 64,
+            "AddressOrigin": "Static",
+            "AddressState": "Preferred"
+        }
+    ],
+    "VLANs": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs"
+    },
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/EthernetInterfaces/Members/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/EthernetInterfaces/12446A3B8890/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/EthernetInterfaces/12446A3B8890/index.json
@@ -1,0 +1,43 @@
+{
+    "@odata.type": "#EthernetInterface.v1_0_2.EthernetInterface",
+    "Id": "2",
+    "Name": "Ethernet Interface",
+    "Description": "System NIC 2",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "PermanentMACAddress": "12:44:6A:3B:88:90",
+    "MACAddress": "AA:BB:CC:DD:EE:00",
+    "SpeedMbps": 1000,
+    "FullDuplex": true,
+    "HostName": "backup-web483",
+    "FQDN": "backup-web483.contoso.com",
+    "IPv6DefaultGateway": "fe80::3ed9:2bff:fe34:600",
+    "NameServers": [
+        "names.contoso.com"
+    ],
+    "IPv4Addresses": [
+        {
+            "Address": "192.168.0.11",
+            "SubnetMask": "255.255.255.0",
+            "AddressOrigin": "Static",
+            "Gateway": "192.168.0.1"
+        }
+    ],
+    "IPv6Addresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e33",
+            "PrefixLength": 64,
+            "AddressOrigin": "Static",
+            "AddressState": "Preferred"
+        }
+    ],
+    "VLAN": {
+        "VLANEnable": true,
+        "VLANId": 101
+    },
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/EthernetInterfaces/Members/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B8890",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/EthernetInterfaces/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/EthernetInterfaces/index.json
@@ -1,0 +1,18 @@
+{
+    "@odata.type": "#EthernetInterfaceCollection.EthernetInterfaceCollection",
+    "Name": "Ethernet Interface Collection",
+    "Description": "System NICs on Contoso Servers",
+    "Members@odata.count": 2,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B8890"
+        }
+    ],
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/EthernetInterfaces/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/LogServices/Log1/Entries/1/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/LogServices/Log1/Entries/1/index.json
@@ -1,0 +1,28 @@
+{
+    "@odata.type": "#LogEntry.v1_0_2.LogEntry",
+    "Id": "1",
+    "Name": "Log Entry 1",
+    "EntryType": "SEL",
+    "OemRecordFormat": "Contoso",
+    "RecordId": 1,
+    "Severity": "Critical",
+    "Created": "2012-03-07T14:44",
+    "EntryCode": "Assert",
+    "SensorType": "Temperature",
+    "SensorNumber": 1,
+    "Message": "Temperature threshold exceeded",
+    "MessageID": "Contoso.1.0.TempAssert",
+    "MessageArgs": [
+        "42"
+    ],
+    "Links": {
+        "OriginOfCondition": {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal"
+        },
+        "Oem": {}
+    },
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/LogServices/Members/Log1/Entries/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1/Entries/1",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/LogServices/Log1/Entries/2/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/LogServices/Log1/Entries/2/index.json
@@ -1,0 +1,28 @@
+{
+    "@odata.type": "#LogEntry.v1_0_2.LogEntry",
+    "Id": "2",
+    "Name": "Log Entry 2",
+    "EntryType": "SEL",
+    "OEMRecordFormat": "Contoso",
+    "RecordId": 2,
+    "Severity": "Critical",
+    "Created": "2012-03-07T14:45",
+    "EntryCode": "Assert",
+    "SensorType": "Temperature",
+    "SensorNumber": 2,
+    "Message": "Temperature threshold exceeded",
+    "MessageID": "Contoso.1.0.TempAssert",
+    "MessageArgs": [
+        "46"
+    ],
+    "Links": {
+        "OriginOfCondition": {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal"
+        },
+        "Oem": {}
+    },
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/LogServices/Members/Log1/Entries/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1/Entries/2",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/LogServices/Log1/Entries/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/LogServices/Log1/Entries/index.json
@@ -1,0 +1,64 @@
+{
+    "@odata.type": "#LogEntryCollection.LogEntryCollection",
+    "Name": "Log Service Collection",
+    "Description": "Collection of Logs for this System",
+    "Members@odata.count": 2,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1/Entries/1",
+            "@odata.type": "#LogEntry.v1_0_2.LogEntry",
+            "Id": "1",
+            "Name": "Log Entry 1",
+            "EntryType": "SEL",
+            "OemRecordFormat": "Contoso",
+            "RecordId": 1,
+            "Severity": "Warning",
+            "Created": "2012-03-07T14:44",
+            "EntryCode": "Assert",
+            "SensorType": "Temperature",
+            "Number": 1,
+            "Message": "Temperature threshold exceeded",
+            "MessageID": "Contoso.1.0.TempAssert",
+            "MessageArgs": [
+                "42"
+            ],
+            "Links": {
+                "OriginOfCondition": {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal"
+                },
+                "Oem": {}
+            },
+            "Oem": {}
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1/Entries/2",
+            "@odata.type": "#LogEntry.v1_0_2.LogEntry",
+            "Id": "2",
+            "Name": "Log Entry 2",
+            "EntryType": "SEL",
+            "OEMRecordFormat": "Contoso",
+            "RecordId": 2,
+            "Severity": "Critical",
+            "Created": "2012-03-07T14:45",
+            "EntryCode": "Assert",
+            "SensorType": "Temperature",
+            "Number": 2,
+            "Message": "Temperature threshold exceeded",
+            "MessageID": "Contoso.1.0.TempAssert",
+            "MessageArgs": [
+                "46"
+            ],
+            "Links": {
+                "OriginOfCondition": {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal"
+                },
+                "Oem": {}
+            },
+            "Oem": {}
+        }
+    ],
+    "@odata.nextLink": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1/Entries?$skiptoken=2",
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/LogServices/Members/Log1/Entries",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1/Entries",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/LogServices/Log1/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/LogServices/Log1/index.json
@@ -1,0 +1,26 @@
+{
+    "@odata.type": "#LogService.v1_0_2.LogService",
+    "Id": "Log1",
+    "Name": "System Log Service",
+    "MaxNumberOfRecords": 1000,
+    "OverWritePolicy": "WrapsWhenFull",
+    "DateTime": "2015-03-13T04:14:33+06:00",
+    "DateTimeLocalOffset": "+06:00",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Oem": {},
+    "Actions": {
+        "#LogService.ClearLog": {
+            "target": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1/Actions/LogService.Reset"
+        },
+        "Oem": {}
+    },
+    "Entries": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1/Entries"
+    },
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/LogServices/Members/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/LogServices/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/LogServices/index.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#LogServiceCollection.LogServiceCollection",
+    "Name": "Log Service Collection",
+    "Description": "Collection of Logs for this System",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1"
+        }
+    ],
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/LogServices/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/Memory/DIMM1/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/Memory/DIMM1/index.json
@@ -1,0 +1,30 @@
+{
+	"@odata.type": "#Memory.v1_0_0.Memory",
+	"Name": "DIMM Slot 1",
+	"Id": "DIMM1",
+	"RankCount": 2,
+	"MaxTDPMilliWatts": [12000],
+	"CapacityMiB": 32768,
+	"DataWidthBits": 64,
+	"BusWidthBits": 72,
+	"ErrorCorrection": "MultiBitECC",
+	"MemoryLocation": {
+		"Socket": 1,
+		"MemoryController": 1,
+		"Channel": 1,
+		"Slot": 1
+	},
+	"MemoryType": "DRAM",
+	"MemoryDeviceType": "DDR4",
+	"BaseModuleType": "RDIMM",
+	"MemoryMedia": [
+		"DRAM"
+	],
+	"Status": {
+		"State": "Enabled",
+		"Health": "OK"
+	},
+	"@odata.context": "/redfish/v1/$metadata#Memory.Memory",
+	"@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM1",
+	"@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/Memory/DIMM2/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/Memory/DIMM2/index.json
@@ -1,0 +1,30 @@
+{
+	"@odata.type": "#Memory.v1_0_0.Memory",
+	"Name": "DIMM Slot 2",
+	"Id": "DIMM2",
+	"RankCount": 2,
+	"MaxTDPMilliWatts": [12000],
+	"CapacityMiB": 32768,
+	"DataWidthBits": 64,
+	"BusWidthBits": 72,
+	"ErrorCorrection": "MultiBitECC",
+	"MemoryLocation": {
+		"Socket": 1,
+		"MemoryController": 1,
+		"Channel": 1,
+		"Slot": 2
+	},
+	"MemoryType": "DRAM",
+	"MemoryDeviceType": "DDR4",
+	"BaseModuleType": "RDIMM",
+	"MemoryMedia": [
+		"DRAM"
+	],
+	"Status": {
+		"State": "Enabled",
+		"Health": "OK"
+	},
+	"@odata.context": "/redfish/v1/$metadata#Memory.Memory",
+	"@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM2",
+	"@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/Memory/DIMM3/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/Memory/DIMM3/index.json
@@ -1,0 +1,30 @@
+{
+	"@odata.type": "#Memory.v1_0_0.Memory",
+	"Name": "DIMM Slot 3",
+	"Id": "DIMM3",
+	"RankCount": 2,
+	"MaxTDPMilliWatts": [12000],
+	"CapacityMiB": 32768,
+	"DataWidthBits": 64,
+	"BusWidthBits": 72,
+	"ErrorCorrection": "MultiBitECC",
+	"MemoryLocation": {
+		"Socket": 2,
+		"MemoryController": 2,
+		"Channel": 1,
+		"Slot": 3
+	},
+	"MemoryType": "DRAM",
+	"MemoryDeviceType": "DDR4",
+	"BaseModuleType": "RDIMM",
+	"MemoryMedia": [
+		"DRAM"
+	],
+	"Status": {
+		"State": "Enabled",
+		"Health": "OK"
+	},
+	"@odata.context": "/redfish/v1/$metadata#Memory.Memory",
+	"@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM2",
+	"@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/Memory/DIMM4/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/Memory/DIMM4/index.json
@@ -1,0 +1,17 @@
+{
+	"@odata.type": "#Memory.v1_0_0.Memory",
+	"Name": "DIMM Slot 4",
+	"Id": "DIMM4",
+	"MemoryLocation": {
+		"Socket": 2,
+		"MemoryController": 2,
+		"Channel": 1,
+		"Slot": 4
+	},
+	"Status": {
+		"State": "Absent"
+	},
+	"@odata.context": "/redfish/v1/$metadata#Memory.Memory",
+	"@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM4",
+	"@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/Memory/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/Memory/index.json
@@ -1,0 +1,17 @@
+{
+	"@odata.type": "#MemoryCollection.MemoryCollection",
+	"Name": "Memory Module Collection",
+	"Members@odata.count": 4,
+	"Members": [{
+		"@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM1"
+	}, {
+		"@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM2"
+	}, {
+		"@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM3"
+	}, {
+		"@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM4"
+	}],
+	"@odata.context": "/redfish/v1/$metadata#MemoryCollection.MemoryCollection",
+	"@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory",
+	"@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/Processors/CPU1/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/Processors/CPU1/index.json
@@ -1,0 +1,28 @@
+{
+    "@odata.type": "#Processor.v1_0_2.Processor",
+    "Id": "CPU1",
+    "Socket": "CPU 1",
+    "ProcessorType": "CPU",
+    "ProcessorArchitecture": "x86",
+    "InstructionSet": "x86-64",
+    "Manufacturer": "Intel(R) Corporation",
+    "Model": "Multi-Core Intel(R) Xeon(R) processor 7xxx Series",
+    "ProcessorID": {
+        "VendorID": "GenuineIntel",
+        "IdentificationRegisters": "0x34AC34DC8901274A",
+        "EffectiveFamily": "0x42",
+        "EffectiveModel": "0x61",
+        "Step": "0x1",
+        "MicrocodeInfo": "0x429943"
+    },
+    "MaxSpeedMHz": 3700,
+    "TotalCores": 8,
+    "TotalThreads": 16,
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/Processors/Members/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU1",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/Processors/CPU2/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/Processors/CPU2/index.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#Processor.v1_0_2.Processor",
+    "Id": "CPU2",
+    "Socket": "CPU 2",
+    "ProcessorType": "CPU",
+    "Status": {
+        "State": "Absent"
+    },
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/Processors/Members/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU2",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/Processors/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/Processors/index.json
@@ -1,0 +1,16 @@
+{
+    "@odata.type": "#ProcssorCollection.ProcessorCollection",
+    "Name": "Processors Collection",
+    "Members@odata.count": 2,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU2"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#Systems/Links/Members/437XR1138R2/Processors/#entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/SimpleStorage/1/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/SimpleStorage/1/index.json
@@ -1,0 +1,49 @@
+{
+    "@odata.type": "#SimpleStorage.v1_0_2.SimpleStorage",
+    "Id": "1",
+    "Name": "Simple Storage Controller",
+    "Description": "System SATA",
+    "UEFIDevicePath": "Acpi(PNP0A03,0)/Pci(1F|1)/Ata(Primary,Master)/HD(Part3, Sig00110011)",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK",
+        "HealthRollUp": "Degraded"
+    },
+    "Devices": [
+        {
+            "Name": "SATA Bay 1",
+            "Manufacturer": "Contoso",
+            "Model": "3000GT8",
+            "CapacityBytes": 8000000000000,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            }
+        },
+        {
+            "Name": "SATA Bay 2",
+            "Manufacturer": "Contoso",
+            "Model": "3000GT7",
+            "CapacityBytes": 4000000000000,
+            "Status": {
+                "State": "Enabled",
+                "Health": "Degraded"
+            }
+        },
+        {
+            "Name": "SATA Bay 3",
+            "Status": {
+                "State": "Absent"
+            }
+        },
+        {
+            "Name": "SATA Bay 4",
+            "Status": {
+                "State": "Absent"
+            }
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/SimpleStorage/Members/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/SimpleStorage/1",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/SimpleStorage/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/SimpleStorage/index.json
@@ -1,0 +1,13 @@
+{
+    "@odata.type": "#SimpleStorageCollection.SimpleStorageCollection",
+    "Name": "Simple Storage Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/SimpleStorage/1"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/SimpleStorage/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/SimpleStorage",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/437XR1138R2/index.json
@@ -1,0 +1,134 @@
+{
+    "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem",
+    "Id": "437XR1138R2",
+    "Name": "WebFrontEnd483",
+    "SystemType": "Physical",
+    "AssetTag": "Chicago-45Z-2381",
+    "Manufacturer": "Contoso",
+    "Model": "3500RX",
+    "SKU": "8675309",
+    "SerialNumber": "437XR1138R2",
+    "PartNumber": "224071-J23",
+    "Description": "Web Front End node",
+    "UUID": "38947555-7742-3448-3784-823347823834",
+    "HostName": "web483",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK",
+        "HealthRollUp": "OK"
+    },
+    "IndicatorLED": "Off",
+    "PowerState": "On",
+    "Boot": {
+        "BootSourceOverrideEnabled": "Once",
+        "BootSourceOverrideTarget": "Pxe",
+        "BootSourceOverrideTarget@Redfish.AllowableValues": [
+            "None",
+            "Pxe",
+            "Cd",
+            "Usb",
+            "Hdd",
+            "BiosSetup",
+            "Utilities",
+            "Diags",
+            "SDCard",
+            "UefiTarget"
+        ],
+        "BootSourceOverrideMode": "UEFI",
+        "UefiTargetBootSourceOverride": "/0x31/0x33/0x01/0x01"
+    },
+    "TrustedModules": [
+        {
+            "FirmwareVersion": "1.13b",
+            "InterfaceType": "TPM1_2",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            }
+        }
+    ],
+    "Oem": {
+        "Contoso": {
+            "@odata.type": "http://Contoso.com/Schema#Contoso.ComputerSystem",
+            "ProductionLocation": {
+                "FacilityName": "PacWest Production Facility",
+                "Country": "USA"
+            }
+        },
+        "Chipwise": {
+            "@odata.type": "http://Chipwise.com/Schema#Chipwise.ComputerSystem",
+            "Style": "Executive"
+        }
+    },
+    "BiosVersion": "P79 v1.33 (02/28/2015)",
+    "ProcessorSummary": {
+        "Count": 2,
+        "ProcessorFamily": "Multi-Core Intel(R) Xeon(R) processor 7xxx Series",
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK",
+            "HealthRollUp": "OK"
+        }
+    },
+    "MemorySummary": {
+        "TotalSystemMemoryGiB": 96,
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK",
+            "HealthRollUp": "OK"
+        }
+    },
+    "Bios": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/BIOS"
+    },
+    "Processors": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors"
+    },
+    "Memory": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory"
+    },
+    "EthernetInterfaces": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces"
+    },
+    "SimpleStorage": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/SimpleStorage"
+    },
+    "LogServices": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices"
+    },
+    "Links": {
+        "Chassis": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/1U"
+            }
+        ],
+        "ManagedBy": [
+            {
+                "@odata.id": "/redfish/v1/Managers/BMC"
+            }
+        ]
+    },
+    "Actions": {
+        "#ComputerSystem.Reset": {
+            "target": "/redfish/v1/Systems/437XR1138R2/Actions/ComputerSystem.Reset",
+            "ResetType@Redfish.AllowableValues": [
+                "On",
+                "ForceOff",
+                "GracefulShutdown",
+                "GracefulRestart",
+                "ForceRestart",
+                "Nmi",
+                "ForceOn",
+                "PushPowerButton"
+            ]
+        },
+        "Oem": {
+            "#Contoso.Reset": {
+                "target": "/redfish/v1/Systems/437XR1138R2/Oem/Contoso/Actions/Contoso.Reset"
+            }
+        }
+    },
+    "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/Systems/index.json
+++ b/compose/dev/mockups/public-rackmount/Systems/index.json
@@ -1,0 +1,13 @@
+{
+    "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+    "Name": "Computer System Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#Systems",
+    "@odata.id": "/redfish/v1/Systems",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/TaskService/Tasks/545/index.json
+++ b/compose/dev/mockups/public-rackmount/TaskService/Tasks/545/index.json
@@ -1,0 +1,25 @@
+{
+    "@odata.type": "#Tasks.v1_0_2.Task",
+    "Id": "545",
+    "Name": "Task 545",
+    "TaskState": "Completed",
+    "StartTime": "2012-03-07T14:44+06:00",
+    "EndTime": "2012-03-07T14:45+06:00",
+    "TaskStatus": "OK",
+    "Messages": [
+        {
+            "MessageId": "Base.1.0.PropertyNotWriteable",
+            "RelatedProperties": [
+                "SKU"
+            ],
+            "Message": "The property SKU is a read only property and cannot be assigned a value",
+            "MessageArgs": [
+                "SKU"
+            ],
+            "Severity": "Warning"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata/TaskService/Tasks/Members/$entity",
+    "@odata.id": "/redfish/v1/TaskService/Tasks/545",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/TaskService/Tasks/index.json
+++ b/compose/dev/mockups/public-rackmount/TaskService/Tasks/index.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#TasksCollection.TaskCollection",
+    "Name": "Task Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/TaskService/Tasks/545"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#TaskService/Tasks/$entity",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/TaskService/index.json
+++ b/compose/dev/mockups/public-rackmount/TaskService/index.json
@@ -1,0 +1,20 @@
+{
+    "@odata.type": "#TaskService.v1_0_2.TaskService",
+    "Id": "TaskService",
+    "Name": "Tasks Service",
+    "DateTime": "2015-03-13T04:14:33+06:00",
+    "OverWritePolicy": "Never",
+    "LifeCycleEventOnTaskStateChange": true,
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "ServiceEnabled": true,
+    "Tasks": {
+        "@odata.id": "/redfish/v1/TaskService/Tasks"
+    },
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata/TaskService",
+    "@odata.id": "/redfish/v1/TaskService",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/compose/dev/mockups/public-rackmount/explorer_config.json
+++ b/compose/dev/mockups/public-rackmount/explorer_config.json
@@ -1,0 +1,62 @@
+{
+    "name" : "Simple Rack-mounted Server",
+    "description" : "A typical 1U or 2U server intended for scale-out deployments.",
+    "navlinks" : [
+        {
+            "text" : "Main",
+            "target" : "main"
+        },
+        {
+            "text" : "Systems",
+            "target" : "Systems",
+            "navlinks" : [
+                {
+                    "text" : "437XR1138R2",
+                    "target" : "437XR1138R2"
+                }
+            ]
+        },
+        {
+            "text" : "Chassis",
+            "target": "Chassis",
+            "navlinks" : [
+                {
+                    "text" : "1U",
+                    "target" : "1U"
+                }
+            ]
+        },
+        {
+            "text" : "Managers",
+            "target" : "Managers",
+            "navlinks" : [
+                {
+                    "text" : "BMC",
+                    "target" : "BMC"
+                }
+            ]
+        },
+        {
+            "text" : "Task Service",
+            "target" : "TaskService"
+        },
+        {
+            "text" : "Session Service",
+            "target" : "SessionService"
+        },
+        {
+            "target" : "AccountService",
+            "text" : "Account Service"
+        },
+        {
+            "target" :  "EventService",
+            "text" : "Event Service",
+            "navlinks" : [
+                {
+                    "text" : "Subscriptions",
+                    "target" : "Subscriptions"
+                }
+            ]
+        }
+    ]
+}

--- a/compose/dev/mockups/public-rackmount/index.json
+++ b/compose/dev/mockups/public-rackmount/index.json
@@ -1,0 +1,37 @@
+{
+    "@odata.type": "#ServiceRoot.v1_0_2.ServiceRoot",
+    "Id": "RootService",
+    "Name": "Root Service",
+    "RedfishVersion": "1.0.2",
+    "UUID": "92384634-2938-2342-8820-489239905423",
+    "Systems": {
+        "@odata.id": "/redfish/v1/Systems"
+    },
+    "Chassis": {
+        "@odata.id": "/redfish/v1/Chassis"
+    },
+    "Managers": {
+        "@odata.id": "/redfish/v1/Managers"
+    },
+    "Tasks": {
+        "@odata.id": "/redfish/v1/TaskService"
+    },
+    "SessionService": {
+        "@odata.id": "/redfish/v1/SessionService"
+    },
+    "AccountService": {
+        "@odata.id": "/redfish/v1/AccountService"
+    },
+    "EventService": {
+        "@odata.id": "/redfish/v1/EventService"
+    },
+    "Links": {
+        "Sessions": {
+            "@odata.id": "/redfish/v1/SessionService/Sessions"
+        }
+    },
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#ServiceRoot",
+    "@odata.id": "/redfish/v1/",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}


### PR DESCRIPTION
This commit adds support for deploying sushy-tool using dev compose. Sushy-tool provides a static redfish responder that uses mockups enabling redfish API for testing and development.

The kepler-dev service now connects to redfish API endpoint to provide platform metrics.

*NOTE: The mockups contain static Power data and are not real data. This is for testing purposes only and not recommended for production.*