### PR TITLE
test(gpu): add e2e tests with fake NVML library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,19 @@ test-e2e: build ## Test e2e binary build (requires sudo to run)
 	@echo ""
 	@echo "Prerequisites: Intel RAPL, stress-ng (for workload tests)"
 
+# Build GPU e2e test binary (uses fake libnvidia-ml.so.1)
+.PHONY: test-e2e-gpu
+test-e2e-gpu: build ## Test GPU e2e binary build (no real GPU needed)
+	@echo "Building GPU e2e test binary..."
+	cd test/e2e && CGO_ENABLED=1 $(GOTEST) -race -c -o ../../$(BINARY_DIR)/kepler-e2e-gpu.test .
+	@echo ""
+	@echo "GPU e2e test binary built: $(BINARY_DIR)/kepler-e2e-gpu.test"
+	@echo ""
+	@echo "To run (requires root for RAPL access, no GPU needed):"
+	@echo "  sudo ./$(BINARY_DIR)/kepler-e2e-gpu.test -test.v -test.run TestGPU"
+	@echo ""
+	@echo "Prerequisites: Intel RAPL, gcc (for fake NVML build)"
+
 # Build and run k8s e2e tests
 .PHONY: test-e2e-k8s
 test-e2e-k8s: ## Test K8s e2e (requires: make cluster-up image deploy)

--- a/docs/developer/e2e-testing.md
+++ b/docs/developer/e2e-testing.md
@@ -10,6 +10,7 @@ End-to-end (e2e) tests verify that Kepler works correctly as a complete system. 
 | Type           | Location        | Purpose                                   | Requirements                     |
 |----------------|-----------------|-------------------------------------------|----------------------------------|
 | **Bare-metal** | `test/e2e/`     | Node and process metrics on real hardware | Intel RAPL, root access          |
+| **GPU**        | `test/e2e/`     | GPU metrics with fake NVML library        | gcc, root access (no GPU needed) |
 | **Kubernetes** | `test/e2e-k8s/` | Pod and container metrics in a cluster    | K8s cluster with Kepler deployed |
 
 Unlike unit tests that mock dependencies, e2e tests run the actual Kepler binary and verify metrics are correctly exposed.
@@ -357,6 +358,204 @@ func TestNewFeature(t *testing.T) {
     t.Logf("Found metric with value: %v", snapshot.GetAllWithName("kepler_new_metric"))
 }
 ```
+
+## GPU E2E Tests (Fake NVML)
+
+### What It Is
+
+GPU e2e tests verify Kepler's full GPU metrics pipeline — from NVML device discovery through power collection to Prometheus export — without requiring real NVIDIA hardware. They work by replacing the real `libnvidia-ml.so.1` shared library with a fake one that returns canned GPU data read from a JSON config file.
+
+This means the GPU code paths that are normally untestable in CI (because they require physical GPUs) can now be tested on any Linux machine with `gcc` and root access.
+
+### How It Works
+
+Kepler's GPU support relies on [go-nvml](https://github.com/NVIDIA/go-nvml), which loads `libnvidia-ml.so.1` at runtime via `dlopen`. go-nvml then resolves individual NVML functions (e.g. `nvmlDeviceGetPowerUsage`) via `dlsym`. The fake library exploits this dynamic loading:
+
+```text
+┌──────────────────┐     dlopen      ┌─────────────────────┐
+│     go-nvml      │ ──────────────► │  libnvidia-ml.so.1  │
+│  (Kepler's GPU   │     dlsym       │  (FAKE: reads JSON  │
+│   collector)     │ ◄────────────── │   from env var)     │
+└──────────────────┘                 └─────────────────────┘
+         │                                     ▲
+         │  LD_LIBRARY_PATH points             │ FAKE_NVML_CONFIG
+         │  to dir with fake .so               │ points to JSON
+         ▼                                     │
+┌──────────────────┐                 ┌─────────────────────┐
+│  Kepler binary   │                 │  fake_nvml_config   │
+│  exports GPU     │                 │  .json              │
+│  metrics via     │                 │  {"devices": [...]} │
+│  /metrics        │                 └─────────────────────┘
+└──────────────────┘
+```
+
+**Key mechanism**: The test sets `LD_LIBRARY_PATH` to a temp directory containing the fake `.so`, so `dlopen("libnvidia-ml.so.1")` loads the fake instead of looking for a real NVIDIA driver. The fake library reads device configuration from the path in `FAKE_NVML_CONFIG`.
+
+### Main Design Ideas
+
+1. **One fake library, many scenarios**: The same C shared library supports all test scenarios. Different JSON configs produce different GPU topologies (single GPU, multiple GPUs, with/without processes, idle vs. loaded).
+
+2. **Real PIDs for process attribution**: Tests start actual `sleep infinity` processes and use their real PIDs in the fake NVML config. This lets Kepler find them in `/proc`, exercising the full process-to-GPU attribution path.
+
+3. **Accurate C ABI compatibility**: The fake implements the exact C struct layouts and calling conventions from `nvml.h` that go-nvml expects, including version-negotiation symbols (v1/v2/v3 variants) and the two-call pattern for `GetProcessUtilization` (first call returns count, second fills buffer).
+
+4. **Simulated energy counters**: `nvmlDeviceGetTotalEnergyConsumption` returns `powerUsageMilliWatts × elapsed_seconds` since init using `CLOCK_MONOTONIC`, so energy increases monotonically just like real hardware.
+
+5. **No build tags or special flags**: GPU tests live in the same `test/e2e/` package as bare-metal tests and are selected via `-test.run TestGPU`.
+
+### File Layout
+
+```text
+test/e2e/
+├── fake_nvml/
+│   ├── fake_nvml.c          # Fake NVML C library (~420 lines, 44 exported symbols)
+│   ├── cJSON.c              # Vendored MIT-licensed JSON parser (github.com/DaveGamble/cJSON)
+│   └── cJSON.h
+├── gpu_helpers_test.go       # Build helpers, config presets, setup functions
+└── gpu_fake_test.go          # 7 GPU test cases
+```
+
+### JSON Config Format
+
+The fake NVML library reads configuration from the file pointed to by `FAKE_NVML_CONFIG`:
+
+```json
+{
+  "devices": [
+    {
+      "uuid": "GPU-FAKE-0000-0001",
+      "name": "NVIDIA Fake A100",
+      "powerUsageMilliWatts": 150000,
+      "computeMode": 0,
+      "migEnabled": false,
+      "maxMigDevices": 0,
+      "processes": [
+        {
+          "pid": 12345,
+          "memoryUsed": 1073741824,
+          "smUtil": 60
+        }
+      ]
+    }
+  ]
+}
+```
+
+| Field                  | Description                                               |
+|------------------------|-----------------------------------------------------------|
+| `uuid`                 | GPU UUID reported to Kepler                               |
+| `name`                 | GPU model name                                            |
+| `powerUsageMilliWatts` | Constant power draw in milliwatts                         |
+| `computeMode`          | 0=default (time-slicing), 1=exclusive thread, 3=exclusive |
+| `migEnabled`           | Whether MIG mode is active                                |
+| `maxMigDevices`        | Number of MIG device slots                                |
+| `processes`            | Array of GPU processes (use real PIDs from running procs) |
+
+### Test Cases
+
+| Test                                | What It Verifies                                                   |
+|-------------------------------------|--------------------------------------------------------------------|
+| `TestGPU_DeviceDiscovered`          | `kepler_node_gpu_info` exists with correct uuid/name/vendor labels |
+| `TestGPU_NodePowerMetrics`          | `kepler_node_gpu_watts` > 0 for the fake GPU                       |
+| `TestGPU_IdlePower`                 | No processes → active power ≈ 0, total power = idle power          |
+| `TestGPU_ProcessPowerAttribution`   | Real PID in fake config → `kepler_node_gpu_active_watts` > 0       |
+| `TestGPU_MultipleDevices`           | Two fake GPUs both appear in `kepler_node_gpu_info`                |
+| `TestGPU_EnergyIncreases`           | GPU power is consistently positive across two scrapes              |
+| `TestGPU_GracefulStartupWithoutGPU` | Kepler starts and serves CPU metrics even when NVML init fails     |
+
+### GPU Prerequisites
+
+- **gcc**: Required to compile `fake_nvml.c` at test time
+- **Root access**: Kepler needs root to read `/proc/*/exe` for all processes
+
+No GPU hardware, NVIDIA drivers, or CUDA toolkit required.
+
+### Running GPU E2E Tests
+
+```bash
+# Build Kepler binary + GPU e2e test binary
+make test-e2e-gpu
+
+# Run all GPU tests (requires root)
+sudo ./bin/kepler-e2e-gpu.test -test.v -test.run TestGPU
+
+# Run a single test
+sudo ./bin/kepler-e2e-gpu.test -test.v -test.run TestGPU_DeviceDiscovered
+
+# With timeout
+sudo ./bin/kepler-e2e-gpu.test -test.v -test.run TestGPU -test.timeout=3m
+```
+
+### GPU Metrics Tested
+
+| Metric                         | Type  | Labels                                  |
+|--------------------------------|-------|-----------------------------------------|
+| `kepler_node_gpu_info`         | Gauge | `gpu`, `gpu_uuid`, `gpu_name`, `vendor` |
+| `kepler_node_gpu_watts`        | Gauge | `gpu_uuid`                              |
+| `kepler_node_gpu_active_watts` | Gauge | `gpu_uuid`                              |
+
+### GPU Troubleshooting
+
+#### gcc Not Found
+
+**Error**: `Skipping GPU e2e test: gcc not found`
+
+**Solution**: Install gcc (`sudo dnf install gcc` or `sudo apt install gcc`)
+
+#### GPU Metrics Not Appearing
+
+If GPU metrics don't show up in scrapes, check the Kepler stderr output for:
+
+- `fake_nvml: loaded N device(s)` — confirms the fake library loaded the config
+- `discovered GPU` — confirms go-nvml found the fake device
+- `Exporting GPU metrics` — confirms the power collector is emitting GPU metrics
+- `Failed to collect power data` — indicates a Snapshot error (usually means not running as root)
+
+#### Port Conflict
+
+GPU tests use port **28283** (vs. 28282 for bare-metal tests) to avoid conflicts. If you see `bind: address already in use`, kill stale processes: `sudo pkill -f kepler-e2e`
+
+### Writing New GPU Tests
+
+```go
+func TestGPU_NewScenario(t *testing.T) {
+    skipIfNoGCC(t)
+
+    // Define GPU topology via JSON config
+    config := fakeNVMLConfig{
+        Devices: []fakeNVMLDevice{{
+            UUID:                 "GPU-FAKE-0000-0001",
+            Name:                 "NVIDIA Fake A100",
+            PowerUsageMilliWatts: 75000,
+        }},
+    }
+
+    // Start Kepler with fake NVML wired up
+    _, scraper := setupKeplerWithFakeGPU(t, config)
+
+    // Wait for GPU metrics to appear
+    require.True(t, waitForGPUMetrics(t, scraper, "kepler_node_gpu_watts", 30*time.Second))
+
+    // Scrape and assert
+    snapshot, err := scraper.TakeSnapshot()
+    require.NoError(t, err)
+
+    power := snapshot.SumValues("kepler_node_gpu_watts", nil)
+    assert.Greater(t, power, 0.0)
+}
+```
+
+Available helpers in `gpu_helpers_test.go`:
+
+| Helper                        | Purpose                                              |
+|-------------------------------|------------------------------------------------------|
+| `buildFakeNVML(t)`            | Compiles fake `.so`, returns directory path          |
+| `writeFakeNVMLConfig(t,c)`    | Writes JSON config, returns file path                |
+| `writeGPUKeplerConfig(t)`     | Writes Kepler YAML with GPU enabled + fake CPU meter |
+| `setupKeplerWithFakeGPU(t,c)` | One-call setup: build + config + start Kepler        |
+| `singleGPUIdle()`             | Preset: 1 GPU at 40W, no processes                   |
+| `singleGPUWithProcesses(p)`   | Preset: 1 GPU at 150W with given processes           |
+| `waitForGPUMetrics(t,s,m,d)`  | Polls until a named GPU metric appears               |
 
 ## Related Documentation
 

--- a/test/e2e/fake_nvml/cJSON.c
+++ b/test/e2e/fake_nvml/cJSON.c
@@ -1,0 +1,3143 @@
+/*
+  Copyright (c) 2009-2017 Dave Gamble and cJSON contributors
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+/* cJSON */
+/* JSON parser in C. */
+
+/* disable warnings about old C89 functions in MSVC */
+#if !defined(_CRT_SECURE_NO_DEPRECATE) && defined(_MSC_VER)
+#define _CRT_SECURE_NO_DEPRECATE
+#endif
+
+#ifdef __GNUC__
+#pragma GCC visibility push(default)
+#endif
+#if defined(_MSC_VER)
+#pragma warning (push)
+/* disable warning about single line comments in system headers */
+#pragma warning (disable : 4001)
+#endif
+
+#include <string.h>
+#include <stdio.h>
+#include <math.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <ctype.h>
+#include <float.h>
+
+#ifdef ENABLE_LOCALES
+#include <locale.h>
+#endif
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
+#ifdef __GNUC__
+#pragma GCC visibility pop
+#endif
+
+#include "cJSON.h"
+
+/* define our own boolean type */
+#ifdef true
+#undef true
+#endif
+#define true ((cJSON_bool)1)
+
+#ifdef false
+#undef false
+#endif
+#define false ((cJSON_bool)0)
+
+/* define isnan and isinf for ANSI C, if in C99 or above, isnan and isinf has been defined in math.h */
+#ifndef isinf
+#define isinf(d) (isnan((d - d)) && !isnan(d))
+#endif
+#ifndef isnan
+#define isnan(d) (d != d)
+#endif
+
+#ifndef NAN
+#ifdef _WIN32
+#define NAN sqrt(-1.0)
+#else
+#define NAN 0.0/0.0
+#endif
+#endif
+
+typedef struct {
+    const unsigned char *json;
+    size_t position;
+} error;
+static error global_error = { NULL, 0 };
+
+CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void)
+{
+    return (const char*) (global_error.json + global_error.position);
+}
+
+CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item)
+{
+    if (!cJSON_IsString(item))
+    {
+        return NULL;
+    }
+
+    return item->valuestring;
+}
+
+CJSON_PUBLIC(double) cJSON_GetNumberValue(const cJSON * const item)
+{
+    if (!cJSON_IsNumber(item))
+    {
+        return (double) NAN;
+    }
+
+    return item->valuedouble;
+}
+
+/* This is a safeguard to prevent copy-pasters from using incompatible C and header files */
+#if (CJSON_VERSION_MAJOR != 1) || (CJSON_VERSION_MINOR != 7) || (CJSON_VERSION_PATCH != 18)
+    #error cJSON.h and cJSON.c have different versions. Make sure that both have the same.
+#endif
+
+CJSON_PUBLIC(const char*) cJSON_Version(void)
+{
+    static char version[15];
+    sprintf(version, "%i.%i.%i", CJSON_VERSION_MAJOR, CJSON_VERSION_MINOR, CJSON_VERSION_PATCH);
+
+    return version;
+}
+
+/* Case insensitive string comparison, doesn't consider two NULL pointers equal though */
+static int case_insensitive_strcmp(const unsigned char *string1, const unsigned char *string2)
+{
+    if ((string1 == NULL) || (string2 == NULL))
+    {
+        return 1;
+    }
+
+    if (string1 == string2)
+    {
+        return 0;
+    }
+
+    for(; tolower(*string1) == tolower(*string2); (void)string1++, string2++)
+    {
+        if (*string1 == '\0')
+        {
+            return 0;
+        }
+    }
+
+    return tolower(*string1) - tolower(*string2);
+}
+
+typedef struct internal_hooks
+{
+    void *(CJSON_CDECL *allocate)(size_t size);
+    void (CJSON_CDECL *deallocate)(void *pointer);
+    void *(CJSON_CDECL *reallocate)(void *pointer, size_t size);
+} internal_hooks;
+
+#if defined(_MSC_VER)
+/* work around MSVC error C2322: '...' address of dllimport '...' is not static */
+static void * CJSON_CDECL internal_malloc(size_t size)
+{
+    return malloc(size);
+}
+static void CJSON_CDECL internal_free(void *pointer)
+{
+    free(pointer);
+}
+static void * CJSON_CDECL internal_realloc(void *pointer, size_t size)
+{
+    return realloc(pointer, size);
+}
+#else
+#define internal_malloc malloc
+#define internal_free free
+#define internal_realloc realloc
+#endif
+
+/* strlen of character literals resolved at compile time */
+#define static_strlen(string_literal) (sizeof(string_literal) - sizeof(""))
+
+static internal_hooks global_hooks = { internal_malloc, internal_free, internal_realloc };
+
+static unsigned char* cJSON_strdup(const unsigned char* string, const internal_hooks * const hooks)
+{
+    size_t length = 0;
+    unsigned char *copy = NULL;
+
+    if (string == NULL)
+    {
+        return NULL;
+    }
+
+    length = strlen((const char*)string) + sizeof("");
+    copy = (unsigned char*)hooks->allocate(length);
+    if (copy == NULL)
+    {
+        return NULL;
+    }
+    memcpy(copy, string, length);
+
+    return copy;
+}
+
+CJSON_PUBLIC(void) cJSON_InitHooks(cJSON_Hooks* hooks)
+{
+    if (hooks == NULL)
+    {
+        /* Reset hooks */
+        global_hooks.allocate = malloc;
+        global_hooks.deallocate = free;
+        global_hooks.reallocate = realloc;
+        return;
+    }
+
+    global_hooks.allocate = malloc;
+    if (hooks->malloc_fn != NULL)
+    {
+        global_hooks.allocate = hooks->malloc_fn;
+    }
+
+    global_hooks.deallocate = free;
+    if (hooks->free_fn != NULL)
+    {
+        global_hooks.deallocate = hooks->free_fn;
+    }
+
+    /* use realloc only if both free and malloc are used */
+    global_hooks.reallocate = NULL;
+    if ((global_hooks.allocate == malloc) && (global_hooks.deallocate == free))
+    {
+        global_hooks.reallocate = realloc;
+    }
+}
+
+/* Internal constructor. */
+static cJSON *cJSON_New_Item(const internal_hooks * const hooks)
+{
+    cJSON* node = (cJSON*)hooks->allocate(sizeof(cJSON));
+    if (node)
+    {
+        memset(node, '\0', sizeof(cJSON));
+    }
+
+    return node;
+}
+
+/* Delete a cJSON structure. */
+CJSON_PUBLIC(void) cJSON_Delete(cJSON *item)
+{
+    cJSON *next = NULL;
+    while (item != NULL)
+    {
+        next = item->next;
+        if (!(item->type & cJSON_IsReference) && (item->child != NULL))
+        {
+            cJSON_Delete(item->child);
+        }
+        if (!(item->type & cJSON_IsReference) && (item->valuestring != NULL))
+        {
+            global_hooks.deallocate(item->valuestring);
+            item->valuestring = NULL;
+        }
+        if (!(item->type & cJSON_StringIsConst) && (item->string != NULL))
+        {
+            global_hooks.deallocate(item->string);
+            item->string = NULL;
+        }
+        global_hooks.deallocate(item);
+        item = next;
+    }
+}
+
+/* get the decimal point character of the current locale */
+static unsigned char get_decimal_point(void)
+{
+#ifdef ENABLE_LOCALES
+    struct lconv *lconv = localeconv();
+    return (unsigned char) lconv->decimal_point[0];
+#else
+    return '.';
+#endif
+}
+
+typedef struct
+{
+    const unsigned char *content;
+    size_t length;
+    size_t offset;
+    size_t depth; /* How deeply nested (in arrays/objects) is the input at the current offset. */
+    internal_hooks hooks;
+} parse_buffer;
+
+/* check if the given size is left to read in a given parse buffer (starting with 1) */
+#define can_read(buffer, size) ((buffer != NULL) && (((buffer)->offset + size) <= (buffer)->length))
+/* check if the buffer can be accessed at the given index (starting with 0) */
+#define can_access_at_index(buffer, index) ((buffer != NULL) && (((buffer)->offset + index) < (buffer)->length))
+#define cannot_access_at_index(buffer, index) (!can_access_at_index(buffer, index))
+/* get a pointer to the buffer at the position */
+#define buffer_at_offset(buffer) ((buffer)->content + (buffer)->offset)
+
+/* Parse the input text to generate a number, and populate the result into item. */
+static cJSON_bool parse_number(cJSON * const item, parse_buffer * const input_buffer)
+{
+    double number = 0;
+    unsigned char *after_end = NULL;
+    unsigned char number_c_string[64];
+    unsigned char decimal_point = get_decimal_point();
+    size_t i = 0;
+
+    if ((input_buffer == NULL) || (input_buffer->content == NULL))
+    {
+        return false;
+    }
+
+    /* copy the number into a temporary buffer and replace '.' with the decimal point
+     * of the current locale (for strtod)
+     * This also takes care of '\0' not necessarily being available for marking the end of the input */
+    for (i = 0; (i < (sizeof(number_c_string) - 1)) && can_access_at_index(input_buffer, i); i++)
+    {
+        switch (buffer_at_offset(input_buffer)[i])
+        {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            case '+':
+            case '-':
+            case 'e':
+            case 'E':
+                number_c_string[i] = buffer_at_offset(input_buffer)[i];
+                break;
+
+            case '.':
+                number_c_string[i] = decimal_point;
+                break;
+
+            default:
+                goto loop_end;
+        }
+    }
+loop_end:
+    number_c_string[i] = '\0';
+
+    number = strtod((const char*)number_c_string, (char**)&after_end);
+    if (number_c_string == after_end)
+    {
+        return false; /* parse_error */
+    }
+
+    item->valuedouble = number;
+
+    /* use saturation in case of overflow */
+    if (number >= INT_MAX)
+    {
+        item->valueint = INT_MAX;
+    }
+    else if (number <= (double)INT_MIN)
+    {
+        item->valueint = INT_MIN;
+    }
+    else
+    {
+        item->valueint = (int)number;
+    }
+
+    item->type = cJSON_Number;
+
+    input_buffer->offset += (size_t)(after_end - number_c_string);
+    return true;
+}
+
+/* don't ask me, but the original cJSON_SetNumberValue returns an integer or double */
+CJSON_PUBLIC(double) cJSON_SetNumberHelper(cJSON *object, double number)
+{
+    if (number >= INT_MAX)
+    {
+        object->valueint = INT_MAX;
+    }
+    else if (number <= (double)INT_MIN)
+    {
+        object->valueint = INT_MIN;
+    }
+    else
+    {
+        object->valueint = (int)number;
+    }
+
+    return object->valuedouble = number;
+}
+
+/* Note: when passing a NULL valuestring, cJSON_SetValuestring treats this as an error and return NULL */
+CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring)
+{
+    char *copy = NULL;
+    /* if object's type is not cJSON_String or is cJSON_IsReference, it should not set valuestring */
+    if ((object == NULL) || !(object->type & cJSON_String) || (object->type & cJSON_IsReference))
+    {
+        return NULL;
+    }
+    /* return NULL if the object is corrupted or valuestring is NULL */
+    if (object->valuestring == NULL || valuestring == NULL)
+    {
+        return NULL;
+    }
+    if (strlen(valuestring) <= strlen(object->valuestring))
+    {
+        strcpy(object->valuestring, valuestring);
+        return object->valuestring;
+    }
+    copy = (char*) cJSON_strdup((const unsigned char*)valuestring, &global_hooks);
+    if (copy == NULL)
+    {
+        return NULL;
+    }
+    if (object->valuestring != NULL)
+    {
+        cJSON_free(object->valuestring);
+    }
+    object->valuestring = copy;
+
+    return copy;
+}
+
+typedef struct
+{
+    unsigned char *buffer;
+    size_t length;
+    size_t offset;
+    size_t depth; /* current nesting depth (for formatted printing) */
+    cJSON_bool noalloc;
+    cJSON_bool format; /* is this print a formatted print */
+    internal_hooks hooks;
+} printbuffer;
+
+/* realloc printbuffer if necessary to have at least "needed" bytes more */
+static unsigned char* ensure(printbuffer * const p, size_t needed)
+{
+    unsigned char *newbuffer = NULL;
+    size_t newsize = 0;
+
+    if ((p == NULL) || (p->buffer == NULL))
+    {
+        return NULL;
+    }
+
+    if ((p->length > 0) && (p->offset >= p->length))
+    {
+        /* make sure that offset is valid */
+        return NULL;
+    }
+
+    if (needed > INT_MAX)
+    {
+        /* sizes bigger than INT_MAX are currently not supported */
+        return NULL;
+    }
+
+    needed += p->offset + 1;
+    if (needed <= p->length)
+    {
+        return p->buffer + p->offset;
+    }
+
+    if (p->noalloc) {
+        return NULL;
+    }
+
+    /* calculate new buffer size */
+    if (needed > (INT_MAX / 2))
+    {
+        /* overflow of int, use INT_MAX if possible */
+        if (needed <= INT_MAX)
+        {
+            newsize = INT_MAX;
+        }
+        else
+        {
+            return NULL;
+        }
+    }
+    else
+    {
+        newsize = needed * 2;
+    }
+
+    if (p->hooks.reallocate != NULL)
+    {
+        /* reallocate with realloc if available */
+        newbuffer = (unsigned char*)p->hooks.reallocate(p->buffer, newsize);
+        if (newbuffer == NULL)
+        {
+            p->hooks.deallocate(p->buffer);
+            p->length = 0;
+            p->buffer = NULL;
+
+            return NULL;
+        }
+    }
+    else
+    {
+        /* otherwise reallocate manually */
+        newbuffer = (unsigned char*)p->hooks.allocate(newsize);
+        if (!newbuffer)
+        {
+            p->hooks.deallocate(p->buffer);
+            p->length = 0;
+            p->buffer = NULL;
+
+            return NULL;
+        }
+
+        memcpy(newbuffer, p->buffer, p->offset + 1);
+        p->hooks.deallocate(p->buffer);
+    }
+    p->length = newsize;
+    p->buffer = newbuffer;
+
+    return newbuffer + p->offset;
+}
+
+/* calculate the new length of the string in a printbuffer and update the offset */
+static void update_offset(printbuffer * const buffer)
+{
+    const unsigned char *buffer_pointer = NULL;
+    if ((buffer == NULL) || (buffer->buffer == NULL))
+    {
+        return;
+    }
+    buffer_pointer = buffer->buffer + buffer->offset;
+
+    buffer->offset += strlen((const char*)buffer_pointer);
+}
+
+/* securely comparison of floating-point variables */
+static cJSON_bool compare_double(double a, double b)
+{
+    double maxVal = fabs(a) > fabs(b) ? fabs(a) : fabs(b);
+    return (fabs(a - b) <= maxVal * DBL_EPSILON);
+}
+
+/* Render the number nicely from the given item into a string. */
+static cJSON_bool print_number(const cJSON * const item, printbuffer * const output_buffer)
+{
+    unsigned char *output_pointer = NULL;
+    double d = item->valuedouble;
+    int length = 0;
+    size_t i = 0;
+    unsigned char number_buffer[26] = {0}; /* temporary buffer to print the number into */
+    unsigned char decimal_point = get_decimal_point();
+    double test = 0.0;
+
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
+
+    /* This checks for NaN and Infinity */
+    if (isnan(d) || isinf(d))
+    {
+        length = sprintf((char*)number_buffer, "null");
+    }
+	else if(d == (double)item->valueint)
+	{
+		length = sprintf((char*)number_buffer, "%d", item->valueint);
+	}
+    else
+    {
+        /* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */
+        length = sprintf((char*)number_buffer, "%1.15g", d);
+
+        /* Check whether the original double can be recovered */
+        if ((sscanf((char*)number_buffer, "%lg", &test) != 1) || !compare_double((double)test, d))
+        {
+            /* If not, print with 17 decimal places of precision */
+            length = sprintf((char*)number_buffer, "%1.17g", d);
+        }
+    }
+
+    /* sprintf failed or buffer overrun occurred */
+    if ((length < 0) || (length > (int)(sizeof(number_buffer) - 1)))
+    {
+        return false;
+    }
+
+    /* reserve appropriate space in the output */
+    output_pointer = ensure(output_buffer, (size_t)length + sizeof(""));
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+
+    /* copy the printed number to the output and replace locale
+     * dependent decimal point with '.' */
+    for (i = 0; i < ((size_t)length); i++)
+    {
+        if (number_buffer[i] == decimal_point)
+        {
+            output_pointer[i] = '.';
+            continue;
+        }
+
+        output_pointer[i] = number_buffer[i];
+    }
+    output_pointer[i] = '\0';
+
+    output_buffer->offset += (size_t)length;
+
+    return true;
+}
+
+/* parse 4 digit hexadecimal number */
+static unsigned parse_hex4(const unsigned char * const input)
+{
+    unsigned int h = 0;
+    size_t i = 0;
+
+    for (i = 0; i < 4; i++)
+    {
+        /* parse digit */
+        if ((input[i] >= '0') && (input[i] <= '9'))
+        {
+            h += (unsigned int) input[i] - '0';
+        }
+        else if ((input[i] >= 'A') && (input[i] <= 'F'))
+        {
+            h += (unsigned int) 10 + input[i] - 'A';
+        }
+        else if ((input[i] >= 'a') && (input[i] <= 'f'))
+        {
+            h += (unsigned int) 10 + input[i] - 'a';
+        }
+        else /* invalid */
+        {
+            return 0;
+        }
+
+        if (i < 3)
+        {
+            /* shift left to make place for the next nibble */
+            h = h << 4;
+        }
+    }
+
+    return h;
+}
+
+/* converts a UTF-16 literal to UTF-8
+ * A literal can be one or two sequences of the form \uXXXX */
+static unsigned char utf16_literal_to_utf8(const unsigned char * const input_pointer, const unsigned char * const input_end, unsigned char **output_pointer)
+{
+    long unsigned int codepoint = 0;
+    unsigned int first_code = 0;
+    const unsigned char *first_sequence = input_pointer;
+    unsigned char utf8_length = 0;
+    unsigned char utf8_position = 0;
+    unsigned char sequence_length = 0;
+    unsigned char first_byte_mark = 0;
+
+    if ((input_end - first_sequence) < 6)
+    {
+        /* input ends unexpectedly */
+        goto fail;
+    }
+
+    /* get the first utf16 sequence */
+    first_code = parse_hex4(first_sequence + 2);
+
+    /* check that the code is valid */
+    if (((first_code >= 0xDC00) && (first_code <= 0xDFFF)))
+    {
+        goto fail;
+    }
+
+    /* UTF16 surrogate pair */
+    if ((first_code >= 0xD800) && (first_code <= 0xDBFF))
+    {
+        const unsigned char *second_sequence = first_sequence + 6;
+        unsigned int second_code = 0;
+        sequence_length = 12; /* \uXXXX\uXXXX */
+
+        if ((input_end - second_sequence) < 6)
+        {
+            /* input ends unexpectedly */
+            goto fail;
+        }
+
+        if ((second_sequence[0] != '\\') || (second_sequence[1] != 'u'))
+        {
+            /* missing second half of the surrogate pair */
+            goto fail;
+        }
+
+        /* get the second utf16 sequence */
+        second_code = parse_hex4(second_sequence + 2);
+        /* check that the code is valid */
+        if ((second_code < 0xDC00) || (second_code > 0xDFFF))
+        {
+            /* invalid second half of the surrogate pair */
+            goto fail;
+        }
+
+
+        /* calculate the unicode codepoint from the surrogate pair */
+        codepoint = 0x10000 + (((first_code & 0x3FF) << 10) | (second_code & 0x3FF));
+    }
+    else
+    {
+        sequence_length = 6; /* \uXXXX */
+        codepoint = first_code;
+    }
+
+    /* encode as UTF-8
+     * takes at maximum 4 bytes to encode:
+     * 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx */
+    if (codepoint < 0x80)
+    {
+        /* normal ascii, encoding 0xxxxxxx */
+        utf8_length = 1;
+    }
+    else if (codepoint < 0x800)
+    {
+        /* two bytes, encoding 110xxxxx 10xxxxxx */
+        utf8_length = 2;
+        first_byte_mark = 0xC0; /* 11000000 */
+    }
+    else if (codepoint < 0x10000)
+    {
+        /* three bytes, encoding 1110xxxx 10xxxxxx 10xxxxxx */
+        utf8_length = 3;
+        first_byte_mark = 0xE0; /* 11100000 */
+    }
+    else if (codepoint <= 0x10FFFF)
+    {
+        /* four bytes, encoding 1110xxxx 10xxxxxx 10xxxxxx 10xxxxxx */
+        utf8_length = 4;
+        first_byte_mark = 0xF0; /* 11110000 */
+    }
+    else
+    {
+        /* invalid unicode codepoint */
+        goto fail;
+    }
+
+    /* encode as utf8 */
+    for (utf8_position = (unsigned char)(utf8_length - 1); utf8_position > 0; utf8_position--)
+    {
+        /* 10xxxxxx */
+        (*output_pointer)[utf8_position] = (unsigned char)((codepoint | 0x80) & 0xBF);
+        codepoint >>= 6;
+    }
+    /* encode first byte */
+    if (utf8_length > 1)
+    {
+        (*output_pointer)[0] = (unsigned char)((codepoint | first_byte_mark) & 0xFF);
+    }
+    else
+    {
+        (*output_pointer)[0] = (unsigned char)(codepoint & 0x7F);
+    }
+
+    *output_pointer += utf8_length;
+
+    return sequence_length;
+
+fail:
+    return 0;
+}
+
+/* Parse the input text into an unescaped cinput, and populate item. */
+static cJSON_bool parse_string(cJSON * const item, parse_buffer * const input_buffer)
+{
+    const unsigned char *input_pointer = buffer_at_offset(input_buffer) + 1;
+    const unsigned char *input_end = buffer_at_offset(input_buffer) + 1;
+    unsigned char *output_pointer = NULL;
+    unsigned char *output = NULL;
+
+    /* not a string */
+    if (buffer_at_offset(input_buffer)[0] != '\"')
+    {
+        goto fail;
+    }
+
+    {
+        /* calculate approximate size of the output (overestimate) */
+        size_t allocation_length = 0;
+        size_t skipped_bytes = 0;
+        while (((size_t)(input_end - input_buffer->content) < input_buffer->length) && (*input_end != '\"'))
+        {
+            /* is escape sequence */
+            if (input_end[0] == '\\')
+            {
+                if ((size_t)(input_end + 1 - input_buffer->content) >= input_buffer->length)
+                {
+                    /* prevent buffer overflow when last input character is a backslash */
+                    goto fail;
+                }
+                skipped_bytes++;
+                input_end++;
+            }
+            input_end++;
+        }
+        if (((size_t)(input_end - input_buffer->content) >= input_buffer->length) || (*input_end != '\"'))
+        {
+            goto fail; /* string ended unexpectedly */
+        }
+
+        /* This is at most how much we need for the output */
+        allocation_length = (size_t) (input_end - buffer_at_offset(input_buffer)) - skipped_bytes;
+        output = (unsigned char*)input_buffer->hooks.allocate(allocation_length + sizeof(""));
+        if (output == NULL)
+        {
+            goto fail; /* allocation failure */
+        }
+    }
+
+    output_pointer = output;
+    /* loop through the string literal */
+    while (input_pointer < input_end)
+    {
+        if (*input_pointer != '\\')
+        {
+            *output_pointer++ = *input_pointer++;
+        }
+        /* escape sequence */
+        else
+        {
+            unsigned char sequence_length = 2;
+            if ((input_end - input_pointer) < 1)
+            {
+                goto fail;
+            }
+
+            switch (input_pointer[1])
+            {
+                case 'b':
+                    *output_pointer++ = '\b';
+                    break;
+                case 'f':
+                    *output_pointer++ = '\f';
+                    break;
+                case 'n':
+                    *output_pointer++ = '\n';
+                    break;
+                case 'r':
+                    *output_pointer++ = '\r';
+                    break;
+                case 't':
+                    *output_pointer++ = '\t';
+                    break;
+                case '\"':
+                case '\\':
+                case '/':
+                    *output_pointer++ = input_pointer[1];
+                    break;
+
+                /* UTF-16 literal */
+                case 'u':
+                    sequence_length = utf16_literal_to_utf8(input_pointer, input_end, &output_pointer);
+                    if (sequence_length == 0)
+                    {
+                        /* failed to convert UTF16-literal to UTF-8 */
+                        goto fail;
+                    }
+                    break;
+
+                default:
+                    goto fail;
+            }
+            input_pointer += sequence_length;
+        }
+    }
+
+    /* zero terminate the output */
+    *output_pointer = '\0';
+
+    item->type = cJSON_String;
+    item->valuestring = (char*)output;
+
+    input_buffer->offset = (size_t) (input_end - input_buffer->content);
+    input_buffer->offset++;
+
+    return true;
+
+fail:
+    if (output != NULL)
+    {
+        input_buffer->hooks.deallocate(output);
+        output = NULL;
+    }
+
+    if (input_pointer != NULL)
+    {
+        input_buffer->offset = (size_t)(input_pointer - input_buffer->content);
+    }
+
+    return false;
+}
+
+/* Render the cstring provided to an escaped version that can be printed. */
+static cJSON_bool print_string_ptr(const unsigned char * const input, printbuffer * const output_buffer)
+{
+    const unsigned char *input_pointer = NULL;
+    unsigned char *output = NULL;
+    unsigned char *output_pointer = NULL;
+    size_t output_length = 0;
+    /* numbers of additional characters needed for escaping */
+    size_t escape_characters = 0;
+
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
+
+    /* empty string */
+    if (input == NULL)
+    {
+        output = ensure(output_buffer, sizeof("\"\""));
+        if (output == NULL)
+        {
+            return false;
+        }
+        strcpy((char*)output, "\"\"");
+
+        return true;
+    }
+
+    /* set "flag" to 1 if something needs to be escaped */
+    for (input_pointer = input; *input_pointer; input_pointer++)
+    {
+        switch (*input_pointer)
+        {
+            case '\"':
+            case '\\':
+            case '\b':
+            case '\f':
+            case '\n':
+            case '\r':
+            case '\t':
+                /* one character escape sequence */
+                escape_characters++;
+                break;
+            default:
+                if (*input_pointer < 32)
+                {
+                    /* UTF-16 escape sequence uXXXX */
+                    escape_characters += 5;
+                }
+                break;
+        }
+    }
+    output_length = (size_t)(input_pointer - input) + escape_characters;
+
+    output = ensure(output_buffer, output_length + sizeof("\"\""));
+    if (output == NULL)
+    {
+        return false;
+    }
+
+    /* no characters have to be escaped */
+    if (escape_characters == 0)
+    {
+        output[0] = '\"';
+        memcpy(output + 1, input, output_length);
+        output[output_length + 1] = '\"';
+        output[output_length + 2] = '\0';
+
+        return true;
+    }
+
+    output[0] = '\"';
+    output_pointer = output + 1;
+    /* copy the string */
+    for (input_pointer = input; *input_pointer != '\0'; (void)input_pointer++, output_pointer++)
+    {
+        if ((*input_pointer > 31) && (*input_pointer != '\"') && (*input_pointer != '\\'))
+        {
+            /* normal character, copy */
+            *output_pointer = *input_pointer;
+        }
+        else
+        {
+            /* character needs to be escaped */
+            *output_pointer++ = '\\';
+            switch (*input_pointer)
+            {
+                case '\\':
+                    *output_pointer = '\\';
+                    break;
+                case '\"':
+                    *output_pointer = '\"';
+                    break;
+                case '\b':
+                    *output_pointer = 'b';
+                    break;
+                case '\f':
+                    *output_pointer = 'f';
+                    break;
+                case '\n':
+                    *output_pointer = 'n';
+                    break;
+                case '\r':
+                    *output_pointer = 'r';
+                    break;
+                case '\t':
+                    *output_pointer = 't';
+                    break;
+                default:
+                    /* escape and print as unicode codepoint */
+                    sprintf((char*)output_pointer, "u%04x", *input_pointer);
+                    output_pointer += 4;
+                    break;
+            }
+        }
+    }
+    output[output_length + 1] = '\"';
+    output[output_length + 2] = '\0';
+
+    return true;
+}
+
+/* Invoke print_string_ptr (which is useful) on an item. */
+static cJSON_bool print_string(const cJSON * const item, printbuffer * const p)
+{
+    return print_string_ptr((unsigned char*)item->valuestring, p);
+}
+
+/* Predeclare these prototypes. */
+static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buffer);
+static cJSON_bool print_value(const cJSON * const item, printbuffer * const output_buffer);
+static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buffer);
+static cJSON_bool print_array(const cJSON * const item, printbuffer * const output_buffer);
+static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_buffer);
+static cJSON_bool print_object(const cJSON * const item, printbuffer * const output_buffer);
+
+/* Utility to jump whitespace and cr/lf */
+static parse_buffer *buffer_skip_whitespace(parse_buffer * const buffer)
+{
+    if ((buffer == NULL) || (buffer->content == NULL))
+    {
+        return NULL;
+    }
+
+    if (cannot_access_at_index(buffer, 0))
+    {
+        return buffer;
+    }
+
+    while (can_access_at_index(buffer, 0) && (buffer_at_offset(buffer)[0] <= 32))
+    {
+       buffer->offset++;
+    }
+
+    if (buffer->offset == buffer->length)
+    {
+        buffer->offset--;
+    }
+
+    return buffer;
+}
+
+/* skip the UTF-8 BOM (byte order mark) if it is at the beginning of a buffer */
+static parse_buffer *skip_utf8_bom(parse_buffer * const buffer)
+{
+    if ((buffer == NULL) || (buffer->content == NULL) || (buffer->offset != 0))
+    {
+        return NULL;
+    }
+
+    if (can_access_at_index(buffer, 4) && (strncmp((const char*)buffer_at_offset(buffer), "\xEF\xBB\xBF", 3) == 0))
+    {
+        buffer->offset += 3;
+    }
+
+    return buffer;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated)
+{
+    size_t buffer_length;
+
+    if (NULL == value)
+    {
+        return NULL;
+    }
+
+    /* Adding null character size due to require_null_terminated. */
+    buffer_length = strlen(value) + sizeof("");
+
+    return cJSON_ParseWithLengthOpts(value, buffer_length, return_parse_end, require_null_terminated);
+}
+
+/* Parse an object - create a new root, and populate. */
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLengthOpts(const char *value, size_t buffer_length, const char **return_parse_end, cJSON_bool require_null_terminated)
+{
+    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
+    cJSON *item = NULL;
+
+    /* reset error position */
+    global_error.json = NULL;
+    global_error.position = 0;
+
+    if (value == NULL || 0 == buffer_length)
+    {
+        goto fail;
+    }
+
+    buffer.content = (const unsigned char*)value;
+    buffer.length = buffer_length;
+    buffer.offset = 0;
+    buffer.hooks = global_hooks;
+
+    item = cJSON_New_Item(&global_hooks);
+    if (item == NULL) /* memory fail */
+    {
+        goto fail;
+    }
+
+    if (!parse_value(item, buffer_skip_whitespace(skip_utf8_bom(&buffer))))
+    {
+        /* parse failure. ep is set. */
+        goto fail;
+    }
+
+    /* if we require null-terminated JSON without appended garbage, skip and then check for a null terminator */
+    if (require_null_terminated)
+    {
+        buffer_skip_whitespace(&buffer);
+        if ((buffer.offset >= buffer.length) || buffer_at_offset(&buffer)[0] != '\0')
+        {
+            goto fail;
+        }
+    }
+    if (return_parse_end)
+    {
+        *return_parse_end = (const char*)buffer_at_offset(&buffer);
+    }
+
+    return item;
+
+fail:
+    if (item != NULL)
+    {
+        cJSON_Delete(item);
+    }
+
+    if (value != NULL)
+    {
+        error local_error;
+        local_error.json = (const unsigned char*)value;
+        local_error.position = 0;
+
+        if (buffer.offset < buffer.length)
+        {
+            local_error.position = buffer.offset;
+        }
+        else if (buffer.length > 0)
+        {
+            local_error.position = buffer.length - 1;
+        }
+
+        if (return_parse_end != NULL)
+        {
+            *return_parse_end = (const char*)local_error.json + local_error.position;
+        }
+
+        global_error = local_error;
+    }
+
+    return NULL;
+}
+
+/* Default options for cJSON_Parse */
+CJSON_PUBLIC(cJSON *) cJSON_Parse(const char *value)
+{
+    return cJSON_ParseWithOpts(value, 0, 0);
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLength(const char *value, size_t buffer_length)
+{
+    return cJSON_ParseWithLengthOpts(value, buffer_length, 0, 0);
+}
+
+#define cjson_min(a, b) (((a) < (b)) ? (a) : (b))
+
+static unsigned char *print(const cJSON * const item, cJSON_bool format, const internal_hooks * const hooks)
+{
+    static const size_t default_buffer_size = 256;
+    printbuffer buffer[1];
+    unsigned char *printed = NULL;
+
+    memset(buffer, 0, sizeof(buffer));
+
+    /* create buffer */
+    buffer->buffer = (unsigned char*) hooks->allocate(default_buffer_size);
+    buffer->length = default_buffer_size;
+    buffer->format = format;
+    buffer->hooks = *hooks;
+    if (buffer->buffer == NULL)
+    {
+        goto fail;
+    }
+
+    /* print the value */
+    if (!print_value(item, buffer))
+    {
+        goto fail;
+    }
+    update_offset(buffer);
+
+    /* check if reallocate is available */
+    if (hooks->reallocate != NULL)
+    {
+        printed = (unsigned char*) hooks->reallocate(buffer->buffer, buffer->offset + 1);
+        if (printed == NULL) {
+            goto fail;
+        }
+        buffer->buffer = NULL;
+    }
+    else /* otherwise copy the JSON over to a new buffer */
+    {
+        printed = (unsigned char*) hooks->allocate(buffer->offset + 1);
+        if (printed == NULL)
+        {
+            goto fail;
+        }
+        memcpy(printed, buffer->buffer, cjson_min(buffer->length, buffer->offset + 1));
+        printed[buffer->offset] = '\0'; /* just to be sure */
+
+        /* free the buffer */
+        hooks->deallocate(buffer->buffer);
+        buffer->buffer = NULL;
+    }
+
+    return printed;
+
+fail:
+    if (buffer->buffer != NULL)
+    {
+        hooks->deallocate(buffer->buffer);
+        buffer->buffer = NULL;
+    }
+
+    if (printed != NULL)
+    {
+        hooks->deallocate(printed);
+        printed = NULL;
+    }
+
+    return NULL;
+}
+
+/* Render a cJSON item/entity/structure to text. */
+CJSON_PUBLIC(char *) cJSON_Print(const cJSON *item)
+{
+    return (char*)print(item, true, &global_hooks);
+}
+
+CJSON_PUBLIC(char *) cJSON_PrintUnformatted(const cJSON *item)
+{
+    return (char*)print(item, false, &global_hooks);
+}
+
+CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON_bool fmt)
+{
+    printbuffer p = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
+
+    if (prebuffer < 0)
+    {
+        return NULL;
+    }
+
+    p.buffer = (unsigned char*)global_hooks.allocate((size_t)prebuffer);
+    if (!p.buffer)
+    {
+        return NULL;
+    }
+
+    p.length = (size_t)prebuffer;
+    p.offset = 0;
+    p.noalloc = false;
+    p.format = fmt;
+    p.hooks = global_hooks;
+
+    if (!print_value(item, &p))
+    {
+        global_hooks.deallocate(p.buffer);
+        p.buffer = NULL;
+        return NULL;
+    }
+
+    return (char*)p.buffer;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format)
+{
+    printbuffer p = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
+
+    if ((length < 0) || (buffer == NULL))
+    {
+        return false;
+    }
+
+    p.buffer = (unsigned char*)buffer;
+    p.length = (size_t)length;
+    p.offset = 0;
+    p.noalloc = true;
+    p.format = format;
+    p.hooks = global_hooks;
+
+    return print_value(item, &p);
+}
+
+/* Parser core - when encountering text, process appropriately. */
+static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buffer)
+{
+    if ((input_buffer == NULL) || (input_buffer->content == NULL))
+    {
+        return false; /* no input */
+    }
+
+    /* parse the different types of values */
+    /* null */
+    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "null", 4) == 0))
+    {
+        item->type = cJSON_NULL;
+        input_buffer->offset += 4;
+        return true;
+    }
+    /* false */
+    if (can_read(input_buffer, 5) && (strncmp((const char*)buffer_at_offset(input_buffer), "false", 5) == 0))
+    {
+        item->type = cJSON_False;
+        input_buffer->offset += 5;
+        return true;
+    }
+    /* true */
+    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "true", 4) == 0))
+    {
+        item->type = cJSON_True;
+        item->valueint = 1;
+        input_buffer->offset += 4;
+        return true;
+    }
+    /* string */
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '\"'))
+    {
+        return parse_string(item, input_buffer);
+    }
+    /* number */
+    if (can_access_at_index(input_buffer, 0) && ((buffer_at_offset(input_buffer)[0] == '-') || ((buffer_at_offset(input_buffer)[0] >= '0') && (buffer_at_offset(input_buffer)[0] <= '9'))))
+    {
+        return parse_number(item, input_buffer);
+    }
+    /* array */
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '['))
+    {
+        return parse_array(item, input_buffer);
+    }
+    /* object */
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '{'))
+    {
+        return parse_object(item, input_buffer);
+    }
+
+    return false;
+}
+
+/* Render a value to text. */
+static cJSON_bool print_value(const cJSON * const item, printbuffer * const output_buffer)
+{
+    unsigned char *output = NULL;
+
+    if ((item == NULL) || (output_buffer == NULL))
+    {
+        return false;
+    }
+
+    switch ((item->type) & 0xFF)
+    {
+        case cJSON_NULL:
+            output = ensure(output_buffer, 5);
+            if (output == NULL)
+            {
+                return false;
+            }
+            strcpy((char*)output, "null");
+            return true;
+
+        case cJSON_False:
+            output = ensure(output_buffer, 6);
+            if (output == NULL)
+            {
+                return false;
+            }
+            strcpy((char*)output, "false");
+            return true;
+
+        case cJSON_True:
+            output = ensure(output_buffer, 5);
+            if (output == NULL)
+            {
+                return false;
+            }
+            strcpy((char*)output, "true");
+            return true;
+
+        case cJSON_Number:
+            return print_number(item, output_buffer);
+
+        case cJSON_Raw:
+        {
+            size_t raw_length = 0;
+            if (item->valuestring == NULL)
+            {
+                return false;
+            }
+
+            raw_length = strlen(item->valuestring) + sizeof("");
+            output = ensure(output_buffer, raw_length);
+            if (output == NULL)
+            {
+                return false;
+            }
+            memcpy(output, item->valuestring, raw_length);
+            return true;
+        }
+
+        case cJSON_String:
+            return print_string(item, output_buffer);
+
+        case cJSON_Array:
+            return print_array(item, output_buffer);
+
+        case cJSON_Object:
+            return print_object(item, output_buffer);
+
+        default:
+            return false;
+    }
+}
+
+/* Build an array from input text. */
+static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buffer)
+{
+    cJSON *head = NULL; /* head of the linked list */
+    cJSON *current_item = NULL;
+
+    if (input_buffer->depth >= CJSON_NESTING_LIMIT)
+    {
+        return false; /* to deeply nested */
+    }
+    input_buffer->depth++;
+
+    if (buffer_at_offset(input_buffer)[0] != '[')
+    {
+        /* not an array */
+        goto fail;
+    }
+
+    input_buffer->offset++;
+    buffer_skip_whitespace(input_buffer);
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ']'))
+    {
+        /* empty array */
+        goto success;
+    }
+
+    /* check if we skipped to the end of the buffer */
+    if (cannot_access_at_index(input_buffer, 0))
+    {
+        input_buffer->offset--;
+        goto fail;
+    }
+
+    /* step back to character in front of the first element */
+    input_buffer->offset--;
+    /* loop through the comma separated array elements */
+    do
+    {
+        /* allocate next item */
+        cJSON *new_item = cJSON_New_Item(&(input_buffer->hooks));
+        if (new_item == NULL)
+        {
+            goto fail; /* allocation failure */
+        }
+
+        /* attach next item to list */
+        if (head == NULL)
+        {
+            /* start the linked list */
+            current_item = head = new_item;
+        }
+        else
+        {
+            /* add to the end and advance */
+            current_item->next = new_item;
+            new_item->prev = current_item;
+            current_item = new_item;
+        }
+
+        /* parse next value */
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        if (!parse_value(current_item, input_buffer))
+        {
+            goto fail; /* failed to parse value */
+        }
+        buffer_skip_whitespace(input_buffer);
+    }
+    while (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ','));
+
+    if (cannot_access_at_index(input_buffer, 0) || buffer_at_offset(input_buffer)[0] != ']')
+    {
+        goto fail; /* expected end of array */
+    }
+
+success:
+    input_buffer->depth--;
+
+    if (head != NULL) {
+        head->prev = current_item;
+    }
+
+    item->type = cJSON_Array;
+    item->child = head;
+
+    input_buffer->offset++;
+
+    return true;
+
+fail:
+    if (head != NULL)
+    {
+        cJSON_Delete(head);
+    }
+
+    return false;
+}
+
+/* Render an array to text */
+static cJSON_bool print_array(const cJSON * const item, printbuffer * const output_buffer)
+{
+    unsigned char *output_pointer = NULL;
+    size_t length = 0;
+    cJSON *current_element = item->child;
+
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
+
+    /* Compose the output array. */
+    /* opening square bracket */
+    output_pointer = ensure(output_buffer, 1);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+
+    *output_pointer = '[';
+    output_buffer->offset++;
+    output_buffer->depth++;
+
+    while (current_element != NULL)
+    {
+        if (!print_value(current_element, output_buffer))
+        {
+            return false;
+        }
+        update_offset(output_buffer);
+        if (current_element->next)
+        {
+            length = (size_t) (output_buffer->format ? 2 : 1);
+            output_pointer = ensure(output_buffer, length + 1);
+            if (output_pointer == NULL)
+            {
+                return false;
+            }
+            *output_pointer++ = ',';
+            if(output_buffer->format)
+            {
+                *output_pointer++ = ' ';
+            }
+            *output_pointer = '\0';
+            output_buffer->offset += length;
+        }
+        current_element = current_element->next;
+    }
+
+    output_pointer = ensure(output_buffer, 2);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+    *output_pointer++ = ']';
+    *output_pointer = '\0';
+    output_buffer->depth--;
+
+    return true;
+}
+
+/* Build an object from the text. */
+static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_buffer)
+{
+    cJSON *head = NULL; /* linked list head */
+    cJSON *current_item = NULL;
+
+    if (input_buffer->depth >= CJSON_NESTING_LIMIT)
+    {
+        return false; /* to deeply nested */
+    }
+    input_buffer->depth++;
+
+    if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '{'))
+    {
+        goto fail; /* not an object */
+    }
+
+    input_buffer->offset++;
+    buffer_skip_whitespace(input_buffer);
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '}'))
+    {
+        goto success; /* empty object */
+    }
+
+    /* check if we skipped to the end of the buffer */
+    if (cannot_access_at_index(input_buffer, 0))
+    {
+        input_buffer->offset--;
+        goto fail;
+    }
+
+    /* step back to character in front of the first element */
+    input_buffer->offset--;
+    /* loop through the comma separated array elements */
+    do
+    {
+        /* allocate next item */
+        cJSON *new_item = cJSON_New_Item(&(input_buffer->hooks));
+        if (new_item == NULL)
+        {
+            goto fail; /* allocation failure */
+        }
+
+        /* attach next item to list */
+        if (head == NULL)
+        {
+            /* start the linked list */
+            current_item = head = new_item;
+        }
+        else
+        {
+            /* add to the end and advance */
+            current_item->next = new_item;
+            new_item->prev = current_item;
+            current_item = new_item;
+        }
+
+        if (cannot_access_at_index(input_buffer, 1))
+        {
+            goto fail; /* nothing comes after the comma */
+        }
+
+        /* parse the name of the child */
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        if (!parse_string(current_item, input_buffer))
+        {
+            goto fail; /* failed to parse name */
+        }
+        buffer_skip_whitespace(input_buffer);
+
+        /* swap valuestring and string, because we parsed the name */
+        current_item->string = current_item->valuestring;
+        current_item->valuestring = NULL;
+
+        if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != ':'))
+        {
+            goto fail; /* invalid object */
+        }
+
+        /* parse the value */
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        if (!parse_value(current_item, input_buffer))
+        {
+            goto fail; /* failed to parse value */
+        }
+        buffer_skip_whitespace(input_buffer);
+    }
+    while (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ','));
+
+    if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '}'))
+    {
+        goto fail; /* expected end of object */
+    }
+
+success:
+    input_buffer->depth--;
+
+    if (head != NULL) {
+        head->prev = current_item;
+    }
+
+    item->type = cJSON_Object;
+    item->child = head;
+
+    input_buffer->offset++;
+    return true;
+
+fail:
+    if (head != NULL)
+    {
+        cJSON_Delete(head);
+    }
+
+    return false;
+}
+
+/* Render an object to text. */
+static cJSON_bool print_object(const cJSON * const item, printbuffer * const output_buffer)
+{
+    unsigned char *output_pointer = NULL;
+    size_t length = 0;
+    cJSON *current_item = item->child;
+
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
+
+    /* Compose the output: */
+    length = (size_t) (output_buffer->format ? 2 : 1); /* fmt: {\n */
+    output_pointer = ensure(output_buffer, length + 1);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+
+    *output_pointer++ = '{';
+    output_buffer->depth++;
+    if (output_buffer->format)
+    {
+        *output_pointer++ = '\n';
+    }
+    output_buffer->offset += length;
+
+    while (current_item)
+    {
+        if (output_buffer->format)
+        {
+            size_t i;
+            output_pointer = ensure(output_buffer, output_buffer->depth);
+            if (output_pointer == NULL)
+            {
+                return false;
+            }
+            for (i = 0; i < output_buffer->depth; i++)
+            {
+                *output_pointer++ = '\t';
+            }
+            output_buffer->offset += output_buffer->depth;
+        }
+
+        /* print key */
+        if (!print_string_ptr((unsigned char*)current_item->string, output_buffer))
+        {
+            return false;
+        }
+        update_offset(output_buffer);
+
+        length = (size_t) (output_buffer->format ? 2 : 1);
+        output_pointer = ensure(output_buffer, length);
+        if (output_pointer == NULL)
+        {
+            return false;
+        }
+        *output_pointer++ = ':';
+        if (output_buffer->format)
+        {
+            *output_pointer++ = '\t';
+        }
+        output_buffer->offset += length;
+
+        /* print value */
+        if (!print_value(current_item, output_buffer))
+        {
+            return false;
+        }
+        update_offset(output_buffer);
+
+        /* print comma if not last */
+        length = ((size_t)(output_buffer->format ? 1 : 0) + (size_t)(current_item->next ? 1 : 0));
+        output_pointer = ensure(output_buffer, length + 1);
+        if (output_pointer == NULL)
+        {
+            return false;
+        }
+        if (current_item->next)
+        {
+            *output_pointer++ = ',';
+        }
+
+        if (output_buffer->format)
+        {
+            *output_pointer++ = '\n';
+        }
+        *output_pointer = '\0';
+        output_buffer->offset += length;
+
+        current_item = current_item->next;
+    }
+
+    output_pointer = ensure(output_buffer, output_buffer->format ? (output_buffer->depth + 1) : 2);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+    if (output_buffer->format)
+    {
+        size_t i;
+        for (i = 0; i < (output_buffer->depth - 1); i++)
+        {
+            *output_pointer++ = '\t';
+        }
+    }
+    *output_pointer++ = '}';
+    *output_pointer = '\0';
+    output_buffer->depth--;
+
+    return true;
+}
+
+/* Get Array size/item / object item. */
+CJSON_PUBLIC(int) cJSON_GetArraySize(const cJSON *array)
+{
+    cJSON *child = NULL;
+    size_t size = 0;
+
+    if (array == NULL)
+    {
+        return 0;
+    }
+
+    child = array->child;
+
+    while(child != NULL)
+    {
+        size++;
+        child = child->next;
+    }
+
+    /* FIXME: Can overflow here. Cannot be fixed without breaking the API */
+
+    return (int)size;
+}
+
+static cJSON* get_array_item(const cJSON *array, size_t index)
+{
+    cJSON *current_child = NULL;
+
+    if (array == NULL)
+    {
+        return NULL;
+    }
+
+    current_child = array->child;
+    while ((current_child != NULL) && (index > 0))
+    {
+        index--;
+        current_child = current_child->next;
+    }
+
+    return current_child;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_GetArrayItem(const cJSON *array, int index)
+{
+    if (index < 0)
+    {
+        return NULL;
+    }
+
+    return get_array_item(array, (size_t)index);
+}
+
+static cJSON *get_object_item(const cJSON * const object, const char * const name, const cJSON_bool case_sensitive)
+{
+    cJSON *current_element = NULL;
+
+    if ((object == NULL) || (name == NULL))
+    {
+        return NULL;
+    }
+
+    current_element = object->child;
+    if (case_sensitive)
+    {
+        while ((current_element != NULL) && (current_element->string != NULL) && (strcmp(name, current_element->string) != 0))
+        {
+            current_element = current_element->next;
+        }
+    }
+    else
+    {
+        while ((current_element != NULL) && (case_insensitive_strcmp((const unsigned char*)name, (const unsigned char*)(current_element->string)) != 0))
+        {
+            current_element = current_element->next;
+        }
+    }
+
+    if ((current_element == NULL) || (current_element->string == NULL)) {
+        return NULL;
+    }
+
+    return current_element;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON * const object, const char * const string)
+{
+    return get_object_item(object, string, false);
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitive(const cJSON * const object, const char * const string)
+{
+    return get_object_item(object, string, true);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON *object, const char *string)
+{
+    return cJSON_GetObjectItem(object, string) ? 1 : 0;
+}
+
+/* Utility for array list handling. */
+static void suffix_object(cJSON *prev, cJSON *item)
+{
+    prev->next = item;
+    item->prev = prev;
+}
+
+/* Utility for handling references. */
+static cJSON *create_reference(const cJSON *item, const internal_hooks * const hooks)
+{
+    cJSON *reference = NULL;
+    if (item == NULL)
+    {
+        return NULL;
+    }
+
+    reference = cJSON_New_Item(hooks);
+    if (reference == NULL)
+    {
+        return NULL;
+    }
+
+    memcpy(reference, item, sizeof(cJSON));
+    reference->string = NULL;
+    reference->type |= cJSON_IsReference;
+    reference->next = reference->prev = NULL;
+    return reference;
+}
+
+static cJSON_bool add_item_to_array(cJSON *array, cJSON *item)
+{
+    cJSON *child = NULL;
+
+    if ((item == NULL) || (array == NULL) || (array == item))
+    {
+        return false;
+    }
+
+    child = array->child;
+    /*
+     * To find the last item in array quickly, we use prev in array
+     */
+    if (child == NULL)
+    {
+        /* list is empty, start new one */
+        array->child = item;
+        item->prev = item;
+        item->next = NULL;
+    }
+    else
+    {
+        /* append to the end */
+        if (child->prev)
+        {
+            suffix_object(child->prev, item);
+            array->child->prev = item;
+        }
+    }
+
+    return true;
+}
+
+/* Add item to array/object. */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToArray(cJSON *array, cJSON *item)
+{
+    return add_item_to_array(array, item);
+}
+
+#if defined(__clang__) || (defined(__GNUC__)  && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
+    #pragma GCC diagnostic push
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
+/* helper function to cast away const */
+static void* cast_away_const(const void* string)
+{
+    return (void*)string;
+}
+#if defined(__clang__) || (defined(__GNUC__)  && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
+    #pragma GCC diagnostic pop
+#endif
+
+
+static cJSON_bool add_item_to_object(cJSON * const object, const char * const string, cJSON * const item, const internal_hooks * const hooks, const cJSON_bool constant_key)
+{
+    char *new_key = NULL;
+    int new_type = cJSON_Invalid;
+
+    if ((object == NULL) || (string == NULL) || (item == NULL) || (object == item))
+    {
+        return false;
+    }
+
+    if (constant_key)
+    {
+        new_key = (char*)cast_away_const(string);
+        new_type = item->type | cJSON_StringIsConst;
+    }
+    else
+    {
+        new_key = (char*)cJSON_strdup((const unsigned char*)string, hooks);
+        if (new_key == NULL)
+        {
+            return false;
+        }
+
+        new_type = item->type & ~cJSON_StringIsConst;
+    }
+
+    if (!(item->type & cJSON_StringIsConst) && (item->string != NULL))
+    {
+        hooks->deallocate(item->string);
+    }
+
+    item->string = new_key;
+    item->type = new_type;
+
+    return add_item_to_array(object, item);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObject(cJSON *object, const char *string, cJSON *item)
+{
+    return add_item_to_object(object, string, item, &global_hooks, false);
+}
+
+/* Add an item to an object with constant string as key */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJSON *item)
+{
+    return add_item_to_object(object, string, item, &global_hooks, true);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item)
+{
+    if (array == NULL)
+    {
+        return false;
+    }
+
+    return add_item_to_array(array, create_reference(item, &global_hooks));
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToObject(cJSON *object, const char *string, cJSON *item)
+{
+    if ((object == NULL) || (string == NULL))
+    {
+        return false;
+    }
+
+    return add_item_to_object(object, string, create_reference(item, &global_hooks), &global_hooks, false);
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddNullToObject(cJSON * const object, const char * const name)
+{
+    cJSON *null = cJSON_CreateNull();
+    if (add_item_to_object(object, name, null, &global_hooks, false))
+    {
+        return null;
+    }
+
+    cJSON_Delete(null);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddTrueToObject(cJSON * const object, const char * const name)
+{
+    cJSON *true_item = cJSON_CreateTrue();
+    if (add_item_to_object(object, name, true_item, &global_hooks, false))
+    {
+        return true_item;
+    }
+
+    cJSON_Delete(true_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddFalseToObject(cJSON * const object, const char * const name)
+{
+    cJSON *false_item = cJSON_CreateFalse();
+    if (add_item_to_object(object, name, false_item, &global_hooks, false))
+    {
+        return false_item;
+    }
+
+    cJSON_Delete(false_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddBoolToObject(cJSON * const object, const char * const name, const cJSON_bool boolean)
+{
+    cJSON *bool_item = cJSON_CreateBool(boolean);
+    if (add_item_to_object(object, name, bool_item, &global_hooks, false))
+    {
+        return bool_item;
+    }
+
+    cJSON_Delete(bool_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number)
+{
+    cJSON *number_item = cJSON_CreateNumber(number);
+    if (add_item_to_object(object, name, number_item, &global_hooks, false))
+    {
+        return number_item;
+    }
+
+    cJSON_Delete(number_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string)
+{
+    cJSON *string_item = cJSON_CreateString(string);
+    if (add_item_to_object(object, name, string_item, &global_hooks, false))
+    {
+        return string_item;
+    }
+
+    cJSON_Delete(string_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddRawToObject(cJSON * const object, const char * const name, const char * const raw)
+{
+    cJSON *raw_item = cJSON_CreateRaw(raw);
+    if (add_item_to_object(object, name, raw_item, &global_hooks, false))
+    {
+        return raw_item;
+    }
+
+    cJSON_Delete(raw_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddObjectToObject(cJSON * const object, const char * const name)
+{
+    cJSON *object_item = cJSON_CreateObject();
+    if (add_item_to_object(object, name, object_item, &global_hooks, false))
+    {
+        return object_item;
+    }
+
+    cJSON_Delete(object_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObject(cJSON * const object, const char * const name)
+{
+    cJSON *array = cJSON_CreateArray();
+    if (add_item_to_object(object, name, array, &global_hooks, false))
+    {
+        return array;
+    }
+
+    cJSON_Delete(array);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const item)
+{
+    if ((parent == NULL) || (item == NULL))
+    {
+        return NULL;
+    }
+
+    if (item != parent->child)
+    {
+        /* not the first element */
+        item->prev->next = item->next;
+    }
+    if (item->next != NULL)
+    {
+        /* not the last element */
+        item->next->prev = item->prev;
+    }
+
+    if (item == parent->child)
+    {
+        /* first element */
+        parent->child = item->next;
+    }
+    else if (item->next == NULL)
+    {
+        /* last element */
+        parent->child->prev = item->prev;
+    }
+
+    /* make sure the detached item doesn't point anywhere anymore */
+    item->prev = NULL;
+    item->next = NULL;
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromArray(cJSON *array, int which)
+{
+    if (which < 0)
+    {
+        return NULL;
+    }
+
+    return cJSON_DetachItemViaPointer(array, get_array_item(array, (size_t)which));
+}
+
+CJSON_PUBLIC(void) cJSON_DeleteItemFromArray(cJSON *array, int which)
+{
+    cJSON_Delete(cJSON_DetachItemFromArray(array, which));
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObject(cJSON *object, const char *string)
+{
+    cJSON *to_detach = cJSON_GetObjectItem(object, string);
+
+    return cJSON_DetachItemViaPointer(object, to_detach);
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObjectCaseSensitive(cJSON *object, const char *string)
+{
+    cJSON *to_detach = cJSON_GetObjectItemCaseSensitive(object, string);
+
+    return cJSON_DetachItemViaPointer(object, to_detach);
+}
+
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObject(cJSON *object, const char *string)
+{
+    cJSON_Delete(cJSON_DetachItemFromObject(object, string));
+}
+
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObjectCaseSensitive(cJSON *object, const char *string)
+{
+    cJSON_Delete(cJSON_DetachItemFromObjectCaseSensitive(object, string));
+}
+
+/* Replace array/object items with new ones. */
+CJSON_PUBLIC(cJSON_bool) cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newitem)
+{
+    cJSON *after_inserted = NULL;
+
+    if (which < 0 || newitem == NULL)
+    {
+        return false;
+    }
+
+    after_inserted = get_array_item(array, (size_t)which);
+    if (after_inserted == NULL)
+    {
+        return add_item_to_array(array, newitem);
+    }
+
+    if (after_inserted != array->child && after_inserted->prev == NULL) {
+        /* return false if after_inserted is a corrupted array item */
+        return false;
+    }
+
+    newitem->next = after_inserted;
+    newitem->prev = after_inserted->prev;
+    after_inserted->prev = newitem;
+    if (after_inserted == array->child)
+    {
+        array->child = newitem;
+    }
+    else
+    {
+        newitem->prev->next = newitem;
+    }
+    return true;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON * const item, cJSON * replacement)
+{
+    if ((parent == NULL) || (parent->child == NULL) || (replacement == NULL) || (item == NULL))
+    {
+        return false;
+    }
+
+    if (replacement == item)
+    {
+        return true;
+    }
+
+    replacement->next = item->next;
+    replacement->prev = item->prev;
+
+    if (replacement->next != NULL)
+    {
+        replacement->next->prev = replacement;
+    }
+    if (parent->child == item)
+    {
+        if (parent->child->prev == parent->child)
+        {
+            replacement->prev = replacement;
+        }
+        parent->child = replacement;
+    }
+    else
+    {   /*
+         * To find the last item in array quickly, we use prev in array.
+         * We can't modify the last item's next pointer where this item was the parent's child
+         */
+        if (replacement->prev != NULL)
+        {
+            replacement->prev->next = replacement;
+        }
+        if (replacement->next == NULL)
+        {
+            parent->child->prev = replacement;
+        }
+    }
+
+    item->next = NULL;
+    item->prev = NULL;
+    cJSON_Delete(item);
+
+    return true;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInArray(cJSON *array, int which, cJSON *newitem)
+{
+    if (which < 0)
+    {
+        return false;
+    }
+
+    return cJSON_ReplaceItemViaPointer(array, get_array_item(array, (size_t)which), newitem);
+}
+
+static cJSON_bool replace_item_in_object(cJSON *object, const char *string, cJSON *replacement, cJSON_bool case_sensitive)
+{
+    if ((replacement == NULL) || (string == NULL))
+    {
+        return false;
+    }
+
+    /* replace the name in the replacement */
+    if (!(replacement->type & cJSON_StringIsConst) && (replacement->string != NULL))
+    {
+        cJSON_free(replacement->string);
+    }
+    replacement->string = (char*)cJSON_strdup((const unsigned char*)string, &global_hooks);
+    if (replacement->string == NULL)
+    {
+        return false;
+    }
+
+    replacement->type &= ~cJSON_StringIsConst;
+
+    return cJSON_ReplaceItemViaPointer(object, get_object_item(object, string, case_sensitive), replacement);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObject(cJSON *object, const char *string, cJSON *newitem)
+{
+    return replace_item_in_object(object, string, newitem, false);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObjectCaseSensitive(cJSON *object, const char *string, cJSON *newitem)
+{
+    return replace_item_in_object(object, string, newitem, true);
+}
+
+/* Create basic types: */
+CJSON_PUBLIC(cJSON *) cJSON_CreateNull(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_NULL;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateTrue(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_True;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateFalse(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_False;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateBool(cJSON_bool boolean)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = boolean ? cJSON_True : cJSON_False;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateNumber(double num)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_Number;
+        item->valuedouble = num;
+
+        /* use saturation in case of overflow */
+        if (num >= INT_MAX)
+        {
+            item->valueint = INT_MAX;
+        }
+        else if (num <= (double)INT_MIN)
+        {
+            item->valueint = INT_MIN;
+        }
+        else
+        {
+            item->valueint = (int)num;
+        }
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateString(const char *string)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_String;
+        item->valuestring = (char*)cJSON_strdup((const unsigned char*)string, &global_hooks);
+        if(!item->valuestring)
+        {
+            cJSON_Delete(item);
+            return NULL;
+        }
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringReference(const char *string)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item != NULL)
+    {
+        item->type = cJSON_String | cJSON_IsReference;
+        item->valuestring = (char*)cast_away_const(string);
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateObjectReference(const cJSON *child)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item != NULL) {
+        item->type = cJSON_Object | cJSON_IsReference;
+        item->child = (cJSON*)cast_away_const(child);
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateArrayReference(const cJSON *child) {
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item != NULL) {
+        item->type = cJSON_Array | cJSON_IsReference;
+        item->child = (cJSON*)cast_away_const(child);
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateRaw(const char *raw)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_Raw;
+        item->valuestring = (char*)cJSON_strdup((const unsigned char*)raw, &global_hooks);
+        if(!item->valuestring)
+        {
+            cJSON_Delete(item);
+            return NULL;
+        }
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateArray(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type=cJSON_Array;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateObject(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item)
+    {
+        item->type = cJSON_Object;
+    }
+
+    return item;
+}
+
+/* Create Arrays: */
+CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const int *numbers, int count)
+{
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
+
+    if ((count < 0) || (numbers == NULL))
+    {
+        return NULL;
+    }
+
+    a = cJSON_CreateArray();
+
+    for(i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateNumber(numbers[i]);
+        if (!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p, n);
+        }
+        p = n;
+    }
+
+    if (a && a->child) {
+        a->child->prev = n;
+    }
+
+    return a;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateFloatArray(const float *numbers, int count)
+{
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
+
+    if ((count < 0) || (numbers == NULL))
+    {
+        return NULL;
+    }
+
+    a = cJSON_CreateArray();
+
+    for(i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateNumber((double)numbers[i]);
+        if(!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p, n);
+        }
+        p = n;
+    }
+
+    if (a && a->child) {
+        a->child->prev = n;
+    }
+
+    return a;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateDoubleArray(const double *numbers, int count)
+{
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
+
+    if ((count < 0) || (numbers == NULL))
+    {
+        return NULL;
+    }
+
+    a = cJSON_CreateArray();
+
+    for(i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateNumber(numbers[i]);
+        if(!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p, n);
+        }
+        p = n;
+    }
+
+    if (a && a->child) {
+        a->child->prev = n;
+    }
+
+    return a;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char *const *strings, int count)
+{
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
+
+    if ((count < 0) || (strings == NULL))
+    {
+        return NULL;
+    }
+
+    a = cJSON_CreateArray();
+
+    for (i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateString(strings[i]);
+        if(!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p,n);
+        }
+        p = n;
+    }
+
+    if (a && a->child) {
+        a->child->prev = n;
+    }
+
+    return a;
+}
+
+/* Duplication */
+CJSON_PUBLIC(cJSON *) cJSON_Duplicate(const cJSON *item, cJSON_bool recurse)
+{
+    cJSON *newitem = NULL;
+    cJSON *child = NULL;
+    cJSON *next = NULL;
+    cJSON *newchild = NULL;
+
+    /* Bail on bad ptr */
+    if (!item)
+    {
+        goto fail;
+    }
+    /* Create new item */
+    newitem = cJSON_New_Item(&global_hooks);
+    if (!newitem)
+    {
+        goto fail;
+    }
+    /* Copy over all vars */
+    newitem->type = item->type & (~cJSON_IsReference);
+    newitem->valueint = item->valueint;
+    newitem->valuedouble = item->valuedouble;
+    if (item->valuestring)
+    {
+        newitem->valuestring = (char*)cJSON_strdup((unsigned char*)item->valuestring, &global_hooks);
+        if (!newitem->valuestring)
+        {
+            goto fail;
+        }
+    }
+    if (item->string)
+    {
+        newitem->string = (item->type&cJSON_StringIsConst) ? item->string : (char*)cJSON_strdup((unsigned char*)item->string, &global_hooks);
+        if (!newitem->string)
+        {
+            goto fail;
+        }
+    }
+    /* If non-recursive, then we're done! */
+    if (!recurse)
+    {
+        return newitem;
+    }
+    /* Walk the ->next chain for the child. */
+    child = item->child;
+    while (child != NULL)
+    {
+        newchild = cJSON_Duplicate(child, true); /* Duplicate (with recurse) each item in the ->next chain */
+        if (!newchild)
+        {
+            goto fail;
+        }
+        if (next != NULL)
+        {
+            /* If newitem->child already set, then crosswire ->prev and ->next and move on */
+            next->next = newchild;
+            newchild->prev = next;
+            next = newchild;
+        }
+        else
+        {
+            /* Set newitem->child and move to it */
+            newitem->child = newchild;
+            next = newchild;
+        }
+        child = child->next;
+    }
+    if (newitem && newitem->child)
+    {
+        newitem->child->prev = newchild;
+    }
+
+    return newitem;
+
+fail:
+    if (newitem != NULL)
+    {
+        cJSON_Delete(newitem);
+    }
+
+    return NULL;
+}
+
+static void skip_oneline_comment(char **input)
+{
+    *input += static_strlen("//");
+
+    for (; (*input)[0] != '\0'; ++(*input))
+    {
+        if ((*input)[0] == '\n') {
+            *input += static_strlen("\n");
+            return;
+        }
+    }
+}
+
+static void skip_multiline_comment(char **input)
+{
+    *input += static_strlen("/*");
+
+    for (; (*input)[0] != '\0'; ++(*input))
+    {
+        if (((*input)[0] == '*') && ((*input)[1] == '/'))
+        {
+            *input += static_strlen("*/");
+            return;
+        }
+    }
+}
+
+static void minify_string(char **input, char **output) {
+    (*output)[0] = (*input)[0];
+    *input += static_strlen("\"");
+    *output += static_strlen("\"");
+
+
+    for (; (*input)[0] != '\0'; (void)++(*input), ++(*output)) {
+        (*output)[0] = (*input)[0];
+
+        if ((*input)[0] == '\"') {
+            (*output)[0] = '\"';
+            *input += static_strlen("\"");
+            *output += static_strlen("\"");
+            return;
+        } else if (((*input)[0] == '\\') && ((*input)[1] == '\"')) {
+            (*output)[1] = (*input)[1];
+            *input += static_strlen("\"");
+            *output += static_strlen("\"");
+        }
+    }
+}
+
+CJSON_PUBLIC(void) cJSON_Minify(char *json)
+{
+    char *into = json;
+
+    if (json == NULL)
+    {
+        return;
+    }
+
+    while (json[0] != '\0')
+    {
+        switch (json[0])
+        {
+            case ' ':
+            case '\t':
+            case '\r':
+            case '\n':
+                json++;
+                break;
+
+            case '/':
+                if (json[1] == '/')
+                {
+                    skip_oneline_comment(&json);
+                }
+                else if (json[1] == '*')
+                {
+                    skip_multiline_comment(&json);
+                } else {
+                    json++;
+                }
+                break;
+
+            case '\"':
+                minify_string(&json, (char**)&into);
+                break;
+
+            default:
+                into[0] = json[0];
+                json++;
+                into++;
+        }
+    }
+
+    /* and null-terminate. */
+    *into = '\0';
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsInvalid(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Invalid;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsFalse(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_False;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsTrue(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xff) == cJSON_True;
+}
+
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsBool(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & (cJSON_True | cJSON_False)) != 0;
+}
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNull(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_NULL;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNumber(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Number;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsString(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_String;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsArray(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Array;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsObject(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Object;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsRaw(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Raw;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a, const cJSON * const b, const cJSON_bool case_sensitive)
+{
+    if ((a == NULL) || (b == NULL) || ((a->type & 0xFF) != (b->type & 0xFF)))
+    {
+        return false;
+    }
+
+    /* check if type is valid */
+    switch (a->type & 0xFF)
+    {
+        case cJSON_False:
+        case cJSON_True:
+        case cJSON_NULL:
+        case cJSON_Number:
+        case cJSON_String:
+        case cJSON_Raw:
+        case cJSON_Array:
+        case cJSON_Object:
+            break;
+
+        default:
+            return false;
+    }
+
+    /* identical objects are equal */
+    if (a == b)
+    {
+        return true;
+    }
+
+    switch (a->type & 0xFF)
+    {
+        /* in these cases and equal type is enough */
+        case cJSON_False:
+        case cJSON_True:
+        case cJSON_NULL:
+            return true;
+
+        case cJSON_Number:
+            if (compare_double(a->valuedouble, b->valuedouble))
+            {
+                return true;
+            }
+            return false;
+
+        case cJSON_String:
+        case cJSON_Raw:
+            if ((a->valuestring == NULL) || (b->valuestring == NULL))
+            {
+                return false;
+            }
+            if (strcmp(a->valuestring, b->valuestring) == 0)
+            {
+                return true;
+            }
+
+            return false;
+
+        case cJSON_Array:
+        {
+            cJSON *a_element = a->child;
+            cJSON *b_element = b->child;
+
+            for (; (a_element != NULL) && (b_element != NULL);)
+            {
+                if (!cJSON_Compare(a_element, b_element, case_sensitive))
+                {
+                    return false;
+                }
+
+                a_element = a_element->next;
+                b_element = b_element->next;
+            }
+
+            /* one of the arrays is longer than the other */
+            if (a_element != b_element) {
+                return false;
+            }
+
+            return true;
+        }
+
+        case cJSON_Object:
+        {
+            cJSON *a_element = NULL;
+            cJSON *b_element = NULL;
+            cJSON_ArrayForEach(a_element, a)
+            {
+                /* TODO This has O(n^2) runtime, which is horrible! */
+                b_element = get_object_item(b, a_element->string, case_sensitive);
+                if (b_element == NULL)
+                {
+                    return false;
+                }
+
+                if (!cJSON_Compare(a_element, b_element, case_sensitive))
+                {
+                    return false;
+                }
+            }
+
+            /* doing this twice, once on a and b to prevent true comparison if a subset of b
+             * TODO: Do this the proper way, this is just a fix for now */
+            cJSON_ArrayForEach(b_element, b)
+            {
+                a_element = get_object_item(a, b_element->string, case_sensitive);
+                if (a_element == NULL)
+                {
+                    return false;
+                }
+
+                if (!cJSON_Compare(b_element, a_element, case_sensitive))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        default:
+            return false;
+    }
+}
+
+CJSON_PUBLIC(void *) cJSON_malloc(size_t size)
+{
+    return global_hooks.allocate(size);
+}
+
+CJSON_PUBLIC(void) cJSON_free(void *object)
+{
+    global_hooks.deallocate(object);
+    object = NULL;
+}

--- a/test/e2e/fake_nvml/cJSON.h
+++ b/test/e2e/fake_nvml/cJSON.h
@@ -1,0 +1,300 @@
+/*
+  Copyright (c) 2009-2017 Dave Gamble and cJSON contributors
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+#ifndef cJSON__h
+#define cJSON__h
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#if !defined(__WINDOWS__) && (defined(WIN32) || defined(WIN64) || defined(_MSC_VER) || defined(_WIN32))
+#define __WINDOWS__
+#endif
+
+#ifdef __WINDOWS__
+
+/* When compiling for windows, we specify a specific calling convention to avoid issues where we are being called from a project with a different default calling convention.  For windows you have 3 define options:
+
+CJSON_HIDE_SYMBOLS - Define this in the case where you don't want to ever dllexport symbols
+CJSON_EXPORT_SYMBOLS - Define this on library build when you want to dllexport symbols (default)
+CJSON_IMPORT_SYMBOLS - Define this if you want to dllimport symbol
+
+For *nix builds that support visibility attribute, you can define similar behavior by
+
+setting default visibility to hidden by adding
+-fvisibility=hidden (for gcc)
+or
+-xldscope=hidden (for sun cc)
+to CFLAGS
+
+then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJSON_EXPORT_SYMBOLS does
+
+*/
+
+#define CJSON_CDECL __cdecl
+#define CJSON_STDCALL __stdcall
+
+/* export symbols by default, this is necessary for copy pasting the C and header file */
+#if !defined(CJSON_HIDE_SYMBOLS) && !defined(CJSON_IMPORT_SYMBOLS) && !defined(CJSON_EXPORT_SYMBOLS)
+#define CJSON_EXPORT_SYMBOLS
+#endif
+
+#if defined(CJSON_HIDE_SYMBOLS)
+#define CJSON_PUBLIC(type)   type CJSON_STDCALL
+#elif defined(CJSON_EXPORT_SYMBOLS)
+#define CJSON_PUBLIC(type)   __declspec(dllexport) type CJSON_STDCALL
+#elif defined(CJSON_IMPORT_SYMBOLS)
+#define CJSON_PUBLIC(type)   __declspec(dllimport) type CJSON_STDCALL
+#endif
+#else /* !__WINDOWS__ */
+#define CJSON_CDECL
+#define CJSON_STDCALL
+
+#if (defined(__GNUC__) || defined(__SUNPRO_CC) || defined (__SUNPRO_C)) && defined(CJSON_API_VISIBILITY)
+#define CJSON_PUBLIC(type)   __attribute__((visibility("default"))) type
+#else
+#define CJSON_PUBLIC(type) type
+#endif
+#endif
+
+/* project version */
+#define CJSON_VERSION_MAJOR 1
+#define CJSON_VERSION_MINOR 7
+#define CJSON_VERSION_PATCH 18
+
+#include <stddef.h>
+
+/* cJSON Types: */
+#define cJSON_Invalid (0)
+#define cJSON_False  (1 << 0)
+#define cJSON_True   (1 << 1)
+#define cJSON_NULL   (1 << 2)
+#define cJSON_Number (1 << 3)
+#define cJSON_String (1 << 4)
+#define cJSON_Array  (1 << 5)
+#define cJSON_Object (1 << 6)
+#define cJSON_Raw    (1 << 7) /* raw json */
+
+#define cJSON_IsReference 256
+#define cJSON_StringIsConst 512
+
+/* The cJSON structure: */
+typedef struct cJSON
+{
+    /* next/prev allow you to walk array/object chains. Alternatively, use GetArraySize/GetArrayItem/GetObjectItem */
+    struct cJSON *next;
+    struct cJSON *prev;
+    /* An array or object item will have a child pointer pointing to a chain of the items in the array/object. */
+    struct cJSON *child;
+
+    /* The type of the item, as above. */
+    int type;
+
+    /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
+    char *valuestring;
+    /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
+    int valueint;
+    /* The item's number, if type==cJSON_Number */
+    double valuedouble;
+
+    /* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
+    char *string;
+} cJSON;
+
+typedef struct cJSON_Hooks
+{
+      /* malloc/free are CDECL on Windows regardless of the default calling convention of the compiler, so ensure the hooks allow passing those functions directly. */
+      void *(CJSON_CDECL *malloc_fn)(size_t sz);
+      void (CJSON_CDECL *free_fn)(void *ptr);
+} cJSON_Hooks;
+
+typedef int cJSON_bool;
+
+/* Limits how deeply nested arrays/objects can be before cJSON rejects to parse them.
+ * This is to prevent stack overflows. */
+#ifndef CJSON_NESTING_LIMIT
+#define CJSON_NESTING_LIMIT 1000
+#endif
+
+/* returns the version of cJSON as a string */
+CJSON_PUBLIC(const char*) cJSON_Version(void);
+
+/* Supply malloc, realloc and free functions to cJSON */
+CJSON_PUBLIC(void) cJSON_InitHooks(cJSON_Hooks* hooks);
+
+/* Memory Management: the caller is always responsible to free the results from all variants of cJSON_Parse (with cJSON_Delete) and cJSON_Print (with stdlib free, cJSON_Hooks.free_fn, or cJSON_free as appropriate). The exception is cJSON_PrintPreallocated, where the caller has full responsibility of the buffer. */
+/* Supply a block of JSON, and this returns a cJSON object you can interrogate. */
+CJSON_PUBLIC(cJSON *) cJSON_Parse(const char *value);
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLength(const char *value, size_t buffer_length);
+/* ParseWithOpts allows you to require (and check) that the JSON is null terminated, and to retrieve the pointer to the final byte parsed. */
+/* If you supply a ptr in return_parse_end and parsing fails, then return_parse_end will contain a pointer to the error so will match cJSON_GetErrorPtr(). */
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated);
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLengthOpts(const char *value, size_t buffer_length, const char **return_parse_end, cJSON_bool require_null_terminated);
+
+/* Render a cJSON entity to text for transfer/storage. */
+CJSON_PUBLIC(char *) cJSON_Print(const cJSON *item);
+/* Render a cJSON entity to text for transfer/storage without any formatting. */
+CJSON_PUBLIC(char *) cJSON_PrintUnformatted(const cJSON *item);
+/* Render a cJSON entity to text using a buffered strategy. prebuffer is a guess at the final size. guessing well reduces reallocation. fmt=0 gives unformatted, =1 gives formatted */
+CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON_bool fmt);
+/* Render a cJSON entity to text using a buffer already allocated in memory with given length. Returns 1 on success and 0 on failure. */
+/* NOTE: cJSON is not always 100% accurate in estimating how much memory it will use, so to be safe allocate 5 bytes more than you actually need */
+CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format);
+/* Delete a cJSON entity and all subentities. */
+CJSON_PUBLIC(void) cJSON_Delete(cJSON *item);
+
+/* Returns the number of items in an array (or object). */
+CJSON_PUBLIC(int) cJSON_GetArraySize(const cJSON *array);
+/* Retrieve item number "index" from array "array". Returns NULL if unsuccessful. */
+CJSON_PUBLIC(cJSON *) cJSON_GetArrayItem(const cJSON *array, int index);
+/* Get item "string" from object. Case insensitive. */
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON * const object, const char * const string);
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitive(const cJSON * const object, const char * const string);
+CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON *object, const char *string);
+/* For analysing failed parses. This returns a pointer to the parse error. You'll probably need to look a few chars back to make sense of it. Defined when cJSON_Parse() returns 0. 0 when cJSON_Parse() succeeds. */
+CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void);
+
+/* Check item type and return its value */
+CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item);
+CJSON_PUBLIC(double) cJSON_GetNumberValue(const cJSON * const item);
+
+/* These functions check the type of an item */
+CJSON_PUBLIC(cJSON_bool) cJSON_IsInvalid(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsFalse(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsTrue(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsBool(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNull(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNumber(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsString(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsArray(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsObject(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsRaw(const cJSON * const item);
+
+/* These calls create a cJSON item of the appropriate type. */
+CJSON_PUBLIC(cJSON *) cJSON_CreateNull(void);
+CJSON_PUBLIC(cJSON *) cJSON_CreateTrue(void);
+CJSON_PUBLIC(cJSON *) cJSON_CreateFalse(void);
+CJSON_PUBLIC(cJSON *) cJSON_CreateBool(cJSON_bool boolean);
+CJSON_PUBLIC(cJSON *) cJSON_CreateNumber(double num);
+CJSON_PUBLIC(cJSON *) cJSON_CreateString(const char *string);
+/* raw json */
+CJSON_PUBLIC(cJSON *) cJSON_CreateRaw(const char *raw);
+CJSON_PUBLIC(cJSON *) cJSON_CreateArray(void);
+CJSON_PUBLIC(cJSON *) cJSON_CreateObject(void);
+
+/* Create a string where valuestring references a string so
+ * it will not be freed by cJSON_Delete */
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringReference(const char *string);
+/* Create an object/array that only references it's elements so
+ * they will not be freed by cJSON_Delete */
+CJSON_PUBLIC(cJSON *) cJSON_CreateObjectReference(const cJSON *child);
+CJSON_PUBLIC(cJSON *) cJSON_CreateArrayReference(const cJSON *child);
+
+/* These utilities create an Array of count items.
+ * The parameter count cannot be greater than the number of elements in the number array, otherwise array access will be out of bounds.*/
+CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const int *numbers, int count);
+CJSON_PUBLIC(cJSON *) cJSON_CreateFloatArray(const float *numbers, int count);
+CJSON_PUBLIC(cJSON *) cJSON_CreateDoubleArray(const double *numbers, int count);
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char *const *strings, int count);
+
+/* Append item to the specified array/object. */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToArray(cJSON *array, cJSON *item);
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObject(cJSON *object, const char *string, cJSON *item);
+/* Use this when string is definitely const (i.e. a literal, or as good as), and will definitely survive the cJSON object.
+ * WARNING: When this function was used, make sure to always check that (item->type & cJSON_StringIsConst) is zero before
+ * writing to `item->string` */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJSON *item);
+/* Append reference to item to the specified array/object. Use this when you want to add an existing cJSON to a new cJSON, but don't want to corrupt your existing cJSON. */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item);
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToObject(cJSON *object, const char *string, cJSON *item);
+
+/* Remove/Detach items from Arrays/Objects. */
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const item);
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromArray(cJSON *array, int which);
+CJSON_PUBLIC(void) cJSON_DeleteItemFromArray(cJSON *array, int which);
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObject(cJSON *object, const char *string);
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObjectCaseSensitive(cJSON *object, const char *string);
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObject(cJSON *object, const char *string);
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObjectCaseSensitive(cJSON *object, const char *string);
+
+/* Update array items. */
+CJSON_PUBLIC(cJSON_bool) cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newitem); /* Shifts pre-existing items to the right. */
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON * const item, cJSON * replacement);
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInArray(cJSON *array, int which, cJSON *newitem);
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObject(cJSON *object,const char *string,cJSON *newitem);
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObjectCaseSensitive(cJSON *object,const char *string,cJSON *newitem);
+
+/* Duplicate a cJSON item */
+CJSON_PUBLIC(cJSON *) cJSON_Duplicate(const cJSON *item, cJSON_bool recurse);
+/* Duplicate will create a new, identical cJSON item to the one you pass, in new memory that will
+ * need to be released. With recurse!=0, it will duplicate any children connected to the item.
+ * The item->next and ->prev pointers are always zero on return from Duplicate. */
+/* Recursively compare two cJSON items for equality. If either a or b is NULL or invalid, they will be considered unequal.
+ * case_sensitive determines if object keys are treated case sensitive (1) or case insensitive (0) */
+CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a, const cJSON * const b, const cJSON_bool case_sensitive);
+
+/* Minify a strings, remove blank characters(such as ' ', '\t', '\r', '\n') from strings.
+ * The input pointer json cannot point to a read-only address area, such as a string constant,
+ * but should point to a readable and writable address area. */
+CJSON_PUBLIC(void) cJSON_Minify(char *json);
+
+/* Helper functions for creating and adding items to an object at the same time.
+ * They return the added item or NULL on failure. */
+CJSON_PUBLIC(cJSON*) cJSON_AddNullToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddTrueToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddFalseToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddBoolToObject(cJSON * const object, const char * const name, const cJSON_bool boolean);
+CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number);
+CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
+CJSON_PUBLIC(cJSON*) cJSON_AddRawToObject(cJSON * const object, const char * const name, const char * const raw);
+CJSON_PUBLIC(cJSON*) cJSON_AddObjectToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObject(cJSON * const object, const char * const name);
+
+/* When assigning an integer value, it needs to be propagated to valuedouble too. */
+#define cJSON_SetIntValue(object, number) ((object) ? (object)->valueint = (object)->valuedouble = (number) : (number))
+/* helper for the cJSON_SetNumberValue macro */
+CJSON_PUBLIC(double) cJSON_SetNumberHelper(cJSON *object, double number);
+#define cJSON_SetNumberValue(object, number) ((object != NULL) ? cJSON_SetNumberHelper(object, (double)number) : (number))
+/* Change the valuestring of a cJSON_String object, only takes effect when type of object is cJSON_String */
+CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring);
+
+/* If the object is not a boolean type this does nothing and returns cJSON_Invalid else it returns the new type*/
+#define cJSON_SetBoolValue(object, boolValue) ( \
+    (object != NULL && ((object)->type & (cJSON_False|cJSON_True))) ? \
+    (object)->type=((object)->type &(~(cJSON_False|cJSON_True)))|((boolValue)?cJSON_True:cJSON_False) : \
+    cJSON_Invalid\
+)
+
+/* Macro for iterating over an array or object */
+#define cJSON_ArrayForEach(element, array) for(element = (array != NULL) ? (array)->child : NULL; element != NULL; element = element->next)
+
+/* malloc/free objects using the malloc/free functions that have been set with cJSON_InitHooks */
+CJSON_PUBLIC(void *) cJSON_malloc(size_t size);
+CJSON_PUBLIC(void) cJSON_free(void *object);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/test/e2e/fake_nvml/fake_nvml.c
+++ b/test/e2e/fake_nvml/fake_nvml.c
@@ -1,0 +1,669 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// fake_nvml.c - Fake libnvidia-ml.so.1 for GPU e2e testing
+//
+// This shared library implements the NVML C API functions that go-nvml
+// loads via dlopen/dlsym. It reads device configuration from a JSON file
+// specified by the FAKE_NVML_CONFIG environment variable and returns
+// canned GPU data. This allows testing Kepler's GPU code paths without
+// real NVIDIA hardware.
+//
+// Build: gcc -shared -fPIC -o libnvidia-ml.so.1 fake_nvml.c cJSON.c -lpthread
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <pthread.h>
+
+#include "cJSON.h"
+
+// ---------- NVML type definitions (matching nvml.h) ----------
+
+typedef int nvmlReturn_t;
+
+#define NVML_SUCCESS                       0
+#define NVML_ERROR_UNINITIALIZED           1
+#define NVML_ERROR_INVALID_ARGUMENT        2
+#define NVML_ERROR_NOT_SUPPORTED           3
+#define NVML_ERROR_INSUFFICIENT_SIZE       7
+#define NVML_ERROR_NOT_FOUND               6
+#define NVML_ERROR_UNKNOWN                 999
+
+typedef void* nvmlDevice_t;
+
+typedef unsigned int nvmlComputeMode_t;
+#define NVML_COMPUTEMODE_DEFAULT           0
+#define NVML_COMPUTEMODE_EXCLUSIVE_THREAD  1
+#define NVML_COMPUTEMODE_PROHIBITED        2
+#define NVML_COMPUTEMODE_EXCLUSIVE_PROCESS 3
+
+typedef unsigned int nvmlEnableState_t;
+#define NVML_FEATURE_DISABLED  0
+#define NVML_FEATURE_ENABLED   1
+
+// v1 process info struct: {pid:u32, pad:4, usedGpuMemory:u64}
+typedef struct {
+    unsigned int        pid;
+    unsigned long long  usedGpuMemory;
+} nvmlProcessInfo_v1_t;
+
+// v2 process info struct (also used as nvmlProcessInfo_t for v3)
+typedef struct {
+    unsigned int        pid;
+    unsigned long long  usedGpuMemory;
+    unsigned int        gpuInstanceId;
+    unsigned int        computeInstanceId;
+} nvmlProcessInfo_v2_t;
+
+typedef struct {
+    unsigned int        pid;
+    unsigned long long  timeStamp;
+    unsigned int        smUtil;
+    unsigned int        memUtil;
+    unsigned int        encUtil;
+    unsigned int        decUtil;
+} nvmlProcessUtilizationSample_t;
+
+// ---------- Internal state ----------
+
+#define MAX_DEVICES    16
+#define MAX_PROCESSES  64
+#define MAX_MIG_DEVICES 8
+
+typedef struct {
+    unsigned int pid;
+    unsigned long long memoryUsed;
+    unsigned int smUtil;
+} FakeProcess;
+
+typedef struct {
+    char uuid[80];
+    char name[80];
+    unsigned int powerUsageMilliWatts;
+    nvmlComputeMode_t computeMode;
+    int migEnabled;
+    int maxMigDevices;
+    FakeProcess processes[MAX_PROCESSES];
+    int processCount;
+} FakeDevice;
+
+static FakeDevice g_devices[MAX_DEVICES];
+static int g_deviceCount = 0;
+static int g_initialized = 0;
+static struct timespec g_initTime;
+static pthread_mutex_t g_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+// ---------- Handle encoding ----------
+// Top-level GPU i:   (void*)(uintptr_t)(i + 1)
+// MIG device p,m:    (void*)(uintptr_t)((p+1)*100 + m+1)
+
+static inline int handle_to_index(nvmlDevice_t device) {
+    unsigned long h = (unsigned long)(device);
+    if (h == 0) return -1;
+    if (h >= 100) return -1; // MIG device, not a top-level GPU
+    return (int)(h - 1);
+}
+
+static inline int handle_is_mig(nvmlDevice_t device) {
+    unsigned long h = (unsigned long)(device);
+    return h >= 100;
+}
+
+static inline int handle_to_parent(nvmlDevice_t device) {
+    unsigned long h = (unsigned long)(device);
+    return (int)(h / 100) - 1;
+}
+
+static inline int handle_to_mig_index(nvmlDevice_t device) {
+    unsigned long h = (unsigned long)(device);
+    return (int)(h % 100) - 1;
+}
+
+// ---------- JSON config loading ----------
+
+static int load_config(void) {
+    const char *configPath = getenv("FAKE_NVML_CONFIG");
+    if (!configPath || *configPath == '\0') {
+        fprintf(stderr, "fake_nvml: FAKE_NVML_CONFIG not set\n");
+        return -1;
+    }
+
+    FILE *f = fopen(configPath, "r");
+    if (!f) {
+        fprintf(stderr, "fake_nvml: cannot open %s\n", configPath);
+        return -1;
+    }
+
+    fseek(f, 0, SEEK_END);
+    long fsize = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    char *json_str = malloc(fsize + 1);
+    if (!json_str) {
+        fclose(f);
+        return -1;
+    }
+    fread(json_str, 1, fsize, f);
+    json_str[fsize] = '\0';
+    fclose(f);
+
+    cJSON *root = cJSON_Parse(json_str);
+    free(json_str);
+    if (!root) {
+        fprintf(stderr, "fake_nvml: JSON parse error\n");
+        return -1;
+    }
+
+    cJSON *devices = cJSON_GetObjectItem(root, "devices");
+    if (!cJSON_IsArray(devices)) {
+        fprintf(stderr, "fake_nvml: 'devices' is not an array\n");
+        cJSON_Delete(root);
+        return -1;
+    }
+
+    g_deviceCount = 0;
+    cJSON *dev;
+    cJSON_ArrayForEach(dev, devices) {
+        if (g_deviceCount >= MAX_DEVICES) break;
+
+        FakeDevice *d = &g_devices[g_deviceCount];
+        memset(d, 0, sizeof(FakeDevice));
+
+        cJSON *uuid = cJSON_GetObjectItem(dev, "uuid");
+        if (cJSON_IsString(uuid))
+            snprintf(d->uuid, sizeof(d->uuid), "%s", uuid->valuestring);
+        else
+            snprintf(d->uuid, sizeof(d->uuid), "GPU-FAKE-%04d", g_deviceCount);
+
+        cJSON *name = cJSON_GetObjectItem(dev, "name");
+        if (cJSON_IsString(name))
+            snprintf(d->name, sizeof(d->name), "%s", name->valuestring);
+        else
+            snprintf(d->name, sizeof(d->name), "NVIDIA Fake GPU %d", g_deviceCount);
+
+        cJSON *power = cJSON_GetObjectItem(dev, "powerUsageMilliWatts");
+        d->powerUsageMilliWatts = cJSON_IsNumber(power) ? (unsigned int)power->valuedouble : 40000;
+
+        cJSON *cm = cJSON_GetObjectItem(dev, "computeMode");
+        d->computeMode = cJSON_IsNumber(cm) ? (unsigned int)cm->valuedouble : NVML_COMPUTEMODE_DEFAULT;
+
+        cJSON *mig = cJSON_GetObjectItem(dev, "migEnabled");
+        d->migEnabled = cJSON_IsTrue(mig) ? 1 : 0;
+
+        cJSON *maxMig = cJSON_GetObjectItem(dev, "maxMigDevices");
+        d->maxMigDevices = cJSON_IsNumber(maxMig) ? (int)maxMig->valuedouble : 0;
+
+        cJSON *procs = cJSON_GetObjectItem(dev, "processes");
+        d->processCount = 0;
+        if (cJSON_IsArray(procs)) {
+            cJSON *proc;
+            cJSON_ArrayForEach(proc, procs) {
+                if (d->processCount >= MAX_PROCESSES) break;
+
+                FakeProcess *p = &d->processes[d->processCount];
+                cJSON *pid = cJSON_GetObjectItem(proc, "pid");
+                p->pid = cJSON_IsNumber(pid) ? (unsigned int)pid->valuedouble : 0;
+
+                cJSON *mem = cJSON_GetObjectItem(proc, "memoryUsed");
+                p->memoryUsed = cJSON_IsNumber(mem) ? (unsigned long long)mem->valuedouble : 0;
+
+                cJSON *sm = cJSON_GetObjectItem(proc, "smUtil");
+                p->smUtil = cJSON_IsNumber(sm) ? (unsigned int)sm->valuedouble : 0;
+
+                d->processCount++;
+            }
+        }
+
+        g_deviceCount++;
+    }
+
+    cJSON_Delete(root);
+    fprintf(stderr, "fake_nvml: loaded %d device(s) from %s\n", g_deviceCount, configPath);
+    return 0;
+}
+
+// ---------- Time helpers ----------
+
+static double elapsed_seconds(void) {
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    return (double)(now.tv_sec - g_initTime.tv_sec)
+         + (double)(now.tv_nsec - g_initTime.tv_nsec) / 1e9;
+}
+
+// ---------- NVML API implementations ----------
+
+// nvmlInit_v2 is called by go-nvml after version negotiation
+nvmlReturn_t nvmlInit_v2(void) {
+    pthread_mutex_lock(&g_mutex);
+    if (g_initialized) {
+        pthread_mutex_unlock(&g_mutex);
+        return NVML_SUCCESS;
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &g_initTime);
+
+    if (load_config() != 0) {
+        pthread_mutex_unlock(&g_mutex);
+        return NVML_ERROR_UNKNOWN;
+    }
+
+    g_initialized = 1;
+    pthread_mutex_unlock(&g_mutex);
+    return NVML_SUCCESS;
+}
+
+// nvmlInit_v1 - fallback, same as v2
+nvmlReturn_t nvmlInit_v1(void) {
+    return nvmlInit_v2();
+}
+
+nvmlReturn_t nvmlInitWithFlags(unsigned int flags) {
+    (void)flags;
+    return nvmlInit_v2();
+}
+
+nvmlReturn_t nvmlShutdown(void) {
+    pthread_mutex_lock(&g_mutex);
+    g_initialized = 0;
+    g_deviceCount = 0;
+    pthread_mutex_unlock(&g_mutex);
+    return NVML_SUCCESS;
+}
+
+const char* nvmlErrorString(nvmlReturn_t result) {
+    switch (result) {
+        case NVML_SUCCESS:                return "Success";
+        case NVML_ERROR_UNINITIALIZED:    return "Uninitialized";
+        case NVML_ERROR_INVALID_ARGUMENT: return "Invalid Argument";
+        case NVML_ERROR_NOT_SUPPORTED:    return "Not Supported";
+        case NVML_ERROR_INSUFFICIENT_SIZE:return "Insufficient Size";
+        case NVML_ERROR_NOT_FOUND:        return "Not Found";
+        default:                          return "Unknown Error";
+    }
+}
+
+nvmlReturn_t nvmlSystemGetDriverVersion(char *version, unsigned int length) {
+    if (!version || length == 0) return NVML_ERROR_INVALID_ARGUMENT;
+    snprintf(version, length, "999.99.99");
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlSystemGetNVMLVersion(char *version, unsigned int length) {
+    if (!version || length == 0) return NVML_ERROR_INVALID_ARGUMENT;
+    snprintf(version, length, "12.999.999");
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetCount_v2(unsigned int *deviceCount) {
+    if (!deviceCount) return NVML_ERROR_INVALID_ARGUMENT;
+    if (!g_initialized) return NVML_ERROR_UNINITIALIZED;
+    *deviceCount = (unsigned int)g_deviceCount;
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetCount_v1(unsigned int *deviceCount) {
+    return nvmlDeviceGetCount_v2(deviceCount);
+}
+
+nvmlReturn_t nvmlDeviceGetHandleByIndex_v2(unsigned int index, nvmlDevice_t *device) {
+    if (!device) return NVML_ERROR_INVALID_ARGUMENT;
+    if (!g_initialized) return NVML_ERROR_UNINITIALIZED;
+    if (index >= (unsigned int)g_deviceCount) return NVML_ERROR_INVALID_ARGUMENT;
+    *device = (nvmlDevice_t)(unsigned long)(index + 1);
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetHandleByIndex_v1(unsigned int index, nvmlDevice_t *device) {
+    return nvmlDeviceGetHandleByIndex_v2(index, device);
+}
+
+nvmlReturn_t nvmlDeviceGetUUID(nvmlDevice_t device, char *uuid, unsigned int length) {
+    if (!uuid || length == 0) return NVML_ERROR_INVALID_ARGUMENT;
+    if (!g_initialized) return NVML_ERROR_UNINITIALIZED;
+
+    int idx = handle_to_index(device);
+    if (idx < 0 || idx >= g_deviceCount) return NVML_ERROR_INVALID_ARGUMENT;
+
+    snprintf(uuid, length, "%s", g_devices[idx].uuid);
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetName(nvmlDevice_t device, char *name, unsigned int length) {
+    if (!name || length == 0) return NVML_ERROR_INVALID_ARGUMENT;
+    if (!g_initialized) return NVML_ERROR_UNINITIALIZED;
+
+    int idx = handle_to_index(device);
+    if (idx < 0 || idx >= g_deviceCount) return NVML_ERROR_INVALID_ARGUMENT;
+
+    snprintf(name, length, "%s", g_devices[idx].name);
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetPowerUsage(nvmlDevice_t device, unsigned int *power) {
+    if (!power) return NVML_ERROR_INVALID_ARGUMENT;
+    if (!g_initialized) return NVML_ERROR_UNINITIALIZED;
+
+    int idx = handle_to_index(device);
+    if (idx < 0 || idx >= g_deviceCount) return NVML_ERROR_INVALID_ARGUMENT;
+
+    *power = g_devices[idx].powerUsageMilliWatts;
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetTotalEnergyConsumption(nvmlDevice_t device, unsigned long long *energy) {
+    if (!energy) return NVML_ERROR_INVALID_ARGUMENT;
+    if (!g_initialized) return NVML_ERROR_UNINITIALIZED;
+
+    int idx = handle_to_index(device);
+    if (idx < 0 || idx >= g_deviceCount) return NVML_ERROR_INVALID_ARGUMENT;
+
+    // Energy in millijoules = powerMilliWatts * elapsed_seconds
+    // P(mW) * t(s) = E(mJ)  (since mW * s = mJ)
+    double elapsed = elapsed_seconds();
+    *energy = (unsigned long long)(g_devices[idx].powerUsageMilliWatts * elapsed);
+    return NVML_SUCCESS;
+}
+
+// v1: nvmlProcessInfo_v1_t {pid, usedGpuMemory}
+nvmlReturn_t nvmlDeviceGetComputeRunningProcesses(nvmlDevice_t device,
+        unsigned int *infoCount, nvmlProcessInfo_v1_t *infos) {
+    if (!infoCount) return NVML_ERROR_INVALID_ARGUMENT;
+    if (!g_initialized) return NVML_ERROR_UNINITIALIZED;
+
+    int idx = handle_to_index(device);
+    if (idx < 0 || idx >= g_deviceCount) return NVML_ERROR_INVALID_ARGUMENT;
+
+    FakeDevice *d = &g_devices[idx];
+    unsigned int needed = (unsigned int)d->processCount;
+
+    if (!infos || *infoCount < needed) {
+        *infoCount = needed;
+        return (needed == 0) ? NVML_SUCCESS : NVML_ERROR_INSUFFICIENT_SIZE;
+    }
+
+    for (int i = 0; i < d->processCount; i++) {
+        infos[i].pid = d->processes[i].pid;
+        infos[i].usedGpuMemory = d->processes[i].memoryUsed;
+    }
+    *infoCount = needed;
+    return NVML_SUCCESS;
+}
+
+// v2: nvmlProcessInfo_v2_t {pid, usedGpuMemory, gpuInstanceId, computeInstanceId}
+nvmlReturn_t nvmlDeviceGetComputeRunningProcesses_v2(nvmlDevice_t device,
+        unsigned int *infoCount, nvmlProcessInfo_v2_t *infos) {
+    if (!infoCount) return NVML_ERROR_INVALID_ARGUMENT;
+    if (!g_initialized) return NVML_ERROR_UNINITIALIZED;
+
+    int idx = handle_to_index(device);
+    if (idx < 0 || idx >= g_deviceCount) return NVML_ERROR_INVALID_ARGUMENT;
+
+    FakeDevice *d = &g_devices[idx];
+    unsigned int needed = (unsigned int)d->processCount;
+
+    if (!infos || *infoCount < needed) {
+        *infoCount = needed;
+        return (needed == 0) ? NVML_SUCCESS : NVML_ERROR_INSUFFICIENT_SIZE;
+    }
+
+    for (int i = 0; i < d->processCount; i++) {
+        infos[i].pid = d->processes[i].pid;
+        infos[i].usedGpuMemory = d->processes[i].memoryUsed;
+        infos[i].gpuInstanceId = 0xFFFFFFFF;
+        infos[i].computeInstanceId = 0xFFFFFFFF;
+    }
+    *infoCount = needed;
+    return NVML_SUCCESS;
+}
+
+// v3 uses same struct as v2
+nvmlReturn_t nvmlDeviceGetComputeRunningProcesses_v3(nvmlDevice_t device,
+        unsigned int *infoCount, nvmlProcessInfo_v2_t *infos) {
+    return nvmlDeviceGetComputeRunningProcesses_v2(device, infoCount, infos);
+}
+
+// GetProcessUtilization: go-nvml calls twice:
+//   1st: utilization=NULL → set *count, return ERROR_INSUFFICIENT_SIZE
+//   2nd: utilization=buffer → fill buffer, return SUCCESS
+nvmlReturn_t nvmlDeviceGetProcessUtilization(nvmlDevice_t device,
+        nvmlProcessUtilizationSample_t *utilization,
+        unsigned int *processSamplesCount,
+        unsigned long long lastSeenTimeStamp) {
+    (void)lastSeenTimeStamp;
+    if (!processSamplesCount) return NVML_ERROR_INVALID_ARGUMENT;
+    if (!g_initialized) return NVML_ERROR_UNINITIALIZED;
+
+    int idx = handle_to_index(device);
+    if (idx < 0 || idx >= g_deviceCount) return NVML_ERROR_INVALID_ARGUMENT;
+
+    FakeDevice *d = &g_devices[idx];
+    unsigned int needed = (unsigned int)d->processCount;
+
+    if (needed == 0) {
+        *processSamplesCount = 0;
+        return NVML_ERROR_NOT_FOUND;
+    }
+
+    // First call: utilization is NULL, return count via ERROR_INSUFFICIENT_SIZE
+    if (!utilization) {
+        *processSamplesCount = needed;
+        return NVML_ERROR_INSUFFICIENT_SIZE;
+    }
+
+    // Second call: fill the buffer
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    unsigned long long ts = (unsigned long long)now.tv_sec * 1000000ULL
+                          + (unsigned long long)now.tv_nsec / 1000ULL;
+
+    unsigned int count = *processSamplesCount < needed ? *processSamplesCount : needed;
+    for (unsigned int i = 0; i < count; i++) {
+        utilization[i].pid = d->processes[i].pid;
+        utilization[i].timeStamp = ts;
+        utilization[i].smUtil = d->processes[i].smUtil;
+        utilization[i].memUtil = 0;
+        utilization[i].encUtil = 0;
+        utilization[i].decUtil = 0;
+    }
+    *processSamplesCount = count;
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetComputeMode(nvmlDevice_t device, nvmlComputeMode_t *mode) {
+    if (!mode) return NVML_ERROR_INVALID_ARGUMENT;
+    if (!g_initialized) return NVML_ERROR_UNINITIALIZED;
+
+    int idx = handle_to_index(device);
+    if (idx < 0 || idx >= g_deviceCount) return NVML_ERROR_INVALID_ARGUMENT;
+
+    *mode = g_devices[idx].computeMode;
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetMigMode(nvmlDevice_t device, unsigned int *currentMode, unsigned int *pendingMode) {
+    if (!currentMode || !pendingMode) return NVML_ERROR_INVALID_ARGUMENT;
+    if (!g_initialized) return NVML_ERROR_UNINITIALIZED;
+
+    int idx = handle_to_index(device);
+    if (idx < 0 || idx >= g_deviceCount) return NVML_ERROR_INVALID_ARGUMENT;
+
+    if (!g_devices[idx].migEnabled && g_devices[idx].maxMigDevices == 0) {
+        return NVML_ERROR_NOT_SUPPORTED;
+    }
+
+    *currentMode = g_devices[idx].migEnabled ? 1 : 0;
+    *pendingMode = *currentMode;
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetMigDeviceHandleByIndex(nvmlDevice_t device,
+        unsigned int index, nvmlDevice_t *migDevice) {
+    if (!migDevice) return NVML_ERROR_INVALID_ARGUMENT;
+    if (!g_initialized) return NVML_ERROR_UNINITIALIZED;
+
+    int parentIdx = handle_to_index(device);
+    if (parentIdx < 0 || parentIdx >= g_deviceCount) return NVML_ERROR_INVALID_ARGUMENT;
+
+    FakeDevice *d = &g_devices[parentIdx];
+    if (!d->migEnabled || (int)index >= d->maxMigDevices) {
+        return NVML_ERROR_NOT_FOUND;
+    }
+
+    // Encode as MIG handle: (parent+1)*100 + mig+1
+    *migDevice = (nvmlDevice_t)(unsigned long)((parentIdx + 1) * 100 + index + 1);
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetGpuInstanceId(nvmlDevice_t device, unsigned int *id) {
+    if (!id) return NVML_ERROR_INVALID_ARGUMENT;
+    if (!g_initialized) return NVML_ERROR_UNINITIALIZED;
+
+    if (!handle_is_mig(device)) {
+        return NVML_ERROR_NOT_SUPPORTED;
+    }
+
+    *id = (unsigned int)handle_to_mig_index(device);
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetMaxMigDeviceCount(nvmlDevice_t device, unsigned int *count) {
+    if (!count) return NVML_ERROR_INVALID_ARGUMENT;
+    if (!g_initialized) return NVML_ERROR_UNINITIALIZED;
+
+    int idx = handle_to_index(device);
+    if (idx < 0 || idx >= g_deviceCount) {
+        // Might be a MIG device itself
+        if (handle_is_mig(device)) {
+            *count = 0;
+            return NVML_SUCCESS;
+        }
+        return NVML_ERROR_INVALID_ARGUMENT;
+    }
+
+    *count = (unsigned int)g_devices[idx].maxMigDevices;
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetAccountingMode(nvmlDevice_t device, nvmlEnableState_t *mode) {
+    (void)device;
+    if (!mode) return NVML_ERROR_INVALID_ARGUMENT;
+    *mode = NVML_FEATURE_ENABLED;
+    return NVML_SUCCESS;
+}
+
+// ---------- Stub functions for symbols go-nvml probes ----------
+// These are looked up via dlsym for version negotiation but may not
+// be actively used. Returning NOT_SUPPORTED is safe.
+
+nvmlReturn_t nvmlDeviceGetPciInfo_v2(nvmlDevice_t device, void *pci) {
+    (void)device; (void)pci;
+    return NVML_ERROR_NOT_SUPPORTED;
+}
+
+nvmlReturn_t nvmlDeviceGetPciInfo_v3(nvmlDevice_t device, void *pci) {
+    (void)device; (void)pci;
+    return NVML_ERROR_NOT_SUPPORTED;
+}
+
+nvmlReturn_t nvmlDeviceGetNvLinkRemotePciInfo_v2(nvmlDevice_t device,
+        unsigned int link, void *pci) {
+    (void)device; (void)link; (void)pci;
+    return NVML_ERROR_NOT_SUPPORTED;
+}
+
+nvmlReturn_t nvmlDeviceGetGridLicensableFeatures_v2(nvmlDevice_t device, void *features) {
+    (void)device; (void)features;
+    return NVML_ERROR_NOT_SUPPORTED;
+}
+
+nvmlReturn_t nvmlDeviceGetGridLicensableFeatures_v3(nvmlDevice_t device, void *features) {
+    (void)device; (void)features;
+    return NVML_ERROR_NOT_SUPPORTED;
+}
+
+nvmlReturn_t nvmlDeviceGetGridLicensableFeatures_v4(nvmlDevice_t device, void *features) {
+    (void)device; (void)features;
+    return NVML_ERROR_NOT_SUPPORTED;
+}
+
+nvmlReturn_t nvmlEventSetWait_v2(void *set, void *data, unsigned int timeoutms) {
+    (void)set; (void)data; (void)timeoutms;
+    return NVML_ERROR_NOT_SUPPORTED;
+}
+
+nvmlReturn_t nvmlDeviceGetAttributes_v2(nvmlDevice_t device, void *attributes) {
+    (void)device; (void)attributes;
+    return NVML_ERROR_NOT_SUPPORTED;
+}
+
+nvmlReturn_t nvmlComputeInstanceGetInfo_v2(void *ci, void *info) {
+    (void)ci; (void)info;
+    return NVML_ERROR_NOT_SUPPORTED;
+}
+
+nvmlReturn_t nvmlDeviceGetGraphicsRunningProcesses(nvmlDevice_t device,
+        unsigned int *infoCount, void *infos) {
+    (void)device; (void)infos;
+    if (infoCount) *infoCount = 0;
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetGraphicsRunningProcesses_v2(nvmlDevice_t device,
+        unsigned int *infoCount, void *infos) {
+    (void)device; (void)infos;
+    if (infoCount) *infoCount = 0;
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetGraphicsRunningProcesses_v3(nvmlDevice_t device,
+        unsigned int *infoCount, void *infos) {
+    (void)device; (void)infos;
+    if (infoCount) *infoCount = 0;
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetMPSComputeRunningProcesses(nvmlDevice_t device,
+        unsigned int *infoCount, void *infos) {
+    (void)device; (void)infos;
+    if (infoCount) *infoCount = 0;
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetMPSComputeRunningProcesses_v2(nvmlDevice_t device,
+        unsigned int *infoCount, void *infos) {
+    (void)device; (void)infos;
+    if (infoCount) *infoCount = 0;
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetMPSComputeRunningProcesses_v3(nvmlDevice_t device,
+        unsigned int *infoCount, void *infos) {
+    (void)device; (void)infos;
+    if (infoCount) *infoCount = 0;
+    return NVML_SUCCESS;
+}
+
+nvmlReturn_t nvmlDeviceGetHandleByPciBusId_v2(const char *pciBusId, nvmlDevice_t *device) {
+    (void)pciBusId; (void)device;
+    return NVML_ERROR_NOT_SUPPORTED;
+}
+
+nvmlReturn_t nvmlDeviceGetGpuInstancePossiblePlacements_v2(nvmlDevice_t device,
+        unsigned int profileId, void *placements, unsigned int *count) {
+    (void)device; (void)profileId; (void)placements;
+    if (count) *count = 0;
+    return NVML_ERROR_NOT_SUPPORTED;
+}
+
+nvmlReturn_t nvmlVgpuInstanceGetLicenseInfo_v2(unsigned int vgpuInstance, void *info) {
+    (void)vgpuInstance; (void)info;
+    return NVML_ERROR_NOT_SUPPORTED;
+}
+
+nvmlReturn_t nvmlDeviceGetDriverModel_v2(nvmlDevice_t device, void *current, void *pending) {
+    (void)device; (void)current; (void)pending;
+    return NVML_ERROR_NOT_SUPPORTED;
+}

--- a/test/e2e/gpu_fake_test.go
+++ b/test/e2e/gpu_fake_test.go
@@ -1,0 +1,253 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sustainable-computing-io/kepler/test/common"
+)
+
+// skipIfNoGCC skips the test if gcc is not available (needed to build fake NVML)
+func skipIfNoGCC(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("gcc"); err != nil {
+		t.Skip("Skipping GPU e2e test: gcc not found")
+	}
+}
+
+// TestGPU_DeviceDiscovered verifies that the fake GPU is discovered and
+// kepler_node_gpu_info metric is present with correct labels.
+func TestGPU_DeviceDiscovered(t *testing.T) {
+	skipIfNoGCC(t)
+
+	config := singleGPUIdle()
+	_, scraper := setupKeplerWithFakeGPU(t, config)
+
+	require.True(t, waitForGPUMetrics(t, scraper, "kepler_node_gpu_info", 30*time.Second),
+		"kepler_node_gpu_info should appear")
+
+	metrics, err := scraper.ScrapeMetric("kepler_node_gpu_info")
+	require.NoError(t, err)
+	require.NotEmpty(t, metrics, "Should have at least one GPU info metric")
+
+	m := metrics[0]
+	assert.Equal(t, "GPU-FAKE-0000-0001", m.Labels["gpu_uuid"],
+		"GPU UUID should match fake config")
+	assert.Equal(t, "NVIDIA Fake A100", m.Labels["gpu_name"],
+		"GPU name should match fake config")
+	assert.Equal(t, "nvidia", m.Labels["vendor"],
+		"Vendor should be nvidia")
+
+	t.Logf("GPU discovered: uuid=%s name=%s", m.Labels["gpu_uuid"], m.Labels["gpu_name"])
+}
+
+// TestGPU_NodePowerMetrics verifies that node-level GPU power metrics are exported.
+func TestGPU_NodePowerMetrics(t *testing.T) {
+	skipIfNoGCC(t)
+
+	config := singleGPUIdle()
+	_, scraper := setupKeplerWithFakeGPU(t, config)
+
+	require.True(t, waitForGPUMetrics(t, scraper, "kepler_node_gpu_watts", 30*time.Second),
+		"kepler_node_gpu_watts should appear")
+
+	metrics, err := scraper.ScrapeMetric("kepler_node_gpu_watts")
+	require.NoError(t, err)
+	require.NotEmpty(t, metrics)
+
+	// Fake GPU reports 40W
+	found := false
+	for _, m := range metrics {
+		if m.Labels["gpu_uuid"] == "GPU-FAKE-0000-0001" && m.Value > 0 {
+			found = true
+			t.Logf("GPU power: %.2f W (expected ~40W)", m.Value)
+		}
+	}
+	assert.True(t, found, "Should have positive GPU power for fake device")
+}
+
+// TestGPU_IdlePower verifies that when no processes are running on the GPU,
+// active power is near zero and idle power accounts for total power.
+func TestGPU_IdlePower(t *testing.T) {
+	skipIfNoGCC(t)
+
+	config := singleGPUIdle()
+	_, scraper := setupKeplerWithFakeGPU(t, config)
+
+	// Wait for metrics to stabilize (need at least 2 collection cycles for idle detection)
+	require.True(t, waitForGPUMetrics(t, scraper, "kepler_node_gpu_watts", 30*time.Second),
+		"kepler_node_gpu_watts should appear")
+	time.Sleep(10 * time.Second) // Allow idle power to be detected
+
+	snapshot, err := scraper.TakeSnapshot()
+	require.NoError(t, err)
+
+	totalPower := snapshot.SumValues("kepler_node_gpu_watts", nil)
+	activePower := snapshot.SumValues("kepler_node_gpu_active_watts", nil)
+
+	t.Logf("GPU total=%.2f W, active=%.2f W", totalPower, activePower)
+
+	assert.Greater(t, totalPower, 0.0, "Total GPU power should be > 0")
+
+	// With no processes, active power should be zero or near-zero
+	// (tolerance for floating-point and timing)
+	assert.LessOrEqual(t, activePower, totalPower,
+		"Active power should not exceed total power")
+}
+
+// TestGPU_ProcessPowerAttribution verifies that process-level GPU power
+// is attributed when a real process is visible to the fake GPU.
+func TestGPU_ProcessPowerAttribution(t *testing.T) {
+	skipIfNoGCC(t)
+
+	// Start a real process whose PID we can report in the fake NVML config
+	sleepCmd := exec.Command("sleep", "infinity")
+	require.NoError(t, sleepCmd.Start(), "Failed to start sleep process")
+	t.Cleanup(func() {
+		_ = sleepCmd.Process.Kill()
+		_ = sleepCmd.Wait()
+	})
+
+	pid := sleepCmd.Process.Pid
+	t.Logf("Started sleep process with PID %d", pid)
+
+	config := singleGPUWithProcesses([]fakeNVMLProcess{{
+		PID:        pid,
+		MemoryUsed: 1 << 30, // 1 GiB
+		SmUtil:     60,
+	}})
+
+	_, scraper := setupKeplerWithFakeGPU(t, config)
+
+	require.True(t, waitForGPUMetrics(t, scraper, "kepler_node_gpu_watts", 30*time.Second),
+		"kepler_node_gpu_watts should appear")
+
+	// Wait for process attribution to kick in
+	time.Sleep(10 * time.Second)
+
+	snapshot, err := scraper.TakeSnapshot()
+	require.NoError(t, err)
+
+	totalPower := snapshot.SumValues("kepler_node_gpu_watts", nil)
+	activePower := snapshot.SumValues("kepler_node_gpu_active_watts", nil)
+
+	t.Logf("GPU total=%.2f W, active=%.2f W", totalPower, activePower)
+
+	assert.Greater(t, totalPower, 0.0, "Total GPU power should be > 0")
+	assert.Greater(t, activePower, 0.0, "Active GPU power should be > 0 with a running process")
+
+	// Check process-level GPU power
+	processGPUMetrics := snapshot.GetAllWithName("kepler_process_gpu_watts")
+	if len(processGPUMetrics) > 0 {
+		t.Logf("Found %d process GPU metrics", len(processGPUMetrics))
+		for _, m := range processGPUMetrics {
+			if m.Value > 0 {
+				t.Logf("  PID=%s comm=%s power=%.4f W", m.Labels["pid"], m.Labels["comm"], m.Value)
+			}
+		}
+	} else {
+		t.Log("No process GPU metrics found yet - this may require more collection cycles")
+	}
+}
+
+// TestGPU_MultipleDevices verifies that multiple GPUs are discovered correctly.
+func TestGPU_MultipleDevices(t *testing.T) {
+	skipIfNoGCC(t)
+
+	config := fakeNVMLConfig{
+		Devices: []fakeNVMLDevice{
+			{
+				UUID:                 "GPU-FAKE-0000-0001",
+				Name:                 "NVIDIA Fake A100",
+				PowerUsageMilliWatts: 40000,
+			},
+			{
+				UUID:                 "GPU-FAKE-0000-0002",
+				Name:                 "NVIDIA Fake H100",
+				PowerUsageMilliWatts: 60000,
+			},
+		},
+	}
+
+	_, scraper := setupKeplerWithFakeGPU(t, config)
+
+	require.True(t, waitForGPUMetrics(t, scraper, "kepler_node_gpu_info", 30*time.Second),
+		"kepler_node_gpu_info should appear")
+
+	metrics, err := scraper.ScrapeMetric("kepler_node_gpu_info")
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(metrics), 2, "Should discover both GPUs")
+
+	uuids := make(map[string]bool)
+	for _, m := range metrics {
+		uuids[m.Labels["gpu_uuid"]] = true
+	}
+	assert.True(t, uuids["GPU-FAKE-0000-0001"], "First GPU should be discovered")
+	assert.True(t, uuids["GPU-FAKE-0000-0002"], "Second GPU should be discovered")
+
+	t.Logf("Discovered %d GPUs", len(uuids))
+}
+
+// TestGPU_EnergyIncreases verifies that GPU energy counters increase monotonically
+// between two scrapes.
+func TestGPU_EnergyIncreases(t *testing.T) {
+	skipIfNoGCC(t)
+
+	config := singleGPUIdle()
+	_, scraper := setupKeplerWithFakeGPU(t, config)
+
+	require.True(t, waitForGPUMetrics(t, scraper, "kepler_node_gpu_watts", 30*time.Second),
+		"kepler_node_gpu_watts should appear")
+
+	// Take two snapshots separated by time
+	snapshot1, err := scraper.TakeSnapshot()
+	require.NoError(t, err)
+
+	time.Sleep(5 * time.Second)
+
+	snapshot2, err := scraper.TakeSnapshot()
+	require.NoError(t, err)
+
+	// Check power is reported consistently across scrapes
+	power1 := snapshot1.SumValues("kepler_node_gpu_watts", nil)
+	power2 := snapshot2.SumValues("kepler_node_gpu_watts", nil)
+
+	t.Logf("Snapshot 1: GPU power=%.2f W", power1)
+	t.Logf("Snapshot 2: GPU power=%.2f W", power2)
+
+	assert.Greater(t, power1, 0.0, "First snapshot should have positive GPU power")
+	assert.Greater(t, power2, 0.0, "Second snapshot should have positive GPU power")
+}
+
+// TestGPU_GracefulStartupWithoutGPU verifies that Kepler starts correctly
+// even when the fake NVML library fails to initialize (no config file).
+func TestGPU_GracefulStartupWithoutGPU(t *testing.T) {
+	skipIfNoGCC(t)
+
+	// Build fake NVML but don't set FAKE_NVML_CONFIG - init should fail
+	libDir := buildFakeNVML(t)
+	keplerConfig := writeGPUKeplerConfig(t)
+
+	k := startKepler(t,
+		withLogOutput(os.Stderr),
+		withConfigFile(keplerConfig),
+		withPort(gpuMetricsPort),
+		withEnv("LD_LIBRARY_PATH", libDir),
+		// No FAKE_NVML_CONFIG → nvmlInit_v2 will fail
+	)
+
+	assert.True(t, k.IsRunning(), "Kepler should still start even if GPU init fails")
+
+	// Verify basic metrics still work (CPU metrics)
+	s := common.NewMetricsScraper(k.MetricsURL())
+	require.True(t, WaitForValidCPUMetrics(t, s, 30*time.Second),
+		"CPU metrics should still work without GPU")
+}

--- a/test/e2e/gpu_helpers_test.go
+++ b/test/e2e/gpu_helpers_test.go
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sustainable-computing-io/kepler/test/common"
+)
+
+const gpuMetricsPort = 28283
+
+// fakeNVMLDevice represents a GPU device in the fake NVML config
+type fakeNVMLDevice struct {
+	UUID                  string            `json:"uuid"`
+	Name                  string            `json:"name"`
+	PowerUsageMilliWatts  uint              `json:"powerUsageMilliWatts"`
+	ComputeMode           int               `json:"computeMode"`
+	MIGEnabled            bool              `json:"migEnabled"`
+	MaxMIGDevices         int               `json:"maxMigDevices"`
+	Processes             []fakeNVMLProcess `json:"processes"`
+}
+
+// fakeNVMLProcess represents a process using the GPU
+type fakeNVMLProcess struct {
+	PID        int    `json:"pid"`
+	MemoryUsed uint64 `json:"memoryUsed"`
+	SmUtil     uint   `json:"smUtil"`
+}
+
+// fakeNVMLConfig is the top-level config for the fake NVML library
+type fakeNVMLConfig struct {
+	Devices []fakeNVMLDevice `json:"devices"`
+}
+
+// buildFakeNVML compiles the fake libnvidia-ml.so.1 and returns the directory containing it
+func buildFakeNVML(t *testing.T) string {
+	t.Helper()
+
+	// Look for source files relative to common locations
+	candidates := []string{
+		"test/e2e/fake_nvml",
+		"fake_nvml",
+		"../e2e/fake_nvml",
+	}
+
+	var fakeDir string
+	for _, c := range candidates {
+		if absPath, err := filepath.Abs(c); err == nil {
+			if _, err := os.Stat(filepath.Join(absPath, "fake_nvml.c")); err == nil {
+				fakeDir = absPath
+				break
+			}
+		}
+	}
+	if fakeDir == "" {
+		t.Fatal("Cannot find fake_nvml source directory")
+	}
+
+	srcFiles := []string{
+		filepath.Join(fakeDir, "fake_nvml.c"),
+		filepath.Join(fakeDir, "cJSON.c"),
+	}
+	for _, f := range srcFiles {
+		if _, err := os.Stat(f); os.IsNotExist(err) {
+			t.Fatalf("Source file not found: %s", f)
+		}
+	}
+
+	outDir := t.TempDir()
+	outPath := filepath.Join(outDir, "libnvidia-ml.so.1")
+
+	cmd := exec.Command("gcc",
+		"-shared", "-fPIC",
+		"-o", outPath,
+		srcFiles[0], srcFiles[1],
+		"-lpthread",
+	)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to compile fake NVML: %v", err)
+	}
+
+	t.Logf("Built fake NVML at %s", outPath)
+	return outDir
+}
+
+// writeFakeNVMLConfig writes a JSON config file for the fake NVML library
+func writeFakeNVMLConfig(t *testing.T, config fakeNVMLConfig) string {
+	t.Helper()
+
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		t.Fatalf("Failed to marshal fake NVML config: %v", err)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "fake_nvml_config.json")
+	if err := os.WriteFile(configPath, data, 0644); err != nil {
+		t.Fatalf("Failed to write fake NVML config: %v", err)
+	}
+
+	return configPath
+}
+
+// writeGPUKeplerConfig writes a Kepler config YAML with GPU enabled
+func writeGPUKeplerConfig(t *testing.T) string {
+	t.Helper()
+
+	config := `# SPDX-FileCopyrightText: 2025 The Kepler Authors
+# SPDX-License-Identifier: Apache-2.0
+log:
+  level: debug
+  format: text
+monitor:
+  interval: 3s
+  staleness: 10s
+  maxTerminated: 100
+  minTerminatedEnergyThreshold: 1
+host:
+  procfs: /proc
+  sysfs: /sys
+exporter:
+  prometheus:
+    enabled: true
+    metricsLevel:
+      - node
+      - process
+      - container
+      - vm
+      - pod
+web:
+  listenAddresses:
+    - :` + fmt.Sprintf("%d", gpuMetricsPort) + `
+kube:
+  enabled: false
+dev:
+  fake-cpu-meter:
+    enabled: true
+experimental:
+  gpu:
+    enabled: true
+    idlePower: 0
+`
+	configPath := filepath.Join(t.TempDir(), "gpu-e2e-config.yaml")
+	if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+		t.Fatalf("Failed to write GPU kepler config: %v", err)
+	}
+
+	return configPath
+}
+
+// setupKeplerWithFakeGPU starts Kepler with the fake NVML library
+func setupKeplerWithFakeGPU(t *testing.T, config fakeNVMLConfig) (*KeplerInstance, *common.MetricsScraper) {
+	t.Helper()
+
+	// Build fake NVML shared library
+	libDir := buildFakeNVML(t)
+
+	// Write fake NVML config JSON
+	nvmlConfigPath := writeFakeNVMLConfig(t, config)
+
+	// Write Kepler config with GPU enabled
+	keplerConfig := writeGPUKeplerConfig(t)
+
+	// Start Kepler with env vars pointing to the fake library
+	k := startKepler(t,
+		withLogOutput(os.Stderr),
+		withConfigFile(keplerConfig),
+		withPort(gpuMetricsPort),
+		withEnv("LD_LIBRARY_PATH", libDir),
+		withEnv("FAKE_NVML_CONFIG", nvmlConfigPath),
+	)
+
+	return k, common.NewMetricsScraper(k.MetricsURL())
+}
+
+// singleGPUIdle returns a config for 1 idle GPU with no processes
+func singleGPUIdle() fakeNVMLConfig {
+	return fakeNVMLConfig{
+		Devices: []fakeNVMLDevice{{
+			UUID:                 "GPU-FAKE-0000-0001",
+			Name:                 "NVIDIA Fake A100",
+			PowerUsageMilliWatts: 40000, // 40W idle
+			ComputeMode:          0,     // default (time-slicing)
+			Processes:            nil,
+		}},
+	}
+}
+
+// singleGPUWithProcesses returns a config for 1 GPU with active processes
+func singleGPUWithProcesses(processes []fakeNVMLProcess) fakeNVMLConfig {
+	return fakeNVMLConfig{
+		Devices: []fakeNVMLDevice{{
+			UUID:                 "GPU-FAKE-0000-0001",
+			Name:                 "NVIDIA Fake A100",
+			PowerUsageMilliWatts: 150000, // 150W under load
+			ComputeMode:          0,
+			Processes:            processes,
+		}},
+	}
+}
+
+// waitForGPUMetrics waits for GPU metrics to appear in Kepler's output
+func waitForGPUMetrics(t *testing.T, scraper *common.MetricsScraper, metricName string, timeout time.Duration) bool {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	err := common.WaitForCondition(ctx, 2*time.Second, func() bool {
+		metrics, err := scraper.ScrapeMetric(metricName)
+		if err != nil {
+			return false
+		}
+		return len(metrics) > 0
+	})
+	if err != nil {
+		t.Logf("Timeout waiting for GPU metric %s", metricName)
+		return false
+	}
+	return true
+}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -85,6 +85,7 @@ type KeplerInstance struct {
 	binaryPath string
 	port       int
 	logOutput  io.Writer
+	envVars    []string
 }
 
 // keplerOption configures KeplerInstance
@@ -93,6 +94,23 @@ type keplerOption func(*KeplerInstance)
 // withLogOutput sets where to write logs
 func withLogOutput(w io.Writer) keplerOption {
 	return func(k *KeplerInstance) { k.logOutput = w }
+}
+
+// withEnv adds an environment variable for the Kepler process
+func withEnv(key, value string) keplerOption {
+	return func(k *KeplerInstance) {
+		k.envVars = append(k.envVars, key+"="+value)
+	}
+}
+
+// withConfigFile overrides the config file path
+func withConfigFile(path string) keplerOption {
+	return func(k *KeplerInstance) { k.configPath = path }
+}
+
+// withPort overrides the metrics port
+func withPort(port int) keplerOption {
+	return func(k *KeplerInstance) { k.port = port }
 }
 
 // startKepler starts Kepler and registers cleanup
@@ -140,6 +158,10 @@ func (k *KeplerInstance) start(t *testing.T) error {
 	}
 
 	k.cmd = exec.Command(binaryPath, args...)
+
+	if len(k.envVars) > 0 {
+		k.cmd.Env = append(os.Environ(), k.envVars...)
+	}
 
 	stdout, _ := k.cmd.StdoutPipe()
 	stderr, _ := k.cmd.StderrPipe()


### PR DESCRIPTION
  Introduce a fake libnvidia-ml.so.1 (C shared library) that go-nvml
  loads via dlopen, returning canned GPU data from a JSON config file.
  This enables testing the full GPU metrics pipeline without real
  NVIDIA hardware.

  - fake_nvml.c: 44 NVML symbols, reads config from FAKE_NVML_CONFIG env
  - cJSON vendored (MIT) for JSON parsing in C
  - 7 test cases: discovery, power, idle, process attribution, multi-GPU, energy consistency, graceful degradation
  - Makefile test-e2e-gpu target
  - Documentation in docs/developer/e2e-testing.md