### PR TITLE
feat(kvm): support kvm vm processes on proxmox VE

### DIFF
--- a/internal/resource/vm.go
+++ b/internal/resource/vm.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	// QEMU/KVM patterns - matches both qemu-system-* and qemu-kvm variants
-	qemuPattern = regexp.MustCompile(`(bin/qemu-system-\w+|libexec/qemu-kvm)`)
+	qemuPattern = regexp.MustCompile(`(bin/qemu-system-\w+|libexec/qemu-kvm|bin/kvm)`)
 
 	// TODO: add patterns for virtual box,  VMware, Xen
 

--- a/internal/resource/vm_test.go
+++ b/internal/resource/vm_test.go
@@ -104,6 +104,16 @@ func TestVMInfoFromCmdLine(t *testing.T) {
 			vmID:       "instance-0000008b",
 		},
 	}, {
+		name: "KVM with name",
+		cmdline: []string{
+			"/usr/bin/kvm",
+			"-name", "test-vm",
+		},
+		expected: expect{
+			hypervisor: KVMHypervisor,
+			vmID:       "test-vm",
+		},
+	}, {
 		name: "Not a VM process",
 		cmdline: []string{
 			"/usr/bin/firefox",


### PR DESCRIPTION
I recently tried using Kepler in a Proxmox virtual environment (https://www.proxmox.com/en/). Although Proxmox uses KVM/QEMU for virtualisation, Kepler was unable to detect the corresponding processes as virtual machines because they look like this:

`/usr/bin/kvm -id 109 -name some-vm-name [...]`

This can easily be fixed by adjusting the qemuPattern in the internal/resource/vm.go file, as demonstrated in this pull request. Therefore, it would be great if this fix could be merged.