### PR TITLE
ci: skip commit message check for dependabot PRs

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -102,7 +102,6 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   pre-commit:
-    if: ${{ github.actor != 'dependabot[bot]' || github.actor != 'dependabot' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -118,7 +117,8 @@ jobs:
         run: pre-commit run --all-files
 
   commit-msg-check:
-    if: ${{ github.actor != 'dependabot[bot]' || github.actor != 'dependabot' }}
+    # NOTE: Skipping the commit-msg check for dependabot PRs
+    if: ${{ !startsWith(github.actor, 'dependabot') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source


### PR DESCRIPTION
Skip the commit-msg-check job for any PR created by dependabot to avoid failures on automated dependency updates that may not follow conventional commit message format.

- Use !startsWith(github.actor, 'dependabot') condition
- Covers all dependabot variants (dependabot, dependabot[bot], etc.)
- Maintains commit message validation for human contributors