### PR TITLE
ci(codecov): raise patch coverage target from 70% to 90%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,7 @@ coverage:
         threshold: 1%
     patch:
       default:
-        target: 70%
+        target: 90%
 
 ignore:
   - internal/device/gpu/nvidia/nvml_lib.go


### PR DESCRIPTION
At 70% well tested files in a PR can mask entirely untested
files because codecov computes patch coverage as a blended
average across all changed lines. 90% limits uncovered lines to
10% preventing whole functions from passing without tests

