### PR TITLE
ci: fetch base branch as local ref

### DIFF
--- a/.github/workflows/check-x-crypto-deps.yaml
+++ b/.github/workflows/check-x-crypto-deps.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: fetch base branch
         run: |
           git fetch https://github.com/${{ github.event.pull_request.base.repo.full_name }}.git \
-            +${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+            +${{ github.event.pull_request.base.ref }}:refs/heads/${{ github.event.pull_request.base.ref }}
 
       - name: setup go
         uses: actions/setup-go@v6.2.0


### PR DESCRIPTION
The fetch step stored the base branch under refs/remotes/origin/ which git archive could not resolve as a bare name when the checkout origin points to a fork. Store it under refs/heads/ instead so that