### PR TITLE
feat: push helm chart to OCI registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,3 +108,11 @@ jobs:
         shell: bash
         run: |
           make push VERSION=${{ steps.version.outputs.version }}
+
+      - name: Push Helm Chart to OCI registry
+        shell: bash
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          # Remove 'v' prefix from version
+          CHART_VERSION=${VERSION#v}
+          helm push helm-releases/kepler-helm-${CHART_VERSION}.tgz oci://${{ env.IMG_BASE }}/charts


### PR DESCRIPTION
I refer to [how Prometheus does with their helm chart release to OCI registry](https://github.com/prometheus-community/helm-charts/blob/main/.github/workflows/release.yaml#L56) and provide one more step to push packaged helm chart to OCI registry.

After pushing, we can run the following command for installing kepler helm chart `helm install [RELEASE_NAME] oci://quay.io/sustainable_computing_io/charts/kepler-helm`

https://github.com/sustainable-computing-io/kepler/issues/2302