### PR TITLE
chore: add experimental config validation skip option

### DIFF
--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -41,8 +41,10 @@ jobs:
           go-version-file: go.mod
           cache: false
 
+      # NOTE: Using a specific SHA of pprof as
+      # the latest version of pprof requires Go 1.24 or later
       - name: Install pprof
-        run: go install github.com/google/pprof@latest
+        run: go install github.com/google/pprof@6e76a2b096b5fa52e4bb3f7f7a357bd6e6b3b7b1
 
       - name: Run Docker Compose services
         shell: bash
@@ -130,8 +132,10 @@ jobs:
           go-version-file: go.mod
           cache: false
 
+      # NOTE: Using a specific SHA of pprof as
+      # the latest version of pprof requires Go 1.24 or later
       - name: Install pprof
-        run: go install github.com/google/pprof@latest
+        run: go install github.com/google/pprof@6e76a2b096b5fa52e4bb3f7f7a357bd6e6b3b7b1
 
       - name: Download profiling artifacts
         uses: actions/download-artifact@v5

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -590,6 +590,21 @@ func TestValidateWithSkip(t *testing.T) {
 	// Validate with skipping host validation
 	err := cfg.Validate(SkipHostValidation)
 	assert.NoError(t, err, "Should pass when SkipHostValidation is provided")
+
+	// Create a config with invalid experimental config
+	cfg = DefaultConfig()
+	cfg.Experimental = &Experimental{
+		Platform: Platform{
+			Redfish: Redfish{
+				Enabled:    ptr.To(true),
+				ConfigFile: "/path/invalid",
+			},
+		},
+	}
+
+	// Validate with skipping experimental validation
+	err = cfg.Validate(SkipExperimentalValidation)
+	assert.NoError(t, err, "Should pass when SkipExperimentalValidation is provided")
 }
 
 func TestMonitorConfig(t *testing.T) {
@@ -2355,7 +2370,7 @@ func TestValidateExperimentalConfig(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			errors := tc.config.validateExperimentalConfig()
+			errors := tc.config.validateExperimentalConfig(nil)
 
 			if tc.expectedErrors == nil {
 				assert.Empty(t, errors)


### PR DESCRIPTION
Enable skipping validation of experimental configuration in controller manager. When experimental config is enabled and Kepler is deployed via operator, the controller manager previously attempted to validate the experimental config, which could cause issues. This change allows the controller manager to skip experimental config validation, deferring validation to the Kepler pods where the actual configuration will be properly validated.