### PR TITLE
ci(dep): update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
   - package-ecosystem: gomod
@@ -15,6 +14,12 @@ updates:
     ignore:
       - dependency-name: k8s.io/*
         update-types: [version-update:semver-major, version-update:semver-minor]
+    commit-message:
+      include: scope
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - go
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -24,3 +29,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+    commit-message:
+      include: scope
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions


### PR DESCRIPTION
This commit updates the existing dependabot configuration:

Changes include:
* Explicitly set PR limits to 5
* Add labels - All PRs will be tagged with:
  * `dependencies` (common label)
  * Ecosystem label (go, github-actions)