### PR TITLE
ci: skip codecov for dependabot PRs

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -99,7 +99,7 @@ jobs:
 
   test-and-codecov:
     needs: check-changes
-    if: needs.check-changes.outputs.changes == 'true'
+    if: needs.check-changes.outputs.changes == 'true' && github.actor != 'dependabot[bot]'
     permissions:
       contents: read
     uses: ./.github/workflows/test-and-codecov.yaml


### PR DESCRIPTION
Dependabot PRs fail codecov upload with "Token required because branch is protected" error. This change modifies the test-and-codecov job condition to exclude dependabot PRs while maintaining normal codecov functionality for all other contributors.