### PR TITLE
test: add fake NVML backend for GPU dev/testing

### DIFF
--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -11,11 +11,12 @@ import (
 	"syscall"
 
 	"github.com/alecthomas/kingpin/v2"
+	"k8s.io/utils/ptr"
 
 	"github.com/sustainable-computing-io/kepler/config"
 	"github.com/sustainable-computing-io/kepler/internal/device"
 	"github.com/sustainable-computing-io/kepler/internal/device/gpu"
-	_ "github.com/sustainable-computing-io/kepler/internal/device/gpu/nvidia" // Register NVIDIA backend
+	"github.com/sustainable-computing-io/kepler/internal/device/gpu/nvidia"
 	"github.com/sustainable-computing-io/kepler/internal/exporter/prometheus"
 	"github.com/sustainable-computing-io/kepler/internal/exporter/stdout"
 	"github.com/sustainable-computing-io/kepler/internal/k8s/pod"
@@ -319,6 +320,10 @@ func createPrometheusExporter(
 // Uses the registry pattern to support multiple GPU vendors (NVIDIA, AMD, Intel).
 // Returns empty slice if GPU is not enabled or no GPUs are available (soft-fail).
 func createGPUMeters(logger *slog.Logger, cfg *config.Config) []gpu.GPUPowerMeter {
+	if fake := cfg.Dev.FakeGPUMeter; ptr.Deref(fake.Enabled, false) {
+		return createFakeGPUMeter(logger, fake.DeviceCount, fake.SharingMode)
+	}
+
 	if !cfg.IsFeatureEnabled(config.ExperimentalGPUFeature) {
 		return nil
 	}
@@ -338,4 +343,57 @@ func createGPUMeters(logger *slog.Logger, cfg *config.Config) []gpu.GPUPowerMete
 	}
 
 	return meters
+}
+
+// createFakeGPUMeter creates a GPU meter backed by FakeNVMLBackend for
+// development and testing. Not for production use.
+func createFakeGPUMeter(logger *slog.Logger, deviceCount int, sharingMode string) []gpu.GPUPowerMeter {
+	if deviceCount <= 0 {
+		logger.Error("invalid fake GPU device count", "deviceCount", deviceCount)
+		return nil
+	}
+
+	var mode nvidia.ComputeMode
+	switch sharingMode {
+	case "exclusive":
+		mode = nvidia.ComputeModeExclusiveProcess
+	case "time-slicing":
+		mode = nvidia.ComputeModeDefault
+	default:
+		logger.Error("invalid fake GPU sharing mode", "sharingMode", sharingMode)
+		return nil
+	}
+
+	logger.Warn("using FAKE NVML backend (dev/testing mode)",
+		"deviceCount", deviceCount,
+		"sharingMode", sharingMode)
+
+	devices := make([]*nvidia.FakeNVMLDevice, deviceCount)
+	for i := range devices {
+		devices[i] = &nvidia.FakeNVMLDevice{
+			Idx:         i,
+			DeviceUUID:  fmt.Sprintf("FAKE-GPU-%04d", i),
+			DeviceName:  "Fake NVIDIA GPU",
+			DevicePower: 225 * device.Watt,
+			Mode:        mode,
+		}
+	}
+	// TODO: Add fake GPU processes when e2e workloads can supply stable PIDs.
+
+	backend := nvidia.NewFakeNVMLBackend(devices...)
+	collector, err := nvidia.NewGPUPowerCollector(logger, nvidia.WithNVMLBackend(backend))
+	if err != nil {
+		logger.Error("failed to create GPU collector with fake backend", "error", err)
+		return nil
+	}
+
+	// Init must be called before returning, matching the real path (gpu.Discover
+	// calls Init before returning the meter). This ensures Devices() is populated
+	// when the monitor logs GPU meter info during its own Init.
+	if err := collector.Init(); err != nil {
+		logger.Error("failed to initialize fake GPU collector", "error", err)
+		return nil
+	}
+
+	return []gpu.GPUPowerMeter{collector}
 }

--- a/compose/default/kepler/etc/kepler/config.yaml
+++ b/compose/default/kepler/etc/kepler/config.yaml
@@ -79,6 +79,10 @@ dev:
   fake-cpu-meter:
     enabled: false # DEPRECATED: set cpu.preferredMeters: ["fake"] instead. Overrides cpu.preferredMeters and emits a deprecation warning when true.
     zones: [] # zones to be enabled, empty enables all default zones
+  fake-gpu-meter:
+    enabled: false
+    deviceCount: 1
+    sharingMode: time-slicing
 
 # EXPERIMENTAL FEATURES - These features are experimental and may be unstable
 # and are disabled by default

--- a/compose/dev/kepler-dev/etc/kepler/config.yaml
+++ b/compose/dev/kepler-dev/etc/kepler/config.yaml
@@ -79,6 +79,10 @@ dev:
   fake-cpu-meter:
     enabled: false # DEPRECATED: set cpu.preferredMeters: ["fake"] instead. Overrides cpu.preferredMeters and emits a deprecation warning when true.
     zones: [] # zones to be enabled, empty enables all default zones
+  fake-gpu-meter:
+    enabled: false
+    deviceCount: 1
+    sharingMode: time-slicing
 
 # EXPERIMENTAL FEATURES - These features are experimental and may be unstable
 # and are disabled by default

--- a/config/config.go
+++ b/config/config.go
@@ -99,6 +99,11 @@ type (
 			Enabled *bool    `yaml:"enabled"`
 			Zones   []string `yaml:"zones"`
 		} `yaml:"fake-cpu-meter"`
+		FakeGPUMeter struct {
+			Enabled     *bool  `yaml:"enabled"`
+			DeviceCount int    `yaml:"deviceCount"` // number of fake GPUs (default: 1)
+			SharingMode string `yaml:"sharingMode"` // "exclusive" or "time-slicing" (default: "time-slicing")
+		} `yaml:"fake-gpu-meter"`
 	}
 	Web struct {
 		Config          string   `yaml:"configFile"`
@@ -375,6 +380,9 @@ func DefaultConfig() *Config {
 	}
 
 	cfg.Dev.FakeCpuMeter.Enabled = ptr.To(false)
+	cfg.Dev.FakeGPUMeter.Enabled = ptr.To(false)
+	cfg.Dev.FakeGPUMeter.DeviceCount = 1
+	cfg.Dev.FakeGPUMeter.SharingMode = "time-slicing"
 	return cfg
 }
 
@@ -946,6 +954,20 @@ func (c *Config) Validate(skips ...SkipValidation) error {
 
 		if c.Monitor.MinTerminatedEnergyThreshold < 0 {
 			errs = append(errs, fmt.Sprintf("invalid monitor min terminated energy threshold: %d can't be negative", c.Monitor.MinTerminatedEnergyThreshold))
+		}
+	}
+	{ // Development
+		fakeGPU := c.Dev.FakeGPUMeter
+		if ptr.Deref(fakeGPU.Enabled, false) {
+			if fakeGPU.DeviceCount <= 0 {
+				errs = append(errs, fmt.Sprintf("invalid dev.fake-gpu-meter.deviceCount: %d, must be greater than 0", fakeGPU.DeviceCount))
+			}
+			switch fakeGPU.SharingMode {
+			case "exclusive", "time-slicing":
+				// valid
+			default:
+				errs = append(errs, fmt.Sprintf("invalid dev.fake-gpu-meter.sharingMode: %q, must be \"exclusive\" or \"time-slicing\"", fakeGPU.SharingMode))
+			}
 		}
 	}
 	{ // Kubernetes

--- a/config/config_gpu_test.go
+++ b/config/config_gpu_test.go
@@ -149,3 +149,62 @@ func TestApplyGPUConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestFakeGPUMeterConfigValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		enabled       bool
+		deviceCount   int
+		sharingMode   string
+		expectedError string
+	}{
+		{
+			name:        "valid time-slicing config",
+			enabled:     true,
+			deviceCount: 1,
+			sharingMode: "time-slicing",
+		},
+		{
+			name:        "valid exclusive config",
+			enabled:     true,
+			deviceCount: 2,
+			sharingMode: "exclusive",
+		},
+		{
+			name:          "zero devices",
+			enabled:       true,
+			deviceCount:   0,
+			sharingMode:   "time-slicing",
+			expectedError: "invalid dev.fake-gpu-meter.deviceCount",
+		},
+		{
+			name:          "invalid sharing mode",
+			enabled:       true,
+			deviceCount:   1,
+			sharingMode:   "exclusve",
+			expectedError: "invalid dev.fake-gpu-meter.sharingMode",
+		},
+		{
+			name:        "disabled config is ignored",
+			enabled:     false,
+			deviceCount: 0,
+			sharingMode: "invalid",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Dev.FakeGPUMeter.Enabled = ptr.To(tc.enabled)
+			cfg.Dev.FakeGPUMeter.DeviceCount = tc.deviceCount
+			cfg.Dev.FakeGPUMeter.SharingMode = tc.sharingMode
+
+			err := cfg.Validate(SkipHostValidation)
+			if tc.expectedError == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, tc.expectedError)
+		})
+	}
+}

--- a/docs/developer/design/architecture/configuration.md
+++ b/docs/developer/design/architecture/configuration.md
@@ -270,6 +270,11 @@ type Dev struct {
         Enabled *bool    `yaml:"enabled"`  // Use fake CPU meter
         Zones   []string `yaml:"zones"`    // Fake zone list
     } `yaml:"fake-cpu-meter"`
+    FakeGPUMeter struct {
+        Enabled     *bool  `yaml:"enabled"`
+        DeviceCount int    `yaml:"deviceCount"`
+        SharingMode string `yaml:"sharingMode"`
+    } `yaml:"fake-gpu-meter"`
 }
 ```
 

--- a/docs/developer/e2e-testing.md
+++ b/docs/developer/e2e-testing.md
@@ -101,6 +101,7 @@ The e2e tests are organized by concern across multiple files:
 | `metrics_test.go`    | Metric format validation: required labels, non-negative values, multiple scrapes       |
 | `invariants_test.go` | Energy conservation laws: Total = Active + Idle, process power attribution             |
 | `workload_test.go`   | Workload detection: stress-ng detection, power changes under load, terminated tracking |
+| `gpu_test.go`        | GPU metrics: presence, labels, non-negative values, power conservation (uses fake GPU) |
 
 ### Test Configuration
 
@@ -130,6 +131,12 @@ monitor:
 - `kepler_node_cpu_idle_joules_total` / `kepler_node_cpu_idle_watts` - Idle power
 - `kepler_node_cpu_usage_ratio` - CPU utilization (0.0 to 1.0)
 - `kepler_node_cpu_info` - CPU hardware information
+- `kepler_node_gpu_watts` - Total GPU power (fake GPU)
+- `kepler_node_gpu_active_watts` / `kepler_node_gpu_idle_watts` - Active and idle GPU power (currently exercises the idle case)
+- `kepler_node_gpu_info` - GPU device information
+
+GPU tests require GPU metrics to be enabled, as in the default e2e configuration.
+Custom configurations passed through `-kepler.config` must also enable GPU metrics when running these tests.
 
 ### Process-Level Metrics
 
@@ -154,12 +161,13 @@ monitor:
 
 ## What Is NOT Covered (and Why)
 
-| Feature                    | Reason Not Tested in Bare-Metal E2E                                      | Where It's Tested                             |
-|----------------------------|--------------------------------------------------------------------------|-----------------------------------------------|
-| VM metrics (`kepler_vm_*`) | Requires libvirt/hypervisor not available in test environment            | Unit tests in `internal/monitor/vm_test.go`   |
-| Redfish platform metrics   | Requires BMC hardware access not available in CI/dev environments        | Unit tests in `internal/platform/redfish/`    |
-| Metrics level filtering    | Low priority; config parsing is unit tested; e2e uses full metrics level | Unit tests in `config/`                       |
-| pprof debug endpoints      | Debug feature with low e2e value                                         | Unit tests in `internal/server/pprof_test.go` |
+| Feature                    | Reason Not Tested in Bare-Metal E2E                                      | Where It's Tested                                            |
+|----------------------------|--------------------------------------------------------------------------|--------------------------------------------------------------|
+| GPU pod/container metrics  | The fake GPU meter does not expose any fake processes yet                | Unit tests in `internal/monitor/`; Phase 2: fake-gpu K8s e2e |
+| VM metrics (`kepler_vm_*`) | Requires libvirt/hypervisor not available in test environment            | Unit tests in `internal/monitor/vm_test.go`                  |
+| Redfish platform metrics   | Requires BMC hardware access not available in CI/dev environments        | Unit tests in `internal/platform/redfish/`                   |
+| Metrics level filtering    | Low priority; config parsing is unit tested; e2e uses full metrics level | Unit tests in `config/`                                      |
+| pprof debug endpoints      | Debug feature with low e2e value                                         | Unit tests in `internal/server/pprof_test.go`                |
 
 > **Note**: Container and Pod metrics are tested in the [Kubernetes E2E tests](#kubernetes-e2e-tests) which run against a real cluster.
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -186,6 +186,10 @@ dev:
   fake-cpu-meter:
     enabled: false
     zones: []  # Zones to be enabled, empty enables all default zones
+  fake-gpu-meter:
+    enabled: false
+    deviceCount: 1            # Number of fake GPUs to simulate (default: 1)
+    sharingMode: time-slicing # GPU sharing mode: "exclusive" or "time-slicing" (default: "time-slicing")
 ```
 
 ## 🧩 Configuration Options in Detail
@@ -577,6 +581,10 @@ cpu:
 dev:
   fake-cpu-meter:
     zones: []
+  fake-gpu-meter:
+    enabled: false
+    deviceCount: 1
+    sharingMode: time-slicing
 ```
 
 ⚠️ **WARNING**: This section is for development and testing only. Do not enable in production.
@@ -585,6 +593,10 @@ dev:
   - Select via `cpu.preferredMeters: ["fake"]` (preferred)
   - `dev.fake-cpu-meter.enabled: true` is **deprecated**: it overrides `cpu.preferredMeters` and emits a deprecation warning
   - `zones`: Specific zones to enable, empty enables all
+- **fake-gpu-meter**: When enabled, uses a fake GPU backend instead of real NVIDIA hardware
+  - `enabled`: Set to `true` to enable fake GPU meter. This takes precedence over `experimental.gpu.enabled`, so the experimental GPU flag does not also need to be enabled
+  - `deviceCount`: Number of simulated GPUs. Must be greater than 0 (default: 1)
+  - `sharingMode`: Set to `"exclusive"` or `"time-slicing"` (default: `"time-slicing"`). This changes the detected sharing mode but has no effect on exported metrics because the fake GPU meter does not configure any processes.
 
 ## 📖 Further Reading
 

--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -79,6 +79,10 @@ dev:
   fake-cpu-meter:
     enabled: false # DEPRECATED: set cpu.preferredMeters: ["fake"] instead. Overrides cpu.preferredMeters and emits a deprecation warning when true.
     zones: [] # zones to be enabled, empty enables all default zones
+  fake-gpu-meter:
+    enabled: false
+    deviceCount: 1
+    sharingMode: time-slicing
 
 # EXPERIMENTAL FEATURES - These features are experimental and may be unstable
 # and are disabled by default

--- a/internal/device/gpu/nvidia/collector.go
+++ b/internal/device/gpu/nvidia/collector.go
@@ -57,21 +57,37 @@ type GPUPowerCollector struct {
 	processPowerGroup singleflight.Group
 }
 
+// CollectorOption configures the GPUPowerCollector.
+type CollectorOption func(*GPUPowerCollector)
+
+// WithNVMLBackend configures the collector to use the provided NVML backend.
+func WithNVMLBackend(backend NVMLBackend) CollectorOption {
+	return func(c *GPUPowerCollector) {
+		c.nvml = backend
+	}
+}
+
 // NewGPUPowerCollector creates a new NVIDIA GPU power collector.
-func NewGPUPowerCollector(logger *slog.Logger) (*GPUPowerCollector, error) {
+func NewGPUPowerCollector(logger *slog.Logger, opts ...CollectorOption) (*GPUPowerCollector, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
 
 	nvmlBackend := NewNVMLBackend(logger)
 
-	return &GPUPowerCollector{
+	c := &GPUPowerCollector{
 		logger:           logger.With("component", "nvidia-gpu-collector"),
 		nvml:             nvmlBackend,
 		minObservedPower: make(map[string]float64),
 		idleObserved:     make(map[string]bool),
 		sharingModes:     make(map[int]gpu.SharingMode),
-	}, nil
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c, nil
 }
 
 // Name returns the service name

--- a/internal/device/gpu/nvidia/fake_backend.go
+++ b/internal/device/gpu/nvidia/fake_backend.go
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidia
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sustainable-computing-io/kepler/internal/device"
+	"github.com/sustainable-computing-io/kepler/internal/device/gpu"
+)
+
+// NOTE: This fake backend is not intended for production use. It is for
+// development and testing only, similar to fakeRaplMeter for CPU power.
+
+// FakeNVMLBackend implements NVMLBackend for testing without real GPUs.
+type FakeNVMLBackend struct {
+	mu      sync.RWMutex
+	devices []*FakeNVMLDevice
+}
+
+// FakeNVMLDevice implements NVMLDevice with configurable behavior.
+// Set exported fields before concurrent use. Callers must not read or write
+// them directly while device methods are running. Methods synchronize internal
+// updates to cumulative energy.
+type FakeNVMLDevice struct {
+	// Idx is the device index (0-based).
+	Idx int
+
+	// DeviceUUID is the unique identifier for this fake GPU.
+	DeviceUUID string
+
+	// DeviceName is the product name for this fake GPU.
+	DeviceName string
+
+	// DevicePower is the current power reading returned by GetPowerUsage.
+	DevicePower device.Power
+
+	// TotalEnergy is cumulative energy; GetTotalEnergy integrates DevicePower
+	// over the elapsed time since its previous call.
+	TotalEnergy device.Energy
+
+	// Mode is the compute mode (ComputeModeDefault for time-slicing,
+	// ComputeModeExclusiveProcess for exclusive).
+	Mode ComputeMode
+
+	// MIG controls whether IsMIGEnabled returns true.
+	MIG bool
+
+	// Processes is the list of "running" GPU processes returned by
+	// GetComputeRunningProcesses.
+	Processes []gpu.ProcessGPUInfo
+
+	// Utilization is the per-process utilization returned by GetProcessUtilization.
+	Utilization []gpu.ProcessUtilization
+
+	// UtilError, if set, is returned by GetProcessUtilization instead of Utilization.
+	// This allows testing the time-slicing fallback path.
+	UtilError error
+
+	mu sync.RWMutex
+
+	lastEnergyRead time.Time
+	now            func() time.Time
+}
+
+// Verify interface compliance at compile time.
+var (
+	_ NVMLBackend = (*FakeNVMLBackend)(nil)
+	_ NVMLDevice  = (*FakeNVMLDevice)(nil)
+)
+
+// NewFakeNVMLBackend creates a FakeNVMLBackend with the given devices.
+func NewFakeNVMLBackend(devices ...*FakeNVMLDevice) *FakeNVMLBackend {
+	return &FakeNVMLBackend{devices: devices}
+}
+
+func (b *FakeNVMLBackend) Init() error {
+	return nil
+}
+
+func (b *FakeNVMLBackend) Shutdown() error {
+	return nil
+}
+
+func (b *FakeNVMLBackend) DeviceCount() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.devices)
+}
+
+func (b *FakeNVMLBackend) GetDevice(index int) (NVMLDevice, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if index < 0 || index >= len(b.devices) {
+		return nil, gpu.ErrGPUNotFound{DeviceIndex: index}
+	}
+	return b.devices[index], nil
+}
+
+func (b *FakeNVMLBackend) DiscoverDevices() ([]gpu.GPUDevice, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	devices := make([]gpu.GPUDevice, len(b.devices))
+	for i, d := range b.devices {
+		devices[i] = gpu.GPUDevice{
+			Index:  d.Idx,
+			UUID:   d.DeviceUUID,
+			Name:   d.DeviceName,
+			Vendor: gpu.VendorNVIDIA,
+		}
+	}
+	return devices, nil
+}
+
+// FakeNVMLDevice method implementations
+
+func (d *FakeNVMLDevice) Index() int {
+	return d.Idx
+}
+
+func (d *FakeNVMLDevice) UUID() string {
+	return d.DeviceUUID
+}
+
+func (d *FakeNVMLDevice) Name() string {
+	return d.DeviceName
+}
+
+func (d *FakeNVMLDevice) GetPowerUsage() (device.Power, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.DevicePower, nil
+}
+
+func (d *FakeNVMLDevice) GetTotalEnergy() (device.Energy, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	now := time.Now()
+	if d.now != nil {
+		now = d.now()
+	}
+	if !d.lastEnergyRead.IsZero() {
+		elapsed := now.Sub(d.lastEnergyRead).Seconds()
+		if elapsed > 0 && d.DevicePower > 0 {
+			d.TotalEnergy += device.Energy(d.DevicePower.Watts() * elapsed * float64(device.Joule))
+		}
+	}
+	d.lastEnergyRead = now
+	return d.TotalEnergy, nil
+}
+
+func (d *FakeNVMLDevice) GetComputeRunningProcesses() ([]gpu.ProcessGPUInfo, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	// Return a copy to prevent mutation.
+	procs := make([]gpu.ProcessGPUInfo, len(d.Processes))
+	copy(procs, d.Processes)
+
+	// Fill in timestamps if not set.
+	now := time.Now()
+	if d.now != nil {
+		now = d.now()
+	}
+	for i := range procs {
+		if procs[i].Timestamp.IsZero() {
+			procs[i].Timestamp = now
+		}
+		if procs[i].DeviceIndex == 0 && d.Idx != 0 {
+			procs[i].DeviceIndex = d.Idx
+		}
+		if procs[i].DeviceUUID == "" {
+			procs[i].DeviceUUID = d.DeviceUUID
+		}
+	}
+	return procs, nil
+}
+
+func (d *FakeNVMLDevice) GetProcessUtilization(lastSeen uint64) ([]gpu.ProcessUtilization, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	if d.UtilError != nil {
+		return nil, d.UtilError
+	}
+
+	utils := make([]gpu.ProcessUtilization, len(d.Utilization))
+	copy(utils, d.Utilization)
+	return utils, nil
+}
+
+func (d *FakeNVMLDevice) GetComputeMode() (ComputeMode, error) {
+	return d.Mode, nil
+}
+
+func (d *FakeNVMLDevice) IsMIGEnabled() (bool, error) {
+	return d.MIG, nil
+}
+
+func (d *FakeNVMLDevice) GetMIGInstances() ([]MIGInstance, error) {
+	return nil, nil
+}
+
+func (d *FakeNVMLDevice) GetMIGDeviceByInstanceID(gpuInstanceID uint) (NVMLDevice, error) {
+	return nil, fmt.Errorf("MIG not supported on fake device")
+}
+
+func (d *FakeNVMLDevice) GetMaxMigDeviceCount() (int, error) {
+	return 0, nil
+}

--- a/internal/device/gpu/nvidia/fake_backend_test.go
+++ b/internal/device/gpu/nvidia/fake_backend_test.go
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidia
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/sustainable-computing-io/kepler/internal/device"
+	"github.com/sustainable-computing-io/kepler/internal/device/gpu"
+)
+
+func TestFakeNVMLBackend_DiscoverDevices(t *testing.T) {
+	backend := NewFakeNVMLBackend(
+		&FakeNVMLDevice{Idx: 0, DeviceUUID: "FAKE-GPU-0000", DeviceName: "Fake GPU 0"},
+		&FakeNVMLDevice{Idx: 1, DeviceUUID: "FAKE-GPU-0001", DeviceName: "Fake GPU 1"},
+	)
+
+	assert.NoError(t, backend.Init())
+	assert.Equal(t, 2, backend.DeviceCount())
+
+	devices, err := backend.DiscoverDevices()
+	require.NoError(t, err)
+	assert.Len(t, devices, 2)
+	assert.Equal(t, "FAKE-GPU-0000", devices[0].UUID)
+	assert.Equal(t, gpu.VendorNVIDIA, devices[0].Vendor)
+
+	assert.NoError(t, backend.Shutdown())
+}
+
+func TestFakeNVMLBackend_GetDevice(t *testing.T) {
+	backend := NewFakeNVMLBackend(
+		&FakeNVMLDevice{Idx: 0, DeviceUUID: "FAKE-GPU-0000"},
+	)
+
+	dev, err := backend.GetDevice(0)
+	require.NoError(t, err)
+	assert.Equal(t, "FAKE-GPU-0000", dev.UUID())
+
+	_, err = backend.GetDevice(99)
+	assert.Error(t, err)
+	_, err = backend.GetDevice(-1)
+	assert.Error(t, err)
+}
+
+func TestFakeNVMLDeviceMetadataAndPower(t *testing.T) {
+	dev := &FakeNVMLDevice{
+		Idx:         1,
+		DeviceUUID:  "FAKE-GPU-0001",
+		DeviceName:  "Fake GPU 1",
+		DevicePower: 225 * device.Watt,
+		Mode:        ComputeModeExclusiveProcess,
+		MIG:         true,
+	}
+
+	assert.Equal(t, 1, dev.Index())
+	assert.Equal(t, "FAKE-GPU-0001", dev.UUID())
+	assert.Equal(t, "Fake GPU 1", dev.Name())
+	power, err := dev.GetPowerUsage()
+	require.NoError(t, err)
+	assert.Equal(t, 225*device.Watt, power)
+
+	mode, err := dev.GetComputeMode()
+	require.NoError(t, err)
+	assert.Equal(t, ComputeModeExclusiveProcess, mode)
+	migEnabled, err := dev.IsMIGEnabled()
+	require.NoError(t, err)
+	assert.True(t, migEnabled)
+	instances, err := dev.GetMIGInstances()
+	require.NoError(t, err)
+	assert.Nil(t, instances)
+	_, err = dev.GetMIGDeviceByInstanceID(0)
+	assert.ErrorContains(t, err, "MIG not supported")
+	maxDevices, err := dev.GetMaxMigDeviceCount()
+	require.NoError(t, err)
+	assert.Zero(t, maxDevices)
+}
+
+func TestFakeNVMLDeviceTotalEnergy(t *testing.T) {
+	now := time.Unix(1_000, 0)
+	dev := &FakeNVMLDevice{
+		DevicePower: 225 * device.Watt,
+		TotalEnergy: 10 * device.Joule,
+		now:         func() time.Time { return now },
+	}
+
+	energy, err := dev.GetTotalEnergy()
+	require.NoError(t, err)
+	assert.Equal(t, 10*device.Joule, energy, "first read establishes the energy baseline")
+	now = now.Add(3 * time.Second)
+	energy, err = dev.GetTotalEnergy()
+	require.NoError(t, err)
+	assert.Equal(t, 685*device.Joule, energy, "225 W over 3 s should add 675 J")
+}
+
+func TestFakeNVMLDeviceComputeRunningProcesses(t *testing.T) {
+	now := time.Unix(1_000, 0)
+	dev := &FakeNVMLDevice{
+		Idx:        1,
+		DeviceUUID: "FAKE-GPU-0001",
+		Processes:  []gpu.ProcessGPUInfo{{PID: 1001}},
+		now:        func() time.Time { return now },
+	}
+
+	processes, err := dev.GetComputeRunningProcesses()
+	require.NoError(t, err)
+	require.Len(t, processes, 1)
+	assert.Equal(t, 1, processes[0].DeviceIndex)
+	assert.Equal(t, "FAKE-GPU-0001", processes[0].DeviceUUID)
+	assert.Equal(t, now, processes[0].Timestamp)
+	processes[0].PID = 9999
+	assert.Equal(t, uint32(1001), dev.Processes[0].PID, "returned processes must be a copy")
+}
+
+func TestFakeNVMLDeviceProcessUtilization(t *testing.T) {
+	utilErr := errors.New("utilization unavailable")
+	dev := &FakeNVMLDevice{
+		Utilization: []gpu.ProcessUtilization{{PID: 1001, ComputeUtil: 80}},
+	}
+
+	utilization, err := dev.GetProcessUtilization(0)
+	require.NoError(t, err)
+	require.Len(t, utilization, 1)
+	utilization[0].PID = 9999
+	assert.Equal(t, uint32(1001), dev.Utilization[0].PID, "returned utilization must be a copy")
+
+	dev.UtilError = utilErr
+	_, err = dev.GetProcessUtilization(0)
+	assert.ErrorIs(t, err, utilErr)
+}
+
+// TestFakeNVMLBackend_ThroughRealCollector verifies the fake backend wires
+// correctly through the real GPUPowerCollector (Init + Devices + GetProcessPower).
+func TestFakeNVMLBackend_ThroughRealCollector(t *testing.T) {
+	backend := NewFakeNVMLBackend(&FakeNVMLDevice{
+		Idx:         0,
+		DeviceUUID:  "FAKE-GPU-0000",
+		DeviceName:  "Fake NVIDIA GPU",
+		DevicePower: 225 * device.Watt,
+		Mode:        ComputeModeDefault,
+		Processes: []gpu.ProcessGPUInfo{
+			{PID: 1001},
+		},
+		Utilization: []gpu.ProcessUtilization{
+			{PID: 1001, ComputeUtil: 80},
+		},
+	})
+
+	collector, err := NewGPUPowerCollector(slog.Default(), WithNVMLBackend(backend))
+	require.NoError(t, err)
+
+	err = collector.Init()
+	require.NoError(t, err)
+
+	// Verify devices discovered
+	assert.Len(t, collector.Devices(), 1)
+	assert.Equal(t, "FAKE-GPU-0000", collector.Devices()[0].UUID)
+
+	// Verify GetProcessPower returns data through the real collector logic
+	power, err := collector.GetProcessPower()
+	require.NoError(t, err)
+	assert.NotEmpty(t, power, "GetProcessPower should return data for fake process")
+	assert.Contains(t, power, uint32(1001))
+
+	assert.NoError(t, collector.Shutdown())
+}

--- a/manifests/helm/kepler/values.yaml
+++ b/manifests/helm/kepler/values.yaml
@@ -116,6 +116,10 @@ config:
     fake-cpu-meter:
       enabled: false # DEPRECATED: set cpu.preferredMeters: ["fake"] instead. Overrides cpu.preferredMeters and emits a deprecation warning when true.
       zones: []
+    fake-gpu-meter:
+      enabled: false
+      deviceCount: 1
+      sharingMode: time-slicing
   # EXPERIMENTAL FEATURES - These features are experimental and may be unstable
   # and are disabled by default
   experimental:

--- a/manifests/k8s/configmap.yaml
+++ b/manifests/k8s/configmap.yaml
@@ -51,6 +51,10 @@ data:
       fake-cpu-meter:
         enabled: false # DEPRECATED: set cpu.preferredMeters: ["fake"] instead. Overrides cpu.preferredMeters and emits a deprecation warning when true.
         zones: []
+      fake-gpu-meter:
+        enabled: false
+        deviceCount: 1
+        sharingMode: time-slicing
     # EXPERIMENTAL FEATURES - These features are experimental and may be unstable
     # and are disabled by default
     experimental:

--- a/test/e2e/gpu_test.go
+++ b/test/e2e/gpu_test.go
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/sustainable-computing-io/kepler/test/common"
+)
+
+// TODO: Give GPU e2e tests a fake-CPU setup so they can run on hosts without RAPL.
+
+// waitForGPUMetrics waits until Kepler exposes GPU node metrics.
+// This indicates the fake GPU backend has initialized and the monitor
+// has completed at least one refresh cycle with GPU data.
+func waitForGPUMetrics(t *testing.T, scraper *common.MetricsScraper, timeout time.Duration) bool {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	err := common.WaitForCondition(ctx, 2*time.Second, func() bool {
+		metrics, err := scraper.ScrapeMetric("kepler_node_gpu_watts")
+		return err == nil && len(metrics) > 0
+	})
+
+	return err == nil
+}
+
+// TestGPUNodeMetricsPresent verifies that GPU node-level metrics exist when
+// the fake GPU meter is enabled in e2e-config.yaml.
+func TestGPUNodeMetricsPresent(t *testing.T) {
+	_, scraper := setupKeplerForTest(t)
+
+	require.True(t, waitForGPUMetrics(t, scraper, 30*time.Second),
+		"Kepler should have GPU metrics when fake GPU meter is enabled")
+
+	snapshot, err := scraper.TakeSnapshot()
+	require.NoError(t, err, "Failed to take metrics snapshot")
+
+	gpuMetrics := []string{
+		"kepler_node_gpu_watts",
+		"kepler_node_gpu_idle_watts",
+		"kepler_node_gpu_active_watts",
+	}
+
+	for _, metric := range gpuMetrics {
+		assert.True(t, snapshot.HasMetric(metric),
+			"metric %s should exist when fake GPU meter is enabled", metric)
+	}
+
+	// GPU info metric should also be present
+	assert.True(t, snapshot.HasMetric("kepler_node_gpu_info"),
+		"kepler_node_gpu_info should exist when fake GPU meter is enabled")
+}
+
+// TestGPUNodeMetricsLabels verifies GPU node metrics have required labels.
+func TestGPUNodeMetricsLabels(t *testing.T) {
+	_, scraper := setupKeplerForTest(t)
+
+	require.True(t, waitForGPUMetrics(t, scraper, 30*time.Second),
+		"Kepler should have GPU metrics when fake GPU meter is enabled")
+
+	snapshot, err := scraper.TakeSnapshot()
+	require.NoError(t, err)
+
+	requiredLabels := []string{"gpu", "gpu_uuid", "gpu_name", "vendor"}
+
+	metrics := snapshot.GetAllWithName("kepler_node_gpu_watts")
+	require.NotEmpty(t, metrics)
+
+	for _, m := range metrics {
+		for _, label := range requiredLabels {
+			assert.Contains(t, m.Labels, label,
+				"kepler_node_gpu_watts should have %s label", label)
+		}
+	}
+}
+
+// TestGPUNodeMetricsNonNegative verifies all GPU power metric values are >= 0.
+func TestGPUNodeMetricsNonNegative(t *testing.T) {
+	_, scraper := setupKeplerForTest(t)
+
+	require.True(t, waitForGPUMetrics(t, scraper, 30*time.Second),
+		"Kepler should have GPU metrics when fake GPU meter is enabled")
+
+	snapshot, err := scraper.TakeSnapshot()
+	require.NoError(t, err)
+
+	gpuMetrics := []string{
+		"kepler_node_gpu_watts",
+		"kepler_node_gpu_idle_watts",
+		"kepler_node_gpu_active_watts",
+	}
+
+	for _, metricName := range gpuMetrics {
+		metrics := snapshot.GetAllWithName(metricName)
+		for _, m := range metrics {
+			assert.GreaterOrEqual(t, m.Value, float64(0),
+				"%s should be >= 0 (gpu=%s)", metricName, m.Labels["gpu"])
+		}
+	}
+}
+
+// TestGPUNodePowerConservation verifies: Total GPU Watts = Active + Idle.
+func TestGPUNodePowerConservation(t *testing.T) {
+	_, scraper := setupKeplerForTest(t)
+
+	require.True(t, waitForGPUMetrics(t, scraper, 30*time.Second),
+		"Kepler should have GPU metrics when fake GPU meter is enabled")
+
+	snapshot, err := scraper.TakeSnapshot()
+	require.NoError(t, err)
+
+	totalMetrics := snapshot.GetAllWithName("kepler_node_gpu_watts")
+	require.NotEmpty(t, totalMetrics)
+
+	activeMetrics := snapshot.GetAllWithName("kepler_node_gpu_active_watts")
+	idleMetrics := snapshot.GetAllWithName("kepler_node_gpu_idle_watts")
+
+	// Build maps by gpu label for matching
+	activeByGPU := make(map[string]float64)
+	for _, m := range activeMetrics {
+		activeByGPU[m.Labels["gpu"]] = m.Value
+	}
+	idleByGPU := make(map[string]float64)
+	for _, m := range idleMetrics {
+		idleByGPU[m.Labels["gpu"]] = m.Value
+	}
+
+	verified := 0
+	for _, m := range totalMetrics {
+		gpuLabel := m.Labels["gpu"]
+		active := activeByGPU[gpuLabel]
+		idle := idleByGPU[gpuLabel]
+		computed := active + idle
+
+		t.Logf("GPU %s: total=%.4f W, active=%.4f W, idle=%.4f W, computed=%.4f W",
+			gpuLabel, m.Value, active, idle, computed)
+
+		assertWithinTolerance(t, m.Value, computed, powerTolerance, absolutePowerTolerance,
+			"GPU %s: total (%.4f) should equal active + idle (%.4f)", gpuLabel, m.Value, computed)
+
+		verified++
+	}
+
+	assert.Greater(t, verified, 0, "Should verify at least one GPU power conservation")
+}

--- a/test/testdata/e2e-config.yaml
+++ b/test/testdata/e2e-config.yaml
@@ -28,3 +28,9 @@ web:
 # Disable Kubernetes integration for bare-metal testing
 kube:
   enabled: false
+# Enable fake GPU meter for e2e testing without GPU hardware
+dev:
+  fake-gpu-meter:
+    enabled: true
+    deviceCount: 1
+    sharingMode: time-slicing


### PR DESCRIPTION
This commit adds a FakeNVMLBackend that implements the NVMLBackend/NVMLDevice interfaces, enabling GPU feature development and e2e testing without real NVIDIA hardware.

- Add FakeNVMLBackend and FakeNVMLDevice in nvidia package
- Add WithNVMLBackend() collector option for backend injection
- Add dev.fake-gpu-meter config (enabled, deviceCount, sharingMode)
- Wire fake backend in createGPUMeters() when config is enabled
- Add bare-metal e2e GPU tests (metrics presence, labels, conservation)
- Add fake-gpu-meter config to all deployment manifests
- Update e2e testing docs with gpu_test.go