### PR TITLE
chore(helm): trigger DaemonSet rollout on ConfigMap changes

### DIFF
--- a/manifests/helm/kepler/templates/daemonset.yaml
+++ b/manifests/helm/kepler/templates/daemonset.yaml
@@ -20,10 +20,11 @@ spec:
         {{- with .Values.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.annotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.annotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "kepler.serviceAccountName" . }}
       hostPID: {{ .Values.daemonset.hostPID }}


### PR DESCRIPTION
Currently a change to the `ConfigMap` does not trigger an update of the `DaemonSet`, you need to manually restart/delete pods.

This PR adds the `checksum/config` annotation to `DaemonSet` pod template that includes a SHA256 hash of the `ConfigMap` content.

This ensures pods are automatically restarted when configuration changes are deployed via `helm upgrade`.