### PR TITLE
fix Makefile minor typos, and update 'help' target description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,14 +96,14 @@ help: ## Show this help message
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## .*(Documentation|Generate|Run|Help)/ {printf "    %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo ''
 	@echo 'Examples:'
-	@echo '  make build           # Build production binary'
+	@echo '  make build           # Build binary (set PRODUCTION=1 to build production binary, ./bin/kepler-release)'
 	@echo '  make test            # Run tests with coverage'
 	@echo '  make cluster-up      # Setup local k8s cluster'
 	@echo '  make deploy          # Deploy to k8s cluster'
 
 # Build the application
 .PHONY: build
-build: ## Build production binary
+build: ## Build binary
 	mkdir -p $(BINARY_DIR)
 	CGO_ENABLED=$(CGO_ENABLED) $(GOBUILD) $(BUILD_ARGS) \
 		$(LDFLAGS) \


### PR DESCRIPTION
by merging these changes, we:
  - fix the text of the 'help' target that mentions about the binary build;
  - update information how a "production build" must be done (setting `PRODUCTION=1`);
  - reflect that update to the comment on the `Makefile` itself;
  - ensure folks are aware that a production builds produce `kepler-release` instead of `kepler`.

pipelines building `kepler` that deploy it into production environments should be aware that the release builds require an extra variable to be set, so they can fix that.

> the current workflow of this repository **releases the correct binary** already because it properly uses the `make build` target by setting up PRODUCTION=1 and then renames the file from `kepler-release` to `kepler`: https://github.com/sustainable-computing-io/kepler/blob/60af48fe49cc05439fd9f66f79b8cc4c78aa45f0/.github/workflows/release.yaml#L74