### PR TITLE
feat(gpu): add GPU power monitoring foundation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,9 @@ const (
 
 	// PprofFeature represents the pprof debug endpoints feature
 	PprofFeature Feature = "pprof"
+
+	// ExperimentalGPUFeature represents GPU power monitoring (experimental)
+	ExperimentalGPUFeature Feature = "gpu"
 )
 
 // Config represents the complete application configuration
@@ -133,10 +136,17 @@ type (
 		HTTPTimeout time.Duration `yaml:"httpTimeout"` // HTTP client timeout for BMC requests
 	}
 
+	// ExperimentalGPU contains GPU power monitoring settings
+	ExperimentalGPU struct {
+		// Enabled controls whether GPU power monitoring is enabled
+		Enabled *bool `yaml:"enabled"`
+	}
+
 	// Experimental contains experimental features (no stability guarantees)
 	Experimental struct {
-		Platform Platform `yaml:"platform"`
-		Hwmon    Hwmon    `yaml:"hwmon"`
+		Platform Platform        `yaml:"platform"`
+		Hwmon    Hwmon           `yaml:"hwmon"`
+		GPU      ExperimentalGPU `yaml:"gpu"`
 	}
 
 	Config struct {
@@ -637,6 +647,11 @@ func (c *Config) IsFeatureEnabled(feature Feature) bool {
 		return ptr.Deref(c.Exporter.Stdout.Enabled, false)
 	case PprofFeature:
 		return ptr.Deref(c.Debug.Pprof.Enabled, false)
+	case ExperimentalGPUFeature:
+		if c.Experimental == nil {
+			return false
+		}
+		return ptr.Deref(c.Experimental.GPU.Enabled, false)
 	default:
 		return false
 	}
@@ -658,6 +673,10 @@ func (c *Config) experimentalFeatureEnabled() bool {
 		return true
 	}
 
+	// Check if GPU is enabled
+	if ptr.Deref(c.Experimental.GPU.Enabled, false) {
+		return true
+	}
 	// Add checks for future experimental features here
 
 	return false

--- a/internal/device/gpu/interface.go
+++ b/internal/device/gpu/interface.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gpu
+
+import (
+	"time"
+
+	"github.com/sustainable-computing-io/kepler/internal/device"
+	"github.com/sustainable-computing-io/kepler/internal/service"
+)
+
+// GPUDevice represents a single GPU device with its properties.
+// This struct is vendor-agnostic - vendor-specific details (like NVIDIA MIG)
+// are handled internally by each vendor's implementation.
+type GPUDevice struct {
+	// Index is the device index as reported by the GPU driver (0-based).
+	// For NVIDIA: corresponds to NVML device index from nvmlDeviceGetHandleByIndex()
+	// For AMD: corresponds to ROCm device index
+	Index int
+
+	// UUID is the globally unique identifier for this GPU
+	UUID string
+
+	// Name is the product name (e.g., "NVIDIA A100-SXM4-40GB", "AMD MI250X")
+	Name string
+
+	// Vendor identifies the GPU manufacturer
+	Vendor Vendor
+}
+
+// GPUPowerStats contains power statistics for a GPU device
+type GPUPowerStats struct {
+	// TotalPower is the current total power consumption in Watts
+	TotalPower float64
+
+	// IdlePower is the detected or configured idle power in Watts
+	IdlePower float64
+
+	// ActivePower is the power attributed to workloads (TotalPower - IdlePower) in Watts
+	ActivePower float64
+}
+
+// GPUPowerMeter is the interface for GPU power measurement and process attribution.
+// Implementations must be thread-safe for concurrent access.
+type GPUPowerMeter interface {
+	service.Service     // Name()
+	service.Initializer // Init()
+	service.Shutdowner  // Shutdown()
+
+	// Vendor returns the GPU vendor (nvidia, amd, intel)
+	Vendor() Vendor
+
+	// Devices returns all discovered GPU devices
+	Devices() []GPUDevice
+
+	// GetPowerUsage returns the current power consumption for a specific device in Watts
+	GetPowerUsage(deviceIndex int) (device.Power, error)
+
+	// GetTotalEnergy returns the cumulative energy consumption for a device in Joules
+	GetTotalEnergy(deviceIndex int) (device.Energy, error)
+
+	// GetDevicePowerStats returns power statistics including idle power detection
+	GetDevicePowerStats(deviceIndex int) (GPUPowerStats, error)
+
+	// GetProcessPower returns power attribution per process.
+	// The map key is PID and value is power in Watts.
+	GetProcessPower() (map[uint32]float64, error)
+
+	// GetProcessInfo returns detailed GPU metrics per process
+	GetProcessInfo() ([]ProcessGPUInfo, error)
+}
+
+// ProcessGPUInfo contains per-process GPU metrics collected from the device.
+// This struct is vendor-agnostic.
+type ProcessGPUInfo struct {
+	// PID is the process ID using the GPU
+	PID uint32
+
+	// DeviceIndex is the GPU device index (0-based)
+	DeviceIndex int
+
+	// DeviceUUID is the unique identifier of the GPU device
+	DeviceUUID string
+
+	// ComputeUtil is the compute utilization ratio (0.0-1.0)
+	// For NVIDIA: SM (Streaming Multiprocessor) utilization
+	// For AMD: CU (Compute Unit) utilization
+	ComputeUtil float64
+
+	// MemoryUsed is the GPU memory used by this process in bytes
+	MemoryUsed uint64
+
+	// Timestamp is when this measurement was taken
+	Timestamp time.Time
+}

--- a/internal/device/gpu/registry.go
+++ b/internal/device/gpu/registry.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gpu
+
+import (
+	"log/slog"
+	"sync"
+)
+
+// Factory is a function that creates a GPUPowerMeter for a specific vendor.
+// It receives a logger and returns a meter or an error if the vendor's
+// hardware/drivers are not available.
+type Factory func(logger *slog.Logger) (GPUPowerMeter, error)
+
+var (
+	registry   = make(map[Vendor]Factory)
+	registryMu sync.RWMutex
+)
+
+// Register adds a GPU backend factory for the given vendor.
+func Register(vendor Vendor, factory Factory) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry[vendor] = factory
+}
+
+// DiscoverAll probes all registered GPU backends and returns meters for
+// vendors with available hardware. Backends that fail to initialize or
+// have no devices are silently skipped.
+//
+// Returns an empty slice if no GPUs are found.
+func DiscoverAll(logger *slog.Logger) []GPUPowerMeter {
+	vendors := RegisteredVendors()
+
+	var meters []GPUPowerMeter
+	for _, vendor := range vendors {
+		if meter := Discover(vendor, logger); meter != nil {
+			meters = append(meters, meter)
+		}
+	}
+
+	return meters
+}
+
+// Discover returns a GPUPowerMeter for a specific vendor, or nil if
+// the vendor is not registered or has no available hardware.
+func Discover(vendor Vendor, logger *slog.Logger) GPUPowerMeter {
+	registryMu.RLock()
+	factory, ok := registry[vendor]
+	registryMu.RUnlock()
+
+	if !ok {
+		logger.Debug("GPU vendor not registered", "vendor", vendor)
+		return nil
+	}
+
+	meter, err := factory(logger)
+	if err != nil {
+		logger.Debug("GPU vendor factory failed",
+			"vendor", vendor,
+			"error", err)
+		return nil
+	}
+
+	if err := meter.Init(); err != nil {
+		logger.Debug("GPU vendor init failed",
+			"vendor", vendor,
+			"error", err)
+		return nil
+	}
+
+	if len(meter.Devices()) == 0 {
+		logger.Debug("GPU vendor has no devices", "vendor", vendor)
+		_ = meter.Shutdown()
+		return nil
+	}
+
+	return meter
+}
+
+// RegisteredVendors returns a list of all registered GPU vendors.
+// Useful for debugging and logging available backends.
+func RegisteredVendors() []Vendor {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	vendors := make([]Vendor, 0, len(registry))
+	for vendor := range registry {
+		vendors = append(vendors, vendor)
+	}
+	return vendors
+}
+
+// ClearRegistry removes all registered vendors.
+// This is primarily useful for testing.
+func ClearRegistry() {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry = make(map[Vendor]Factory)
+}

--- a/internal/device/gpu/registry_test.go
+++ b/internal/device/gpu/registry_test.go
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gpu
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/sustainable-computing-io/kepler/internal/device"
+)
+
+// mockGPUPowerMeter is a test implementation of GPUPowerMeter
+type mockGPUPowerMeter struct {
+	vendor      Vendor
+	devices     []GPUDevice
+	initErr     error
+	initialized bool
+	shutdown    bool
+}
+
+func (m *mockGPUPowerMeter) Name() string { return "mock-" + string(m.vendor) }
+
+func (m *mockGPUPowerMeter) Init() error {
+	if m.initErr != nil {
+		return m.initErr
+	}
+	m.initialized = true
+	return nil
+}
+
+func (m *mockGPUPowerMeter) Shutdown() error {
+	m.shutdown = true
+	return nil
+}
+
+func (m *mockGPUPowerMeter) Vendor() Vendor {
+	return m.vendor
+}
+
+func (m *mockGPUPowerMeter) Devices() []GPUDevice {
+	return m.devices
+}
+
+func (m *mockGPUPowerMeter) GetPowerUsage(_ int) (device.Power, error) {
+	return 0, nil
+}
+
+func (m *mockGPUPowerMeter) GetTotalEnergy(_ int) (device.Energy, error) {
+	return 0, nil
+}
+
+func (m *mockGPUPowerMeter) GetDevicePowerStats(_ int) (GPUPowerStats, error) {
+	return GPUPowerStats{}, nil
+}
+
+func (m *mockGPUPowerMeter) GetProcessPower() (map[uint32]float64, error) {
+	return nil, nil
+}
+
+func (m *mockGPUPowerMeter) GetProcessInfo() ([]ProcessGPUInfo, error) {
+	return nil, nil
+}
+
+// Verify mockGPUPowerMeter implements GPUPowerMeter
+var _ GPUPowerMeter = (*mockGPUPowerMeter)(nil)
+
+func TestRegisterAndDiscoverAll(t *testing.T) {
+	// Clear registry before test
+	ClearRegistry()
+	defer ClearRegistry()
+
+	logger := slog.Default()
+
+	// Register a mock NVIDIA backend with devices
+	nvidiaMeter := &mockGPUPowerMeter{
+		vendor: VendorNVIDIA,
+		devices: []GPUDevice{
+			{Index: 0, UUID: "GPU-123", Name: "Test GPU", Vendor: VendorNVIDIA},
+		},
+	}
+	Register(VendorNVIDIA, func(_ *slog.Logger) (GPUPowerMeter, error) {
+		return nvidiaMeter, nil
+	})
+
+	// Discover all
+	meters := DiscoverAll(logger)
+
+	require.Len(t, meters, 1)
+	assert.Equal(t, VendorNVIDIA, meters[0].Vendor())
+	assert.True(t, nvidiaMeter.initialized, "meter should be initialized")
+}
+
+func TestDiscoverAllSkipsFailedInit(t *testing.T) {
+	ClearRegistry()
+	defer ClearRegistry()
+
+	logger := slog.Default()
+
+	// Register backend that fails init
+	Register(VendorAMD, func(_ *slog.Logger) (GPUPowerMeter, error) {
+		return &mockGPUPowerMeter{
+			vendor:  VendorAMD,
+			initErr: errors.New("driver not available"),
+		}, nil
+	})
+
+	meters := DiscoverAll(logger)
+	assert.Empty(t, meters)
+}
+
+func TestDiscoverAllSkipsNoDevices(t *testing.T) {
+	ClearRegistry()
+	defer ClearRegistry()
+
+	logger := slog.Default()
+
+	// Register backend with no devices
+	noDevicesMeter := &mockGPUPowerMeter{
+		vendor:  VendorIntel,
+		devices: []GPUDevice{}, // empty
+	}
+	Register(VendorIntel, func(_ *slog.Logger) (GPUPowerMeter, error) {
+		return noDevicesMeter, nil
+	})
+
+	meters := DiscoverAll(logger)
+	assert.Empty(t, meters)
+	assert.True(t, noDevicesMeter.shutdown, "meter with no devices should be shutdown")
+}
+
+func TestDiscoverAllSkipsFactoryError(t *testing.T) {
+	ClearRegistry()
+	defer ClearRegistry()
+
+	logger := slog.Default()
+
+	// Register factory that returns error
+	Register(VendorNVIDIA, func(_ *slog.Logger) (GPUPowerMeter, error) {
+		return nil, errors.New("NVML not available")
+	})
+
+	meters := DiscoverAll(logger)
+	assert.Empty(t, meters)
+}
+
+func TestDiscover(t *testing.T) {
+	ClearRegistry()
+	defer ClearRegistry()
+
+	logger := slog.Default()
+
+	// Register NVIDIA
+	Register(VendorNVIDIA, func(_ *slog.Logger) (GPUPowerMeter, error) {
+		return &mockGPUPowerMeter{
+			vendor: VendorNVIDIA,
+			devices: []GPUDevice{
+				{Index: 0, UUID: "GPU-456", Name: "A100", Vendor: VendorNVIDIA},
+			},
+		}, nil
+	})
+
+	// Discover specific vendor
+	meter := Discover(VendorNVIDIA, logger)
+	require.NotNil(t, meter)
+	assert.Equal(t, VendorNVIDIA, meter.Vendor())
+
+	// Discover unregistered vendor
+	meter = Discover(VendorAMD, logger)
+	assert.Nil(t, meter)
+}
+
+func TestRegisteredVendors(t *testing.T) {
+	ClearRegistry()
+	defer ClearRegistry()
+
+	// Initially empty
+	vendors := RegisteredVendors()
+	assert.Empty(t, vendors)
+
+	// Register some vendors
+	Register(VendorNVIDIA, func(_ *slog.Logger) (GPUPowerMeter, error) {
+		return nil, nil
+	})
+	Register(VendorAMD, func(_ *slog.Logger) (GPUPowerMeter, error) {
+		return nil, nil
+	})
+
+	vendors = RegisteredVendors()
+	assert.Len(t, vendors, 2)
+	assert.Contains(t, vendors, VendorNVIDIA)
+	assert.Contains(t, vendors, VendorAMD)
+}
+
+func TestClearRegistry(t *testing.T) {
+	ClearRegistry()
+
+	Register(VendorNVIDIA, func(_ *slog.Logger) (GPUPowerMeter, error) {
+		return nil, nil
+	})
+	require.Len(t, RegisteredVendors(), 1)
+
+	ClearRegistry()
+	assert.Empty(t, RegisteredVendors())
+}

--- a/internal/device/gpu/types.go
+++ b/internal/device/gpu/types.go
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gpu
+
+import "fmt"
+
+// Vendor represents the GPU manufacturer
+type Vendor string
+
+const (
+	VendorNVIDIA  Vendor = "nvidia"
+	VendorAMD     Vendor = "amd"
+	VendorIntel   Vendor = "intel"
+	VendorUnknown Vendor = "unknown"
+)
+
+// SharingMode represents how a GPU is shared among processes
+type SharingMode int
+
+const (
+	// SharingModeUnknown indicates the sharing mode could not be determined
+	SharingModeUnknown SharingMode = iota
+
+	// SharingModeExclusive indicates a single process has exclusive access to the GPU.
+	// Power attribution: 100% to the single process.
+	SharingModeExclusive
+
+	// SharingModeTimeSlicing indicates multiple processes share the GPU via time-slicing.
+	// Power attribution: Proportional to compute utilization.
+	SharingModeTimeSlicing
+
+	// SharingModePartitioned indicates the GPU is partitioned into isolated instances.
+	// For NVIDIA: Multi-Instance GPU (MIG)
+	// Power attribution: Proportional to partition size and activity within each instance.
+	SharingModePartitioned
+)
+
+// String returns a human-readable name for the sharing mode
+func (m SharingMode) String() string {
+	switch m {
+	case SharingModeExclusive:
+		return "exclusive"
+	case SharingModeTimeSlicing:
+		return "time-slicing"
+	case SharingModePartitioned:
+		return "partitioned"
+	default:
+		return "unknown"
+	}
+}
+
+// ProcessUtilization holds per-process GPU utilization metrics
+type ProcessUtilization struct {
+	// PID is the process ID
+	PID uint32
+
+	// ComputeUtil is the compute unit utilization percentage (0-100)
+	ComputeUtil uint32
+
+	// MemUtil is the memory utilization percentage (0-100)
+	MemUtil uint32
+
+	// EncUtil is the encoder utilization percentage (0-100)
+	EncUtil uint32
+
+	// DecUtil is the decoder utilization percentage (0-100)
+	DecUtil uint32
+
+	// Timestamp is the measurement time in microseconds
+	Timestamp uint64
+}
+
+// ErrGPUNotFound is returned when a GPU device is not found
+type ErrGPUNotFound struct {
+	DeviceIndex int
+}
+
+func (e ErrGPUNotFound) Error() string {
+	return fmt.Sprintf("GPU device not found: index %d", e.DeviceIndex)
+}
+
+// ErrGPUNotInitialized is returned when GPU operations are attempted before initialization
+type ErrGPUNotInitialized struct{}
+
+func (e ErrGPUNotInitialized) Error() string {
+	return "GPU power meter not initialized"
+}
+
+// ErrPartitioningNotSupported is returned when partitioning operations are attempted on unsupported hardware
+type ErrPartitioningNotSupported struct {
+	DeviceIndex int
+}
+
+func (e ErrPartitioningNotSupported) Error() string {
+	return fmt.Sprintf("GPU partitioning not supported on device: index %d", e.DeviceIndex)
+}
+
+// ErrProcessUtilizationUnavailable is returned when per-process utilization cannot be obtained
+type ErrProcessUtilizationUnavailable struct {
+	Reason string
+}
+
+func (e ErrProcessUtilizationUnavailable) Error() string {
+	return fmt.Sprintf("process utilization unavailable: %s", e.Reason)
+}

--- a/internal/device/gpu/types_test.go
+++ b/internal/device/gpu/types_test.go
@@ -1,0 +1,328 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gpu
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVendorConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		vendor   Vendor
+		expected string
+	}{
+		{"nvidia", VendorNVIDIA, "nvidia"},
+		{"amd", VendorAMD, "amd"},
+		{"intel", VendorIntel, "intel"},
+		{"unknown", VendorUnknown, "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, string(tt.vendor))
+		})
+	}
+}
+
+func TestSharingMode_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     SharingMode
+		expected string
+	}{
+		{"exclusive", SharingModeExclusive, "exclusive"},
+		{"time-slicing", SharingModeTimeSlicing, "time-slicing"},
+		{"partitioned", SharingModePartitioned, "partitioned"},
+		{"unknown", SharingModeUnknown, "unknown"},
+		{"invalid negative", SharingMode(-1), "unknown"},
+		{"invalid large", SharingMode(100), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.mode.String())
+		})
+	}
+}
+
+func TestSharingMode_IotaValues(t *testing.T) {
+	// Verify iota ordering
+	assert.Equal(t, SharingMode(0), SharingModeUnknown)
+	assert.Equal(t, SharingMode(1), SharingModeExclusive)
+	assert.Equal(t, SharingMode(2), SharingModeTimeSlicing)
+	assert.Equal(t, SharingMode(3), SharingModePartitioned)
+}
+
+func TestErrGPUNotFound_Error(t *testing.T) {
+	tests := []struct {
+		name        string
+		deviceIndex int
+		expected    string
+	}{
+		{"device 0", 0, "GPU device not found: index 0"},
+		{"device 1", 1, "GPU device not found: index 1"},
+		{"device 42", 42, "GPU device not found: index 42"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ErrGPUNotFound{DeviceIndex: tt.deviceIndex}
+			assert.Equal(t, tt.expected, err.Error())
+		})
+	}
+}
+
+func TestErrGPUNotInitialized_Error(t *testing.T) {
+	err := ErrGPUNotInitialized{}
+	assert.Equal(t, "GPU power meter not initialized", err.Error())
+}
+
+func TestErrPartitioningNotSupported_Error(t *testing.T) {
+	tests := []struct {
+		name        string
+		deviceIndex int
+		expected    string
+	}{
+		{"device 0", 0, "GPU partitioning not supported on device: index 0"},
+		{"device 3", 3, "GPU partitioning not supported on device: index 3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ErrPartitioningNotSupported{DeviceIndex: tt.deviceIndex}
+			assert.Equal(t, tt.expected, err.Error())
+		})
+	}
+}
+
+func TestErrProcessUtilizationUnavailable_Error(t *testing.T) {
+	tests := []struct {
+		name     string
+		reason   string
+		expected string
+	}{
+		{"driver error", "driver not responding", "process utilization unavailable: driver not responding"},
+		{"no permission", "insufficient permissions", "process utilization unavailable: insufficient permissions"},
+		{"empty reason", "", "process utilization unavailable: "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ErrProcessUtilizationUnavailable{Reason: tt.reason}
+			assert.Equal(t, tt.expected, err.Error())
+		})
+	}
+}
+
+func TestErrorTypes_ImplementErrorInterface(t *testing.T) {
+	// Compile-time check that all error types implement error interface
+	var _ error = ErrGPUNotFound{}
+	var _ error = ErrGPUNotInitialized{}
+	var _ error = ErrPartitioningNotSupported{}
+	var _ error = ErrProcessUtilizationUnavailable{}
+
+	// Runtime check
+	errors := []error{
+		ErrGPUNotFound{DeviceIndex: 0},
+		ErrGPUNotInitialized{},
+		ErrPartitioningNotSupported{DeviceIndex: 0},
+		ErrProcessUtilizationUnavailable{Reason: "test"},
+	}
+
+	for _, err := range errors {
+		assert.NotEmpty(t, err.Error())
+	}
+}
+
+func TestProcessUtilization(t *testing.T) {
+	t.Run("zero value", func(t *testing.T) {
+		var pu ProcessUtilization
+		assert.Equal(t, uint32(0), pu.PID)
+		assert.Equal(t, uint32(0), pu.ComputeUtil)
+		assert.Equal(t, uint32(0), pu.MemUtil)
+		assert.Equal(t, uint32(0), pu.EncUtil)
+		assert.Equal(t, uint32(0), pu.DecUtil)
+		assert.Equal(t, uint64(0), pu.Timestamp)
+	})
+
+	t.Run("populated", func(t *testing.T) {
+		pu := ProcessUtilization{
+			PID:         1234,
+			ComputeUtil: 75,
+			MemUtil:     50,
+			EncUtil:     25,
+			DecUtil:     10,
+			Timestamp:   1704067200000000, // microseconds
+		}
+
+		assert.Equal(t, uint32(1234), pu.PID)
+		assert.Equal(t, uint32(75), pu.ComputeUtil)
+		assert.Equal(t, uint32(50), pu.MemUtil)
+		assert.Equal(t, uint32(25), pu.EncUtil)
+		assert.Equal(t, uint32(10), pu.DecUtil)
+		assert.Equal(t, uint64(1704067200000000), pu.Timestamp)
+	})
+
+	t.Run("max utilization values", func(t *testing.T) {
+		pu := ProcessUtilization{
+			PID:         1,
+			ComputeUtil: 100,
+			MemUtil:     100,
+			EncUtil:     100,
+			DecUtil:     100,
+		}
+
+		assert.Equal(t, uint32(100), pu.ComputeUtil)
+		assert.Equal(t, uint32(100), pu.MemUtil)
+		assert.Equal(t, uint32(100), pu.EncUtil)
+		assert.Equal(t, uint32(100), pu.DecUtil)
+	})
+}
+
+func TestGPUDevice(t *testing.T) {
+	tests := []struct {
+		name   string
+		device GPUDevice
+	}{
+		{
+			name: "nvidia device",
+			device: GPUDevice{
+				Index:  0,
+				UUID:   "GPU-12345678-abcd-1234-abcd-123456789012",
+				Name:   "NVIDIA A100-SXM4-40GB",
+				Vendor: VendorNVIDIA,
+			},
+		},
+		{
+			name: "amd device",
+			device: GPUDevice{
+				Index:  1,
+				UUID:   "AMD-GPU-001",
+				Name:   "AMD MI250X",
+				Vendor: VendorAMD,
+			},
+		},
+		{
+			name: "intel device",
+			device: GPUDevice{
+				Index:  0,
+				UUID:   "INTEL-GPU-001",
+				Name:   "Intel Data Center GPU Max 1550",
+				Vendor: VendorIntel,
+			},
+		},
+		{
+			name: "unknown vendor",
+			device: GPUDevice{
+				Index:  0,
+				UUID:   "UNKNOWN-001",
+				Name:   "Generic GPU",
+				Vendor: VendorUnknown,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.GreaterOrEqual(t, tt.device.Index, 0)
+			assert.NotEmpty(t, tt.device.UUID)
+			assert.NotEmpty(t, tt.device.Name)
+			assert.NotEmpty(t, string(tt.device.Vendor))
+		})
+	}
+}
+
+func TestGPUPowerStats(t *testing.T) {
+	t.Run("zero power", func(t *testing.T) {
+		stats := GPUPowerStats{
+			TotalPower:  0,
+			IdlePower:   0,
+			ActivePower: 0,
+		}
+
+		assert.Equal(t, 0.0, stats.TotalPower)
+		assert.Equal(t, 0.0, stats.IdlePower)
+		assert.Equal(t, 0.0, stats.ActivePower)
+	})
+
+	t.Run("typical power values", func(t *testing.T) {
+		stats := GPUPowerStats{
+			TotalPower:  250.0, // 250W total
+			IdlePower:   50.0,  // 50W idle
+			ActivePower: 200.0, // 200W active (250 - 50)
+		}
+
+		assert.Equal(t, 250.0, stats.TotalPower)
+		assert.Equal(t, 50.0, stats.IdlePower)
+		assert.Equal(t, 200.0, stats.ActivePower)
+		// Verify ActivePower = TotalPower - IdlePower
+		assert.Equal(t, stats.TotalPower-stats.IdlePower, stats.ActivePower)
+	})
+
+	t.Run("idle only", func(t *testing.T) {
+		stats := GPUPowerStats{
+			TotalPower:  50.0,
+			IdlePower:   50.0,
+			ActivePower: 0.0,
+		}
+
+		assert.Equal(t, stats.IdlePower, stats.TotalPower)
+		assert.Equal(t, 0.0, stats.ActivePower)
+	})
+}
+
+func TestProcessGPUInfo(t *testing.T) {
+	t.Run("zero value", func(t *testing.T) {
+		var info ProcessGPUInfo
+		assert.Equal(t, uint32(0), info.PID)
+		assert.Equal(t, 0, info.DeviceIndex)
+		assert.Empty(t, info.DeviceUUID)
+		assert.Equal(t, 0.0, info.ComputeUtil)
+		assert.Equal(t, uint64(0), info.MemoryUsed)
+		assert.True(t, info.Timestamp.IsZero())
+	})
+
+	t.Run("populated", func(t *testing.T) {
+		now := time.Now()
+		info := ProcessGPUInfo{
+			PID:         5678,
+			DeviceIndex: 0,
+			DeviceUUID:  "GPU-12345678",
+			ComputeUtil: 0.85,                   // 85%
+			MemoryUsed:  4 * 1024 * 1024 * 1024, // 4GB
+			Timestamp:   now,
+		}
+
+		assert.Equal(t, uint32(5678), info.PID)
+		assert.Equal(t, 0, info.DeviceIndex)
+		assert.Equal(t, "GPU-12345678", info.DeviceUUID)
+		assert.Equal(t, 0.85, info.ComputeUtil)
+		assert.Equal(t, uint64(4*1024*1024*1024), info.MemoryUsed)
+		assert.Equal(t, now, info.Timestamp)
+	})
+
+	t.Run("compute util range", func(t *testing.T) {
+		// ComputeUtil is a ratio from 0.0 to 1.0
+		tests := []struct {
+			name string
+			util float64
+		}{
+			{"zero", 0.0},
+			{"half", 0.5},
+			{"full", 1.0},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				info := ProcessGPUInfo{ComputeUtil: tt.util}
+				assert.GreaterOrEqual(t, info.ComputeUtil, 0.0)
+				assert.LessOrEqual(t, info.ComputeUtil, 1.0)
+			})
+		}
+	})
+}


### PR DESCRIPTION
  Add internal/device/gpu package with multi-vendor GPU power monitoring
  infrastructure:

  - GPUPowerMeter interface with service lifecycle integration
  - Vendor, SharingMode, ComputeMode types for GPU configuration
  - Registry pattern for runtime GPU backend discovery
  - Error types for GPU-specific failure modes