### PR TITLE
chore: remove GPU logs when feature is disabled

### DIFF
--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -362,7 +362,6 @@ func createCPUMeter(logger *slog.Logger, cfg *config.Config) (device.CPUPowerMet
 // Returns empty slice if GPU is not enabled or no GPUs are available (soft-fail).
 func createGPUMeters(logger *slog.Logger, cfg *config.Config) []gpu.GPUPowerMeter {
 	if !cfg.IsFeatureEnabled(config.ExperimentalGPUFeature) {
-		logger.Info("GPU feature disabled")
 		return nil
 	}
 

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -135,12 +135,8 @@ func (pm *PowerMonitor) Init() error {
 		"zone", primaryEnergyZone.Name())
 
 	// Log GPU meter status
-	if len(pm.gpuMeters) > 0 {
-		for _, m := range pm.gpuMeters {
-			pm.logger.Info("GPU meter configured", "vendor", m.Vendor(), "devices", len(m.Devices()))
-		}
-	} else {
-		pm.logger.Info("No GPU meters configured")
+	for _, m := range pm.gpuMeters {
+		pm.logger.Info("GPU meter configured", "vendor", m.Vendor(), "devices", len(m.Devices()))
 	}
 
 	// Initialize terminated workload trackers with the primary energy zone and minimum energy threshold


### PR DESCRIPTION
This commit removes the GPU related log noise that appears when the experimental GPU feature is disabled