### PR TITLE
ci: restrict workflows to run only on main repo

### DIFF
--- a/.github/workflows/k8s-bm.yaml
+++ b/.github/workflows/k8s-bm.yaml
@@ -30,7 +30,7 @@ jobs:
 
   build-and-deploy:
     needs: [check-changes]
-    if: needs.check-changes.outputs.changes == 'true'
+    if: needs.check-changes.outputs.changes == 'true' && github.repository_owner == 'sustainable-computing-io'
     runs-on: self-hosted
     steps:
       # NOTE: In case of self-hosted runners, tools like docker, make, kubectl etc. are installed at the time of setting up the runner.

--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -28,7 +28,7 @@ jobs:
 
   profiling:
     needs: check-changes
-    if: needs.check-changes.outputs.changes == 'true'
+    if: needs.check-changes.outputs.changes == 'true' && github.repository_owner == 'sustainable-computing-io'
     runs-on: self-hosted
     steps:
       # NOTE: In case of self-hosted runners, tools like docker, make, kubectl etc. are installed at the time of setting up the runner.

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -23,6 +23,7 @@ jobs:
     uses: ./.github/workflows/scorecard.yml
 
   publish:
+    if: github.repository_owner == 'sustainable-computing-io'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,9 +7,9 @@ on: # yamllint disable-line rule:truthy
 
 # default permissions as read only
 permissions: read-all
-
 jobs:
   build:
+    if: github.repository_owner == 'sustainable-computing-io'
     runs-on: ubuntu-latest
     env:
       IMG_BASE: quay.io/sustainable_computing_io
@@ -45,22 +45,15 @@ jobs:
         shell: bash
         run: make deps
 
-      - name: Extract version
-        shell: bash
-        id: version
-        run: |
-          TAG_NAME=${{ github.ref_name }}
-          echo "version=$TAG_NAME" >> "$GITHUB_OUTPUT"
-
       - name: Build Image
         shell: bash
         run: |
-          make image VERSION=${{ steps.version.outputs.version }}
+          make image VERSION=${{ github.ref_name }}
 
       - name: Update Helm Chart Version
         shell: bash
         run: |
-          VERSION=${{ steps.version.outputs.version }}
+          VERSION=${{ github.ref_name }}
           # Remove 'v' prefix from version
           CHART_VERSION=${VERSION#v}
           # Update Chart.yaml with the release version
@@ -71,7 +64,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p helm-releases
-          VERSION=${{ steps.version.outputs.version }}
+          VERSION=${{ github.ref_name }}
           # Remove 'v' prefix from version
           CHART_VERSION=${VERSION#v}
           helm package manifests/helm/kepler -d helm-releases
@@ -81,7 +74,7 @@ jobs:
       - name: Build Kepler binary
         shell: bash
         run: |
-          VERSION=${{ steps.version.outputs.version }}
+          VERSION=${{ github.ref_name }}
           # Remove 'v' prefix from version
           VERSION=${VERSION#v}
           make build PRODUCTION=1
@@ -101,12 +94,12 @@ jobs:
       - name: Push Image
         shell: bash
         run: |
-          make push VERSION=${{ steps.version.outputs.version }}
+          make push VERSION=${{ github.ref_name }}
 
       - name: Push Helm Chart to OCI registry
         shell: bash
         run: |
-          VERSION=${{ steps.version.outputs.version }}
+          VERSION=${{ github.ref_name }}
           # Remove 'v' prefix from version
           CHART_VERSION=${VERSION#v}
           helm push helm-releases/kepler-helm-${CHART_VERSION}.tgz oci://${{ env.IMG_BASE }}/charts
@@ -125,18 +118,11 @@ jobs:
         with:
           name: release-artifacts
 
-      - name: Extract version
-        shell: bash
-        id: version
-        run: |
-          TAG_NAME=${{ github.ref_name }}
-          echo "version=$TAG_NAME" >> "$GITHUB_OUTPUT"
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          name: release-${{ steps.version.outputs.version }}
+          name: release-${{ github.ref_name }}
           generate_release_notes: true
           draft: false
           make_latest: true


### PR DESCRIPTION
Prevent workflows from running on forks by adding repository owner checks to workflows that publish artifacts or use self-hosted runners.

- Add check to `push.yaml` to prevent image publishing on forks
- Add check to `release.yaml` to prevent release creation on forks
- Add check to `k8s-bm.yaml` to prevent self-hosted runner usage on forks
- Add check to `profiling.yaml` to prevent self-hosted runner usage on forks
- Removed `Extract version` step from `release.yaml` since it is
      redundant and just copying `github.ref_name` to a step variable
      output without any transformation or processing

This ensures fork contributors don't need to manually disable workflows and prevents unnecessary runs on forks.