### PR TITLE
test(monitor): increase assertion timeout

### DIFF
--- a/internal/monitor/monitor_collection_test.go
+++ b/internal/monitor/monitor_collection_test.go
@@ -113,7 +113,7 @@ func TestPeriodicCollection(t *testing.T) {
 	}()
 
 	t.Log("Waiting for first collection")
-	assertDataUpdated(t, dataCh, 5*time.Millisecond, "expected first collection as soon as run is invoked")
+	assertDataUpdated(t, dataCh, 100*time.Millisecond, "expected first collection as soon as run is invoked")
 	assert.GreaterOrEqual(t, energyCalls.Load(), int32(1), "Should have made at least one energy call")
 	assertDataChannelEmpty(t, dataCh, 3*time.Millisecond)
 


### PR DESCRIPTION
This commit increases the assertion timeout for the monitor test. The 5ms timeoit on assertDataUpdated is too tight for CI The go routine needs to be scheduled, sleep 1ms in assertDataChannelEmpty, then run the collectionLoop all before the main goroutine exits. On CI runners that doesn't happen in 5ms

c164049e fixed the exact same problem in TestCollectionCancellation