### PR TITLE
ci: harden github actions permissions for scorecard compliance

### DIFF
--- a/.github/workflows/assign-labels.yaml
+++ b/.github/workflows/assign-labels.yaml
@@ -3,10 +3,12 @@ name: Assign Labels
 on: # yamllint disable-line rule:truthy
   pull_request_target:
 
+# default permissions as read only
+permissions: read-all
+
 jobs:
   assign-labels:
     permissions:
-      contents: read
       pull-requests: write
       issues: write
     runs-on: ubuntu-latest

--- a/.github/workflows/check-x-crypto-deps.yaml
+++ b/.github/workflows/check-x-crypto-deps.yaml
@@ -3,10 +3,12 @@ name: Check x/crypto
 on: # yamllint disable-line rule:truthy
   pull_request:
 
+# default permissions as read only
+permissions: read-all
+
 jobs:
   check-x-crypto-deps:
     permissions:
-      contents: read
       pull-requests: write
     runs-on: ubuntu-latest
     name: Check x/crypto Dependencies in Pull Request

--- a/.github/workflows/config-change.yaml
+++ b/.github/workflows/config-change.yaml
@@ -3,6 +3,9 @@ name: Check Config Changes
 on: # yamllint disable-line rule:truthy
   pull_request:
 
+# default permissions as read only
+permissions: read-all
+
 jobs:
   check-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/k8s-bm.yaml
+++ b/.github/workflows/k8s-bm.yaml
@@ -3,9 +3,8 @@ name: Build and Deploy K8s on Self Hosted BM
 on: # yamllint disable-line rule:truthy
   pull_request:
 
-permissions:
-  pull-requests: write
-  contents: write
+# default permissions as read only
+permissions: read-all
 
 jobs:
   check-changes:

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -3,6 +3,9 @@ name: PR Checks
 on: # yamllint disable-line rule:truthy
   pull_request:
 
+# default permissions as read only
+permissions: read-all
+
 jobs:
   check-changes:
     runs-on: ubuntu-latest
@@ -97,9 +100,18 @@ jobs:
   test-and-codecov:
     needs: check-changes
     if: needs.check-changes.outputs.changes == 'true'
+    permissions:
+      contents: read
     uses: ./.github/workflows/test-and-codecov.yaml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  scorecard:
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+    uses: ./.github/workflows/scorecard.yml
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -11,12 +11,13 @@ on: # yamllint disable-line rule:truthy
     types:
       - completed
 
-permissions:
-  pull-requests: write
-  actions: read
+# default permissions as read only
+permissions: read-all
 
 jobs:
   comment-on-pr:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     # Only run if the triggering workflow succeeded
     if: github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -2,6 +2,9 @@ name: Profiling Report
 on: # yamllint disable-line rule:truthy
   pull_request:
 
+# default permissions as read only
+permissions: read-all
+
 jobs:
   check-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -4,14 +4,22 @@ on: # yamllint disable-line rule:truthy
   push:
     branches: [main]
 
+# default permissions as read only
+permissions: read-all
+
 jobs:
   test-and-codecov:
+    permissions:
+      contents: read
     uses: ./.github/workflows/test-and-codecov.yaml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  # for each PR merge, openSSF scan
   scorecard:
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
     uses: ./.github/workflows/scorecard.yml
 
   publish:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,15 +5,14 @@ on: # yamllint disable-line rule:truthy
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 
-jobs:
-  release:
-    permissions:
-      contents: write
+# default permissions as read only
+permissions: read-all
 
+jobs:
+  build:
     runs-on: ubuntu-latest
     env:
       IMG_BASE: quay.io/sustainable_computing_io
-
     steps:
       - name: Checkout source
         uses: actions/checkout@v5
@@ -90,19 +89,14 @@ jobs:
           # Currently the binary is built for linux-amd64 only
           tar -czvf bin/kepler-${VERSION}.linux-amd64.tar.gz bin/kepler
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+      - name: Upload Release Artifacts
+        uses: actions/upload-artifact@v4
         with:
-          tag_name: ${{ github.ref_name }}
-          name: release-${{ steps.version.outputs.version }}
-          generate_release_notes: true
-          draft: false
-          make_latest: true
-          files: |
+          name: release-artifacts
+          retention-days: 1 # Keep the artifacts for 1 day
+          path: |
             helm-releases/*.tgz
             bin/*.tar.gz
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Image
         shell: bash
@@ -116,3 +110,38 @@ jobs:
           # Remove 'v' prefix from version
           CHART_VERSION=${VERSION#v}
           helm push helm-releases/kepler-helm-${CHART_VERSION}.tgz oci://${{ env.IMG_BASE }}/charts
+
+  release:
+    needs: build
+    permissions:
+      # contents: write is required for publishing Github Releases
+      # This follows Github's recommended pattern: top-level read-all with minimal job-level permissions
+      # See: https://github.com/softprops/action-gh-release?tab=readme-ov-file#permissions
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Release Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts
+
+      - name: Extract version
+        shell: bash
+        id: version
+        run: |
+          TAG_NAME=${{ github.ref_name }}
+          echo "version=$TAG_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: release-${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          draft: false
+          make_latest: true
+          files: |
+            helm-releases/*.tgz
+            bin/*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,20 +6,22 @@ name: Scorecard supply-chain security
 on: # yamllint disable-line rule:truthy
   workflow_call:
 
-# Declare default permissions as read only.
-permissions: read-all
+# Restrict permissions for GITHUB_TOKEN by default.
+# Each job must explicitly declare what it needs.
+permissions: {}
 
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
+      # Needed to checkout code.
+      contents: read
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
       # Needed to publish results and get a badge (see publish_results below).
       id-token: write
       # Uncomment the permissions below if installing in a private repository.
-      # contents: read
       # actions: read
 
     steps:
@@ -55,7 +57,7 @@ jobs:
         with:
           name: SARIF file
           path: scorecard-results.sarif
-          retention-days: 5
+          retention-days: 1 # Keeping the results for 1 day
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: Upload to code-scanning

--- a/.github/workflows/test-and-codecov.yaml
+++ b/.github/workflows/test-and-codecov.yaml
@@ -7,9 +7,15 @@ on: # yamllint disable-line rule:truthy
         description: Codecov token
         required: true
 
+# Restrict permissions for GITHUB_TOKEN by default.
+# Each job must explicitly declare what it needs.
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout source
         uses: actions/checkout@v5
@@ -32,6 +38,8 @@ jobs:
   coverage-upload:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout source
         uses: actions/checkout@v5


### PR DESCRIPTION
Implement OpenSSF scorecard security recommendations to
improve workflow security

- Set default  `read-all` permissions at the workflow level
  across all workflows
- Define minimal job-level permissions following least privilege
  principle
- Refactor release workflow to separate build and release steps
- Add scorecard job to PR checks workflow
- Reduce artifact retention to 1 day for scorecard results
