### PR TITLE
feat(gpu): add GPU energy joules metrics at all levels

### DIFF
--- a/docs/user/metrics.md
+++ b/docs/user/metrics.md
@@ -95,6 +95,18 @@ These metrics provide energy and power information at the node level.
 - **Constant Labels**:
   - `node_name`
 
+#### kepler_node_gpu_active_joules_total
+
+- **Type**: COUNTER
+- **Description**: Energy consumption of gpu in active state at node level in joules
+- **Labels**:
+  - `gpu`
+  - `gpu_uuid`
+  - `gpu_name`
+  - `vendor`
+- **Constant Labels**:
+  - `node_name`
+
 #### kepler_node_gpu_active_watts
 
 - **Type**: GAUGE
@@ -107,10 +119,34 @@ These metrics provide energy and power information at the node level.
 - **Constant Labels**:
   - `node_name`
 
+#### kepler_node_gpu_idle_joules_total
+
+- **Type**: COUNTER
+- **Description**: Energy consumption of gpu in idle state at node level in joules
+- **Labels**:
+  - `gpu`
+  - `gpu_uuid`
+  - `gpu_name`
+  - `vendor`
+- **Constant Labels**:
+  - `node_name`
+
 #### kepler_node_gpu_idle_watts
 
 - **Type**: GAUGE
 - **Description**: GPU idle power (auto-detected minimum) in watts
+- **Labels**:
+  - `gpu`
+  - `gpu_uuid`
+  - `gpu_name`
+  - `vendor`
+- **Constant Labels**:
+  - `node_name`
+
+#### kepler_node_gpu_joules_total
+
+- **Type**: COUNTER
+- **Description**: Energy consumption of gpu at node level in joules
 - **Labels**:
   - `gpu`
   - `gpu_uuid`
@@ -159,6 +195,19 @@ These metrics provide energy and power information for containers.
   - `runtime`
   - `state`
   - `zone`
+  - `pod_id`
+- **Constant Labels**:
+  - `node_name`
+
+#### kepler_container_gpu_joules_total
+
+- **Type**: COUNTER
+- **Description**: Energy consumption of gpu at container level in joules
+- **Labels**:
+  - `container_id`
+  - `container_name`
+  - `runtime`
+  - `state`
   - `pod_id`
 - **Constant Labels**:
   - `node_name`
@@ -223,6 +272,21 @@ These metrics provide energy and power information for individual processes.
   - `container_id`
   - `vm_id`
   - `zone`
+- **Constant Labels**:
+  - `node_name`
+
+#### kepler_process_gpu_joules_total
+
+- **Type**: COUNTER
+- **Description**: Energy consumption of gpu at process level in joules
+- **Labels**:
+  - `pid`
+  - `comm`
+  - `exe`
+  - `type`
+  - `state`
+  - `container_id`
+  - `vm_id`
 - **Constant Labels**:
   - `node_name`
 
@@ -298,6 +362,18 @@ These metrics provide energy and power information for pods.
   - `pod_namespace`
   - `state`
   - `zone`
+- **Constant Labels**:
+  - `node_name`
+
+#### kepler_pod_gpu_joules_total
+
+- **Type**: COUNTER
+- **Description**: Energy consumption of gpu at pod level in joules
+- **Labels**:
+  - `pod_id`
+  - `pod_name`
+  - `pod_namespace`
+  - `state`
 - **Constant Labels**:
   - `node_name`
 

--- a/internal/exporter/prometheus/collector/power_collector_test.go
+++ b/internal/exporter/prometheus/collector/power_collector_test.go
@@ -216,11 +216,13 @@ func TestPowerCollector(t *testing.T) {
 
 	testProcesses := monitor.Processes{
 		"123": {
-			PID:          123,
-			Comm:         "test-process",
-			Exe:          "/usr/bin/123",
-			Type:         resource.RegularProcess,
-			CPUTotalTime: 100,
+			PID:            123,
+			Comm:           "test-process",
+			Exe:            "/usr/bin/123",
+			Type:           resource.RegularProcess,
+			CPUTotalTime:   100,
+			GPUPower:       50.5,
+			GPUEnergyTotal: 250 * device.Joule,
 			Zones: monitor.ZoneUsageMap{
 				packageZone: {
 					EnergyTotal: 100 * device.Joule,
@@ -232,11 +234,12 @@ func TestPowerCollector(t *testing.T) {
 
 	testContainers := monitor.Containers{
 		"abcd-efgh": {
-			ID:       "abcd-efgh",
-			Name:     "test-container",
-			Runtime:  resource.PodmanRuntime,
-			GPUPower: 42.5,
-			PodID:    "test-pod",
+			ID:             "abcd-efgh",
+			Name:           "test-container",
+			Runtime:        resource.PodmanRuntime,
+			GPUPower:       42.5,
+			GPUEnergyTotal: 250 * device.Joule,
+			PodID:          "test-pod",
 			Zones: monitor.ZoneUsageMap{
 				packageZone: {
 					EnergyTotal: 100 * device.Joule,
@@ -262,9 +265,10 @@ func TestPowerCollector(t *testing.T) {
 
 	testPods := monitor.Pods{
 		"test-pod": {
-			Name:      "test-pod",
-			Namespace: "default",
-			GPUPower:  42.5,
+			Name:           "test-pod",
+			Namespace:      "default",
+			GPUPower:       42.5,
+			GPUEnergyTotal: 250 * device.Joule,
 			Zones: monitor.ZoneUsageMap{
 				packageZone: {
 					EnergyTotal: 100 * device.Joule,
@@ -277,13 +281,16 @@ func TestPowerCollector(t *testing.T) {
 	// Create test GPU stats
 	testGPUStats := []monitor.GPUDeviceStats{
 		{
-			DeviceIndex: 0,
-			UUID:        "GPU-12345678-1234-1234-1234-123456789abc",
-			Name:        "NVIDIA A100-SXM4-40GB",
-			Vendor:      "nvidia",
-			TotalPower:  150.5,
-			IdlePower:   25.0,
-			ActivePower: 125.5,
+			DeviceIndex:       0,
+			UUID:              "GPU-12345678-1234-1234-1234-123456789abc",
+			Name:              "NVIDIA A100-SXM4-40GB",
+			Vendor:            "nvidia",
+			TotalPower:        150.5,
+			IdlePower:         25.0,
+			ActivePower:       125.5,
+			EnergyTotal:       5000 * device.Joule,
+			ActiveEnergyTotal: 4000 * device.Joule,
+			IdleEnergyTotal:   1000 * device.Joule,
 		},
 	}
 
@@ -333,10 +340,13 @@ func TestPowerCollector(t *testing.T) {
 			"kepler_process_cpu_joules_total",
 			"kepler_process_cpu_watts",
 			"kepler_process_cpu_seconds_total",
+			"kepler_process_gpu_watts",
+			"kepler_process_gpu_joules_total",
 
 			"kepler_container_cpu_joules_total",
 			"kepler_container_cpu_watts",
 			"kepler_container_gpu_watts",
+			"kepler_container_gpu_joules_total",
 
 			"kepler_vm_cpu_joules_total",
 			"kepler_vm_cpu_watts",
@@ -344,10 +354,14 @@ func TestPowerCollector(t *testing.T) {
 			"kepler_pod_cpu_joules_total",
 			"kepler_pod_cpu_watts",
 			"kepler_pod_gpu_watts",
+			"kepler_pod_gpu_joules_total",
 
 			"kepler_node_gpu_watts",
 			"kepler_node_gpu_idle_watts",
 			"kepler_node_gpu_active_watts",
+			"kepler_node_gpu_joules_total",
+			"kepler_node_gpu_active_joules_total",
+			"kepler_node_gpu_idle_joules_total",
 		}
 
 		assert.ElementsMatch(t, expectedMetricNames, metricNames(metrics))
@@ -506,6 +520,19 @@ func TestPowerCollector(t *testing.T) {
 		assertMetricLabelValues(t, registry, "kepler_pod_cpu_watts", expectedLabels, 5.0)
 	})
 
+	t.Run("Process GPU Metrics", func(t *testing.T) {
+		expectedLabels := map[string]string{
+			"node_name": "test-node",
+			"pid":       "123",
+			"comm":      "test-process",
+			"exe":       "/usr/bin/123",
+			"type":      "regular",
+			"state":     "running",
+		}
+		assertMetricLabelValues(t, registry, "kepler_process_gpu_watts", expectedLabels, 50.5)
+		assertMetricLabelValues(t, registry, "kepler_process_gpu_joules_total", expectedLabels, 250.0)
+	})
+
 	t.Run("Container GPU Metrics", func(t *testing.T) {
 		expectedLabels := map[string]string{
 			"node_name":      "test-node",
@@ -516,6 +543,7 @@ func TestPowerCollector(t *testing.T) {
 			"pod_id":         "test-pod",
 		}
 		assertMetricLabelValues(t, registry, "kepler_container_gpu_watts", expectedLabels, 42.5)
+		assertMetricLabelValues(t, registry, "kepler_container_gpu_joules_total", expectedLabels, 250.0)
 	})
 
 	t.Run("Pod GPU Metrics", func(t *testing.T) {
@@ -527,6 +555,7 @@ func TestPowerCollector(t *testing.T) {
 			"state":         "running",
 		}
 		assertMetricLabelValues(t, registry, "kepler_pod_gpu_watts", expectedLabels, 42.5)
+		assertMetricLabelValues(t, registry, "kepler_pod_gpu_joules_total", expectedLabels, 250.0)
 	})
 
 	t.Run("GPU Metrics Labels", func(t *testing.T) {
@@ -540,6 +569,9 @@ func TestPowerCollector(t *testing.T) {
 		assertMetricLabelValues(t, registry, "kepler_node_gpu_watts", expectedLabels, 150.5)
 		assertMetricLabelValues(t, registry, "kepler_node_gpu_idle_watts", expectedLabels, 25.0)
 		assertMetricLabelValues(t, registry, "kepler_node_gpu_active_watts", expectedLabels, 125.5)
+		assertMetricLabelValues(t, registry, "kepler_node_gpu_joules_total", expectedLabels, 5000.0)
+		assertMetricLabelValues(t, registry, "kepler_node_gpu_active_joules_total", expectedLabels, 4000.0)
+		assertMetricLabelValues(t, registry, "kepler_node_gpu_idle_joules_total", expectedLabels, 1000.0)
 	})
 
 	// Verify mock expectations

--- a/internal/monitor/container.go
+++ b/internal/monitor/container.go
@@ -35,13 +35,14 @@ func (pm *PowerMonitor) firstContainerRead(snapshot *Snapshot) error {
 
 		containers[id] = container
 	}
-	// Aggregate GPU power from processes into containers
+	// Aggregate GPU power and energy from processes into containers
 	for _, proc := range snapshot.Processes {
-		if proc.ContainerID == "" || proc.GPUPower == 0 {
+		if proc.ContainerID == "" {
 			continue
 		}
 		if container, ok := containers[proc.ContainerID]; ok {
 			container.GPUPower += proc.GPUPower
+			container.GPUEnergyTotal += proc.GPUEnergyTotal
 		}
 	}
 
@@ -149,13 +150,14 @@ func (pm *PowerMonitor) calculateContainerPower(prev, newSnapshot *Snapshot) err
 		containerMap[id] = container
 	}
 
-	// Aggregate GPU power from processes into containers
+	// Aggregate GPU power and energy from processes into containers
 	for _, proc := range newSnapshot.Processes {
-		if proc.ContainerID == "" || proc.GPUPower == 0 {
+		if proc.ContainerID == "" {
 			continue
 		}
 		if container, ok := containerMap[proc.ContainerID]; ok {
 			container.GPUPower += proc.GPUPower
+			container.GPUEnergyTotal += proc.GPUEnergyTotal
 		}
 	}
 

--- a/internal/monitor/pod.go
+++ b/internal/monitor/pod.go
@@ -35,13 +35,14 @@ func (pm *PowerMonitor) firstPodRead(snapshot *Snapshot) error {
 
 		pods[id] = pod
 	}
-	// Aggregate GPU power from containers into pods
+	// Aggregate GPU power and energy from containers into pods
 	for _, container := range snapshot.Containers {
-		if container.PodID == "" || container.GPUPower == 0 {
+		if container.PodID == "" {
 			continue
 		}
 		if pod, ok := pods[container.PodID]; ok {
 			pod.GPUPower += container.GPUPower
+			pod.GPUEnergyTotal += container.GPUEnergyTotal
 		}
 	}
 
@@ -127,13 +128,14 @@ func (pm *PowerMonitor) calculatePodPower(prev, newSnapshot *Snapshot) error {
 		podMap[id] = pod
 	}
 
-	// Aggregate GPU power from containers into pods
+	// Aggregate GPU power and energy from containers into pods
 	for _, container := range newSnapshot.Containers {
-		if container.PodID == "" || container.GPUPower == 0 {
+		if container.PodID == "" {
 			continue
 		}
 		if pod, ok := podMap[container.PodID]; ok {
 			pod.GPUPower += container.GPUPower
+			pod.GPUEnergyTotal += container.GPUEnergyTotal
 		}
 	}
 

--- a/internal/monitor/types.go
+++ b/internal/monitor/types.go
@@ -84,7 +84,8 @@ type Process struct {
 	Zones ZoneUsageMap
 
 	// GPU power attribution (in Watts). Only set if GPU is available and process uses GPU.
-	GPUPower float64
+	GPUPower       float64
+	GPUEnergyTotal Energy // Cumulative GPU energy in microjoules
 
 	ContainerID      string // empty if not a container
 	VirtualMachineID string // empty if not a virtual machine
@@ -125,7 +126,8 @@ type Container struct {
 	Zones ZoneUsageMap
 
 	// GPU power attribution (in Watts). Aggregated from process-level GPU power.
-	GPUPower float64
+	GPUPower       float64
+	GPUEnergyTotal Energy // Cumulative GPU energy, aggregated from processes
 
 	// pod id is empty if the container is not a pod
 	PodID string
@@ -198,7 +200,8 @@ type Pod struct {
 	Zones ZoneUsageMap
 
 	// GPU power attribution (in Watts). Aggregated from container-level GPU power.
-	GPUPower float64
+	GPUPower       float64
+	GPUEnergyTotal Energy // Cumulative GPU energy, aggregated from containers
 }
 
 func (p *Pod) Clone() *Pod {
@@ -235,13 +238,16 @@ type GPUDeviceStats struct {
 	// DeviceIndex is the GPU index as reported by the driver (0, 1, 2...).
 	// Corresponds to nvidia-smi output for easy correlation during debugging.
 	// Note: not persistent across reboots; use UUID for unique identification.
-	DeviceIndex int
-	UUID        string  // GPU UUID - globally unique, persistent identifier
-	Name        string  // GPU product name (e.g., "NVIDIA A100-SXM4-40GB")
-	Vendor      string  // GPU vendor (nvidia, amd, intel)
-	TotalPower  float64 // Current total power in Watts
-	IdlePower   float64 // Detected idle power in Watts
-	ActivePower float64 // Active power (Total - Idle) in Watts
+	DeviceIndex       int
+	UUID              string  // GPU UUID - globally unique, persistent identifier
+	Name              string  // GPU product name (e.g., "NVIDIA A100-SXM4-40GB")
+	Vendor            string  // GPU vendor (nvidia, amd, intel)
+	TotalPower        float64 // Current total power in Watts
+	IdlePower         float64 // Detected idle power in Watts
+	ActivePower       float64 // Active power (Total - Idle) in Watts
+	EnergyTotal       Energy  // Cumulative GPU energy from hardware counter
+	ActiveEnergyTotal Energy  // Cumulative active GPU energy (split from EnergyTotal using power ratio)
+	IdleEnergyTotal   Energy  // Cumulative idle GPU energy (split from EnergyTotal using power ratio)
 }
 
 // Snapshot encapsulates power monitoring data


### PR DESCRIPTION
feat(gpu): add GPU energy joules metrics at all levels

  Add cumulative GPU energy counters (joules_total) for node, process,
  container, and pod levels. Node-level reads directly from hardware
  counter (NVML GetTotalEnergy); process-level integrates power over
  time and aggregates upward to container and pod levels.

  New metrics: `kepler_node_gpu_joules_total`,
  `kepler_process_gpu_joules_total`, `kepler_container_gpu_joules_total`,
  `kepler_pod_gpu_joules_total`