### PR TITLE
chore: add podman-compose fix and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,10 @@ Choose your preferred method:
 make build && sudo ./bin/kepler
 
 # ✨ Docker Compose (with Prometheus & Grafana)
-cd compose/dev && docker-compose up -d
+cd compose/dev && docker compose up -d
+
+# 🐋 Podman Compose
+cd compose/dev && podman-compose -f compose-podman.yaml up -d
 
 # 🐳 Kubernetes with Kustomize
 kubectl kustomize manifests/k8s | \

--- a/compose/dev/README-podman.md
+++ b/compose/dev/README-podman.md
@@ -1,0 +1,177 @@
+<!-- SPDX-FileCopyrightText: 2025 The Kepler Authors -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Podman Compose Setup for Kepler Development
+
+This directory contains a podman-compose compatible version of the development environment.
+
+## Why a Separate File?
+
+The standard `compose.yaml` uses Docker Compose v2.20+ features like the `include` directive, which podman-compose doesn't fully support. The `compose-podman.yaml` file merges all services from:
+
+- `../compose.yaml` (base Kepler services)
+- `../monitoring/compose.yaml` (Prometheus & Grafana)
+- `./override.yaml` (dev-specific overrides)
+
+into a single file that works with podman-compose.
+
+## Usage
+
+### With Podman Compose
+
+```bash
+cd compose/dev
+
+# Start all services
+podman-compose -f compose-podman.yaml up -d
+
+# View logs
+podman-compose -f compose-podman.yaml logs -f kepler-dev
+
+# Stop and clean up
+podman-compose -f compose-podman.yaml down --volumes
+```
+
+### With Docker Compose (Standard)
+
+For Docker Compose users, continue using the standard file:
+
+```bash
+cd compose/dev
+
+# Start all services
+docker compose up -d
+
+# View logs
+docker compose logs -f kepler-dev
+
+# Stop and clean up
+docker compose down --volumes
+```
+
+## Access Points
+
+Once running, you can access:
+
+- **Kepler Metrics**: <http://localhost:28283/metrics>
+- **Prometheus**: <http://localhost:29090>
+- **Grafana**: <http://localhost:23000> (credentials: admin/admin)
+- **Scaphandre**: <http://localhost:28880/metrics> (not available on ARM)
+- **Node Exporter**: <http://localhost:29100/metrics>
+- **Sushy Static (Redfish Mock)**: <http://localhost:28001>
+
+## Configuration
+
+### Grafana User ID
+
+Update the `user` field in the `grafana` service to match your user ID:
+
+```bash
+id -u  # Get your user ID
+```
+
+Then edit `compose-podman.yaml` and change:
+
+```yaml
+grafana:
+  user: "1000"  # Change to your user ID
+```
+
+### Kubernetes Integration
+
+To test with a Kind cluster:
+
+1. Create a Kind cluster and get kubeconfig:
+
+   ```bash
+   make cluster-up
+   cp ~/.kube/config ./shared/kube/kubeconfig
+   ```
+
+2. Update the kubeconfig to use `kind-control-plane:6443` as the server address
+
+3. Uncomment the `kind` network in `compose-podman.yaml`:
+
+   ```yaml
+   networks:
+     - kind
+
+   networks:
+     kind:
+       external: true
+   ```
+
+## Differences from compose.yaml
+
+The main differences in `compose-podman.yaml`:
+
+1. **No `include` directive** - All services are defined in one file
+2. **Merged overrides** - Dev-specific configurations are already applied
+3. **Explicit network connections** - All services explicitly list their networks
+4. **Hardcoded healthcheck intervals** - Environment variables replaced with default values
+5. **No `extra_hosts: host.docker.internal:host-gateway`** - This Docker-specific feature is not supported by Podman. If you need to access host services from containers, use `host.containers.internal` or the host's actual IP address instead.
+
+## Platform-Specific Notes
+
+### Apple Silicon / ARM Macs
+
+**Scaphandre Not Available**: The `hubblo/scaphandre` image is not available for ARM architecture. On Apple Silicon Macs, the scaphandre service will fail to start.
+
+**Solutions**:
+
+1. **Comment out scaphandre** in `compose-podman.yaml`:
+
+   ```yaml
+   # scaphandre:
+   #   image: hubblo/scaphandre
+   #   ...
+   ```
+
+2. **Remove from Prometheus scrape config** in `prometheus/scrape-configs/dev.yaml` if you commented it out
+
+3. **Use Kepler and node-exporter only** - These work on ARM and provide comprehensive metrics
+
+## Troubleshooting
+
+### Permission Issues
+
+If you encounter permission errors with `/proc` or `/sys`:
+
+```bash
+# Run with sudo (not recommended for production)
+sudo podman-compose -f compose-podman.yaml up
+
+# Or configure rootless podman properly
+```
+
+### Build Context Issues
+
+If builds fail with context errors, ensure you're in the `compose/dev` directory:
+
+```bash
+pwd  # Should show: /path/to/kepler/compose/dev
+```
+
+### Network Issues
+
+If services can't communicate:
+
+```bash
+# Check networks
+podman network ls
+
+# Recreate networks
+podman-compose -f compose-podman.yaml down
+podman-compose -f compose-podman.yaml up
+```
+
+## Maintenance
+
+When updating the standard compose files, remember to sync changes to `compose-podman.yaml`:
+
+1. Check for changes in `compose.yaml`
+2. Check for changes in `../monitoring/compose.yaml`
+3. Check for changes in `override.yaml`
+4. Merge all changes into `compose-podman.yaml`
+
+Consider using a script to automate this process in the future.

--- a/compose/dev/compose-podman.yaml
+++ b/compose/dev/compose-podman.yaml
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: 2025 The Kepler Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Podman-compose compatible version (without 'include' directive)
+# All services from compose.yaml, monitoring/compose.yaml, and override.yaml are merged here
+
+name: dev
+
+services:
+  ### 📦 kepler created from the current repo (local development)
+  kepler-dev:
+    build:
+      context: ../../
+      dockerfile: Dockerfile
+      args:
+        VERSION: 0.0.0-dev
+        GIT_COMMIT: dev
+        GIT_BRANCH: dev
+
+    ports:
+      # NOTE: Use 28282 for host
+      - 28283:28282
+    privileged: true
+    volumes:
+      - type: bind
+        source: /proc
+        target: /host/proc
+        read_only: true
+      - type: bind
+        source: /sys
+        target: /host/sys
+        read_only: true
+      - type: bind
+        source: ./kepler-dev/etc/kepler/
+        target: /etc/kepler
+        read_only: true
+
+      # NOTE: place kubeconfig here
+      # e.g. cp $KUBECONFIG ./shared/kube/kubeconfig
+      # for kind cluster, rename host in kubeconfig to kind-control-plane:6443
+      - type: bind
+        source: ./shared/kube
+        target: /host/kube
+        read_only: true
+
+    command:
+      - --config.file=/etc/kepler/config.yaml
+
+    depends_on:
+      - sushy-static
+
+    networks:
+      - kepler-dev
+      - sushy-network
+      - monitoring
+      # - kind  # NOTE: uncomment to use kind
+
+  scaphandre:
+    image: hubblo/scaphandre
+    privileged: true
+    ports:
+      - 28880:8080
+    volumes:
+      - type: bind
+        source: /proc
+        target: /proc
+      - type: bind
+        source: /sys/class/powercap
+        target: /sys/class/powercap
+    command: [prometheus]
+    networks:
+      - scaph-network
+      - monitoring
+
+  node-exporter:
+    image: quay.io/prometheus/node-exporter:latest
+    pid: host
+    ports:
+      - 29100:9100
+    volumes:
+      - type: bind
+        source: /proc
+        target: /host/proc
+      - type: bind
+        source: /sys
+        target: /host/sys
+      - type: bind
+        source: /
+        target: /rootfs
+    command:
+      # - --log.level=debug
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --path.rootfs=/rootfs
+      - --collector.disable-defaults
+      - --collector.cpu
+      - --collector.cpufreq
+      - --collector.perf
+      - --collector.perf.cpus=0-19 # specify range of all cpus
+      - --collector.perf.software-profilers=ContextSwitch
+      - --collector.meminfo
+      - --collector.rapl
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+    user: root
+    cap_add: # Add capabilities for perf collection.
+      - SYS_ADMIN
+      - SYS_PTRACE
+    networks:
+      - node-exporter-network
+      - monitoring
+
+  sushy-static:
+    image: quay.io/metal3-io/sushy-tools:latest
+    ports:
+      - 28001:8001
+    volumes:
+      - type: bind
+        source: ../../hack/mockups
+        target: /mockups
+    command:
+      - sushy-static
+      - -m
+      - /mockups/public-rackmount
+      - -i
+      - 0.0.0.0
+      - -p
+      - "8001"
+    networks:
+      - sushy-network
+
+  # Monitoring stack services (from ../monitoring/compose.yaml + override.yaml)
+  prometheus:
+    build:
+      context: ../monitoring/prometheus
+    ports:
+      - 29090:9090
+    volumes:
+      - prom-data:/prometheus
+      - type: bind
+        source: ../monitoring/prometheus/prometheus.yml
+        target: /etc/prometheus/prometheus.yml
+      - type: bind
+        source: ./prometheus/scrape-configs/dev.yaml
+        target: /etc/prometheus/scrape-configs/dev.yaml
+    networks:
+      - monitoring
+      - kepler-dev
+      - scaph-network
+      - node-exporter-network
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.enable-admin-api
+
+    healthcheck:
+      test: wget -q --spider http://localhost:9090/ -O /dev/null || exit 1
+      interval: 50s
+      timeout: 30s
+      retries: 3
+      start_period: 1m
+
+  grafana:
+    build:
+      context: ../monitoring/grafana
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /var/lib/grafana/dashboards/dev/dashboard.json
+
+    user: "1000" # NOTE: change this to your `id -u`
+    depends_on:
+      - prometheus
+    ports:
+      - 23000:3000
+    volumes:
+      - type: bind
+        source: ./grafana/dashboards/dev
+        target: /var/lib/grafana/dashboards/dev
+    networks:
+      - monitoring
+
+    healthcheck:
+      test: curl -f http://localhost:3000/ || exit 1
+      interval: 50s
+      timeout: 30s
+      retries: 3
+      start_period: 1m
+
+volumes:
+  # volume for holding prometheus (ts)db
+  prom-data:
+
+networks:
+  kepler-dev:
+  scaph-network:
+  node-exporter-network:
+  sushy-network:
+  monitoring:
+  # NOTE: uncomment to use kind
+  # kind:
+  #   external: true
+
+# Made with Bob

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -158,6 +158,8 @@ sudo ./bin/kepler --log.level=debug --exporter.stdout
 
 The Docker Compose setup provides a complete monitoring stack with Kepler, Prometheus, and Grafana:
 
+#### Docker Compose
+
 ```bash
 cd compose/dev
 
@@ -170,6 +172,25 @@ docker compose logs -f kepler-dev
 # Stop the stack
 docker compose down --volumes
 ```
+
+#### Podman Compose
+
+For Podman users (especially on macOS/ARM), use the podman-compatible version:
+
+```bash
+cd compose/dev
+
+# Start the complete stack
+podman-compose -f compose-podman.yaml up --build -d
+
+# View logs
+podman-compose -f compose-podman.yaml logs -f kepler-dev
+
+# Stop the stack
+podman-compose -f compose-podman.yaml down --volumes
+```
+
+> **Note for ARM/Apple Silicon users**: The Scaphandre service is not available for ARM architecture. See [compose/dev/README-podman.md](../../compose/dev/README-podman.md) for platform-specific notes and workarounds.
 
 **Access Points:**
 


### PR DESCRIPTION
The current dev compose cannot be up with podman-compose command.

The main problem with podman-compose compatibility is the include directive, which is a Docker Compose v2.20+ feature that podman-compose doesn't fully support.

This PR adds that fix by explicitly merge including compose and add README with instruction to install and maintain for podman-compose compatibility. 

Also, must note that the Scaphandre service is not available for ARM architecture (not available image for this architecture).