### PR TITLE
feat(gpu): add container and pod GPU power metrics

### DIFF
--- a/docs/user/metrics.md
+++ b/docs/user/metrics.md
@@ -163,6 +163,19 @@ These metrics provide energy and power information for containers.
 - **Constant Labels**:
   - `node_name`
 
+#### kepler_container_gpu_watts
+
+- **Type**: GAUGE
+- **Description**: Power consumption of gpu at container level in watts
+- **Labels**:
+  - `container_id`
+  - `container_name`
+  - `runtime`
+  - `state`
+  - `pod_id`
+- **Constant Labels**:
+  - `node_name`
+
 ### Process Metrics
 
 These metrics provide energy and power information for individual processes.
@@ -285,6 +298,18 @@ These metrics provide energy and power information for pods.
   - `pod_namespace`
   - `state`
   - `zone`
+- **Constant Labels**:
+  - `node_name`
+
+#### kepler_pod_gpu_watts
+
+- **Type**: GAUGE
+- **Description**: Power consumption of gpu at pod level in watts
+- **Labels**:
+  - `pod_id`
+  - `pod_name`
+  - `pod_namespace`
+  - `state`
 - **Constant Labels**:
   - `node_name`
 

--- a/internal/monitor/container.go
+++ b/internal/monitor/container.go
@@ -35,6 +35,16 @@ func (pm *PowerMonitor) firstContainerRead(snapshot *Snapshot) error {
 
 		containers[id] = container
 	}
+	// Aggregate GPU power from processes into containers
+	for _, proc := range snapshot.Processes {
+		if proc.ContainerID == "" || proc.GPUPower == 0 {
+			continue
+		}
+		if container, ok := containers[proc.ContainerID]; ok {
+			container.GPUPower += proc.GPUPower
+		}
+	}
+
 	snapshot.Containers = containers
 
 	pm.logger.Debug("Initialized container power tracking",
@@ -137,6 +147,16 @@ func (pm *PowerMonitor) calculateContainerPower(prev, newSnapshot *Snapshot) err
 		}
 
 		containerMap[id] = container
+	}
+
+	// Aggregate GPU power from processes into containers
+	for _, proc := range newSnapshot.Processes {
+		if proc.ContainerID == "" || proc.GPUPower == 0 {
+			continue
+		}
+		if container, ok := containerMap[proc.ContainerID]; ok {
+			container.GPUPower += proc.GPUPower
+		}
 	}
 
 	// Update the snapshot

--- a/internal/monitor/container_power_test.go
+++ b/internal/monitor/container_power_test.go
@@ -219,6 +219,130 @@ func TestContainerPowerCalculation(t *testing.T) {
 	mockMeter.AssertExpectations(t)
 }
 
+func TestContainerGPUPowerAggregation(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	fakeClock := testingclock.NewFakeClock(time.Now())
+
+	zones := CreateTestZones()
+	mockMeter := &MockCPUPowerMeter{}
+	mockMeter.On("Zones").Return(zones, nil)
+	mockMeter.On("PrimaryEnergyZone").Return(zones[0], nil)
+
+	resInformer := &MockResourceInformer{}
+
+	monitor := &PowerMonitor{
+		logger:    logger,
+		cpu:       mockMeter,
+		clock:     fakeClock,
+		resources: resInformer,
+	}
+
+	err := monitor.Init()
+	require.NoError(t, err)
+
+	t.Run("GPU power aggregated from processes to containers", func(t *testing.T) {
+		resInformer.ClearExpectations()
+
+		prevSnapshot := NewSnapshot()
+		newSnapshot := NewSnapshot()
+		newSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.5)
+
+		// Populate processes with GPU power in the new snapshot
+		// Two processes in container-1, one with GPU power
+		newSnapshot.Processes = Processes{
+			"123": &Process{
+				PID:         123,
+				Comm:        "gpu-proc-1",
+				ContainerID: "container-1",
+				GPUPower:    50.0, // 50W GPU
+				Zones:       make(ZoneUsageMap),
+			},
+			"124": &Process{
+				PID:         124,
+				Comm:        "gpu-proc-2",
+				ContainerID: "container-1",
+				GPUPower:    30.0, // 30W GPU
+				Zones:       make(ZoneUsageMap),
+			},
+			"125": &Process{
+				PID:         125,
+				Comm:        "gpu-proc-3",
+				ContainerID: "container-2",
+				GPUPower:    20.0, // 20W GPU
+				Zones:       make(ZoneUsageMap),
+			},
+			"126": &Process{
+				PID:         126,
+				Comm:        "no-gpu-proc",
+				ContainerID: "container-2",
+				GPUPower:    0, // no GPU
+				Zones:       make(ZoneUsageMap),
+			},
+			"127": &Process{
+				PID:      127,
+				Comm:     "orphan-gpu-proc",
+				GPUPower: 10.0, // GPU but no container
+				Zones:    make(ZoneUsageMap),
+			},
+		}
+
+		containers := &resource.Containers{
+			Running: map[string]*resource.Container{
+				"container-1": {ID: "container-1", Name: "cont1", Runtime: resource.DockerRuntime, CPUTimeDelta: 30.0},
+				"container-2": {ID: "container-2", Name: "cont2", Runtime: resource.PodmanRuntime, CPUTimeDelta: 20.0},
+			},
+			Terminated: map[string]*resource.Container{},
+		}
+
+		tr := CreateTestResources(createOnly(testNode))
+		resInformer.On("Node").Return(tr.Node, nil)
+		resInformer.On("Containers").Return(containers)
+
+		err := monitor.calculateContainerPower(prevSnapshot, newSnapshot)
+		require.NoError(t, err)
+
+		// container-1 should have 50 + 30 = 80W GPU power
+		assert.Equal(t, 80.0, newSnapshot.Containers["container-1"].GPUPower)
+
+		// container-2 should have 20W GPU power (proc 126 has 0 GPU)
+		assert.Equal(t, 20.0, newSnapshot.Containers["container-2"].GPUPower)
+
+		resInformer.AssertExpectations(t)
+	})
+
+	t.Run("firstContainerRead aggregates GPU power", func(t *testing.T) {
+		resInformer.ClearExpectations()
+
+		tr := CreateTestResources(createOnly(testContainers, testNode))
+		resInformer.SetExpectations(t, tr)
+
+		snapshot := NewSnapshot()
+		err := monitor.firstNodeRead(snapshot.Node)
+		require.NoError(t, err)
+
+		// Add GPU-using processes to the snapshot before calling firstContainerRead
+		snapshot.Processes = Processes{
+			"123": &Process{
+				PID:         123,
+				Comm:        "gpu-proc",
+				ContainerID: "container-1",
+				GPUPower:    75.0,
+				Zones:       make(ZoneUsageMap),
+			},
+		}
+
+		err = monitor.firstContainerRead(snapshot)
+		require.NoError(t, err)
+
+		assert.Equal(t, 75.0, snapshot.Containers["container-1"].GPUPower)
+		assert.Equal(t, 0.0, snapshot.Containers["container-2"].GPUPower)
+
+		resInformer.AssertExpectations(t)
+	})
+
+	mockMeter.AssertExpectations(t)
+}
+
 func TestContainerPowerConsistency(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	fakeClock := testingclock.NewFakeClock(time.Now())
@@ -650,6 +774,90 @@ func TestTerminatedContainerTracking(t *testing.T) {
 
 		assert.Len(t, snapshot3.Containers, 1, "Should have 1 running container")
 		assert.Contains(t, snapshot3.Containers, "container-3")
+
+		resInformer.AssertExpectations(t)
+	})
+
+	t.Run("terminated container preserves GPU power", func(t *testing.T) {
+		mockMeter := &MockCPUPowerMeter{}
+		mockMeter.On("Zones").Return(zones, nil)
+		mockMeter.On("PrimaryEnergyZone").Return(zones[0], nil)
+		resInformer := &MockResourceInformer{}
+
+		monitor := &PowerMonitor{
+			logger:        logger,
+			cpu:           mockMeter,
+			clock:         fakeClock,
+			resources:     resInformer,
+			maxTerminated: 500,
+		}
+
+		err := monitor.Init()
+		require.NoError(t, err)
+
+		// Create previous snapshot with a container that has GPU power
+		prevSnapshot := NewSnapshot()
+		prevSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now().Add(-time.Second), 0.5)
+
+		prevSnapshot.Containers["container-1"] = &Container{
+			ID:           "container-1",
+			Name:         "gpu-container",
+			Runtime:      resource.DockerRuntime,
+			CPUTotalTime: 50.0,
+			GPUPower:     75.0,
+			Zones:        make(ZoneUsageMap, len(zones)),
+		}
+		for _, zone := range zones {
+			prevSnapshot.Containers["container-1"].Zones[zone] = Usage{
+				EnergyTotal: 20 * Joule,
+				Power:       10 * Watt,
+			}
+		}
+
+		// Create new snapshot where container-1 terminates
+		newSnapshot := NewSnapshot()
+		newSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.5)
+
+		// Populate processes with GPU power so aggregation assigns GPUPower
+		newSnapshot.Processes = Processes{
+			"200": &Process{
+				PID:         200,
+				Comm:        "gpu-proc",
+				ContainerID: "container-1",
+				GPUPower:    75.0,
+				Zones:       make(ZoneUsageMap),
+			},
+		}
+
+		containers := &resource.Containers{
+			Running: map[string]*resource.Container{},
+			Terminated: map[string]*resource.Container{
+				"container-1": {ID: "container-1", Name: "gpu-container", Runtime: resource.DockerRuntime, CPUTotalTime: 80.0, CPUTimeDelta: 30.0},
+			},
+		}
+
+		tr := CreateTestResources(createOnly(testNode))
+		resInformer.On("Node").Return(tr.Node, nil).Maybe()
+		resInformer.On("Containers").Return(containers).Once()
+
+		err = monitor.calculateContainerPower(prevSnapshot, newSnapshot)
+		require.NoError(t, err)
+
+		// Populate terminated from tracker
+		newSnapshot.TerminatedContainers = monitor.terminatedContainersTracker.Items()
+
+		// Verify the terminated container preserves GPU power
+		assert.Len(t, newSnapshot.TerminatedContainers, 1, "Should have 1 terminated container")
+
+		var terminatedCntr1 *Container
+		for _, cntr := range newSnapshot.TerminatedContainers {
+			if cntr.ID == "container-1" {
+				terminatedCntr1 = cntr
+				break
+			}
+		}
+		require.NotNil(t, terminatedCntr1, "container-1 should exist in terminated containers")
+		assert.Equal(t, 75.0, terminatedCntr1.GPUPower, "Terminated container should preserve GPU power")
 
 		resInformer.AssertExpectations(t)
 	})

--- a/internal/monitor/pod_power_test.go
+++ b/internal/monitor/pod_power_test.go
@@ -199,6 +199,122 @@ func TestPodPowerCalculation(t *testing.T) {
 	})
 }
 
+func TestPodGPUPowerAggregation(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	fakeClock := testingclock.NewFakeClock(time.Now())
+
+	zones := CreateTestZones()
+	mockMeter := &MockCPUPowerMeter{}
+	mockMeter.On("Zones").Return(zones, nil)
+	mockMeter.On("PrimaryEnergyZone").Return(zones[0], nil)
+
+	resInformer := &MockResourceInformer{}
+
+	monitor := &PowerMonitor{
+		logger:        logger,
+		cpu:           mockMeter,
+		clock:         fakeClock,
+		resources:     resInformer,
+		maxTerminated: 500,
+	}
+
+	err := monitor.Init()
+	require.NoError(t, err)
+
+	t.Run("GPU power aggregated from containers to pods", func(t *testing.T) {
+		resInformer.ClearExpectations()
+
+		prevSnapshot := NewSnapshot()
+		newSnapshot := NewSnapshot()
+		newSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.5)
+
+		// Populate containers with GPU power in the new snapshot
+		newSnapshot.Containers = Containers{
+			"container-1": &Container{
+				ID:       "container-1",
+				Name:     "cont1",
+				PodID:    "pod-1",
+				GPUPower: 80.0,
+				Zones:    make(ZoneUsageMap),
+			},
+			"container-2": &Container{
+				ID:       "container-2",
+				Name:     "cont2",
+				PodID:    "pod-1",
+				GPUPower: 20.0,
+				Zones:    make(ZoneUsageMap),
+			},
+			"container-3": &Container{
+				ID:       "container-3",
+				Name:     "cont3",
+				PodID:    "pod-2",
+				GPUPower: 45.0,
+				Zones:    make(ZoneUsageMap),
+			},
+			"container-4": &Container{
+				ID:       "container-4",
+				Name:     "cont4",
+				GPUPower: 10.0, // no pod
+				Zones:    make(ZoneUsageMap),
+			},
+		}
+
+		pods := &resource.Pods{
+			Running: map[string]*resource.Pod{
+				"pod-1": {ID: "pod-1", Name: "test-pod-1", Namespace: "default", CPUTimeDelta: 30.0},
+				"pod-2": {ID: "pod-2", Name: "test-pod-2", Namespace: "default", CPUTimeDelta: 20.0},
+			},
+			Terminated: map[string]*resource.Pod{},
+		}
+
+		tr := CreateTestResources(createOnly(testNode))
+		resInformer.On("Node").Return(tr.Node, nil)
+		resInformer.On("Pods").Return(pods)
+
+		err := monitor.calculatePodPower(prevSnapshot, newSnapshot)
+		require.NoError(t, err)
+
+		// pod-1 should have 80 + 20 = 100W GPU power
+		assert.Equal(t, 100.0, newSnapshot.Pods["pod-1"].GPUPower)
+
+		// pod-2 should have 45W GPU power
+		assert.Equal(t, 45.0, newSnapshot.Pods["pod-2"].GPUPower)
+
+		resInformer.AssertExpectations(t)
+	})
+
+	t.Run("firstPodRead aggregates GPU power", func(t *testing.T) {
+		resInformer.ClearExpectations()
+
+		tr := CreateTestResources(createOnly(testPods, testNode))
+		resInformer.SetExpectations(t, tr)
+
+		snapshot := NewSnapshot()
+		err := monitor.firstNodeRead(snapshot.Node)
+		require.NoError(t, err)
+
+		// Add containers with GPU power before calling firstPodRead
+		snapshot.Containers = Containers{
+			"container-1": &Container{
+				ID:       "container-1",
+				Name:     "cont1",
+				PodID:    "pod-id-1",
+				GPUPower: 60.0,
+				Zones:    make(ZoneUsageMap),
+			},
+		}
+
+		err = monitor.firstPodRead(snapshot)
+		require.NoError(t, err)
+
+		assert.Equal(t, 60.0, snapshot.Pods["pod-id-1"].GPUPower)
+
+		resInformer.AssertExpectations(t)
+	})
+
+	mockMeter.AssertExpectations(t)
+}
+
 func TestPodPowerConsistency(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	fakeClock := testingclock.NewFakeClock(time.Now())
@@ -563,6 +679,90 @@ func TestTerminatedPodTracking(t *testing.T) {
 
 		assert.Len(t, snapshot3.Pods, 1, "Should have 1 running pod")
 		assert.Contains(t, snapshot3.Pods, "pod-3")
+	})
+
+	t.Run("terminated pod preserves GPU power", func(t *testing.T) {
+		mockMeter := &MockCPUPowerMeter{}
+		mockMeter.On("Zones").Return(zones, nil)
+		mockMeter.On("PrimaryEnergyZone").Return(zones[0], nil)
+		resInformer := &MockResourceInformer{}
+
+		monitor := &PowerMonitor{
+			logger:        logger,
+			cpu:           mockMeter,
+			clock:         fakeClock,
+			resources:     resInformer,
+			maxTerminated: 500,
+		}
+
+		err := monitor.Init()
+		require.NoError(t, err)
+
+		// Create previous snapshot with a pod that has GPU power
+		prevSnapshot := NewSnapshot()
+		prevSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now(), 0.5)
+
+		prevSnapshot.Pods["pod-1"] = &Pod{
+			ID:           "pod-1",
+			Name:         "gpu-pod",
+			Namespace:    "default",
+			CPUTotalTime: 50.0,
+			GPUPower:     100.0,
+			Zones:        make(ZoneUsageMap, len(zones)),
+		}
+		for _, zone := range zones {
+			prevSnapshot.Pods["pod-1"].Zones[zone] = Usage{
+				EnergyTotal: 20 * Joule,
+				Power:       10 * Watt,
+			}
+		}
+
+		// Pre-populate containers with GPU power so aggregation works
+		prevSnapshot.Containers = Containers{
+			"container-1": &Container{
+				ID:       "container-1",
+				Name:     "gpu-cont",
+				PodID:    "pod-1",
+				GPUPower: 100.0,
+				Zones:    make(ZoneUsageMap),
+			},
+		}
+
+		// Create new snapshot where pod-1 terminates
+		newSnapshot := NewSnapshot()
+		newSnapshot.Node = createNodeSnapshot(zones, fakeClock.Now().Add(time.Second), 0.5)
+
+		pods := &resource.Pods{
+			Running: map[string]*resource.Pod{},
+			Terminated: map[string]*resource.Pod{
+				"pod-1": {ID: "pod-1", Name: "gpu-pod", Namespace: "default", CPUTimeDelta: 30.0},
+			},
+		}
+
+		tr := CreateTestResources(createOnly(testNode))
+		resInformer.On("Node").Return(tr.Node, nil).Maybe()
+		resInformer.On("Pods").Return(pods).Once()
+
+		err = monitor.calculatePodPower(prevSnapshot, newSnapshot)
+		require.NoError(t, err)
+
+		// Populate terminated from tracker
+		newSnapshot.TerminatedPods = monitor.terminatedPodsTracker.Items()
+
+		// Verify the terminated pod preserves GPU power
+		assert.Len(t, newSnapshot.TerminatedPods, 1, "Should have 1 terminated pod")
+
+		var terminatedPod1 *Pod
+		for _, pod := range newSnapshot.TerminatedPods {
+			if pod.ID == "pod-1" {
+				terminatedPod1 = pod
+				break
+			}
+		}
+		require.NotNil(t, terminatedPod1, "pod-1 should exist in terminated pods")
+		assert.Equal(t, 100.0, terminatedPod1.GPUPower, "Terminated pod should preserve GPU power")
+
+		resInformer.AssertExpectations(t)
 	})
 
 	t.Run("terminated_pod_with_zero_energy_filtering", func(t *testing.T) {

--- a/internal/monitor/types.go
+++ b/internal/monitor/types.go
@@ -124,6 +124,9 @@ type Container struct {
 
 	Zones ZoneUsageMap
 
+	// GPU power attribution (in Watts). Aggregated from process-level GPU power.
+	GPUPower float64
+
 	// pod id is empty if the container is not a pod
 	PodID string
 }
@@ -193,6 +196,9 @@ type Pod struct {
 
 	// Replace single Usage with ZoneUsageMap
 	Zones ZoneUsageMap
+
+	// GPU power attribution (in Watts). Aggregated from container-level GPU power.
+	GPUPower float64
 }
 
 func (p *Pod) Clone() *Pod {


### PR DESCRIPTION
  Aggregate process-level GPU power upward through the hierarchy:
  Process → Container → Pod. Expose as kepler_container_gpu_watts
  and kepler_pod_gpu_watts Prometheus metrics.


<img width="1472" height="1481" alt="image" src="https://github.com/user-attachments/assets/c6347fa1-4645-4686-b849-90549b546e0a" />
