### PR TITLE
feat(gpu): add NVIDIA GPU power monitoring via NVML

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /workspace
 COPY . .
 
 RUN make build \
+  CGO_ENABLED=1 \
   PRODUCTION=1 \
   VERSION=${VERSION} \
   GIT_COMMIT=${GIT_COMMIT} \

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2025 The Kepler Authors
+# SPDX-License-Identifier: Apache-2.0
+
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%
+    patch:
+      default:
+        target: 70%
+
+ignore:
+  - internal/device/gpu/nvidia/nvml_lib.go

--- a/compose/default/kepler/etc/kepler/config.yaml
+++ b/compose/default/kepler/etc/kepler/config.yaml
@@ -83,3 +83,5 @@ experimental:
   hwmon:
     enabled: false # Enable experimental hwmon power monitoring
     zones: [] # List of zones to enable (default enable all)
+  gpu:
+    enabled: false # Enable experimental GPU power monitoring

--- a/compose/dev/kepler-dev/etc/kepler/config.yaml
+++ b/compose/dev/kepler-dev/etc/kepler/config.yaml
@@ -83,3 +83,5 @@ experimental:
   hwmon:
     enabled: false # Enable experimental hwmon power monitoring
     zones: [] # List of zones to enable (default enable all)
+  gpu:
+    enabled: false # Enable experimental GPU power monitoring

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -38,6 +38,7 @@ You can configure Kepler by passing flags when starting the service. The followi
 | `--experimental.platform.redfish.config-file` | Path to experimental Redfish BMC configuration file                     | `""`                            | Any valid file path                                                |
 | `--experimental.hwmon.enabled`                | Enable experimental hwmon power monitoring                              | `false`                         | `true`, `false`                                                    |
 | `--experimental.hwmon.zones`                  | hwmon zones to be enabled (can be specified multiple times)             | All available zones             | Any valid hwmon zone name                                          |
+| `--experimental.gpu.enabled`                  | Enable experimental GPU power monitoring                                | `false`                         | `true`, `false`                                                    |
 
 ### 💡 Examples
 
@@ -72,6 +73,9 @@ kepler --experimental.hwmon.enabled=true
 kepler --experimental.hwmon.enabled=true \
        --experimental.hwmon.zones=power1 \
        --experimental.hwmon.zones=power2
+
+# Enable experimental GPU power monitoring
+kepler --experimental.gpu.enabled=true
 
 # Export only node and container level metrics
 kepler --metrics=node --metrics=container
@@ -153,6 +157,8 @@ experimental:   # experimental features (no stability guarantees)
   hwmon:        # hwmon power monitoring
     enabled: false                    # Enable hwmon power monitoring (default: false)
     zones: []                         # hwmon zones to be enabled, empty enables all available zones
+  gpu:          # GPU power monitoring
+    enabled: false                    # Enable GPU power monitoring (default: false)
 
 # WARN: DO NOT ENABLE THIS IN PRODUCTION - for development/testing only
 dev:
@@ -328,6 +334,8 @@ experimental:
   hwmon:
     enabled: false
     zones: []
+  gpu:
+    enabled: false
 ```
 
 ⚠️ **WARNING**: This section contains experimental features with no stability guarantees.
@@ -392,6 +400,21 @@ experimental:
   hwmon:
     enabled: true
     zones: ["power1", "power2"]
+```
+
+#### GPU Power Monitoring
+
+- **enabled**: Enable experimental GPU power monitoring (default: false)
+  - When enabled, Kepler will collect power metrics from NVIDIA GPUs using NVML
+  - Requires NVIDIA drivers and NVML library to be available
+  - Supports per-process power attribution based on GPU compute utilization
+
+**Example:**
+
+```yaml
+experimental:
+  gpu:
+    enabled: true
 ```
 
 ### 🧑‍🔬 Development Configuration

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.24.9
 
 require (
 	dario.cat/mergo v1.0.2
+	github.com/NVIDIA/go-nvml v0.13.0-1
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/go-logr/logr v1.4.2
 	github.com/oklog/run v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
+github.com/NVIDIA/go-nvml v0.13.0-1 h1:OLX8Jq3dONuPOQPC7rndB6+iDmDakw0XTYgzMxObkEw=
+github.com/NVIDIA/go-nvml v0.13.0-1/go.mod h1:+KNA7c7gIBH7SKSJ1ntlwkfN80zdx8ovl4hrK3LmPt4=
 github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
 github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=

--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -83,3 +83,5 @@ experimental:
   hwmon:
     enabled: false # Enable experimental hwmon power monitoring
     zones: [] # List of zones to enable (default enable all)
+  gpu:
+    enabled: false # Enable experimental GPU power monitoring

--- a/internal/device/gpu/nvidia/collector.go
+++ b/internal/device/gpu/nvidia/collector.go
@@ -1,0 +1,343 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidia
+
+import (
+	"log/slog"
+	"sync"
+
+	"github.com/sustainable-computing-io/kepler/internal/device"
+	"github.com/sustainable-computing-io/kepler/internal/device/gpu"
+)
+
+func init() {
+	gpu.Register(gpu.VendorNVIDIA, func(logger *slog.Logger) (gpu.GPUPowerMeter, error) {
+		return NewGPUPowerCollector(logger)
+	})
+}
+
+// GPUPowerCollector implements gpu.GPUPowerMeter for NVIDIA GPUs.
+// It uses NVML for device discovery, power readings, and process utilization.
+type GPUPowerCollector struct {
+	logger   *slog.Logger
+	nvml     NVMLBackend
+	detector SharingModeDetector
+
+	devices      []gpu.GPUDevice
+	sharingModes map[int]gpu.SharingMode
+
+	// minObservedPower tracks minimum power per device for idle detection
+	minObservedPower map[string]float64
+
+	// lastSeenTimestamp for GetProcessUtilization calls
+	lastSeenTimestamp map[int]uint64
+
+	mu sync.RWMutex
+}
+
+// NewGPUPowerCollector creates a new NVIDIA GPU power collector.
+func NewGPUPowerCollector(logger *slog.Logger) (*GPUPowerCollector, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	nvmlBackend := NewNVMLBackend(logger)
+
+	return &GPUPowerCollector{
+		logger:            logger.With("component", "nvidia-gpu-collector"),
+		nvml:              nvmlBackend,
+		minObservedPower:  make(map[string]float64),
+		lastSeenTimestamp: make(map[int]uint64),
+		sharingModes:      make(map[int]gpu.SharingMode),
+	}, nil
+}
+
+// Name returns the service name
+func (c *GPUPowerCollector) Name() string {
+	return "nvidia-gpu-power-collector"
+}
+
+// Init initializes the NVML backend and discovers devices
+func (c *GPUPowerCollector) Init() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.nvml.Init(); err != nil {
+		return err
+	}
+
+	devices, err := c.nvml.DiscoverDevices()
+	if err != nil {
+		return err
+	}
+	c.devices = devices
+
+	// Initialize detector and detect sharing modes
+	c.detector = NewSharingModeDetector(c.logger, c.nvml)
+	modes, err := c.detector.DetectAllModes()
+	if err != nil {
+		c.logger.Warn("failed to detect sharing modes", "error", err)
+	}
+	c.sharingModes = modes
+
+	// Log detected modes
+	for idx, mode := range modes {
+		c.logger.Info("GPU sharing mode detected",
+			"device", idx,
+			"mode", mode.String())
+	}
+
+	return nil
+}
+
+// Shutdown cleans up NVML resources
+func (c *GPUPowerCollector) Shutdown() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.nvml.Shutdown()
+}
+
+// Vendor returns the GPU vendor
+func (c *GPUPowerCollector) Vendor() gpu.Vendor {
+	return gpu.VendorNVIDIA
+}
+
+// Devices returns all discovered GPU devices
+func (c *GPUPowerCollector) Devices() []gpu.GPUDevice {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.devices
+}
+
+// GetPowerUsage returns the current power consumption for a device
+func (c *GPUPowerCollector) GetPowerUsage(deviceIndex int) (device.Power, error) {
+	dev, err := c.nvml.GetDevice(deviceIndex)
+	if err != nil {
+		return 0, err
+	}
+
+	power, err := dev.GetPowerUsage()
+	if err != nil {
+		return 0, err
+	}
+
+	// Track minimum observed power for idle detection
+	c.mu.Lock()
+	uuid := dev.UUID()
+	powerWatts := power.Watts()
+	if min, exists := c.minObservedPower[uuid]; !exists || powerWatts < min {
+		c.minObservedPower[uuid] = powerWatts
+	}
+	c.mu.Unlock()
+
+	return power, nil
+}
+
+// GetTotalEnergy returns cumulative energy consumption for a device
+func (c *GPUPowerCollector) GetTotalEnergy(deviceIndex int) (device.Energy, error) {
+	dev, err := c.nvml.GetDevice(deviceIndex)
+	if err != nil {
+		return 0, err
+	}
+
+	return dev.GetTotalEnergy()
+}
+
+// GetDevicePowerStats returns power statistics including idle power detection
+func (c *GPUPowerCollector) GetDevicePowerStats(deviceIndex int) (gpu.GPUPowerStats, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.getDevicePowerStatsLocked(deviceIndex)
+}
+
+// getDevicePowerStatsLocked is the internal version that assumes the lock is already held
+func (c *GPUPowerCollector) getDevicePowerStatsLocked(deviceIndex int) (gpu.GPUPowerStats, error) {
+	dev, err := c.nvml.GetDevice(deviceIndex)
+	if err != nil {
+		return gpu.GPUPowerStats{}, err
+	}
+
+	power, err := dev.GetPowerUsage()
+	if err != nil {
+		return gpu.GPUPowerStats{}, err
+	}
+
+	totalPower := power.Watts()
+
+	// Update minimum observed power
+	uuid := dev.UUID()
+	if min, exists := c.minObservedPower[uuid]; !exists || totalPower < min {
+		c.minObservedPower[uuid] = totalPower
+	}
+	idlePower := c.minObservedPower[uuid]
+
+	activePower := totalPower - idlePower
+	if activePower < 0 {
+		activePower = 0
+	}
+
+	return gpu.GPUPowerStats{
+		TotalPower:  totalPower,
+		IdlePower:   idlePower,
+		ActivePower: activePower,
+	}, nil
+}
+
+// GetProcessPower returns power attribution per process.
+func (c *GPUPowerCollector) GetProcessPower() (map[uint32]float64, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	result := make(map[uint32]float64)
+
+	for _, dev := range c.devices {
+		mode := c.sharingModes[dev.Index]
+
+		switch mode {
+		case gpu.SharingModePartitioned:
+			// Partitioned (MIG) support will be added in PR-3
+			c.logger.Debug("partitioned mode detected, skipping (not yet implemented)",
+				"device", dev.Index)
+			continue
+
+		case gpu.SharingModeExclusive:
+			if err := c.attributeExclusive(dev.Index, result); err != nil {
+				c.logger.Debug("exclusive attribution failed",
+					"device", dev.Index, "error", err)
+			}
+
+		default: // Time-slicing
+			if err := c.attributeTimeSlicing(dev.Index, result); err != nil {
+				c.logger.Debug("time-slicing attribution failed",
+					"device", dev.Index, "error", err)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// attributeExclusive assigns 100% of active power to the single process
+// NOTE: caller must hold c.mu lock
+func (c *GPUPowerCollector) attributeExclusive(deviceIndex int, result map[uint32]float64) error {
+	nvmlDev, err := c.nvml.GetDevice(deviceIndex)
+	if err != nil {
+		return err
+	}
+
+	// Get active power
+	stats, err := c.getDevicePowerStatsLocked(deviceIndex)
+	if err != nil {
+		return err
+	}
+
+	// Get running processes
+	procs, err := nvmlDev.GetComputeRunningProcesses()
+	if err != nil {
+		return err
+	}
+
+	if len(procs) == 0 {
+		return nil
+	}
+
+	// In exclusive mode, attribute all active power to the single process
+	// (or split equally if somehow multiple processes exist)
+	powerPerProc := stats.ActivePower / float64(len(procs))
+	for _, p := range procs {
+		result[p.PID] += powerPerProc
+	}
+
+	return nil
+}
+
+// attributeTimeSlicing distributes power based on SM utilization
+// NOTE: caller must hold c.mu lock
+func (c *GPUPowerCollector) attributeTimeSlicing(deviceIndex int, result map[uint32]float64) error {
+	nvmlDev, err := c.nvml.GetDevice(deviceIndex)
+	if err != nil {
+		return err
+	}
+
+	// Get active power
+	stats, err := c.getDevicePowerStatsLocked(deviceIndex)
+	if err != nil {
+		return err
+	}
+
+	if stats.ActivePower <= 0 {
+		return nil
+	}
+
+	// Get process utilization
+	lastSeen := c.lastSeenTimestamp[deviceIndex]
+	utils, err := nvmlDev.GetProcessUtilization(lastSeen)
+	if err != nil {
+		// Fall back to equal distribution among running processes
+		c.logger.Debug("GetProcessUtilization unavailable, using equal distribution",
+			"device", deviceIndex, "error", err)
+		return c.attributeExclusive(deviceIndex, result)
+	}
+
+	if len(utils) == 0 {
+		return nil
+	}
+
+	// Update lastSeen timestamp
+	var maxTimestamp uint64
+	for _, u := range utils {
+		if u.Timestamp > maxTimestamp {
+			maxTimestamp = u.Timestamp
+		}
+	}
+	c.lastSeenTimestamp[deviceIndex] = maxTimestamp
+
+	// Calculate total compute utilization
+	// Safe: max ~43M processes needed to overflow
+	var totalComputeUtil uint32
+	for _, u := range utils {
+		totalComputeUtil += u.ComputeUtil
+	}
+
+	if totalComputeUtil == 0 {
+		return nil
+	}
+
+	// Distribute active power proportionally to compute utilization
+	for _, u := range utils {
+		fraction := float64(u.ComputeUtil) / float64(totalComputeUtil)
+		result[u.PID] += stats.ActivePower * fraction
+	}
+
+	return nil
+}
+
+// GetProcessInfo returns detailed GPU metrics per process
+func (c *GPUPowerCollector) GetProcessInfo() ([]gpu.ProcessGPUInfo, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	var allProcs []gpu.ProcessGPUInfo
+
+	for _, dev := range c.devices {
+		nvmlDev, err := c.nvml.GetDevice(dev.Index)
+		if err != nil {
+			continue
+		}
+
+		procs, err := nvmlDev.GetComputeRunningProcesses()
+		if err != nil {
+			continue
+		}
+
+		allProcs = append(allProcs, procs...)
+	}
+
+	return allProcs, nil
+}
+
+// Ensure GPUPowerCollector implements gpu.GPUPowerMeter
+var _ gpu.GPUPowerMeter = (*GPUPowerCollector)(nil)

--- a/internal/device/gpu/nvidia/collector_test.go
+++ b/internal/device/gpu/nvidia/collector_test.go
@@ -1,0 +1,1131 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidia
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/sustainable-computing-io/kepler/internal/device"
+	"github.com/sustainable-computing-io/kepler/internal/device/gpu"
+)
+
+func TestNewGPUPowerCollector(t *testing.T) {
+	t.Run("with logger", func(t *testing.T) {
+		collector, err := NewGPUPowerCollector(slog.Default())
+		assert.NoError(t, err)
+		assert.NotNil(t, collector)
+		assert.NotNil(t, collector.nvml)
+		assert.NotNil(t, collector.minObservedPower)
+		assert.NotNil(t, collector.lastSeenTimestamp)
+		assert.NotNil(t, collector.sharingModes)
+	})
+
+	t.Run("with nil logger uses default", func(t *testing.T) {
+		collector, err := NewGPUPowerCollector(nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, collector)
+		assert.NotNil(t, collector.logger)
+	})
+}
+
+func TestGPUPowerCollector_Name(t *testing.T) {
+	collector := &GPUPowerCollector{}
+	assert.Equal(t, "nvidia-gpu-power-collector", collector.Name())
+}
+
+func TestGPUPowerCollector_Vendor(t *testing.T) {
+	collector := &GPUPowerCollector{}
+	assert.Equal(t, gpu.VendorNVIDIA, collector.Vendor())
+}
+
+func TestGPUPowerCollector_Init(t *testing.T) {
+	t.Run("successful init", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		mockBackend.On("Init").Return(nil)
+		mockBackend.On("DiscoverDevices").Return([]gpu.GPUDevice{
+			{Index: 0, UUID: "GPU-123", Name: "Test GPU", Vendor: gpu.VendorNVIDIA},
+		}, nil)
+		mockBackend.On("DeviceCount").Return(1)
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("IsMIGEnabled").Return(false, nil)
+		mockDevice.On("GetComputeMode").Return(ComputeModeDefault, nil)
+
+		collector := &GPUPowerCollector{
+			logger:            slog.Default(),
+			nvml:              mockBackend,
+			minObservedPower:  make(map[string]float64),
+			lastSeenTimestamp: make(map[int]uint64),
+			sharingModes:      make(map[int]gpu.SharingMode),
+		}
+
+		err := collector.Init()
+
+		assert.NoError(t, err)
+		assert.Len(t, collector.devices, 1)
+		assert.Equal(t, gpu.SharingModeTimeSlicing, collector.sharingModes[0])
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+
+	t.Run("init failure", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockBackend.On("Init").Return(gpu.ErrGPUNotInitialized{})
+
+		collector := &GPUPowerCollector{
+			nvml:              mockBackend,
+			minObservedPower:  make(map[string]float64),
+			lastSeenTimestamp: make(map[int]uint64),
+			sharingModes:      make(map[int]gpu.SharingMode),
+		}
+
+		err := collector.Init()
+
+		assert.Error(t, err)
+
+		mockBackend.AssertExpectations(t)
+	})
+
+	t.Run("discover devices failure", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockBackend.On("Init").Return(nil)
+		mockBackend.On("DiscoverDevices").Return(nil, gpu.ErrGPUNotInitialized{})
+
+		collector := &GPUPowerCollector{
+			logger:            slog.Default(),
+			nvml:              mockBackend,
+			minObservedPower:  make(map[string]float64),
+			lastSeenTimestamp: make(map[int]uint64),
+			sharingModes:      make(map[int]gpu.SharingMode),
+		}
+
+		err := collector.Init()
+
+		assert.Error(t, err)
+
+		mockBackend.AssertExpectations(t)
+	})
+
+	t.Run("detect modes failure is non-fatal", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+
+		mockBackend.On("Init").Return(nil)
+		mockBackend.On("DiscoverDevices").Return([]gpu.GPUDevice{
+			{Index: 0, UUID: "GPU-123", Name: "Test GPU", Vendor: gpu.VendorNVIDIA},
+		}, nil)
+		mockBackend.On("DeviceCount").Return(1)
+		mockBackend.On("GetDevice", 0).Return(nil, gpu.ErrGPUNotFound{DeviceIndex: 0})
+
+		collector := &GPUPowerCollector{
+			logger:            slog.Default(),
+			nvml:              mockBackend,
+			minObservedPower:  make(map[string]float64),
+			lastSeenTimestamp: make(map[int]uint64),
+			sharingModes:      make(map[int]gpu.SharingMode),
+		}
+
+		err := collector.Init()
+
+		// Init should succeed even if mode detection fails
+		assert.NoError(t, err)
+		assert.Len(t, collector.devices, 1)
+
+		mockBackend.AssertExpectations(t)
+	})
+}
+
+func TestGPUPowerCollector_Shutdown(t *testing.T) {
+	mockBackend := new(MockNVMLBackend)
+	mockBackend.On("Shutdown").Return(nil)
+
+	collector := &GPUPowerCollector{
+		nvml: mockBackend,
+	}
+
+	err := collector.Shutdown()
+
+	assert.NoError(t, err)
+	mockBackend.AssertExpectations(t)
+}
+
+func TestGPUPowerCollector_Devices(t *testing.T) {
+	devices := []gpu.GPUDevice{
+		{Index: 0, UUID: "GPU-123", Name: "Test GPU 0", Vendor: gpu.VendorNVIDIA},
+		{Index: 1, UUID: "GPU-456", Name: "Test GPU 1", Vendor: gpu.VendorNVIDIA},
+	}
+
+	collector := &GPUPowerCollector{
+		devices: devices,
+	}
+
+	result := collector.Devices()
+
+	assert.Equal(t, devices, result)
+}
+
+func TestGPUPowerCollector_GetPowerUsage(t *testing.T) {
+	t.Run("successful power reading", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		expectedPower := device.Power(100 * device.Watt)
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetPowerUsage").Return(expectedPower, nil)
+		mockDevice.On("UUID").Return("GPU-123")
+
+		collector := &GPUPowerCollector{
+			nvml:             mockBackend,
+			minObservedPower: make(map[string]float64),
+		}
+
+		power, err := collector.GetPowerUsage(0)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedPower, power)
+		assert.Equal(t, 100.0, collector.minObservedPower["GPU-123"])
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+
+	t.Run("device not found", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockBackend.On("GetDevice", 99).Return(nil, gpu.ErrGPUNotFound{DeviceIndex: 99})
+
+		collector := &GPUPowerCollector{
+			nvml:             mockBackend,
+			minObservedPower: make(map[string]float64),
+		}
+
+		_, err := collector.GetPowerUsage(99)
+
+		assert.Error(t, err)
+
+		mockBackend.AssertExpectations(t)
+	})
+
+	t.Run("power reading error", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetPowerUsage").Return(device.Power(0), errors.New("NVML error"))
+
+		collector := &GPUPowerCollector{
+			nvml:             mockBackend,
+			minObservedPower: make(map[string]float64),
+		}
+
+		_, err := collector.GetPowerUsage(0)
+
+		assert.Error(t, err)
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+
+	t.Run("updates minimum observed power", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("UUID").Return("GPU-123")
+
+		// First call: 100W
+		mockDevice.On("GetPowerUsage").Return(device.Power(100*device.Watt), nil).Once()
+
+		collector := &GPUPowerCollector{
+			nvml:             mockBackend,
+			minObservedPower: make(map[string]float64),
+		}
+
+		_, _ = collector.GetPowerUsage(0)
+		assert.Equal(t, 100.0, collector.minObservedPower["GPU-123"])
+
+		// Second call: 80W (lower)
+		mockDevice.On("GetPowerUsage").Return(device.Power(80*device.Watt), nil).Once()
+
+		_, _ = collector.GetPowerUsage(0)
+		assert.Equal(t, 80.0, collector.minObservedPower["GPU-123"])
+
+		// Third call: 120W (higher, should not update min)
+		mockDevice.On("GetPowerUsage").Return(device.Power(120*device.Watt), nil).Once()
+
+		_, _ = collector.GetPowerUsage(0)
+		assert.Equal(t, 80.0, collector.minObservedPower["GPU-123"])
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+}
+
+func TestGPUPowerCollector_GetTotalEnergy(t *testing.T) {
+	t.Run("successful energy reading", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		expectedEnergy := device.Energy(1000 * device.Joule)
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetTotalEnergy").Return(expectedEnergy, nil)
+
+		collector := &GPUPowerCollector{
+			nvml: mockBackend,
+		}
+
+		energy, err := collector.GetTotalEnergy(0)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedEnergy, energy)
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+
+	t.Run("device not found", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockBackend.On("GetDevice", 99).Return(nil, gpu.ErrGPUNotFound{DeviceIndex: 99})
+
+		collector := &GPUPowerCollector{
+			nvml: mockBackend,
+		}
+
+		_, err := collector.GetTotalEnergy(99)
+
+		assert.Error(t, err)
+
+		mockBackend.AssertExpectations(t)
+	})
+}
+
+func TestGPUPowerCollector_GetDevicePowerStats(t *testing.T) {
+	t.Run("calculates idle and active power", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		// Pre-populate minimum observed power (idle power)
+		collector := &GPUPowerCollector{
+			nvml: mockBackend,
+			minObservedPower: map[string]float64{
+				"GPU-123": 40.0, // 40W idle
+			},
+		}
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetPowerUsage").Return(device.Power(100*device.Watt), nil)
+		mockDevice.On("UUID").Return("GPU-123")
+
+		stats, err := collector.GetDevicePowerStats(0)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 100.0, stats.TotalPower)
+		assert.Equal(t, 40.0, stats.IdlePower)
+		assert.Equal(t, 60.0, stats.ActivePower)
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+
+	t.Run("active power cannot be negative", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		// Min power higher than current (edge case)
+		collector := &GPUPowerCollector{
+			nvml: mockBackend,
+			minObservedPower: map[string]float64{
+				"GPU-123": 100.0,
+			},
+		}
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetPowerUsage").Return(device.Power(80*device.Watt), nil)
+		mockDevice.On("UUID").Return("GPU-123")
+
+		stats, err := collector.GetDevicePowerStats(0)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 80.0, stats.TotalPower)
+		assert.Equal(t, 80.0, stats.IdlePower) // Updated to new minimum
+		assert.Equal(t, 0.0, stats.ActivePower)
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+
+	t.Run("device not found", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockBackend.On("GetDevice", 99).Return(nil, gpu.ErrGPUNotFound{DeviceIndex: 99})
+
+		collector := &GPUPowerCollector{
+			nvml:             mockBackend,
+			minObservedPower: make(map[string]float64),
+		}
+
+		_, err := collector.GetDevicePowerStats(99)
+
+		assert.Error(t, err)
+
+		mockBackend.AssertExpectations(t)
+	})
+}
+
+func TestGPUPowerCollector_GetProcessPower(t *testing.T) {
+	t.Run("exclusive mode attribution", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		collector := &GPUPowerCollector{
+			logger: slog.Default(),
+			nvml:   mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-123"},
+			},
+			sharingModes: map[int]gpu.SharingMode{
+				0: gpu.SharingModeExclusive,
+			},
+			minObservedPower: map[string]float64{
+				"GPU-123": 40.0,
+			},
+			lastSeenTimestamp: make(map[int]uint64),
+		}
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetPowerUsage").Return(device.Power(100*device.Watt), nil)
+		mockDevice.On("UUID").Return("GPU-123")
+		mockDevice.On("GetComputeRunningProcesses").Return([]gpu.ProcessGPUInfo{
+			{PID: 1234, DeviceIndex: 0},
+		}, nil)
+
+		result, err := collector.GetProcessPower()
+
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, 60.0, result[1234]) // 100W - 40W idle = 60W active
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+
+	t.Run("time slicing mode attribution", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		collector := &GPUPowerCollector{
+			logger: slog.Default(),
+			nvml:   mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-123"},
+			},
+			sharingModes: map[int]gpu.SharingMode{
+				0: gpu.SharingModeTimeSlicing,
+			},
+			minObservedPower: map[string]float64{
+				"GPU-123": 40.0,
+			},
+			lastSeenTimestamp: make(map[int]uint64),
+		}
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetPowerUsage").Return(device.Power(100*device.Watt), nil)
+		mockDevice.On("UUID").Return("GPU-123")
+		mockDevice.On("GetProcessUtilization", mock.Anything).Return([]gpu.ProcessUtilization{
+			{PID: 1001, ComputeUtil: 60, Timestamp: 100}, // 60% SM util
+			{PID: 1002, ComputeUtil: 40, Timestamp: 100}, // 40% SM util
+		}, nil)
+
+		result, err := collector.GetProcessPower()
+
+		assert.NoError(t, err)
+		assert.Len(t, result, 2)
+		// Active power = 60W, distributed by SM utilization
+		assert.InDelta(t, 36.0, result[1001], 0.01) // 60% of 60W = 36W
+		assert.InDelta(t, 24.0, result[1002], 0.01) // 40% of 60W = 24W
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+
+	t.Run("time slicing fallback to equal distribution", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		collector := &GPUPowerCollector{
+			logger: slog.Default(),
+			nvml:   mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-123"},
+			},
+			sharingModes: map[int]gpu.SharingMode{
+				0: gpu.SharingModeTimeSlicing,
+			},
+			minObservedPower: map[string]float64{
+				"GPU-123": 40.0,
+			},
+			lastSeenTimestamp: make(map[int]uint64),
+		}
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetPowerUsage").Return(device.Power(100*device.Watt), nil)
+		mockDevice.On("UUID").Return("GPU-123")
+		// GetProcessUtilization fails, falls back to equal distribution
+		mockDevice.On("GetProcessUtilization", mock.Anything).Return(nil, gpu.ErrProcessUtilizationUnavailable{})
+		mockDevice.On("GetComputeRunningProcesses").Return([]gpu.ProcessGPUInfo{
+			{PID: 1001, DeviceIndex: 0},
+			{PID: 1002, DeviceIndex: 0},
+		}, nil)
+
+		result, err := collector.GetProcessPower()
+
+		assert.NoError(t, err)
+		assert.Len(t, result, 2)
+		// Active power = 60W, split equally
+		assert.Equal(t, 30.0, result[1001])
+		assert.Equal(t, 30.0, result[1002])
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+
+	t.Run("no active power returns empty result", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		// Idle power equals total power - no active work
+		collector := &GPUPowerCollector{
+			logger: slog.Default(),
+			nvml:   mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-123"},
+			},
+			sharingModes: map[int]gpu.SharingMode{
+				0: gpu.SharingModeTimeSlicing,
+			},
+			minObservedPower: map[string]float64{
+				"GPU-123": 100.0, // Same as total
+			},
+			lastSeenTimestamp: make(map[int]uint64),
+		}
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetPowerUsage").Return(device.Power(100*device.Watt), nil)
+		mockDevice.On("UUID").Return("GPU-123")
+		// Note: GetProcessUtilization is NOT called when active power is 0
+		// because attributeTimeSlicing returns early
+
+		result, err := collector.GetProcessPower()
+
+		assert.NoError(t, err)
+		assert.Empty(t, result) // No power to attribute
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+
+	t.Run("exclusive mode with no running processes", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		collector := &GPUPowerCollector{
+			logger: slog.Default(),
+			nvml:   mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-123"},
+			},
+			sharingModes: map[int]gpu.SharingMode{
+				0: gpu.SharingModeExclusive,
+			},
+			minObservedPower: map[string]float64{
+				"GPU-123": 40.0,
+			},
+			lastSeenTimestamp: make(map[int]uint64),
+		}
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetPowerUsage").Return(device.Power(100*device.Watt), nil)
+		mockDevice.On("UUID").Return("GPU-123")
+		mockDevice.On("GetComputeRunningProcesses").Return([]gpu.ProcessGPUInfo{}, nil)
+
+		result, err := collector.GetProcessPower()
+
+		assert.NoError(t, err)
+		assert.Empty(t, result) // No processes to attribute power to
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+
+	t.Run("time slicing with zero total compute utilization", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		collector := &GPUPowerCollector{
+			logger: slog.Default(),
+			nvml:   mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-123"},
+			},
+			sharingModes: map[int]gpu.SharingMode{
+				0: gpu.SharingModeTimeSlicing,
+			},
+			minObservedPower: map[string]float64{
+				"GPU-123": 40.0,
+			},
+			lastSeenTimestamp: make(map[int]uint64),
+		}
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetPowerUsage").Return(device.Power(100*device.Watt), nil)
+		mockDevice.On("UUID").Return("GPU-123")
+		mockDevice.On("GetProcessUtilization", mock.Anything).Return([]gpu.ProcessUtilization{
+			{PID: 1001, ComputeUtil: 0, Timestamp: 100}, // 0% SM util
+			{PID: 1002, ComputeUtil: 0, Timestamp: 100}, // 0% SM util
+		}, nil)
+
+		result, err := collector.GetProcessPower()
+
+		assert.NoError(t, err)
+		assert.Empty(t, result) // Zero utilization means no power to attribute
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+
+	t.Run("time slicing with empty process utilization", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		collector := &GPUPowerCollector{
+			logger: slog.Default(),
+			nvml:   mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-123"},
+			},
+			sharingModes: map[int]gpu.SharingMode{
+				0: gpu.SharingModeTimeSlicing,
+			},
+			minObservedPower: map[string]float64{
+				"GPU-123": 40.0,
+			},
+			lastSeenTimestamp: make(map[int]uint64),
+		}
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetPowerUsage").Return(device.Power(100*device.Watt), nil)
+		mockDevice.On("UUID").Return("GPU-123")
+		mockDevice.On("GetProcessUtilization", mock.Anything).Return([]gpu.ProcessUtilization{}, nil)
+
+		result, err := collector.GetProcessPower()
+
+		assert.NoError(t, err)
+		assert.Empty(t, result)
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+
+	t.Run("partitioned mode skipped", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+
+		collector := &GPUPowerCollector{
+			logger: slog.Default(),
+			nvml:   mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-123"},
+			},
+			sharingModes: map[int]gpu.SharingMode{
+				0: gpu.SharingModePartitioned,
+			},
+			minObservedPower:  make(map[string]float64),
+			lastSeenTimestamp: make(map[int]uint64),
+		}
+
+		result, err := collector.GetProcessPower()
+
+		assert.NoError(t, err)
+		assert.Empty(t, result) // Partitioned mode not yet implemented
+
+		mockBackend.AssertExpectations(t)
+	})
+}
+
+func TestGPUPowerCollector_GetProcessInfo(t *testing.T) {
+	t.Run("returns processes from all devices", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice0 := new(MockNVMLDevice)
+		mockDevice1 := new(MockNVMLDevice)
+
+		collector := &GPUPowerCollector{
+			nvml: mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-0"},
+				{Index: 1, UUID: "GPU-1"},
+			},
+		}
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice0, nil)
+		mockBackend.On("GetDevice", 1).Return(mockDevice1, nil)
+		mockDevice0.On("GetComputeRunningProcesses").Return([]gpu.ProcessGPUInfo{
+			{PID: 1001, DeviceIndex: 0},
+		}, nil)
+		mockDevice1.On("GetComputeRunningProcesses").Return([]gpu.ProcessGPUInfo{
+			{PID: 2001, DeviceIndex: 1},
+			{PID: 2002, DeviceIndex: 1},
+		}, nil)
+
+		result, err := collector.GetProcessInfo()
+
+		assert.NoError(t, err)
+		assert.Len(t, result, 3)
+
+		mockBackend.AssertExpectations(t)
+		mockDevice0.AssertExpectations(t)
+		mockDevice1.AssertExpectations(t)
+	})
+
+	t.Run("continues on device error", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice1 := new(MockNVMLDevice)
+
+		collector := &GPUPowerCollector{
+			nvml: mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-0"},
+				{Index: 1, UUID: "GPU-1"},
+			},
+		}
+
+		mockBackend.On("GetDevice", 0).Return(nil, gpu.ErrGPUNotFound{DeviceIndex: 0})
+		mockBackend.On("GetDevice", 1).Return(mockDevice1, nil)
+		mockDevice1.On("GetComputeRunningProcesses").Return([]gpu.ProcessGPUInfo{
+			{PID: 2001, DeviceIndex: 1},
+		}, nil)
+
+		result, err := collector.GetProcessInfo()
+
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, uint32(2001), result[0].PID)
+
+		mockBackend.AssertExpectations(t)
+		mockDevice1.AssertExpectations(t)
+	})
+
+	t.Run("continues on GetComputeRunningProcesses error", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice0 := new(MockNVMLDevice)
+		mockDevice1 := new(MockNVMLDevice)
+
+		collector := &GPUPowerCollector{
+			nvml: mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-0"},
+				{Index: 1, UUID: "GPU-1"},
+			},
+		}
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice0, nil)
+		mockBackend.On("GetDevice", 1).Return(mockDevice1, nil)
+		mockDevice0.On("GetComputeRunningProcesses").Return(nil, errors.New("NVML error"))
+		mockDevice1.On("GetComputeRunningProcesses").Return([]gpu.ProcessGPUInfo{
+			{PID: 2001, DeviceIndex: 1},
+		}, nil)
+
+		result, err := collector.GetProcessInfo()
+
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, uint32(2001), result[0].PID)
+
+		mockBackend.AssertExpectations(t)
+		mockDevice0.AssertExpectations(t)
+		mockDevice1.AssertExpectations(t)
+	})
+
+	t.Run("empty result when no devices", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+
+		collector := &GPUPowerCollector{
+			nvml:    mockBackend,
+			devices: []gpu.GPUDevice{},
+		}
+
+		result, err := collector.GetProcessInfo()
+
+		assert.NoError(t, err)
+		assert.Empty(t, result)
+	})
+}
+
+func TestGPUPowerCollector_GetProcessPower_ErrorPaths(t *testing.T) {
+	t.Run("exclusive mode GetDevice error", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+
+		collector := &GPUPowerCollector{
+			logger: slog.Default(),
+			nvml:   mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-123"},
+			},
+			sharingModes: map[int]gpu.SharingMode{
+				0: gpu.SharingModeExclusive,
+			},
+			minObservedPower:  make(map[string]float64),
+			lastSeenTimestamp: make(map[int]uint64),
+		}
+
+		mockBackend.On("GetDevice", 0).Return(nil, gpu.ErrGPUNotFound{DeviceIndex: 0})
+
+		result, err := collector.GetProcessPower()
+
+		// GetProcessPower returns no error but logs warning
+		assert.NoError(t, err)
+		assert.Empty(t, result)
+
+		mockBackend.AssertExpectations(t)
+	})
+
+	t.Run("exclusive mode GetComputeRunningProcesses error", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		collector := &GPUPowerCollector{
+			logger: slog.Default(),
+			nvml:   mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-123"},
+			},
+			sharingModes: map[int]gpu.SharingMode{
+				0: gpu.SharingModeExclusive,
+			},
+			minObservedPower: map[string]float64{
+				"GPU-123": 40.0,
+			},
+			lastSeenTimestamp: make(map[int]uint64),
+		}
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetPowerUsage").Return(device.Power(100*device.Watt), nil)
+		mockDevice.On("UUID").Return("GPU-123")
+		mockDevice.On("GetComputeRunningProcesses").Return(nil, errors.New("NVML error"))
+
+		result, err := collector.GetProcessPower()
+
+		// GetProcessPower returns no error but logs warning
+		assert.NoError(t, err)
+		assert.Empty(t, result)
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+
+	t.Run("exclusive mode GetPowerUsage error in attributeExclusive", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		collector := &GPUPowerCollector{
+			logger: slog.Default(),
+			nvml:   mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-123"},
+			},
+			sharingModes: map[int]gpu.SharingMode{
+				0: gpu.SharingModeExclusive,
+			},
+			minObservedPower:  make(map[string]float64),
+			lastSeenTimestamp: make(map[int]uint64),
+		}
+
+		// GetDevice succeeds but GetPowerUsage fails
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetPowerUsage").Return(device.Power(0), errors.New("power reading failed"))
+
+		result, err := collector.GetProcessPower()
+
+		// GetProcessPower returns no error but logs warning
+		assert.NoError(t, err)
+		assert.Empty(t, result)
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+
+	t.Run("time slicing mode GetDevice error", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+
+		collector := &GPUPowerCollector{
+			logger: slog.Default(),
+			nvml:   mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-123"},
+			},
+			sharingModes: map[int]gpu.SharingMode{
+				0: gpu.SharingModeTimeSlicing,
+			},
+			minObservedPower:  make(map[string]float64),
+			lastSeenTimestamp: make(map[int]uint64),
+		}
+
+		mockBackend.On("GetDevice", 0).Return(nil, gpu.ErrGPUNotFound{DeviceIndex: 0})
+
+		result, err := collector.GetProcessPower()
+
+		assert.NoError(t, err)
+		assert.Empty(t, result)
+
+		mockBackend.AssertExpectations(t)
+	})
+
+	t.Run("time slicing mode GetPowerUsage error", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		collector := &GPUPowerCollector{
+			logger: slog.Default(),
+			nvml:   mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-123"},
+			},
+			sharingModes: map[int]gpu.SharingMode{
+				0: gpu.SharingModeTimeSlicing,
+			},
+			minObservedPower:  make(map[string]float64),
+			lastSeenTimestamp: make(map[int]uint64),
+		}
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetPowerUsage").Return(device.Power(0), errors.New("NVML error"))
+
+		result, err := collector.GetProcessPower()
+
+		assert.NoError(t, err)
+		assert.Empty(t, result)
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+
+	t.Run("multiple devices with mixed errors", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice1 := new(MockNVMLDevice)
+
+		collector := &GPUPowerCollector{
+			logger: slog.Default(),
+			nvml:   mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-0"},
+				{Index: 1, UUID: "GPU-1"},
+			},
+			sharingModes: map[int]gpu.SharingMode{
+				0: gpu.SharingModeExclusive, // Will fail
+				1: gpu.SharingModeExclusive, // Will succeed
+			},
+			minObservedPower: map[string]float64{
+				"GPU-0": 40.0,
+				"GPU-1": 50.0,
+			},
+			lastSeenTimestamp: make(map[int]uint64),
+		}
+
+		// Device 0 fails
+		mockBackend.On("GetDevice", 0).Return(nil, gpu.ErrGPUNotFound{DeviceIndex: 0})
+
+		// Device 1 succeeds
+		mockBackend.On("GetDevice", 1).Return(mockDevice1, nil)
+		mockDevice1.On("GetPowerUsage").Return(device.Power(100*device.Watt), nil)
+		mockDevice1.On("UUID").Return("GPU-1")
+		mockDevice1.On("GetComputeRunningProcesses").Return([]gpu.ProcessGPUInfo{
+			{PID: 2001, DeviceIndex: 1},
+		}, nil)
+
+		result, err := collector.GetProcessPower()
+
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, 50.0, result[2001]) // 100W - 50W idle = 50W
+
+		mockBackend.AssertExpectations(t)
+		mockDevice1.AssertExpectations(t)
+	})
+
+	t.Run("power accumulates across same PID on multiple devices", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice0 := new(MockNVMLDevice)
+		mockDevice1 := new(MockNVMLDevice)
+
+		collector := &GPUPowerCollector{
+			logger: slog.Default(),
+			nvml:   mockBackend,
+			devices: []gpu.GPUDevice{
+				{Index: 0, UUID: "GPU-0"},
+				{Index: 1, UUID: "GPU-1"},
+			},
+			sharingModes: map[int]gpu.SharingMode{
+				0: gpu.SharingModeExclusive,
+				1: gpu.SharingModeExclusive,
+			},
+			minObservedPower: map[string]float64{
+				"GPU-0": 40.0,
+				"GPU-1": 40.0,
+			},
+			lastSeenTimestamp: make(map[int]uint64),
+		}
+
+		// Both devices have same PID (process using multiple GPUs)
+		mockBackend.On("GetDevice", 0).Return(mockDevice0, nil)
+		mockDevice0.On("GetPowerUsage").Return(device.Power(100*device.Watt), nil)
+		mockDevice0.On("UUID").Return("GPU-0")
+		mockDevice0.On("GetComputeRunningProcesses").Return([]gpu.ProcessGPUInfo{
+			{PID: 1234, DeviceIndex: 0},
+		}, nil)
+
+		mockBackend.On("GetDevice", 1).Return(mockDevice1, nil)
+		mockDevice1.On("GetPowerUsage").Return(device.Power(100*device.Watt), nil)
+		mockDevice1.On("UUID").Return("GPU-1")
+		mockDevice1.On("GetComputeRunningProcesses").Return([]gpu.ProcessGPUInfo{
+			{PID: 1234, DeviceIndex: 1}, // Same PID
+		}, nil)
+
+		result, err := collector.GetProcessPower()
+
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		// 60W from GPU-0 + 60W from GPU-1 = 120W
+		assert.Equal(t, 120.0, result[1234])
+
+		mockBackend.AssertExpectations(t)
+		mockDevice0.AssertExpectations(t)
+		mockDevice1.AssertExpectations(t)
+	})
+}
+
+func TestGPUPowerCollector_GetDevicePowerStats_ErrorPaths(t *testing.T) {
+	t.Run("GetPowerUsage error", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		collector := &GPUPowerCollector{
+			nvml:             mockBackend,
+			minObservedPower: make(map[string]float64),
+		}
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetPowerUsage").Return(device.Power(0), errors.New("NVML error"))
+
+		_, err := collector.GetDevicePowerStats(0)
+
+		assert.Error(t, err)
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+
+	t.Run("first observation sets idle power", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		// Empty minObservedPower - first observation
+		collector := &GPUPowerCollector{
+			nvml:             mockBackend,
+			minObservedPower: make(map[string]float64),
+		}
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetPowerUsage").Return(device.Power(100*device.Watt), nil)
+		mockDevice.On("UUID").Return("GPU-123")
+
+		stats, err := collector.GetDevicePowerStats(0)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 100.0, stats.TotalPower)
+		assert.Equal(t, 100.0, stats.IdlePower) // First reading becomes idle
+		assert.Equal(t, 0.0, stats.ActivePower)
+
+		// Verify min was set
+		assert.Equal(t, 100.0, collector.minObservedPower["GPU-123"])
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+}
+
+func TestGPUPowerCollector_GetTotalEnergy_ErrorPaths(t *testing.T) {
+	t.Run("GetTotalEnergy error", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice := new(MockNVMLDevice)
+
+		mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+		mockDevice.On("GetTotalEnergy").Return(device.Energy(0), errors.New("NVML error"))
+
+		collector := &GPUPowerCollector{
+			nvml: mockBackend,
+		}
+
+		_, err := collector.GetTotalEnergy(0)
+
+		assert.Error(t, err)
+
+		mockBackend.AssertExpectations(t)
+		mockDevice.AssertExpectations(t)
+	})
+}
+
+func TestGPUPowerCollector_Init_DetectAllModesErrorPath(t *testing.T) {
+	// Test the error path where DetectAllModes fails
+	// Note: Current implementation of DetectAllModes never returns an error,
+	// it handles device errors internally. This test documents that behavior.
+	mockBackend := new(MockNVMLBackend)
+	mockDevice := new(MockNVMLDevice)
+
+	mockBackend.On("Init").Return(nil)
+	mockBackend.On("DiscoverDevices").Return([]gpu.GPUDevice{
+		{Index: 0, UUID: "GPU-123", Name: "Test GPU", Vendor: gpu.VendorNVIDIA},
+	}, nil)
+	mockBackend.On("DeviceCount").Return(1)
+	// GetDevice fails, which causes DetectAllModes to set mode to Unknown
+	mockBackend.On("GetDevice", 0).Return(nil, errors.New("device error"))
+
+	collector := &GPUPowerCollector{
+		logger:            slog.Default(),
+		nvml:              mockBackend,
+		minObservedPower:  make(map[string]float64),
+		lastSeenTimestamp: make(map[int]uint64),
+		sharingModes:      make(map[int]gpu.SharingMode),
+	}
+
+	err := collector.Init()
+
+	// Init succeeds even with device errors in mode detection
+	assert.NoError(t, err)
+	// Mode defaults to Unknown when detection fails
+	assert.Equal(t, gpu.SharingModeUnknown, collector.sharingModes[0])
+
+	mockBackend.AssertExpectations(t)
+	mockDevice.AssertExpectations(t)
+}
+
+func TestRegistration(t *testing.T) {
+	// Verify that the nvidia package registers itself on import
+	vendors := gpu.RegisteredVendors()
+
+	found := false
+	for _, v := range vendors {
+		if v == gpu.VendorNVIDIA {
+			found = true
+			break
+		}
+	}
+
+	assert.True(t, found, "NVIDIA vendor should be registered")
+}
+
+// Ensure interface implementation
+var _ gpu.GPUPowerMeter = (*GPUPowerCollector)(nil)

--- a/internal/device/gpu/nvidia/detector.go
+++ b/internal/device/gpu/nvidia/detector.go
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidia
+
+import (
+	"log/slog"
+
+	"github.com/sustainable-computing-io/kepler/internal/device/gpu"
+)
+
+// SharingModeDetector determines the GPU sharing mode at runtime.
+// This is critical for selecting the correct power attribution strategy:
+//
+//   - MIG mode: Use DCGM profiling (Field 1001) because NVML returns N/A
+//   - Time-slicing: Use NVML GetProcessUtilization() which correctly handles
+//     context switching
+//   - Exclusive: 100% attribution to single process
+type SharingModeDetector interface {
+	// DetectMode determines the sharing mode for a specific GPU device
+	DetectMode(deviceIndex int) (gpu.SharingMode, error)
+
+	// DetectAllModes returns the sharing mode for all devices
+	DetectAllModes() (map[int]gpu.SharingMode, error)
+
+	// Refresh re-detects modes for all devices
+	Refresh() error
+}
+
+// sharingModeDetector is the concrete implementation of SharingModeDetector
+type sharingModeDetector struct {
+	logger      *slog.Logger
+	nvml        NVMLBackend
+	cachedModes map[int]gpu.SharingMode
+}
+
+// NewSharingModeDetector creates a new GPU sharing mode detector
+func NewSharingModeDetector(logger *slog.Logger, nvml NVMLBackend) SharingModeDetector {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &sharingModeDetector{
+		logger:      logger.With("component", "gpu-sharing-mode-detector"),
+		nvml:        nvml,
+		cachedModes: make(map[int]gpu.SharingMode),
+	}
+}
+
+// DetectMode determines the sharing mode for a specific GPU device.
+//
+// Detection logic (in order):
+//  1. Check if MIG is enabled -> SharingModePartitioned
+//  2. Check GPU compute mode via NVML:
+//     - EXCLUSIVE_PROCESS -> SharingModeExclusive
+//     - DEFAULT (shared) -> SharingModeTimeSlicing
+func (d *sharingModeDetector) DetectMode(deviceIndex int) (gpu.SharingMode, error) {
+	device, err := d.nvml.GetDevice(deviceIndex)
+	if err != nil {
+		return gpu.SharingModeUnknown, err
+	}
+
+	// Step 1: Check for MIG mode first
+	migEnabled, err := device.IsMIGEnabled()
+	if err != nil {
+		d.logger.Warn("failed to check MIG mode, assuming disabled",
+			"device", deviceIndex, "error", err)
+		migEnabled = false
+	}
+
+	if migEnabled {
+		d.logger.Debug("detected MIG mode", "device", deviceIndex)
+		return gpu.SharingModePartitioned, nil
+	}
+
+	// Step 2: Check compute mode via NVML
+	computeMode, err := device.GetComputeMode()
+	if err != nil {
+		d.logger.Warn("failed to get compute mode, defaulting to time-slicing",
+			"device", deviceIndex, "error", err)
+		return gpu.SharingModeTimeSlicing, nil
+	}
+
+	d.logger.Debug("detected compute mode", "device", deviceIndex, "mode", computeMode)
+
+	switch computeMode {
+	case ComputeModeExclusiveProcess, ComputeModeExclusiveThread:
+		return gpu.SharingModeExclusive, nil
+	default:
+		return gpu.SharingModeTimeSlicing, nil
+	}
+}
+
+// DetectAllModes returns the sharing mode for all discovered GPU devices
+func (d *sharingModeDetector) DetectAllModes() (map[int]gpu.SharingMode, error) {
+	modes := make(map[int]gpu.SharingMode)
+
+	deviceCount := d.nvml.DeviceCount()
+	for i := range deviceCount {
+		mode, err := d.DetectMode(i)
+		if err != nil {
+			d.logger.Warn("failed to detect mode for device",
+				"device", i, "error", err)
+			mode = gpu.SharingModeUnknown
+		}
+		modes[i] = mode
+	}
+
+	d.cachedModes = modes
+	return modes, nil
+}
+
+// Refresh re-detects the sharing mode for all devices.
+func (d *sharingModeDetector) Refresh() error {
+	_, err := d.DetectAllModes()
+	return err
+}
+
+// GetCachedMode returns the last detected mode for a device without re-checking.
+// Returns SharingModeUnknown if the device hasn't been checked.
+func (d *sharingModeDetector) GetCachedMode(deviceIndex int) gpu.SharingMode {
+	if mode, ok := d.cachedModes[deviceIndex]; ok {
+		return mode
+	}
+	return gpu.SharingModeUnknown
+}

--- a/internal/device/gpu/nvidia/detector_test.go
+++ b/internal/device/gpu/nvidia/detector_test.go
@@ -1,0 +1,283 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidia
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/sustainable-computing-io/kepler/internal/device/gpu"
+)
+
+func TestNewSharingModeDetector(t *testing.T) {
+	t.Run("with logger", func(t *testing.T) {
+		logger := slog.Default()
+		mockNVML := new(MockNVMLBackend)
+
+		detector := NewSharingModeDetector(logger, mockNVML)
+
+		assert.NotNil(t, detector)
+	})
+
+	t.Run("with nil logger uses default", func(t *testing.T) {
+		mockNVML := new(MockNVMLBackend)
+
+		detector := NewSharingModeDetector(nil, mockNVML)
+
+		assert.NotNil(t, detector)
+	})
+}
+
+func TestSharingModeDetector_DetectMode(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMock     func(*MockNVMLBackend, *MockNVMLDevice)
+		deviceIndex   int
+		expectedMode  gpu.SharingMode
+		expectedError bool
+	}{
+		{
+			name: "MIG enabled returns partitioned mode",
+			setupMock: func(backend *MockNVMLBackend, device *MockNVMLDevice) {
+				backend.On("GetDevice", 0).Return(device, nil)
+				device.On("IsMIGEnabled").Return(true, nil)
+			},
+			deviceIndex:   0,
+			expectedMode:  gpu.SharingModePartitioned,
+			expectedError: false,
+		},
+		{
+			name: "exclusive process mode",
+			setupMock: func(backend *MockNVMLBackend, device *MockNVMLDevice) {
+				backend.On("GetDevice", 0).Return(device, nil)
+				device.On("IsMIGEnabled").Return(false, nil)
+				device.On("GetComputeMode").Return(ComputeModeExclusiveProcess, nil)
+			},
+			deviceIndex:   0,
+			expectedMode:  gpu.SharingModeExclusive,
+			expectedError: false,
+		},
+		{
+			name: "exclusive thread mode",
+			setupMock: func(backend *MockNVMLBackend, device *MockNVMLDevice) {
+				backend.On("GetDevice", 0).Return(device, nil)
+				device.On("IsMIGEnabled").Return(false, nil)
+				device.On("GetComputeMode").Return(ComputeModeExclusiveThread, nil)
+			},
+			deviceIndex:   0,
+			expectedMode:  gpu.SharingModeExclusive,
+			expectedError: false,
+		},
+		{
+			name: "default mode returns time slicing",
+			setupMock: func(backend *MockNVMLBackend, device *MockNVMLDevice) {
+				backend.On("GetDevice", 0).Return(device, nil)
+				device.On("IsMIGEnabled").Return(false, nil)
+				device.On("GetComputeMode").Return(ComputeModeDefault, nil)
+			},
+			deviceIndex:   0,
+			expectedMode:  gpu.SharingModeTimeSlicing,
+			expectedError: false,
+		},
+		{
+			name: "prohibited mode returns time slicing",
+			setupMock: func(backend *MockNVMLBackend, device *MockNVMLDevice) {
+				backend.On("GetDevice", 0).Return(device, nil)
+				device.On("IsMIGEnabled").Return(false, nil)
+				device.On("GetComputeMode").Return(ComputeModeProhibited, nil)
+			},
+			deviceIndex:   0,
+			expectedMode:  gpu.SharingModeTimeSlicing,
+			expectedError: false,
+		},
+		{
+			name: "device not found returns error",
+			setupMock: func(backend *MockNVMLBackend, device *MockNVMLDevice) {
+				backend.On("GetDevice", 99).Return(nil, gpu.ErrGPUNotFound{DeviceIndex: 99})
+			},
+			deviceIndex:   99,
+			expectedMode:  gpu.SharingModeUnknown,
+			expectedError: true,
+		},
+		{
+			name: "MIG check error defaults to disabled",
+			setupMock: func(backend *MockNVMLBackend, device *MockNVMLDevice) {
+				backend.On("GetDevice", 0).Return(device, nil)
+				device.On("IsMIGEnabled").Return(false, errors.New("MIG check failed"))
+				device.On("GetComputeMode").Return(ComputeModeDefault, nil)
+			},
+			deviceIndex:   0,
+			expectedMode:  gpu.SharingModeTimeSlicing,
+			expectedError: false,
+		},
+		{
+			name: "compute mode error defaults to time slicing",
+			setupMock: func(backend *MockNVMLBackend, device *MockNVMLDevice) {
+				backend.On("GetDevice", 0).Return(device, nil)
+				device.On("IsMIGEnabled").Return(false, nil)
+				device.On("GetComputeMode").Return(ComputeModeDefault, errors.New("compute mode failed"))
+			},
+			deviceIndex:   0,
+			expectedMode:  gpu.SharingModeTimeSlicing,
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockBackend := new(MockNVMLBackend)
+			mockDevice := new(MockNVMLDevice)
+			tt.setupMock(mockBackend, mockDevice)
+
+			detector := NewSharingModeDetector(nil, mockBackend)
+			mode, err := detector.DetectMode(tt.deviceIndex)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedMode, mode)
+
+			mockBackend.AssertExpectations(t)
+			mockDevice.AssertExpectations(t)
+		})
+	}
+}
+
+func TestSharingModeDetector_DetectAllModes(t *testing.T) {
+	t.Run("multiple devices with different modes", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockDevice0 := new(MockNVMLDevice)
+		mockDevice1 := new(MockNVMLDevice)
+
+		mockBackend.On("DeviceCount").Return(2)
+		mockBackend.On("GetDevice", 0).Return(mockDevice0, nil)
+		mockBackend.On("GetDevice", 1).Return(mockDevice1, nil)
+
+		// Device 0: MIG enabled
+		mockDevice0.On("IsMIGEnabled").Return(true, nil)
+
+		// Device 1: Default mode (time-slicing)
+		mockDevice1.On("IsMIGEnabled").Return(false, nil)
+		mockDevice1.On("GetComputeMode").Return(ComputeModeDefault, nil)
+
+		detector := NewSharingModeDetector(nil, mockBackend)
+		modes, err := detector.DetectAllModes()
+
+		assert.NoError(t, err)
+		assert.Len(t, modes, 2)
+		assert.Equal(t, gpu.SharingModePartitioned, modes[0])
+		assert.Equal(t, gpu.SharingModeTimeSlicing, modes[1])
+
+		mockBackend.AssertExpectations(t)
+		mockDevice0.AssertExpectations(t)
+		mockDevice1.AssertExpectations(t)
+	})
+
+	t.Run("device error sets unknown mode", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+
+		mockBackend.On("DeviceCount").Return(1)
+		mockBackend.On("GetDevice", 0).Return(nil, gpu.ErrGPUNotFound{DeviceIndex: 0})
+
+		detector := NewSharingModeDetector(nil, mockBackend)
+		modes, err := detector.DetectAllModes()
+
+		assert.NoError(t, err)
+		assert.Len(t, modes, 1)
+		assert.Equal(t, gpu.SharingModeUnknown, modes[0])
+
+		mockBackend.AssertExpectations(t)
+	})
+
+	t.Run("zero devices", func(t *testing.T) {
+		mockBackend := new(MockNVMLBackend)
+		mockBackend.On("DeviceCount").Return(0)
+
+		detector := NewSharingModeDetector(nil, mockBackend)
+		modes, err := detector.DetectAllModes()
+
+		assert.NoError(t, err)
+		assert.Empty(t, modes)
+
+		mockBackend.AssertExpectations(t)
+	})
+}
+
+func TestSharingModeDetector_Refresh(t *testing.T) {
+	mockBackend := new(MockNVMLBackend)
+	mockDevice := new(MockNVMLDevice)
+
+	mockBackend.On("DeviceCount").Return(1)
+	mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+	mockDevice.On("IsMIGEnabled").Return(false, nil)
+	mockDevice.On("GetComputeMode").Return(ComputeModeDefault, nil)
+
+	detector := NewSharingModeDetector(nil, mockBackend)
+	err := detector.Refresh()
+
+	assert.NoError(t, err)
+
+	mockBackend.AssertExpectations(t)
+	mockDevice.AssertExpectations(t)
+}
+
+func TestSharingModeDetector_GetCachedMode(t *testing.T) {
+	mockBackend := new(MockNVMLBackend)
+	mockDevice := new(MockNVMLDevice)
+
+	mockBackend.On("DeviceCount").Return(1)
+	mockBackend.On("GetDevice", 0).Return(mockDevice, nil)
+	mockDevice.On("IsMIGEnabled").Return(true, nil)
+
+	detector := NewSharingModeDetector(nil, mockBackend).(*sharingModeDetector)
+
+	// Before detection, should return unknown
+	mode := detector.GetCachedMode(0)
+	assert.Equal(t, gpu.SharingModeUnknown, mode)
+
+	// After detection, should return cached value
+	_, _ = detector.DetectAllModes()
+	mode = detector.GetCachedMode(0)
+	assert.Equal(t, gpu.SharingModePartitioned, mode)
+
+	// Non-existent device should return unknown
+	mode = detector.GetCachedMode(99)
+	assert.Equal(t, gpu.SharingModeUnknown, mode)
+
+	mockBackend.AssertExpectations(t)
+	mockDevice.AssertExpectations(t)
+}
+
+// Ensure SharingModeDetector interface is implemented
+var _ SharingModeDetector = (*sharingModeDetector)(nil)
+
+// MockSharingModeDetector for collector tests
+type MockSharingModeDetector struct {
+	mock.Mock
+}
+
+func (m *MockSharingModeDetector) DetectMode(deviceIndex int) (gpu.SharingMode, error) {
+	args := m.Called(deviceIndex)
+	return args.Get(0).(gpu.SharingMode), args.Error(1)
+}
+
+func (m *MockSharingModeDetector) DetectAllModes() (map[int]gpu.SharingMode, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[int]gpu.SharingMode), args.Error(1)
+}
+
+func (m *MockSharingModeDetector) Refresh() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+var _ SharingModeDetector = (*MockSharingModeDetector)(nil)

--- a/internal/device/gpu/nvidia/mock_test.go
+++ b/internal/device/gpu/nvidia/mock_test.go
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidia
+
+import (
+	"github.com/stretchr/testify/mock"
+	"github.com/sustainable-computing-io/kepler/internal/device"
+	"github.com/sustainable-computing-io/kepler/internal/device/gpu"
+)
+
+// MockNVMLBackend is a mock implementation of NVMLBackend for testing
+type MockNVMLBackend struct {
+	mock.Mock
+}
+
+func (m *MockNVMLBackend) Init() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockNVMLBackend) Shutdown() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockNVMLBackend) DeviceCount() int {
+	args := m.Called()
+	return args.Int(0)
+}
+
+func (m *MockNVMLBackend) GetDevice(index int) (NVMLDevice, error) {
+	args := m.Called(index)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(NVMLDevice), args.Error(1)
+}
+
+func (m *MockNVMLBackend) DiscoverDevices() ([]gpu.GPUDevice, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]gpu.GPUDevice), args.Error(1)
+}
+
+// MockNVMLDevice is a mock implementation of NVMLDevice for testing
+type MockNVMLDevice struct {
+	mock.Mock
+}
+
+func (m *MockNVMLDevice) Index() int {
+	args := m.Called()
+	return args.Int(0)
+}
+
+func (m *MockNVMLDevice) UUID() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockNVMLDevice) Name() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockNVMLDevice) GetPowerUsage() (device.Power, error) {
+	args := m.Called()
+	return args.Get(0).(device.Power), args.Error(1)
+}
+
+func (m *MockNVMLDevice) GetTotalEnergy() (device.Energy, error) {
+	args := m.Called()
+	return args.Get(0).(device.Energy), args.Error(1)
+}
+
+func (m *MockNVMLDevice) GetComputeRunningProcesses() ([]gpu.ProcessGPUInfo, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]gpu.ProcessGPUInfo), args.Error(1)
+}
+
+func (m *MockNVMLDevice) GetProcessUtilization(lastSeen uint64) ([]gpu.ProcessUtilization, error) {
+	args := m.Called(lastSeen)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]gpu.ProcessUtilization), args.Error(1)
+}
+
+func (m *MockNVMLDevice) GetComputeMode() (ComputeMode, error) {
+	args := m.Called()
+	return args.Get(0).(ComputeMode), args.Error(1)
+}
+
+func (m *MockNVMLDevice) IsMIGEnabled() (bool, error) {
+	args := m.Called()
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockNVMLDevice) GetMIGInstances() ([]MIGInstance, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]MIGInstance), args.Error(1)
+}
+
+func (m *MockNVMLDevice) GetMIGDeviceByInstanceID(gpuInstanceID uint) (NVMLDevice, error) {
+	args := m.Called(gpuInstanceID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(NVMLDevice), args.Error(1)
+}
+
+func (m *MockNVMLDevice) GetMaxMigDeviceCount() (int, error) {
+	args := m.Called()
+	return args.Int(0), args.Error(1)
+}
+
+// Verify interface implementations
+var _ NVMLBackend = (*MockNVMLBackend)(nil)
+var _ NVMLDevice = (*MockNVMLDevice)(nil)

--- a/internal/device/gpu/nvidia/nvml.go
+++ b/internal/device/gpu/nvidia/nvml.go
@@ -1,0 +1,464 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidia
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/sustainable-computing-io/kepler/internal/device"
+	"github.com/sustainable-computing-io/kepler/internal/device/gpu"
+)
+
+// MIGInstance represents a Multi-Instance GPU partition (NVIDIA-specific)
+type MIGInstance struct {
+	// EntityID is the MIG device index within the parent GPU
+	EntityID uint
+
+	// GPUInstanceID is the GPU Instance ID
+	GPUInstanceID uint
+
+	// ComputeInstances are the compute instances within this GPU instance
+	ComputeInstances []ComputeInstance
+
+	// ProfileSlices is the number of GPU slices allocated to this instance
+	ProfileSlices uint
+}
+
+// ComputeInstance represents a compute instance within a MIG GPU instance
+type ComputeInstance struct {
+	// EntityID is the compute instance entity ID
+	EntityID uint
+
+	// ComputeInstanceID is the compute instance ID
+	ComputeInstanceID uint
+}
+
+// NVMLBackend provides access to NVIDIA GPUs via the NVML library.
+// It is used for:
+//   - Device discovery and power readings (all scenarios)
+//   - Per-process utilization via GetProcessUtilization() (time-slicing scenario)
+//   - MIG mode detection
+//
+// Thread-safety: All methods are safe for concurrent use.
+type NVMLBackend interface {
+	Init() error
+	Shutdown() error
+	DeviceCount() int
+	GetDevice(index int) (NVMLDevice, error)
+	DiscoverDevices() ([]gpu.GPUDevice, error)
+}
+
+// NVMLDevice wraps operations on a single NVIDIA GPU device
+type NVMLDevice interface {
+	Index() int
+	UUID() string
+	Name() string
+	GetPowerUsage() (device.Power, error)
+	GetTotalEnergy() (device.Energy, error)
+	GetComputeRunningProcesses() ([]gpu.ProcessGPUInfo, error)
+	GetProcessUtilization(lastSeen uint64) ([]gpu.ProcessUtilization, error)
+	GetComputeMode() (ComputeMode, error)
+	IsMIGEnabled() (bool, error)
+	GetMIGInstances() ([]MIGInstance, error)
+	GetMIGDeviceByInstanceID(gpuInstanceID uint) (NVMLDevice, error)
+	GetMaxMigDeviceCount() (int, error)
+}
+
+// nvmlBackend is the concrete implementation of NVMLBackend
+type nvmlBackend struct {
+	logger      *slog.Logger
+	lib         nvmlLib
+	devices     []nvmlDevice
+	initialized bool
+	mu          sync.RWMutex
+}
+
+// nvmlDevice wraps a single NVML device handle
+type nvmlDevice struct {
+	index  int
+	handle nvmlDeviceHandle
+	lib    nvmlLib
+	uuid   string
+	name   string
+}
+
+// NewNVMLBackend creates a new NVML backend instance
+func NewNVMLBackend(logger *slog.Logger) NVMLBackend {
+	return newNVMLBackendWithLib(logger, newRealNvmlLib())
+}
+
+// newNVMLBackendWithLib creates an NVML backend with a specific library implementation.
+// This is used for testing with mock implementations.
+func newNVMLBackendWithLib(logger *slog.Logger, lib nvmlLib) *nvmlBackend {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &nvmlBackend{
+		logger: logger.With("component", "nvml"),
+		lib:    lib,
+	}
+}
+
+// Init initializes the NVML library and discovers all GPU devices
+func (n *nvmlBackend) Init() error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if n.initialized {
+		return nil
+	}
+
+	ret := n.lib.Init()
+	if ret != nvml.SUCCESS {
+		return fmt.Errorf("NVML init failed: %s", n.lib.ErrorString(ret))
+	}
+
+	count, ret := n.lib.DeviceGetCount()
+	if ret != nvml.SUCCESS {
+		_ = n.lib.Shutdown()
+		return fmt.Errorf("failed to get device count: %s", n.lib.ErrorString(ret))
+	}
+
+	n.devices = make([]nvmlDevice, 0, count)
+	for i := 0; i < count; i++ {
+		handle, ret := n.lib.DeviceGetHandleByIndex(i)
+		if ret != nvml.SUCCESS {
+			n.logger.Warn("failed to get device handle", "index", i, "error", n.lib.ErrorString(ret))
+			continue
+		}
+
+		uuid, ret := handle.GetUUID()
+		if ret != nvml.SUCCESS {
+			uuid = fmt.Sprintf("gpu-%d", i)
+		}
+
+		name, ret := handle.GetName()
+		if ret != nvml.SUCCESS {
+			name = "Unknown NVIDIA GPU"
+		}
+
+		n.devices = append(n.devices, nvmlDevice{
+			index:  i,
+			handle: handle,
+			lib:    n.lib,
+			uuid:   uuid,
+			name:   name,
+		})
+
+		n.logger.Info("discovered GPU", "index", i, "uuid", uuid, "name", name)
+	}
+
+	n.initialized = true
+	n.logger.Info("NVML initialized", "device_count", len(n.devices))
+	return nil
+}
+
+// Shutdown cleans up NVML resources
+func (n *nvmlBackend) Shutdown() error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if !n.initialized {
+		return nil
+	}
+
+	ret := n.lib.Shutdown()
+	if ret != nvml.SUCCESS {
+		return fmt.Errorf("NVML shutdown failed: %s", n.lib.ErrorString(ret))
+	}
+
+	n.devices = nil
+	n.initialized = false
+	n.logger.Info("NVML shutdown complete")
+	return nil
+}
+
+// DeviceCount returns the number of discovered GPU devices
+func (n *nvmlBackend) DeviceCount() int {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return len(n.devices)
+}
+
+// GetDevice returns an NVMLDevice for the given index
+func (n *nvmlBackend) GetDevice(index int) (NVMLDevice, error) {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+
+	if !n.initialized {
+		return nil, gpu.ErrGPUNotInitialized{}
+	}
+
+	if index < 0 || index >= len(n.devices) {
+		return nil, gpu.ErrGPUNotFound{DeviceIndex: index}
+	}
+
+	return &n.devices[index], nil
+}
+
+// DiscoverDevices returns GPU device information for all discovered devices
+func (n *nvmlBackend) DiscoverDevices() ([]gpu.GPUDevice, error) {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+
+	if !n.initialized {
+		return nil, gpu.ErrGPUNotInitialized{}
+	}
+
+	devices := make([]gpu.GPUDevice, len(n.devices))
+	for i, dev := range n.devices {
+		devices[i] = gpu.GPUDevice{
+			Index:  dev.index,
+			UUID:   dev.uuid,
+			Name:   dev.name,
+			Vendor: gpu.VendorNVIDIA,
+		}
+	}
+
+	return devices, nil
+}
+
+// Index returns the device index
+func (d *nvmlDevice) Index() int {
+	return d.index
+}
+
+// UUID returns the device UUID
+func (d *nvmlDevice) UUID() string {
+	return d.uuid
+}
+
+// Name returns the device name
+func (d *nvmlDevice) Name() string {
+	return d.name
+}
+
+// GetPowerUsage returns the current power consumption in Watts
+func (d *nvmlDevice) GetPowerUsage() (device.Power, error) {
+	// NVML returns power in milliwatts
+	powerMW, ret := d.handle.GetPowerUsage()
+	if ret != nvml.SUCCESS {
+		return 0, fmt.Errorf("failed to get power usage: %s", d.lib.ErrorString(ret))
+	}
+
+	// Convert milliwatts to device.Power (which is in microwatts)
+	return device.Power(powerMW) * device.MilliWatt, nil
+}
+
+// GetTotalEnergy returns cumulative energy consumption in Joules
+func (d *nvmlDevice) GetTotalEnergy() (device.Energy, error) {
+	// NVML returns energy in millijoules
+	energyMJ, ret := d.handle.GetTotalEnergyConsumption()
+	if ret != nvml.SUCCESS {
+		return 0, fmt.Errorf("failed to get total energy: %s", d.lib.ErrorString(ret))
+	}
+
+	// Convert millijoules to device.Energy (which is in microjoules)
+	return device.Energy(energyMJ) * device.MilliJoule, nil
+}
+
+// GetComputeRunningProcesses returns processes currently using the GPU for compute
+func (d *nvmlDevice) GetComputeRunningProcesses() ([]gpu.ProcessGPUInfo, error) {
+	procs, ret := d.handle.GetComputeRunningProcesses()
+	if ret != nvml.SUCCESS {
+		return nil, fmt.Errorf("failed to get running processes: %s", d.lib.ErrorString(ret))
+	}
+
+	now := time.Now()
+	result := make([]gpu.ProcessGPUInfo, len(procs))
+	for i, p := range procs {
+		result[i] = gpu.ProcessGPUInfo{
+			PID:         p.Pid,
+			DeviceIndex: d.index,
+			DeviceUUID:  d.uuid,
+			MemoryUsed:  p.UsedGpuMemory,
+			Timestamp:   now,
+		}
+	}
+
+	return result, nil
+}
+
+// GetProcessUtilization returns per-process SM and memory utilization.
+// This is the key API for time-slicing power attribution.
+//
+// Parameters:
+//   - lastSeen: timestamp (microseconds) from previous call, or 0 for first call
+//
+// Returns slice of ProcessUtilization with SmUtil normalized across all processes.
+func (d *nvmlDevice) GetProcessUtilization(lastSeen uint64) ([]gpu.ProcessUtilization, error) {
+	samples, ret := d.handle.GetProcessUtilization(lastSeen)
+	if ret == nvml.SUCCESS {
+		result := make([]gpu.ProcessUtilization, len(samples))
+		for i, s := range samples {
+			result[i] = gpu.ProcessUtilization{
+				PID:         s.Pid,
+				ComputeUtil: s.SmUtil,
+				MemUtil:     s.MemUtil,
+				EncUtil:     s.EncUtil,
+				DecUtil:     s.DecUtil,
+				Timestamp:   s.TimeStamp,
+			}
+		}
+		return result, nil
+	}
+
+	// Check if accounting mode is the issue
+	mode, accRet := d.handle.GetAccountingMode()
+	if accRet == nvml.SUCCESS && mode == nvml.FEATURE_DISABLED {
+		return nil, gpu.ErrProcessUtilizationUnavailable{
+			Reason: "process utilization requires accounting mode or driver 450+; accounting mode is disabled",
+		}
+	}
+
+	return nil, gpu.ErrProcessUtilizationUnavailable{
+		Reason: fmt.Sprintf("GetProcessUtilization failed: %s", d.lib.ErrorString(ret)),
+	}
+}
+
+// GetComputeMode returns the GPU's compute mode configuration.
+func (d *nvmlDevice) GetComputeMode() (ComputeMode, error) {
+	mode, ret := d.handle.GetComputeMode()
+	if ret != nvml.SUCCESS {
+		return ComputeModeDefault, fmt.Errorf("failed to get compute mode: %s", d.lib.ErrorString(ret))
+	}
+
+	switch mode {
+	case nvml.COMPUTEMODE_DEFAULT:
+		return ComputeModeDefault, nil
+	case nvml.COMPUTEMODE_EXCLUSIVE_THREAD:
+		return ComputeModeExclusiveThread, nil
+	case nvml.COMPUTEMODE_EXCLUSIVE_PROCESS:
+		return ComputeModeExclusiveProcess, nil
+	case nvml.COMPUTEMODE_PROHIBITED:
+		return ComputeModeProhibited, nil
+	default:
+		return ComputeModeDefault, nil
+	}
+}
+
+// IsMIGEnabled checks if Multi-Instance GPU mode is enabled on this device
+func (d *nvmlDevice) IsMIGEnabled() (bool, error) {
+	currentMode, _, ret := d.handle.GetMigMode()
+	if ret == nvml.ERROR_NOT_SUPPORTED {
+		return false, nil
+	}
+	if ret != nvml.SUCCESS {
+		return false, fmt.Errorf("failed to get MIG mode: %s", d.lib.ErrorString(ret))
+	}
+
+	return currentMode == nvml.DEVICE_MIG_ENABLE, nil
+}
+
+// GetMIGInstances returns all MIG GPU instances on this device
+func (d *nvmlDevice) GetMIGInstances() ([]MIGInstance, error) {
+	migEnabled, err := d.IsMIGEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !migEnabled {
+		return nil, gpu.ErrPartitioningNotSupported{DeviceIndex: d.index}
+	}
+
+	return d.enumerateMIGInstances()
+}
+
+// enumerateMIGInstances discovers MIG instances by iterating through possible indices
+func (d *nvmlDevice) enumerateMIGInstances() ([]MIGInstance, error) {
+	maxCount, err := d.GetMaxMigDeviceCount()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get max MIG device count: %w", err)
+	}
+	if maxCount == 0 {
+		return nil, fmt.Errorf("MIG not supported on this device")
+	}
+
+	var instances []MIGInstance
+	for i := 0; i < maxCount; i++ {
+		migDevice, ret := d.handle.GetMigDeviceHandleByIndex(i)
+		if ret != nvml.SUCCESS {
+			continue
+		}
+
+		giID, ret := migDevice.GetGpuInstanceId()
+		if ret != nvml.SUCCESS {
+			continue
+		}
+
+		instances = append(instances, MIGInstance{
+			GPUInstanceID: uint(giID),
+			EntityID:      uint(i),
+		})
+	}
+
+	if len(instances) == 0 {
+		return nil, fmt.Errorf("no MIG instances found")
+	}
+
+	return instances, nil
+}
+
+// GetMIGDeviceByInstanceID returns a MIG device by its GPU Instance ID.
+func (d *nvmlDevice) GetMIGDeviceByInstanceID(gpuInstanceID uint) (NVMLDevice, error) {
+	migEnabled, err := d.IsMIGEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !migEnabled {
+		return nil, gpu.ErrPartitioningNotSupported{DeviceIndex: d.index}
+	}
+
+	// Iterate through MIG devices to find the one with matching GPU Instance ID
+	maxCount, err := d.GetMaxMigDeviceCount()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get max MIG device count: %w", err)
+	}
+
+	for i := 0; i < maxCount; i++ {
+		migHandle, ret := d.handle.GetMigDeviceHandleByIndex(i)
+		if ret != nvml.SUCCESS {
+			continue
+		}
+
+		giID, ret := migHandle.GetGpuInstanceId()
+		if ret != nvml.SUCCESS {
+			continue
+		}
+
+		if uint(giID) == gpuInstanceID {
+			uuid, _ := migHandle.GetUUID()
+			name, _ := migHandle.GetName()
+			if name == "" {
+				name = fmt.Sprintf("MIG-%d-%d", d.index, gpuInstanceID)
+			}
+
+			return &nvmlDevice{
+				index:  d.index,
+				handle: migHandle,
+				lib:    d.lib,
+				uuid:   uuid,
+				name:   name,
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("MIG instance with GPU Instance ID %d not found", gpuInstanceID)
+}
+
+// GetMaxMigDeviceCount returns the maximum number of MIG devices for this GPU.
+// Returns 0 if MIG is not supported.
+func (d *nvmlDevice) GetMaxMigDeviceCount() (int, error) {
+	count, ret := d.handle.GetMaxMigDeviceCount()
+	if ret == nvml.ERROR_NOT_SUPPORTED {
+		return 0, nil
+	}
+	if ret != nvml.SUCCESS {
+		return 0, fmt.Errorf("failed to get max MIG device count: %s", d.lib.ErrorString(ret))
+	}
+	return count, nil
+}

--- a/internal/device/gpu/nvidia/nvml_lib.go
+++ b/internal/device/gpu/nvidia/nvml_lib.go
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidia
+
+import (
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+// nvmlLib abstracts the NVML library functions for testability.
+// This allows mocking NVML calls in unit tests.
+type nvmlLib interface {
+	Init() nvml.Return
+	Shutdown() nvml.Return
+	DeviceGetCount() (int, nvml.Return)
+	DeviceGetHandleByIndex(index int) (nvmlDeviceHandle, nvml.Return)
+	ErrorString(ret nvml.Return) string
+}
+
+// nvmlDeviceHandle abstracts operations on an NVML device handle.
+type nvmlDeviceHandle interface {
+	GetUUID() (string, nvml.Return)
+	GetName() (string, nvml.Return)
+	GetPowerUsage() (uint32, nvml.Return)
+	GetTotalEnergyConsumption() (uint64, nvml.Return)
+	GetComputeRunningProcesses() ([]nvml.ProcessInfo, nvml.Return)
+	GetProcessUtilization(lastSeen uint64) ([]nvml.ProcessUtilizationSample, nvml.Return)
+	GetComputeMode() (nvml.ComputeMode, nvml.Return)
+	GetMigMode() (int, int, nvml.Return)
+	GetMigDeviceHandleByIndex(index int) (nvmlDeviceHandle, nvml.Return)
+	GetGpuInstanceId() (int, nvml.Return)
+	GetMaxMigDeviceCount() (int, nvml.Return)
+	GetAccountingMode() (nvml.EnableState, nvml.Return)
+}
+
+// realNvmlLib is the production implementation that calls the actual NVML library.
+type realNvmlLib struct{}
+
+// realDeviceHandle wraps an actual nvml.Device
+type realDeviceHandle struct {
+	device nvml.Device
+}
+
+// newRealNvmlLib creates a new real NVML library wrapper.
+func newRealNvmlLib() nvmlLib {
+	return &realNvmlLib{}
+}
+
+func (r *realNvmlLib) Init() nvml.Return {
+	return nvml.Init()
+}
+
+func (r *realNvmlLib) Shutdown() nvml.Return {
+	return nvml.Shutdown()
+}
+
+func (r *realNvmlLib) DeviceGetCount() (int, nvml.Return) {
+	return nvml.DeviceGetCount()
+}
+
+func (r *realNvmlLib) DeviceGetHandleByIndex(index int) (nvmlDeviceHandle, nvml.Return) {
+	handle, ret := nvml.DeviceGetHandleByIndex(index)
+	if ret != nvml.SUCCESS {
+		return nil, ret
+	}
+	return &realDeviceHandle{device: handle}, ret
+}
+
+func (r *realNvmlLib) ErrorString(ret nvml.Return) string {
+	return nvml.ErrorString(ret)
+}
+
+func (h *realDeviceHandle) GetUUID() (string, nvml.Return) {
+	return h.device.GetUUID()
+}
+
+func (h *realDeviceHandle) GetName() (string, nvml.Return) {
+	return h.device.GetName()
+}
+
+func (h *realDeviceHandle) GetPowerUsage() (uint32, nvml.Return) {
+	return h.device.GetPowerUsage()
+}
+
+func (h *realDeviceHandle) GetTotalEnergyConsumption() (uint64, nvml.Return) {
+	return h.device.GetTotalEnergyConsumption()
+}
+
+func (h *realDeviceHandle) GetComputeRunningProcesses() ([]nvml.ProcessInfo, nvml.Return) {
+	return h.device.GetComputeRunningProcesses()
+}
+
+func (h *realDeviceHandle) GetProcessUtilization(lastSeen uint64) ([]nvml.ProcessUtilizationSample, nvml.Return) {
+	return h.device.GetProcessUtilization(lastSeen)
+}
+
+func (h *realDeviceHandle) GetComputeMode() (nvml.ComputeMode, nvml.Return) {
+	return h.device.GetComputeMode()
+}
+
+func (h *realDeviceHandle) GetMigMode() (int, int, nvml.Return) {
+	return h.device.GetMigMode()
+}
+
+func (h *realDeviceHandle) GetMigDeviceHandleByIndex(index int) (nvmlDeviceHandle, nvml.Return) {
+	handle, ret := h.device.GetMigDeviceHandleByIndex(index)
+	if ret != nvml.SUCCESS {
+		return nil, ret
+	}
+	return &realDeviceHandle{device: handle}, ret
+}
+
+func (h *realDeviceHandle) GetGpuInstanceId() (int, nvml.Return) {
+	return h.device.GetGpuInstanceId()
+}
+
+func (h *realDeviceHandle) GetMaxMigDeviceCount() (int, nvml.Return) {
+	return h.device.GetMaxMigDeviceCount()
+}
+
+func (h *realDeviceHandle) GetAccountingMode() (nvml.EnableState, nvml.Return) {
+	return h.device.GetAccountingMode()
+}

--- a/internal/device/gpu/nvidia/nvml_test.go
+++ b/internal/device/gpu/nvidia/nvml_test.go
@@ -1,0 +1,925 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidia
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/sustainable-computing-io/kepler/internal/device"
+)
+
+// mockNvmlLib is a mock implementation of nvmlLib for testing
+type mockNvmlLib struct {
+	mock.Mock
+}
+
+func (m *mockNvmlLib) Init() nvml.Return {
+	args := m.Called()
+	return args.Get(0).(nvml.Return)
+}
+
+func (m *mockNvmlLib) Shutdown() nvml.Return {
+	args := m.Called()
+	return args.Get(0).(nvml.Return)
+}
+
+func (m *mockNvmlLib) DeviceGetCount() (int, nvml.Return) {
+	args := m.Called()
+	return args.Int(0), args.Get(1).(nvml.Return)
+}
+
+func (m *mockNvmlLib) DeviceGetHandleByIndex(index int) (nvmlDeviceHandle, nvml.Return) {
+	args := m.Called(index)
+	handle := args.Get(0)
+	if handle == nil {
+		return nil, args.Get(1).(nvml.Return)
+	}
+	return handle.(nvmlDeviceHandle), args.Get(1).(nvml.Return)
+}
+
+func (m *mockNvmlLib) ErrorString(ret nvml.Return) string {
+	args := m.Called(ret)
+	return args.String(0)
+}
+
+// mockDeviceHandle is a mock implementation of nvmlDeviceHandle for testing
+type mockDeviceHandle struct {
+	mock.Mock
+}
+
+func (m *mockDeviceHandle) GetUUID() (string, nvml.Return) {
+	args := m.Called()
+	return args.String(0), args.Get(1).(nvml.Return)
+}
+
+func (m *mockDeviceHandle) GetName() (string, nvml.Return) {
+	args := m.Called()
+	return args.String(0), args.Get(1).(nvml.Return)
+}
+
+func (m *mockDeviceHandle) GetPowerUsage() (uint32, nvml.Return) {
+	args := m.Called()
+	return args.Get(0).(uint32), args.Get(1).(nvml.Return)
+}
+
+func (m *mockDeviceHandle) GetTotalEnergyConsumption() (uint64, nvml.Return) {
+	args := m.Called()
+	return args.Get(0).(uint64), args.Get(1).(nvml.Return)
+}
+
+func (m *mockDeviceHandle) GetComputeRunningProcesses() ([]nvml.ProcessInfo, nvml.Return) {
+	args := m.Called()
+	procs := args.Get(0)
+	if procs == nil {
+		return nil, args.Get(1).(nvml.Return)
+	}
+	return procs.([]nvml.ProcessInfo), args.Get(1).(nvml.Return)
+}
+
+func (m *mockDeviceHandle) GetProcessUtilization(lastSeen uint64) ([]nvml.ProcessUtilizationSample, nvml.Return) {
+	args := m.Called(lastSeen)
+	samples := args.Get(0)
+	if samples == nil {
+		return nil, args.Get(1).(nvml.Return)
+	}
+	return samples.([]nvml.ProcessUtilizationSample), args.Get(1).(nvml.Return)
+}
+
+func (m *mockDeviceHandle) GetComputeMode() (nvml.ComputeMode, nvml.Return) {
+	args := m.Called()
+	return args.Get(0).(nvml.ComputeMode), args.Get(1).(nvml.Return)
+}
+
+func (m *mockDeviceHandle) GetMigMode() (int, int, nvml.Return) {
+	args := m.Called()
+	return args.Int(0), args.Int(1), args.Get(2).(nvml.Return)
+}
+
+func (m *mockDeviceHandle) GetMigDeviceHandleByIndex(index int) (nvmlDeviceHandle, nvml.Return) {
+	args := m.Called(index)
+	handle := args.Get(0)
+	if handle == nil {
+		return nil, args.Get(1).(nvml.Return)
+	}
+	return handle.(nvmlDeviceHandle), args.Get(1).(nvml.Return)
+}
+
+func (m *mockDeviceHandle) GetGpuInstanceId() (int, nvml.Return) {
+	args := m.Called()
+	return args.Int(0), args.Get(1).(nvml.Return)
+}
+
+func (m *mockDeviceHandle) GetMaxMigDeviceCount() (int, nvml.Return) {
+	args := m.Called()
+	return args.Int(0), args.Get(1).(nvml.Return)
+}
+
+func (m *mockDeviceHandle) GetAccountingMode() (nvml.EnableState, nvml.Return) {
+	args := m.Called()
+	return args.Get(0).(nvml.EnableState), args.Get(1).(nvml.Return)
+}
+
+func TestNewNVMLBackend(t *testing.T) {
+	t.Run("with logger", func(t *testing.T) {
+		logger := slog.Default()
+		backend := NewNVMLBackend(logger)
+
+		assert.NotNil(t, backend)
+		b := backend.(*nvmlBackend)
+		assert.False(t, b.initialized)
+		assert.Nil(t, b.devices)
+	})
+
+	t.Run("with nil logger uses default", func(t *testing.T) {
+		backend := NewNVMLBackend(nil)
+
+		assert.NotNil(t, backend)
+		b := backend.(*nvmlBackend)
+		assert.NotNil(t, b.logger)
+	})
+}
+
+func TestNVMLBackend_Init(t *testing.T) {
+	t.Run("successful init with devices", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockLib.On("Init").Return(nvml.SUCCESS)
+		mockLib.On("DeviceGetCount").Return(1, nvml.SUCCESS)
+		mockLib.On("DeviceGetHandleByIndex", 0).Return(mockHandle, nvml.SUCCESS)
+		mockHandle.On("GetUUID").Return("GPU-123", nvml.SUCCESS)
+		mockHandle.On("GetName").Return("Test GPU", nvml.SUCCESS)
+
+		backend := newNVMLBackendWithLib(slog.Default(), mockLib)
+		err := backend.Init()
+
+		assert.NoError(t, err)
+		assert.True(t, backend.initialized)
+		assert.Len(t, backend.devices, 1)
+		assert.Equal(t, "GPU-123", backend.devices[0].uuid)
+		assert.Equal(t, "Test GPU", backend.devices[0].name)
+
+		mockLib.AssertExpectations(t)
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("already initialized", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+
+		backend := newNVMLBackendWithLib(slog.Default(), mockLib)
+		backend.initialized = true
+
+		err := backend.Init()
+
+		assert.NoError(t, err)
+		mockLib.AssertNotCalled(t, "Init")
+	})
+
+	t.Run("init failure", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+
+		mockLib.On("Init").Return(nvml.ERROR_UNKNOWN)
+		mockLib.On("ErrorString", nvml.ERROR_UNKNOWN).Return("Unknown error")
+
+		backend := newNVMLBackendWithLib(slog.Default(), mockLib)
+		err := backend.Init()
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "NVML init failed")
+		assert.False(t, backend.initialized)
+
+		mockLib.AssertExpectations(t)
+	})
+
+	t.Run("device count failure", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+
+		mockLib.On("Init").Return(nvml.SUCCESS)
+		mockLib.On("DeviceGetCount").Return(0, nvml.ERROR_UNKNOWN)
+		mockLib.On("Shutdown").Return(nvml.SUCCESS)
+		mockLib.On("ErrorString", nvml.ERROR_UNKNOWN).Return("Unknown error")
+
+		backend := newNVMLBackendWithLib(slog.Default(), mockLib)
+		err := backend.Init()
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get device count")
+		assert.False(t, backend.initialized)
+
+		mockLib.AssertExpectations(t)
+	})
+
+	t.Run("device handle failure skips device", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockLib.On("Init").Return(nvml.SUCCESS)
+		mockLib.On("DeviceGetCount").Return(2, nvml.SUCCESS)
+		mockLib.On("DeviceGetHandleByIndex", 0).Return(nil, nvml.ERROR_UNKNOWN)
+		mockLib.On("DeviceGetHandleByIndex", 1).Return(mockHandle, nvml.SUCCESS)
+		mockLib.On("ErrorString", nvml.ERROR_UNKNOWN).Return("Unknown error")
+		mockHandle.On("GetUUID").Return("GPU-456", nvml.SUCCESS)
+		mockHandle.On("GetName").Return("Test GPU 1", nvml.SUCCESS)
+
+		backend := newNVMLBackendWithLib(slog.Default(), mockLib)
+		err := backend.Init()
+
+		assert.NoError(t, err)
+		assert.Len(t, backend.devices, 1)
+		assert.Equal(t, "GPU-456", backend.devices[0].uuid)
+
+		mockLib.AssertExpectations(t)
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("UUID failure uses fallback", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockLib.On("Init").Return(nvml.SUCCESS)
+		mockLib.On("DeviceGetCount").Return(1, nvml.SUCCESS)
+		mockLib.On("DeviceGetHandleByIndex", 0).Return(mockHandle, nvml.SUCCESS)
+		mockHandle.On("GetUUID").Return("", nvml.ERROR_UNKNOWN)
+		mockHandle.On("GetName").Return("Test GPU", nvml.SUCCESS)
+
+		backend := newNVMLBackendWithLib(slog.Default(), mockLib)
+		err := backend.Init()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "gpu-0", backend.devices[0].uuid)
+
+		mockLib.AssertExpectations(t)
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("name failure uses fallback", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockLib.On("Init").Return(nvml.SUCCESS)
+		mockLib.On("DeviceGetCount").Return(1, nvml.SUCCESS)
+		mockLib.On("DeviceGetHandleByIndex", 0).Return(mockHandle, nvml.SUCCESS)
+		mockHandle.On("GetUUID").Return("GPU-123", nvml.SUCCESS)
+		mockHandle.On("GetName").Return("", nvml.ERROR_UNKNOWN)
+
+		backend := newNVMLBackendWithLib(slog.Default(), mockLib)
+		err := backend.Init()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "Unknown NVIDIA GPU", backend.devices[0].name)
+
+		mockLib.AssertExpectations(t)
+		mockHandle.AssertExpectations(t)
+	})
+}
+
+func TestNVMLBackend_Shutdown(t *testing.T) {
+	t.Run("successful shutdown", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockLib.On("Shutdown").Return(nvml.SUCCESS)
+
+		backend := newNVMLBackendWithLib(slog.Default(), mockLib)
+		backend.initialized = true
+		backend.devices = []nvmlDevice{{index: 0}}
+
+		err := backend.Shutdown()
+
+		assert.NoError(t, err)
+		assert.False(t, backend.initialized)
+		assert.Nil(t, backend.devices)
+
+		mockLib.AssertExpectations(t)
+	})
+
+	t.Run("not initialized is no-op", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+
+		backend := newNVMLBackendWithLib(slog.Default(), mockLib)
+		backend.initialized = false
+
+		err := backend.Shutdown()
+
+		assert.NoError(t, err)
+		mockLib.AssertNotCalled(t, "Shutdown")
+	})
+
+	t.Run("shutdown failure", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockLib.On("Shutdown").Return(nvml.ERROR_UNKNOWN)
+		mockLib.On("ErrorString", nvml.ERROR_UNKNOWN).Return("Unknown error")
+
+		backend := newNVMLBackendWithLib(slog.Default(), mockLib)
+		backend.initialized = true
+
+		err := backend.Shutdown()
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "NVML shutdown failed")
+
+		mockLib.AssertExpectations(t)
+	})
+}
+
+func TestNVMLBackend_DeviceCount(t *testing.T) {
+	mockLib := new(mockNvmlLib)
+	backend := newNVMLBackendWithLib(slog.Default(), mockLib)
+	backend.devices = []nvmlDevice{{}, {}, {}}
+
+	assert.Equal(t, 3, backend.DeviceCount())
+}
+
+func TestNVMLBackend_GetDevice(t *testing.T) {
+	t.Run("not initialized", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		backend := newNVMLBackendWithLib(slog.Default(), mockLib)
+		backend.initialized = false
+
+		_, err := backend.GetDevice(0)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid index", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		backend := newNVMLBackendWithLib(slog.Default(), mockLib)
+		backend.initialized = true
+		backend.devices = []nvmlDevice{}
+
+		_, err := backend.GetDevice(0)
+		assert.Error(t, err)
+
+		_, err = backend.GetDevice(-1)
+		assert.Error(t, err)
+	})
+
+	t.Run("valid index", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+		backend := newNVMLBackendWithLib(slog.Default(), mockLib)
+		backend.initialized = true
+		backend.devices = []nvmlDevice{
+			{index: 0, handle: mockHandle, lib: mockLib, uuid: "GPU-123", name: "Test"},
+		}
+
+		dev, err := backend.GetDevice(0)
+		assert.NoError(t, err)
+		assert.Equal(t, "GPU-123", dev.UUID())
+	})
+}
+
+func TestNVMLBackend_DiscoverDevices(t *testing.T) {
+	t.Run("not initialized", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		backend := newNVMLBackendWithLib(slog.Default(), mockLib)
+		backend.initialized = false
+
+		_, err := backend.DiscoverDevices()
+		assert.Error(t, err)
+	})
+
+	t.Run("returns devices", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		backend := newNVMLBackendWithLib(slog.Default(), mockLib)
+		backend.initialized = true
+		backend.devices = []nvmlDevice{
+			{index: 0, uuid: "GPU-0", name: "GPU 0"},
+			{index: 1, uuid: "GPU-1", name: "GPU 1"},
+		}
+
+		devices, err := backend.DiscoverDevices()
+		assert.NoError(t, err)
+		assert.Len(t, devices, 2)
+		assert.Equal(t, "GPU-0", devices[0].UUID)
+		assert.Equal(t, "GPU-1", devices[1].UUID)
+	})
+}
+
+func TestNVMLDevice_GetPowerUsage(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetPowerUsage").Return(uint32(100000), nvml.SUCCESS) // 100W in mW
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		power, err := dev.GetPowerUsage()
+
+		assert.NoError(t, err)
+		assert.Equal(t, device.Power(100000)*device.MilliWatt, power)
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetPowerUsage").Return(uint32(0), nvml.ERROR_UNKNOWN)
+		mockLib.On("ErrorString", nvml.ERROR_UNKNOWN).Return("Unknown error")
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		_, err := dev.GetPowerUsage()
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get power usage")
+
+		mockHandle.AssertExpectations(t)
+		mockLib.AssertExpectations(t)
+	})
+}
+
+func TestNVMLDevice_GetTotalEnergy(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetTotalEnergyConsumption").Return(uint64(5000000), nvml.SUCCESS) // 5000J in mJ
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		energy, err := dev.GetTotalEnergy()
+
+		assert.NoError(t, err)
+		assert.Equal(t, device.Energy(5000000)*device.MilliJoule, energy)
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetTotalEnergyConsumption").Return(uint64(0), nvml.ERROR_UNKNOWN)
+		mockLib.On("ErrorString", nvml.ERROR_UNKNOWN).Return("Unknown error")
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		_, err := dev.GetTotalEnergy()
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get total energy")
+
+		mockHandle.AssertExpectations(t)
+		mockLib.AssertExpectations(t)
+	})
+}
+
+func TestNVMLDevice_GetComputeRunningProcesses(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		procs := []nvml.ProcessInfo{
+			{Pid: 1234, UsedGpuMemory: 1024},
+			{Pid: 5678, UsedGpuMemory: 2048},
+		}
+		mockHandle.On("GetComputeRunningProcesses").Return(procs, nvml.SUCCESS)
+
+		dev := &nvmlDevice{index: 0, handle: mockHandle, lib: mockLib, uuid: "GPU-123"}
+		result, err := dev.GetComputeRunningProcesses()
+
+		assert.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, uint32(1234), result[0].PID)
+		assert.Equal(t, uint64(1024), result[0].MemoryUsed)
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetComputeRunningProcesses").Return(nil, nvml.ERROR_UNKNOWN)
+		mockLib.On("ErrorString", nvml.ERROR_UNKNOWN).Return("Unknown error")
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		_, err := dev.GetComputeRunningProcesses()
+
+		assert.Error(t, err)
+
+		mockHandle.AssertExpectations(t)
+		mockLib.AssertExpectations(t)
+	})
+}
+
+func TestNVMLDevice_GetProcessUtilization(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		samples := []nvml.ProcessUtilizationSample{
+			{Pid: 1234, SmUtil: 50, MemUtil: 30, EncUtil: 0, DecUtil: 0, TimeStamp: 12345},
+		}
+		mockHandle.On("GetProcessUtilization", uint64(0)).Return(samples, nvml.SUCCESS)
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		result, err := dev.GetProcessUtilization(0)
+
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, uint32(1234), result[0].PID)
+		assert.Equal(t, uint32(50), result[0].ComputeUtil)
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("accounting mode disabled", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetProcessUtilization", uint64(0)).Return(nil, nvml.ERROR_NOT_SUPPORTED)
+		mockHandle.On("GetAccountingMode").Return(nvml.FEATURE_DISABLED, nvml.SUCCESS)
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		_, err := dev.GetProcessUtilization(0)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "accounting mode is disabled")
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("generic error", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetProcessUtilization", uint64(0)).Return(nil, nvml.ERROR_UNKNOWN)
+		mockHandle.On("GetAccountingMode").Return(nvml.FEATURE_ENABLED, nvml.SUCCESS)
+		mockLib.On("ErrorString", nvml.ERROR_UNKNOWN).Return("Unknown error")
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		_, err := dev.GetProcessUtilization(0)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "GetProcessUtilization failed")
+
+		mockHandle.AssertExpectations(t)
+		mockLib.AssertExpectations(t)
+	})
+}
+
+func TestNVMLDevice_GetComputeMode(t *testing.T) {
+	t.Run("default mode", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetComputeMode").Return(nvml.COMPUTEMODE_DEFAULT, nvml.SUCCESS)
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		mode, err := dev.GetComputeMode()
+
+		assert.NoError(t, err)
+		assert.Equal(t, ComputeModeDefault, mode)
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("exclusive thread mode", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetComputeMode").Return(nvml.COMPUTEMODE_EXCLUSIVE_THREAD, nvml.SUCCESS)
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		mode, err := dev.GetComputeMode()
+
+		assert.NoError(t, err)
+		assert.Equal(t, ComputeModeExclusiveThread, mode)
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("exclusive process mode", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetComputeMode").Return(nvml.COMPUTEMODE_EXCLUSIVE_PROCESS, nvml.SUCCESS)
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		mode, err := dev.GetComputeMode()
+
+		assert.NoError(t, err)
+		assert.Equal(t, ComputeModeExclusiveProcess, mode)
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("prohibited mode", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetComputeMode").Return(nvml.COMPUTEMODE_PROHIBITED, nvml.SUCCESS)
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		mode, err := dev.GetComputeMode()
+
+		assert.NoError(t, err)
+		assert.Equal(t, ComputeModeProhibited, mode)
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("unknown mode defaults", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetComputeMode").Return(nvml.ComputeMode(999), nvml.SUCCESS)
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		mode, err := dev.GetComputeMode()
+
+		assert.NoError(t, err)
+		assert.Equal(t, ComputeModeDefault, mode)
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetComputeMode").Return(nvml.COMPUTEMODE_DEFAULT, nvml.ERROR_UNKNOWN)
+		mockLib.On("ErrorString", nvml.ERROR_UNKNOWN).Return("Unknown error")
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		_, err := dev.GetComputeMode()
+
+		assert.Error(t, err)
+
+		mockHandle.AssertExpectations(t)
+		mockLib.AssertExpectations(t)
+	})
+}
+
+func TestNVMLDevice_IsMIGEnabled(t *testing.T) {
+	t.Run("MIG enabled", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetMigMode").Return(nvml.DEVICE_MIG_ENABLE, 0, nvml.SUCCESS)
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		enabled, err := dev.IsMIGEnabled()
+
+		assert.NoError(t, err)
+		assert.True(t, enabled)
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("MIG disabled", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetMigMode").Return(nvml.DEVICE_MIG_DISABLE, 0, nvml.SUCCESS)
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		enabled, err := dev.IsMIGEnabled()
+
+		assert.NoError(t, err)
+		assert.False(t, enabled)
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("not supported", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetMigMode").Return(0, 0, nvml.ERROR_NOT_SUPPORTED)
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		enabled, err := dev.IsMIGEnabled()
+
+		assert.NoError(t, err)
+		assert.False(t, enabled)
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetMigMode").Return(0, 0, nvml.ERROR_UNKNOWN)
+		mockLib.On("ErrorString", nvml.ERROR_UNKNOWN).Return("Unknown error")
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		_, err := dev.IsMIGEnabled()
+
+		assert.Error(t, err)
+
+		mockHandle.AssertExpectations(t)
+		mockLib.AssertExpectations(t)
+	})
+}
+
+func TestNVMLDevice_GetMIGInstances(t *testing.T) {
+	t.Run("MIG not enabled", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetMigMode").Return(nvml.DEVICE_MIG_DISABLE, 0, nvml.SUCCESS)
+
+		dev := &nvmlDevice{index: 0, handle: mockHandle, lib: mockLib}
+		_, err := dev.GetMIGInstances()
+
+		assert.Error(t, err)
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("MIG enabled with instances", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+		mockMigHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetMigMode").Return(nvml.DEVICE_MIG_ENABLE, 0, nvml.SUCCESS)
+		mockHandle.On("GetMaxMigDeviceCount").Return(7, nvml.SUCCESS)
+		mockHandle.On("GetMigDeviceHandleByIndex", 0).Return(mockMigHandle, nvml.SUCCESS)
+		mockHandle.On("GetMigDeviceHandleByIndex", 1).Return(nil, nvml.ERROR_NOT_FOUND)
+		mockHandle.On("GetMigDeviceHandleByIndex", 2).Return(nil, nvml.ERROR_NOT_FOUND)
+		mockHandle.On("GetMigDeviceHandleByIndex", 3).Return(nil, nvml.ERROR_NOT_FOUND)
+		mockHandle.On("GetMigDeviceHandleByIndex", 4).Return(nil, nvml.ERROR_NOT_FOUND)
+		mockHandle.On("GetMigDeviceHandleByIndex", 5).Return(nil, nvml.ERROR_NOT_FOUND)
+		mockHandle.On("GetMigDeviceHandleByIndex", 6).Return(nil, nvml.ERROR_NOT_FOUND)
+		mockMigHandle.On("GetGpuInstanceId").Return(1, nvml.SUCCESS)
+
+		dev := &nvmlDevice{index: 0, handle: mockHandle, lib: mockLib}
+		instances, err := dev.GetMIGInstances()
+
+		assert.NoError(t, err)
+		assert.Len(t, instances, 1)
+		assert.Equal(t, uint(1), instances[0].GPUInstanceID)
+
+		mockHandle.AssertExpectations(t)
+		mockMigHandle.AssertExpectations(t)
+	})
+
+	t.Run("no MIG instances found", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetMigMode").Return(nvml.DEVICE_MIG_ENABLE, 0, nvml.SUCCESS)
+		mockHandle.On("GetMaxMigDeviceCount").Return(7, nvml.SUCCESS)
+		for i := 0; i < 7; i++ {
+			mockHandle.On("GetMigDeviceHandleByIndex", i).Return(nil, nvml.ERROR_NOT_FOUND)
+		}
+
+		dev := &nvmlDevice{index: 0, handle: mockHandle, lib: mockLib}
+		_, err := dev.GetMIGInstances()
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no MIG instances found")
+
+		mockHandle.AssertExpectations(t)
+	})
+}
+
+func TestNVMLDevice_GetMIGDeviceByInstanceID(t *testing.T) {
+	t.Run("MIG not enabled", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetMigMode").Return(nvml.DEVICE_MIG_DISABLE, 0, nvml.SUCCESS)
+
+		dev := &nvmlDevice{index: 0, handle: mockHandle, lib: mockLib}
+		_, err := dev.GetMIGDeviceByInstanceID(1)
+
+		assert.Error(t, err)
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("found instance", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+		mockMigHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetMigMode").Return(nvml.DEVICE_MIG_ENABLE, 0, nvml.SUCCESS)
+		mockHandle.On("GetMaxMigDeviceCount").Return(7, nvml.SUCCESS)
+		mockHandle.On("GetMigDeviceHandleByIndex", 0).Return(mockMigHandle, nvml.SUCCESS)
+		mockMigHandle.On("GetGpuInstanceId").Return(5, nvml.SUCCESS)
+		mockMigHandle.On("GetUUID").Return("MIG-UUID", nvml.SUCCESS)
+		mockMigHandle.On("GetName").Return("MIG-Name", nvml.SUCCESS)
+
+		dev := &nvmlDevice{index: 0, handle: mockHandle, lib: mockLib}
+		migDev, err := dev.GetMIGDeviceByInstanceID(5)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "MIG-UUID", migDev.UUID())
+		assert.Equal(t, "MIG-Name", migDev.Name())
+
+		mockHandle.AssertExpectations(t)
+		mockMigHandle.AssertExpectations(t)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetMigMode").Return(nvml.DEVICE_MIG_ENABLE, 0, nvml.SUCCESS)
+		mockHandle.On("GetMaxMigDeviceCount").Return(7, nvml.SUCCESS)
+		for i := 0; i < 7; i++ {
+			mockHandle.On("GetMigDeviceHandleByIndex", i).Return(nil, nvml.ERROR_NOT_FOUND)
+		}
+
+		dev := &nvmlDevice{index: 0, handle: mockHandle, lib: mockLib}
+		_, err := dev.GetMIGDeviceByInstanceID(99)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("empty name uses fallback", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+		mockMigHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetMigMode").Return(nvml.DEVICE_MIG_ENABLE, 0, nvml.SUCCESS)
+		mockHandle.On("GetMaxMigDeviceCount").Return(7, nvml.SUCCESS)
+		mockHandle.On("GetMigDeviceHandleByIndex", 0).Return(mockMigHandle, nvml.SUCCESS)
+		mockMigHandle.On("GetGpuInstanceId").Return(1, nvml.SUCCESS)
+		mockMigHandle.On("GetUUID").Return("", nvml.ERROR_UNKNOWN)
+		mockMigHandle.On("GetName").Return("", nvml.ERROR_UNKNOWN)
+
+		dev := &nvmlDevice{index: 0, handle: mockHandle, lib: mockLib}
+		migDev, err := dev.GetMIGDeviceByInstanceID(1)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "MIG-0-1", migDev.Name())
+
+		mockHandle.AssertExpectations(t)
+		mockMigHandle.AssertExpectations(t)
+	})
+}
+
+func TestNVMLDevice_GetMaxMigDeviceCount(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetMaxMigDeviceCount").Return(7, nvml.SUCCESS)
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		count, err := dev.GetMaxMigDeviceCount()
+
+		assert.NoError(t, err)
+		assert.Equal(t, 7, count)
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("not supported", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetMaxMigDeviceCount").Return(0, nvml.ERROR_NOT_SUPPORTED)
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		count, err := dev.GetMaxMigDeviceCount()
+
+		assert.NoError(t, err)
+		assert.Equal(t, 0, count)
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		mockLib := new(mockNvmlLib)
+		mockHandle := new(mockDeviceHandle)
+
+		mockHandle.On("GetMaxMigDeviceCount").Return(0, nvml.ERROR_UNKNOWN)
+		mockLib.On("ErrorString", nvml.ERROR_UNKNOWN).Return("Unknown error")
+
+		dev := &nvmlDevice{handle: mockHandle, lib: mockLib}
+		_, err := dev.GetMaxMigDeviceCount()
+
+		assert.Error(t, err)
+
+		mockHandle.AssertExpectations(t)
+		mockLib.AssertExpectations(t)
+	})
+}
+
+func TestNVMLDevice_SimpleGetters(t *testing.T) {
+	mockLib := new(mockNvmlLib)
+	mockHandle := new(mockDeviceHandle)
+
+	dev := &nvmlDevice{
+		index:  5,
+		handle: mockHandle,
+		lib:    mockLib,
+		uuid:   "GPU-TEST-UUID",
+		name:   "Test GPU Name",
+	}
+
+	assert.Equal(t, 5, dev.Index())
+	assert.Equal(t, "GPU-TEST-UUID", dev.UUID())
+	assert.Equal(t, "Test GPU Name", dev.Name())
+}

--- a/internal/device/gpu/nvidia/types.go
+++ b/internal/device/gpu/nvidia/types.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidia
+
+// ComputeMode represents NVIDIA GPU's compute mode configuration.
+// Maps directly to nvmlComputeMode_t from NVML.
+type ComputeMode int
+
+const (
+	// ComputeModeDefault allows multiple processes to share the GPU (time-slicing)
+	ComputeModeDefault ComputeMode = 0
+
+	// ComputeModeExclusiveThread allows only one compute thread (legacy mode)
+	ComputeModeExclusiveThread ComputeMode = 1
+
+	// ComputeModeExclusiveProcess allows only one compute process
+	ComputeModeExclusiveProcess ComputeMode = 2
+
+	// ComputeModeProhibited disallows compute processes
+	ComputeModeProhibited ComputeMode = 3
+)
+
+// String returns a human-readable name for the compute mode
+func (m ComputeMode) String() string {
+	switch m {
+	case ComputeModeDefault:
+		return "default"
+	case ComputeModeExclusiveThread:
+		return "exclusive-thread"
+	case ComputeModeExclusiveProcess:
+		return "exclusive-process"
+	case ComputeModeProhibited:
+		return "prohibited"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/device/gpu/nvidia/types_test.go
+++ b/internal/device/gpu/nvidia/types_test.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidia
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeMode_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     ComputeMode
+		expected string
+	}{
+		{
+			name:     "default mode",
+			mode:     ComputeModeDefault,
+			expected: "default",
+		},
+		{
+			name:     "exclusive thread mode",
+			mode:     ComputeModeExclusiveThread,
+			expected: "exclusive-thread",
+		},
+		{
+			name:     "exclusive process mode",
+			mode:     ComputeModeExclusiveProcess,
+			expected: "exclusive-process",
+		},
+		{
+			name:     "prohibited mode",
+			mode:     ComputeModeProhibited,
+			expected: "prohibited",
+		},
+		{
+			name:     "unknown mode",
+			mode:     ComputeMode(99),
+			expected: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.mode.String()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestComputeModeConstants(t *testing.T) {
+	// Verify constant values match NVML definitions
+	assert.Equal(t, ComputeMode(0), ComputeModeDefault)
+	assert.Equal(t, ComputeMode(1), ComputeModeExclusiveThread)
+	assert.Equal(t, ComputeMode(2), ComputeModeExclusiveProcess)
+	assert.Equal(t, ComputeMode(3), ComputeModeProhibited)
+}

--- a/manifests/helm/kepler/values.yaml
+++ b/manifests/helm/kepler/values.yaml
@@ -112,6 +112,8 @@ config:
     hwmon:
       enabled: false # Enable experimental hwmon power monitoring
       zones: [] # List of zones to enable (default enable all)
+    gpu:
+      enabled: false # Enable experimental GPU power monitoring
 
 # ServiceMonitor for Prometheus Operator
 serviceMonitor:

--- a/manifests/k8s/configmap.yaml
+++ b/manifests/k8s/configmap.yaml
@@ -55,3 +55,5 @@ data:
       hwmon:
         enabled: false # Enable experimental hwmon power monitoring
         zones: [] # List of zones to enable (default enable all)
+      gpu:
+        enabled: false

--- a/manifests/k8s/daemonset.yaml
+++ b/manifests/k8s/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: kepler
           image: <KEPLER_IMAGE>
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           securityContext:
             privileged: true
             runAsNonRoot: false
@@ -54,6 +54,9 @@ spec:
               mountPath: /etc/kepler/config.yaml
               subPath: config.yaml
               readOnly: true
+            - name: nvidia-driver
+              mountPath: /run/nvidia/driver
+              readOnly: true
           livenessProbe:
             httpGet:
               path: /metrics
@@ -66,6 +69,8 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            - name: LD_LIBRARY_PATH
+              value: /run/nvidia/driver/usr/lib64
       volumes:
         - name: sysfs
           hostPath:
@@ -76,3 +81,7 @@ spec:
         - name: cfm
           configMap:
             name: kepler
+        - name: nvidia-driver
+          hostPath:
+            path: /run/nvidia/driver
+            type: DirectoryOrCreate


### PR DESCRIPTION
feat(gpu): add NVIDIA GPU power monitoring via NVML
  Add experimental GPU power monitoring support:
  - NVIDIA backend using go-nvml for device discovery and power readings
  - GPU sharing mode detection (time-slicing, exclusive, partitioned)
  - Per-process power attribution based on compute utilization
  - experimental.gpu.enabled config flag (disabled by default)

  Sharing mode detection:
  - Partitioned (MIG): GPU partitioned into isolated instances
  - Exclusive: Single process has exclusive GPU access (nvidia-smi -c EXCLUSIVE_PROCESS)
  - Time-slicing: Multiple processes share GPU (default mode)

  Detection logic:
  1. Check if MIG enabled → Partitioned
  2. Check NVML compute mode:
     - EXCLUSIVE_PROCESS/THREAD → Exclusive
     - DEFAULT → Time-slicing


This  PR requires https://github.com/sustainable-computing-io/kepler/pull/2378 to be merged.
