### PR TITLE
chore: re-enable blank issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: 📋 General Support & Questions
     url: https://github.com/sustainable-computing-io/kepler/discussions


### PR DESCRIPTION
allow people to have the option to open a blank