### PR TITLE
feat(platform): set hostUsers explicitly

### DIFF
--- a/manifests/helm/kepler/templates/daemonset.yaml
+++ b/manifests/helm/kepler/templates/daemonset.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       serviceAccountName: {{ include "kepler.serviceAccountName" . }}
       hostPID: {{ .Values.daemonset.hostPID }}
+      hostUsers: {{ .Values.daemonset.hostUsers }}
       {{- with .Values.daemonset.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/manifests/helm/kepler/values.yaml
+++ b/manifests/helm/kepler/values.yaml
@@ -40,8 +40,10 @@ daemonset:
   nodeSelector: {}
   affinity: {}
 
+  hostUsers: true
   securityContext:
     privileged: true
+    runAsNonRoot: false
 
   resources:
     {}

--- a/manifests/k8s/daemonset.yaml
+++ b/manifests/k8s/daemonset.yaml
@@ -18,6 +18,7 @@ spec:
     spec:
       serviceAccountName: kepler
       hostPID: true
+      hostUsers: true
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
@@ -31,6 +32,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
+            runAsNonRoot: false
           command:
             - /usr/bin/kepler
           args:


### PR DESCRIPTION
The daemons require host privileges. Setting this explicitly both documents the incompatibility with user namespaces and ensures, if the default changes, the daemonset will continue to function as expected.