### PR TITLE
feat(gpu): add NVIDIA GPU power monitoring via NVML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GOFMT=$(GOCMD) fmt
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 
-CGO_ENABLED ?= 0
+CGO_ENABLED ?= 1
 
 # Project parameters
 BINARY_NAME=kepler

--- a/docs/developer/design/architecture/gpu-power-monitoring.md
+++ b/docs/developer/design/architecture/gpu-power-monitoring.md
@@ -1,0 +1,192 @@
+# GPU Power Monitoring
+
+This document describes how Kepler monitors GPU power consumption, focusing on the NVIDIA implementation via NVML.
+
+## Overview
+
+GPU power monitoring differs fundamentally from CPU (RAPL) power monitoring:
+
+| Aspect                  | CPU (RAPL)                        | GPU (NVML)                               |
+|-------------------------|-----------------------------------|------------------------------------------|
+| **Power data**          | Cumulative energy counters        | Instantaneous power                      |
+| **Process attribution** | CPU time ratios from `/proc`      | SM utilization from driver               |
+| **Delta calculation**   | Required (monitor computes)       | Not needed (hardware provides)           |
+| **Interface**           | `CPUPowerMeter` with `EnergyZone` | `GPUPowerMeter` with `GetProcessPower()` |
+
+## Architecture
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│                      Monitor Layer                          │
+│                  (internal/monitor/)                        │
+│  - Calls GetProcessPower() for per-process GPU watts        │
+│  - Calls GetDevicePowerStats() for device-level metrics     │
+│  - Stores GPUPower in Process struct                        │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+┌─────────────────────────▼───────────────────────────────────┐
+│                    GPU Interface                            │
+│              (internal/device/gpu/)                         │
+│  - GPUPowerMeter interface                                  │
+│  - Registry pattern for multi-vendor support                │
+│  - Vendor-agnostic types (GPUDevice, GPUPowerStats)         │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+┌─────────────────────────▼───────────────────────────────────┐
+│                  NVIDIA Collector                           │
+│           (internal/device/gpu/nvidia/)                     │
+│  - NVML library wrapper                                     │
+│  - Sharing mode detection (exclusive/time-slicing/MIG)      │
+│  - Power attribution algorithms                             │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+┌─────────────────────────▼───────────────────────────────────┐
+│                    NVML Library                             │
+│              (github.com/NVIDIA/go-nvml)                    │
+│  - nvmlDeviceGetPowerUsage()                                │
+│  - nvmlDeviceGetComputeRunningProcesses()                   │
+│  - nvmlDeviceGetProcessUtilization()                        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## GPU Sharing Modes
+
+NVIDIA GPUs support different sharing configurations:
+
+### 1. Exclusive Mode
+
+One process has exclusive access to the GPU.
+
+```go
+// All active power attributed to the single process
+powerPerProc := stats.ActivePower / float64(len(procs))
+```
+
+### 2. Time-Slicing Mode
+
+Multiple processes share the GPU via time-division multiplexing.
+
+```go
+// Power distributed proportionally to SM utilization
+for _, proc := range runningProcs {
+    smUtil := utilMap[proc.PID]
+    fraction := float64(smUtil) / float64(totalSmUtil)
+    result[proc.PID] = stats.ActivePower * fraction
+}
+```
+
+**Formula**: `P_process = P_active × (SM_util_process / Σ SM_util_all)`
+
+### 3. MIG Mode (Multi-Instance GPU)
+
+GPU partitioned into isolated instances. MIG detection is implemented, but **power attribution is not yet implemented**.
+
+```go
+// Detection works:
+device.IsMIGEnabled()      // returns true if MIG enabled
+device.GetMIGInstances()   // enumerates MIG partitions
+
+// Attribution skipped:
+case gpu.SharingModePartitioned:
+    c.logger.Debug("partitioned mode detected, skipping (not yet implemented)")
+    continue  // no power data returned for MIG devices
+```
+
+Per-instance power attribution requires DCGM integration (NVML returns N/A for MIG power). DCGM support is planned for upcoming PRs.
+
+## Idle Power Detection
+
+Kepler tracks minimum observed power per device as an approximation of idle power:
+
+```go
+if totalPower < c.minObservedPower[uuid] {
+    c.minObservedPower[uuid] = totalPower
+}
+idlePower := c.minObservedPower[uuid]
+activePower := totalPower - idlePower
+```
+
+**Active power** = Total power - Idle power
+
+## Key NVML APIs Used
+
+| API                                      | Purpose                                |
+|------------------------------------------|----------------------------------------|
+| `nvmlDeviceGetPowerUsage()`              | Current power consumption (milliwatts) |
+| `nvmlDeviceGetComputeRunningProcesses()` | List of processes using GPU compute    |
+| `nvmlDeviceGetProcessUtilization()`      | Per-process SM utilization samples     |
+| `nvmlDeviceGetComputeMode()`             | Detect exclusive vs shared mode        |
+| `nvmlDeviceGetMigMode()`                 | Detect if MIG is enabled               |
+
+## Prometheus Metrics
+
+| Metric                         | Description                            |
+|--------------------------------|----------------------------------------|
+| `kepler_node_gpu_info`         | Device metadata (UUID, name, vendor)   |
+| `kepler_node_gpu_watts`        | Total GPU power                        |
+| `kepler_node_gpu_idle_watts`   | Minimum observed power (idle estimate) |
+| `kepler_node_gpu_active_watts` | Power above idle baseline              |
+| `kepler_process_gpu_watts`     | Per-process GPU power attribution      |
+
+## Why GPU Interface Differs from CPU
+
+### 1. Energy vs Power
+
+**RAPL (CPU)**: Returns cumulative energy counters. Kepler must:
+
+- Read energy at T1 and T2
+- Calculate ΔE = E2 - E1
+- Derive power: P = ΔE / Δt
+
+**NVML (GPU)**: Returns instantaneous power directly. No delta calculation needed.
+
+### 2. Process Attribution Data
+
+**CPU**: No per-process energy data from hardware. Kepler must:
+
+- Read cumulative CPU time from `/proc/[pid]/stat`
+- Calculate delta to get CPU time ratio
+- Attribute power: `P_process = ratio × P_active`
+
+**GPU**: NVML provides per-process SM utilization directly via `GetProcessUtilization()`.
+
+### 3. Complexity Location
+
+- **CPU**: Complex logic in monitor layer (delta calculations, ratio attribution)
+- **GPU**: Complex logic in device layer (NVML calls, mode detection), simple pass-through in monitor
+
+## Known Limitations
+
+### 1. Idle Power Calibration
+
+Idle power is estimated as minimum observed power. If Kepler starts while GPU is under load, the first reading becomes the "idle" baseline, causing inaccurate active power calculations.
+
+**Mitigation**: Start Kepler before GPU workloads, or wait for a period of low GPU activity.
+
+### 2. Time-Slicing Accuracy
+
+`GetProcessUtilization()` returns sampled data, not continuous measurements. Rapid process switching may not be fully captured.
+
+### 3. MIG Power Attribution Not Yet Implemented
+
+Multi-Instance GPU mode is detected, but power attribution requires DCGM for per-partition metrics (NVML returns N/A for MIG power). DCGM integration is planned for upcoming PRs.
+
+### 4. Single Vendor Per Node
+
+The implementation assumes homogeneous GPU nodes (single vendor). While the code supports multiple meters, a process using both NVIDIA and AMD GPUs simultaneously is not expected.
+
+## Code References
+
+- **Interface**: `internal/device/gpu/interface.go`
+- **Registry**: `internal/device/gpu/registry.go`
+- **NVIDIA Collector**: `internal/device/gpu/nvidia/collector.go`
+- **NVML Wrapper**: `internal/device/gpu/nvidia/nvml.go`
+- **Monitor Integration**: `internal/monitor/process.go:115-150`
+- **Prometheus Metrics**: `internal/exporter/prometheus/collector/power_collector.go`
+
+## Future Work
+
+1. **MIG Support**: Integrate with DCGM for per-instance power attribution (planned)
+2. **Idle Power Model**: Linear regression from (utilization, power) pairs for better idle estimation
+3. **AMD ROCm Support**: Implement `GPUPowerMeter` for AMD GPUs using ROCm SMI
+4. **Intel GPU Support**: Implement for Intel discrete GPUs

--- a/docs/developer/design/architecture/index.md
+++ b/docs/developer/design/architecture/index.md
@@ -6,7 +6,8 @@ Kepler (Kubernetes Efficient Power Level Exporter) is a Prometheus exporter that
 
 **Key Capabilities:**
 
-- Hardware sensor-based energy measurement (Intel RAPL)
+- Hardware sensor-based energy measurement (Intel RAPL, NVIDIA NVML)
+- GPU power monitoring with per-process attribution
 - Multi-level power attribution (node → process → container/VM → pod)
 - Real-time power monitoring with configurable intervals
 - Prometheus metrics export with multiple collectors
@@ -28,10 +29,11 @@ This section provides comprehensive documentation of Kepler's architecture, desi
 
 ### Implementation Details
 
-| Document                                     | Description                                           |
-|----------------------------------------------|-------------------------------------------------------|
-| **[Interfaces & Contracts](interfaces.md)**  | Key interfaces, service contracts, and API boundaries |
-| **[Configuration System](configuration.md)** | Hierarchical configuration and option management      |
+| Document                                            | Description                                           |
+|-----------------------------------------------------|-------------------------------------------------------|
+| **[Interfaces & Contracts](interfaces.md)**         | Key interfaces, service contracts, and API boundaries |
+| **[Configuration System](configuration.md)**        | Hierarchical configuration and option management      |
+| **[GPU Power Monitoring](gpu-power-monitoring.md)** | NVIDIA GPU power monitoring via NVML                  |
 
 ## Quick Reference
 
@@ -42,9 +44,9 @@ This section provides comprehensive documentation of Kepler's architecture, desi
 **High-Level Data Flow:**
 
 ```text
-Hardware (RAPL) → Device Layer → Monitor (Attribution) → Exporters
-    ↑                                ↑
-/proc filesystem → Resource Layer ----┘
+Hardware (RAPL) ──→ Device Layer ──→ Monitor (Attribution) → Exporters
+Hardware (NVML) ──↗                        ↑
+/proc filesystem → Resource Layer ─────────┘
 ```
 
 ### Power Attribution Flow
@@ -80,6 +82,7 @@ For specific implementation work:
 - **Adding new exporters**: See [Interfaces](interfaces.md#power-data-provider-contract)
 - **Modifying power attribution**: See [Data Flow](data-flow.md#power-attribution-algorithm)
 - **Configuration changes**: See [Configuration System](configuration.md)
+- **GPU power monitoring**: See [GPU Power Monitoring](gpu-power-monitoring.md)
 
 ## Related Documentation
 

--- a/docs/user/metrics.md
+++ b/docs/user/metrics.md
@@ -95,6 +95,42 @@ These metrics provide energy and power information at the node level.
 - **Constant Labels**:
   - `node_name`
 
+#### kepler_node_gpu_active_watts
+
+- **Type**: GAUGE
+- **Description**: GPU active power (total - idle) in watts
+- **Labels**:
+  - `gpu`
+  - `gpu_uuid`
+  - `gpu_name`
+  - `vendor`
+- **Constant Labels**:
+  - `node_name`
+
+#### kepler_node_gpu_idle_watts
+
+- **Type**: GAUGE
+- **Description**: GPU idle power (auto-detected minimum) in watts
+- **Labels**:
+  - `gpu`
+  - `gpu_uuid`
+  - `gpu_name`
+  - `vendor`
+- **Constant Labels**:
+  - `node_name`
+
+#### kepler_node_gpu_watts
+
+- **Type**: GAUGE
+- **Description**: Total GPU power consumption in watts
+- **Labels**:
+  - `gpu`
+  - `gpu_uuid`
+  - `gpu_name`
+  - `vendor`
+- **Constant Labels**:
+  - `node_name`
+
 ### Container Metrics
 
 These metrics provide energy and power information for containers.
@@ -174,6 +210,21 @@ These metrics provide energy and power information for individual processes.
   - `container_id`
   - `vm_id`
   - `zone`
+- **Constant Labels**:
+  - `node_name`
+
+#### kepler_process_gpu_watts
+
+- **Type**: GAUGE
+- **Description**: Power consumption of gpu at process level in watts
+- **Labels**:
+  - `pid`
+  - `comm`
+  - `exe`
+  - `type`
+  - `state`
+  - `container_id`
+  - `vm_id`
 - **Constant Labels**:
   - `node_name`
 

--- a/internal/device/gpu/registry.go
+++ b/internal/device/gpu/registry.go
@@ -57,21 +57,21 @@ func Discover(vendor Vendor, logger *slog.Logger) GPUPowerMeter {
 
 	meter, err := factory(logger)
 	if err != nil {
-		logger.Debug("GPU vendor factory failed",
+		logger.Warn("GPU vendor factory failed",
 			"vendor", vendor,
 			"error", err)
 		return nil
 	}
 
 	if err := meter.Init(); err != nil {
-		logger.Debug("GPU vendor init failed",
+		logger.Warn("GPU vendor init failed",
 			"vendor", vendor,
 			"error", err)
 		return nil
 	}
 
 	if len(meter.Devices()) == 0 {
-		logger.Debug("GPU vendor has no devices", "vendor", vendor)
+		logger.Info("GPU vendor has no devices", "vendor", vendor)
 		_ = meter.Shutdown()
 		return nil
 	}

--- a/internal/exporter/prometheus/collector/gpuinfo.go
+++ b/internal/exporter/prometheus/collector/gpuinfo.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package collector
+
+import (
+	"fmt"
+	"sync"
+
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/sustainable-computing-io/kepler/internal/monitor"
+)
+
+// gpuInfoCollector collects GPU device info metrics.
+type gpuInfoCollector struct {
+	sync.Mutex
+
+	pm       PowerDataProvider
+	desc     *prom.Desc
+	nodeName string
+}
+
+// NewGPUInfoCollector creates a GPUInfoCollector that exports GPU device information.
+func NewGPUInfoCollector(pm PowerDataProvider, nodeName string) *gpuInfoCollector {
+	return &gpuInfoCollector{
+		pm:       pm,
+		nodeName: nodeName,
+		desc: prom.NewDesc(
+			prom.BuildFQName(keplerNS, "node", "gpu_info"),
+			"GPU device information for mapping index to UUID/name",
+			[]string{"gpu", "gpu_uuid", "gpu_name", "vendor"},
+			prom.Labels{nodeNameLabel: nodeName},
+		),
+	}
+}
+
+func (c *gpuInfoCollector) Describe(ch chan<- *prom.Desc) {
+	ch <- c.desc
+}
+
+func (c *gpuInfoCollector) Collect(ch chan<- prom.Metric) {
+	c.Lock()
+	defer c.Unlock()
+
+	snapshot, err := c.pm.Snapshot()
+	if err != nil {
+		return
+	}
+
+	c.collectGPUInfo(ch, snapshot.GPUStats)
+}
+
+func (c *gpuInfoCollector) collectGPUInfo(ch chan<- prom.Metric, gpuStats []monitor.GPUDeviceStats) {
+	for _, stats := range gpuStats {
+		ch <- prom.MustNewConstMetric(
+			c.desc,
+			prom.GaugeValue,
+			1,
+			fmt.Sprintf("%d", stats.DeviceIndex),
+			stats.UUID,
+			stats.Name,
+			stats.Vendor,
+		)
+	}
+}

--- a/internal/exporter/prometheus/collector/gpuinfo_test.go
+++ b/internal/exporter/prometheus/collector/gpuinfo_test.go
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package collector
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/sustainable-computing-io/kepler/internal/monitor"
+)
+
+// sampleGPUStats returns sample GPU stats for testing.
+func sampleGPUStats() []monitor.GPUDeviceStats {
+	return []monitor.GPUDeviceStats{
+		{
+			DeviceIndex: 0,
+			UUID:        "GPU-12345678-1234-1234-1234-123456789abc",
+			Name:        "NVIDIA A100-SXM4-40GB",
+			Vendor:      "nvidia",
+			TotalPower:  150.5,
+			IdlePower:   25.0,
+			ActivePower: 125.5,
+		},
+		{
+			DeviceIndex: 1,
+			UUID:        "GPU-87654321-4321-4321-4321-cba987654321",
+			Name:        "NVIDIA A100-SXM4-40GB",
+			Vendor:      "nvidia",
+			TotalPower:  180.0,
+			IdlePower:   25.0,
+			ActivePower: 155.0,
+		},
+	}
+}
+
+// TestNewGPUInfoCollector tests the creation of a new GPUInfoCollector.
+func TestNewGPUInfoCollector(t *testing.T) {
+	mockPM := NewMockPowerMonitor()
+	collector := NewGPUInfoCollector(mockPM, "test-node")
+
+	assert.NotNil(t, collector)
+	assert.NotNil(t, collector.desc)
+	assert.Equal(t, "test-node", collector.nodeName)
+	assert.Contains(t, collector.desc.String(), "kepler_node_gpu_info")
+	assert.Contains(t, collector.desc.String(), "variableLabels: {gpu,gpu_uuid,gpu_name,vendor}")
+}
+
+// TestGPUInfoCollector_Describe tests the Describe method.
+func TestGPUInfoCollector_Describe(t *testing.T) {
+	mockPM := NewMockPowerMonitor()
+	collector := NewGPUInfoCollector(mockPM, "test-node")
+
+	ch := make(chan *prometheus.Desc, 1)
+	collector.Describe(ch)
+	close(ch)
+
+	desc := <-ch
+	assert.Equal(t, collector.desc, desc)
+}
+
+// TestGPUInfoCollector_Collect_Success tests the Collect method with valid GPU stats.
+func TestGPUInfoCollector_Collect_Success(t *testing.T) {
+	mockPM := NewMockPowerMonitor()
+	snapshot := monitor.NewSnapshot()
+	snapshot.GPUStats = sampleGPUStats()
+	mockPM.On("Snapshot").Return(snapshot, nil)
+
+	collector := NewGPUInfoCollector(mockPM, "test-node")
+
+	ch := make(chan prometheus.Metric, 10)
+	collector.Collect(ch)
+	close(ch)
+
+	var metrics []prometheus.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+
+	assert.Len(t, metrics, 2, "expected two GPU info metrics")
+
+	// Verify metrics have correct labels
+	for i, m := range metrics {
+		dtoMetric := &dto.Metric{}
+		err := m.Write(dtoMetric)
+		assert.NoError(t, err)
+		assert.NotNil(t, dtoMetric.Gauge)
+		assert.NotNil(t, dtoMetric.Gauge.Value)
+		assert.Equal(t, 1.0, *dtoMetric.Gauge.Value)
+
+		// Check labels are present
+		labels := make(map[string]string)
+		for _, l := range dtoMetric.Label {
+			labels[*l.Name] = *l.Value
+		}
+
+		expectedStats := sampleGPUStats()[i]
+		assert.Equal(t, expectedStats.UUID, labels["gpu_uuid"])
+		assert.Equal(t, expectedStats.Name, labels["gpu_name"])
+		assert.Equal(t, expectedStats.Vendor, labels["vendor"])
+	}
+}
+
+// TestGPUInfoCollector_Collect_Error tests the Collect method when Snapshot fails.
+func TestGPUInfoCollector_Collect_Error(t *testing.T) {
+	mockPM := NewMockPowerMonitor()
+	mockPM.On("Snapshot").Return((*monitor.Snapshot)(nil), errors.New("snapshot error"))
+
+	collector := NewGPUInfoCollector(mockPM, "test-node")
+
+	ch := make(chan prometheus.Metric, 10)
+	collector.Collect(ch)
+	close(ch)
+
+	var metrics []prometheus.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+
+	assert.Len(t, metrics, 0, "expected no metrics on error")
+}
+
+// TestGPUInfoCollector_Collect_NoGPUs tests the Collect method when no GPUs are available.
+func TestGPUInfoCollector_Collect_NoGPUs(t *testing.T) {
+	mockPM := NewMockPowerMonitor()
+	snapshot := monitor.NewSnapshot()
+	snapshot.GPUStats = nil
+	mockPM.On("Snapshot").Return(snapshot, nil)
+
+	collector := NewGPUInfoCollector(mockPM, "test-node")
+
+	ch := make(chan prometheus.Metric, 10)
+	collector.Collect(ch)
+	close(ch)
+
+	var metrics []prometheus.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+
+	assert.Len(t, metrics, 0, "expected no metrics when no GPUs")
+}
+
+// TestGPUInfoCollector_Collect_Concurrency tests concurrent calls to Collect.
+func TestGPUInfoCollector_Collect_Concurrency(t *testing.T) {
+	mockPM := NewMockPowerMonitor()
+	snapshot := monitor.NewSnapshot()
+	snapshot.GPUStats = sampleGPUStats()
+	mockPM.On("Snapshot").Return(snapshot, nil)
+
+	collector := NewGPUInfoCollector(mockPM, "test-node")
+
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	ch := make(chan prometheus.Metric, numGoroutines*len(sampleGPUStats()))
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			collector.Collect(ch)
+		}()
+	}
+
+	wg.Wait()
+	close(ch)
+
+	var metrics []prometheus.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+
+	// Expect numGoroutines * number of GPUs metrics
+	expectedMetrics := numGoroutines * len(sampleGPUStats())
+	assert.Equal(t, expectedMetrics, len(metrics), "expected metrics from all goroutines")
+}

--- a/internal/exporter/prometheus/prometheus.go
+++ b/internal/exporter/prometheus/prometheus.go
@@ -162,6 +162,9 @@ func CreateCollectors(pm Monitor, applyOpts ...OptionFn) (map[string]prom.Collec
 	}
 	collectors["cpu_info"] = cpuInfoCollector
 
+	// Add GPU info collector
+	collectors["gpu_info"] = collector.NewGPUInfoCollector(pm, opts.nodeName)
+
 	// Add platform collector if platform data provider is available
 	if opts.platformDataProvider != nil {
 		collectors["platform"] = collector.NewRedfishCollector(opts.platformDataProvider, opts.logger)

--- a/internal/exporter/prometheus/prometheus_test.go
+++ b/internal/exporter/prometheus/prometheus_test.go
@@ -324,5 +324,5 @@ func TestExporter_CreateCollectors(t *testing.T) {
 	mockMonitor.AssertExpectations(t)
 
 	assert.NoError(t, err)
-	assert.Len(t, coll, 3)
+	assert.Len(t, coll, 4) // build_info, power, cpu_info, gpu_info
 }

--- a/internal/monitor/options.go
+++ b/internal/monitor/options.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/sustainable-computing-io/kepler/internal/device/gpu"
 	"github.com/sustainable-computing-io/kepler/internal/resource"
 	"k8s.io/utils/clock"
 )
@@ -16,6 +17,7 @@ type Opts struct {
 	interval                     time.Duration
 	clock                        clock.WithTicker
 	resources                    resource.Informer
+	gpuMeters                    []gpu.GPUPowerMeter
 	maxStaleness                 time.Duration
 	maxTerminated                int
 	minTerminatedEnergyThreshold Energy
@@ -83,5 +85,13 @@ func WithMaxTerminated(max int) OptionFn {
 func WithMinTerminatedEnergyThreshold(threshold Energy) OptionFn {
 	return func(o *Opts) {
 		o.minTerminatedEnergyThreshold = threshold
+	}
+}
+
+// WithGPUPowerMeters sets the GPU power meters for the PowerMonitor.
+// Supports multiple GPU vendors (NVIDIA, AMD, Intel) simultaneously.
+func WithGPUPowerMeters(meters []gpu.GPUPowerMeter) OptionFn {
+	return func(o *Opts) {
+		o.gpuMeters = meters
 	}
 }

--- a/internal/monitor/options_test.go
+++ b/internal/monitor/options_test.go
@@ -7,7 +7,62 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/sustainable-computing-io/kepler/internal/device"
+	"github.com/sustainable-computing-io/kepler/internal/device/gpu"
 )
+
+// MockGPUPowerMeter is a mock implementation of gpu.GPUPowerMeter
+type MockGPUPowerMeter struct {
+	mock.Mock
+}
+
+func (m *MockGPUPowerMeter) Name() string {
+	return "mock-gpu"
+}
+
+func (m *MockGPUPowerMeter) Init() error {
+	return nil
+}
+
+func (m *MockGPUPowerMeter) Shutdown() error {
+	return nil
+}
+
+func (m *MockGPUPowerMeter) Vendor() gpu.Vendor {
+	args := m.Called()
+	return args.Get(0).(gpu.Vendor)
+}
+
+func (m *MockGPUPowerMeter) Devices() []gpu.GPUDevice {
+	args := m.Called()
+	return args.Get(0).([]gpu.GPUDevice)
+}
+
+func (m *MockGPUPowerMeter) GetPowerUsage(deviceIndex int) (device.Power, error) {
+	args := m.Called(deviceIndex)
+	return args.Get(0).(device.Power), args.Error(1)
+}
+
+func (m *MockGPUPowerMeter) GetTotalEnergy(deviceIndex int) (device.Energy, error) {
+	args := m.Called(deviceIndex)
+	return args.Get(0).(device.Energy), args.Error(1)
+}
+
+func (m *MockGPUPowerMeter) GetProcessPower() (map[uint32]float64, error) {
+	args := m.Called()
+	return args.Get(0).(map[uint32]float64), args.Error(1)
+}
+
+func (m *MockGPUPowerMeter) GetDevicePowerStats(deviceIndex int) (gpu.GPUPowerStats, error) {
+	args := m.Called(deviceIndex)
+	return args.Get(0).(gpu.GPUPowerStats), args.Error(1)
+}
+
+func (m *MockGPUPowerMeter) GetProcessInfo() ([]gpu.ProcessGPUInfo, error) {
+	args := m.Called()
+	return args.Get(0).([]gpu.ProcessGPUInfo), args.Error(1)
+}
 
 // TestWithMaxTerminated tests the WithMaxTerminated option function
 func TestWithMaxTerminated(t *testing.T) {
@@ -28,4 +83,57 @@ func TestWithMaxTerminated(t *testing.T) {
 			assert.Equal(t, tt.maxValue, opts.maxTerminated)
 		})
 	}
+}
+
+// TestWithGPUPowerMeters tests the WithGPUPowerMeters option function
+// with 0, 1, and N GPU meters to support multi-vendor scenarios
+func TestWithGPUPowerMeters(t *testing.T) {
+	t.Run("zero meters (no GPUs on node)", func(t *testing.T) {
+		opts := DefaultOpts()
+		option := WithGPUPowerMeters(nil)
+		option(&opts)
+		assert.Nil(t, opts.gpuMeters)
+		assert.Len(t, opts.gpuMeters, 0)
+	})
+
+	t.Run("empty slice (no GPUs on node)", func(t *testing.T) {
+		opts := DefaultOpts()
+		option := WithGPUPowerMeters([]gpu.GPUPowerMeter{})
+		option(&opts)
+		assert.NotNil(t, opts.gpuMeters)
+		assert.Len(t, opts.gpuMeters, 0)
+	})
+
+	t.Run("one meter (single vendor)", func(t *testing.T) {
+		mockMeter := new(MockGPUPowerMeter)
+
+		opts := DefaultOpts()
+		option := WithGPUPowerMeters([]gpu.GPUPowerMeter{mockMeter})
+		option(&opts)
+		assert.Len(t, opts.gpuMeters, 1)
+		assert.Same(t, mockMeter, opts.gpuMeters[0])
+	})
+
+	t.Run("multiple meters (multi-vendor: NVIDIA + AMD)", func(t *testing.T) {
+		nvidiaMeter := new(MockGPUPowerMeter)
+		amdMeter := new(MockGPUPowerMeter)
+
+		opts := DefaultOpts()
+		option := WithGPUPowerMeters([]gpu.GPUPowerMeter{nvidiaMeter, amdMeter})
+		option(&opts)
+		assert.Len(t, opts.gpuMeters, 2)
+		assert.Same(t, nvidiaMeter, opts.gpuMeters[0])
+		assert.Same(t, amdMeter, opts.gpuMeters[1])
+	})
+
+	t.Run("three meters (multi-vendor: NVIDIA + AMD + Intel)", func(t *testing.T) {
+		nvidiaMeter := new(MockGPUPowerMeter)
+		amdMeter := new(MockGPUPowerMeter)
+		intelMeter := new(MockGPUPowerMeter)
+
+		opts := DefaultOpts()
+		option := WithGPUPowerMeters([]gpu.GPUPowerMeter{nvidiaMeter, amdMeter, intelMeter})
+		option(&opts)
+		assert.Len(t, opts.gpuMeters, 3)
+	})
 }

--- a/internal/monitor/types.go
+++ b/internal/monitor/types.go
@@ -83,6 +83,9 @@ type Process struct {
 
 	Zones ZoneUsageMap
 
+	// GPU power attribution (in Watts). Only set if GPU is available and process uses GPU.
+	GPUPower float64
+
 	ContainerID      string // empty if not a container
 	VirtualMachineID string // empty if not a virtual machine
 }
@@ -220,6 +223,21 @@ type (
 	Pods            = map[string]*Pod
 )
 
+// GPUDeviceStats contains power statistics for a single GPU device
+// Used for debugging and monitoring power attribution accuracy
+type GPUDeviceStats struct {
+	// DeviceIndex is the GPU index as reported by the driver (0, 1, 2...).
+	// Corresponds to nvidia-smi output for easy correlation during debugging.
+	// Note: not persistent across reboots; use UUID for unique identification.
+	DeviceIndex int
+	UUID        string  // GPU UUID - globally unique, persistent identifier
+	Name        string  // GPU product name (e.g., "NVIDIA A100-SXM4-40GB")
+	Vendor      string  // GPU vendor (nvidia, amd, intel)
+	TotalPower  float64 // Current total power in Watts
+	IdlePower   float64 // Detected idle power in Watts
+	ActivePower float64 // Active power (Total - Idle) in Watts
+}
+
 // Snapshot encapsulates power monitoring data
 type Snapshot struct {
 	Timestamp time.Time // Timestamp of the snapshot
@@ -235,6 +253,9 @@ type Snapshot struct {
 	TerminatedVirtualMachines VirtualMachines // Terminated VMs with highest energy consumption
 	Pods                      Pods            // Pod power data, keyed by pod ID
 	TerminatedPods            Pods            // Terminated pods with highest energy consumption
+
+	// GPU power statistics for debugging/monitoring (optional, nil if no GPU)
+	GPUStats []GPUDeviceStats
 }
 
 // NewSnapshot creates a new Snapshot instance
@@ -304,6 +325,12 @@ func (s *Snapshot) Clone() *Snapshot {
 	// Deep copy terminated pods map
 	for id, src := range s.TerminatedPods {
 		clone.TerminatedPods[id] = src.Clone()
+	}
+
+	// Copy GPU stats (slice of value types, so shallow copy is sufficient)
+	if len(s.GPUStats) > 0 {
+		clone.GPUStats = make([]GPUDeviceStats, len(s.GPUStats))
+		copy(clone.GPUStats, s.GPUStats)
 	}
 
 	return clone


### PR DESCRIPTION
  Implement GPU power monitoring using NVIDIA NVML library with support
  for time-slicing and exclusive GPU sharing modes.

  Key changes:
  - Add NVIDIA collector with process-level power attribution
  - Integrate GPU meters into monitor via WithGPUPowerMeters() option
  - Add GPU Prometheus metrics:
    - kepler_node_gpu_info (device metadata with labels)
    - kepler_node_gpu_watts (total GPU power)
    - kepler_node_gpu_idle_watts (minimum observed power)
    - kepler_node_gpu_active_watts (power above idle baseline)
    - kepler_process_gpu_watts (per-process GPU power attribution)
  - Add GPUPower field to Process and GPUStats to Snapshot
  - Enable CGO for NVML library linking
  - Add experimental.gpu.enabled config flag (default: false)

  Power attribution uses SM utilization ratio for time-slicing mode:
`P_process = P_active × (SmUtil_process / ΣSmUtil_all)`

  Idle power is tracked as minimum observed power per device. For accurate
  idle calibration, Kepler should be started before GPU workloads begin.
  
  
  
<img width="1471" height="1474" alt="image" src="https://github.com/user-attachments/assets/0a21d2d4-fd93-4002-b098-48b59a5923b2" />
