### PR TITLE
chore: add OCI compliant labels to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Build the binary
 FROM golang:1.24 AS builder
 
+# Build arguments for binary
 ARG VERSION
 ARG GIT_COMMIT
 ARG GIT_BRANCH
@@ -16,6 +17,21 @@ RUN make build \
   GIT_BRANCH=${GIT_BRANCH}
 
 FROM registry.access.redhat.com/ubi9:latest
+
+# Build arguments for labels
+ARG VERSION
+ARG GIT_COMMIT
+ARG BUILD_TIME
+
+LABEL org.opencontainers.image.created=${BUILD_TIME} \
+  org.opencontainers.image.source="https://github.com/sustainable-computing-io/kepler" \
+  org.opencontainers.image.version=${VERSION} \
+  org.opencontainers.image.revision=${GIT_COMMIT} \
+  org.opencontainers.image.licenses="Apache-2.0 AND GPL-2.0-only AND BSD-2-Clause" \
+  org.opencontainers.image.vendor="sustainable-computing-io" \
+  org.opencontainers.image.title="Kepler" \
+  org.opencontainers.image.documentation="https://sustainable-computing.io/" \
+  org.opencontainers.image.description="Kepler (Kubernetes-based Efficient Power Level Exporter) is a Prometheus exporter that measures energy consumption metrics at the container, pod, and node levels in Kubernetes clusters"
 
 COPY --from=builder /workspace/bin/kepler-release /usr/bin/kepler
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ endif
 BINARY_DIR=bin
 MAIN_GO_PATH=./cmd/kepler
 VERSION?=$(shell git describe --tags --always --dirty || echo "dev")
-BUILD_TIME=$(shell date -u '+%Y-%m-%d_%H:%M:%S')
+BUILD_TIME=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null)
 
@@ -167,6 +167,7 @@ deps: ## Dependencies management (tidy and verify)
 image: ## Docker image build
 	docker build -t \
 		$(KEPLER_IMAGE) \
+		--build-arg BUILD_TIME=$(BUILD_TIME) \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg GIT_BRANCH=$(GIT_BRANCH) \


### PR DESCRIPTION
This commit adds the OCI compliant labels to the Dockerfile

Addresses: #2360