### PR TITLE
feat(gpu): add idle power detection and configurable override

### DIFF
--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -135,6 +135,17 @@ func createServices(logger *slog.Logger, cfg *config.Config) ([]service.Service,
 	// GPU meters are optional - returns empty slice if not available
 	gpuMeters := createGPUMeters(logger, cfg)
 
+	// Inject configured idle power into GPU meters that support it
+	if cfg.Experimental != nil && cfg.Experimental.GPU.IdlePower > 0 {
+		for _, m := range gpuMeters {
+			if c, ok := m.(gpu.IdlePowerConfigurable); ok {
+				c.SetIdlePower(cfg.Experimental.GPU.IdlePower)
+				logger.Info("configured GPU idle power",
+					"watts", cfg.Experimental.GPU.IdlePower)
+			}
+		}
+	}
+
 	var services []service.Service
 
 	var podInformer pod.Informer

--- a/compose/default/kepler/etc/kepler/config.yaml
+++ b/compose/default/kepler/etc/kepler/config.yaml
@@ -85,3 +85,4 @@ experimental:
     zones: [] # List of zones to enable (default enable all)
   gpu:
     enabled: false # Enable experimental GPU power monitoring
+    idlePower: 0 # GPU idle power in Watts (0 = auto-detect)

--- a/compose/dev/kepler-dev/etc/kepler/config.yaml
+++ b/compose/dev/kepler-dev/etc/kepler/config.yaml
@@ -85,3 +85,4 @@ experimental:
     zones: [] # List of zones to enable (default enable all)
   gpu:
     enabled: false # Enable experimental GPU power monitoring
+    idlePower: 0 # GPU idle power in Watts (0 = auto-detect)

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -39,6 +39,7 @@ You can configure Kepler by passing flags when starting the service. The followi
 | `--experimental.hwmon.enabled`                | Enable experimental hwmon power monitoring                              | `false`                         | `true`, `false`                                                    |
 | `--experimental.hwmon.zones`                  | hwmon zones to be enabled (can be specified multiple times)             | All available zones             | Any valid hwmon zone name                                          |
 | `--experimental.gpu.enabled`                  | Enable experimental GPU power monitoring                                | `false`                         | `true`, `false`                                                    |
+| `--experimental.gpu.idle-power`               | GPU idle power in Watts (0 = auto-detect)                               | `0`                             | Any non-negative float                                             |
 
 ### 💡 Examples
 
@@ -76,6 +77,9 @@ kepler --experimental.hwmon.enabled=true \
 
 # Enable experimental GPU power monitoring
 kepler --experimental.gpu.enabled=true
+
+# Enable GPU monitoring with configured idle power (e.g. when GPUs are always under load)
+kepler --experimental.gpu.enabled=true --experimental.gpu.idle-power=17.5
 
 # Export only node and container level metrics
 kepler --metrics=node --metrics=container
@@ -159,6 +163,7 @@ experimental:   # experimental features (no stability guarantees)
     zones: []                         # hwmon zones to be enabled, empty enables all available zones
   gpu:          # GPU power monitoring
     enabled: false                    # Enable GPU power monitoring (default: false)
+    idlePower: 0                      # GPU idle power in Watts, 0 = auto-detect (default: 0)
 
 # WARN: DO NOT ENABLE THIS IN PRODUCTION - for development/testing only
 dev:
@@ -408,6 +413,9 @@ experimental:
   - When enabled, Kepler will collect power metrics from NVIDIA GPUs using NVML
   - Requires NVIDIA drivers and NVML library to be available
   - Supports per-process power attribution based on GPU compute utilization
+- **idlePower**: GPU idle power in Watts (default: 0 = auto-detect)
+  - When set to 0, Kepler auto-detects idle power by tracking the minimum power observed when no compute processes are running
+  - Set to a non-zero value to override auto-detection (useful when GPUs are always under load and true idle cannot be observed)
 
 **Example:**
 
@@ -415,6 +423,7 @@ experimental:
 experimental:
   gpu:
     enabled: true
+    idlePower: 17.5  # Override idle power to 17.5W (0 = auto-detect)
 ```
 
 ### 🧑‍🔬 Development Configuration

--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -85,3 +85,4 @@ experimental:
     zones: [] # List of zones to enable (default enable all)
   gpu:
     enabled: false # Enable experimental GPU power monitoring
+    idlePower: 0 # GPU idle power in Watts (0 = auto-detect)

--- a/internal/device/gpu/interface.go
+++ b/internal/device/gpu/interface.go
@@ -71,6 +71,13 @@ type GPUPowerMeter interface {
 	GetProcessInfo() ([]ProcessGPUInfo, error)
 }
 
+// IdlePowerConfigurable is an optional interface for GPU meters that support
+// configuring a static idle power value. This avoids polluting the core
+// GPUPowerMeter interface.
+type IdlePowerConfigurable interface {
+	SetIdlePower(watts float64)
+}
+
 // ProcessGPUInfo contains per-process GPU metrics collected from the device.
 // This struct is vendor-agnostic.
 type ProcessGPUInfo struct {

--- a/manifests/helm/kepler/values.yaml
+++ b/manifests/helm/kepler/values.yaml
@@ -114,6 +114,7 @@ config:
       zones: [] # List of zones to enable (default enable all)
     gpu:
       enabled: false # Enable experimental GPU power monitoring
+      idlePower: 0 # GPU idle power in Watts (0 = auto-detect)
 
 # ServiceMonitor for Prometheus Operator
 serviceMonitor:

--- a/manifests/k8s/configmap.yaml
+++ b/manifests/k8s/configmap.yaml
@@ -57,3 +57,4 @@ data:
         zones: [] # List of zones to enable (default enable all)
       gpu:
         enabled: false
+        idlePower: 0 # GPU idle power in Watts (0 = auto-detect)


### PR DESCRIPTION
  Track minimum observed GPU power only when no compute processes are
  running to establish true idle baseline. Add configurable idle power
  override (experimental.gpu.idle-power) for cases where true idle
  cannot be observed.

<img width="1785" height="1112" alt="image" src="https://github.com/user-attachments/assets/f9b9d1b0-2e4a-4092-ba17-da0cf1525c3c" />


  Test: **GPU Idle Power Detection**

  Tested on a Tesla T4 node with five scenarios:

  1. **Kepler starts idle** (19:30–19:42): No workloads running. Kepler observes true idle power at ~17W.
  2. **Workload starts** (19:42–20:03): Idle baseline holds at 17W. Process power correctly shows ~15-55W (total minus idle).
  3. **Kepler restarted under load** (~20:05): Idle drops to 0W (never observed true idle). Process power jumps to ~60-70W since all GPU power is attributed as active — conservative but correct behavior.
  4. **Workload stops** (~20:10): Kepler detects true idle, brief spike as GPU settles, then locks in ~17W baseline.
  5. **Workload restarts** (20:12+): Idle baseline persists at 17W. Process power returns to correct ~15-20W attribution.

