### PR TITLE
chore: add nikimanoledaki to maintianer list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,17 +3,18 @@
 - **Cycle:** Spring 2026
 - **Period:** April 1, 2026 – September 30, 2026
 
-| Name                  | Company | Github ID    | Email                            | Role                                                          |
-|-----------------------|---------|--------------|----------------------------------|---------------------------------------------------------------|
-| Vimal Kumar           | Red Hat | vimalk78     | <vimal78@gmail.com>              | Project Lead                                                  |
-| Vibhu Prashar         | Red Hat | vprashar2929 | <vibhu.sharma2929@gmail.com>     | Technical Committee, Release Management, Repository Oversight |
-| Kaiyi Liu             | Red Hat | KaiyiLiu1234 | <kaliu@redhat.com>               | Technical Committee                                           |
-| Sunil Thaha           | Red Hat | sthaha       | <gh.dev@thaha.me>                | Technical Committee                                           |
-| Peng Hui Jiang        | cogiot  | jiangphcn    | <jiangphcn@apache.org>           | Technical Committee                                           |
-| Brad McCoy            | Basiq   | bradmccoydev | <bradmccoydev@gmail.com>         | Technical Committee                                           |
-| Yi Yuan               |         | SamYuan1990  | <yy19902439@126.com>             | Community Engagement                                          |
-| Sunyanan Choochotkaew | IBM     | sunya-ch     | <sunyanan.choochotkaew1@ibm.com> | Community Engagement                                          |
-| Vasco Gervasi         |         | yellowhat    | <yellowhat@mailbox.org>          | Helm Chart Maintainer                                         |
+| Name                  | Company      | Github ID      | Email                            | Role                                                          |
+|-----------------------|--------------|----------------|----------------------------------|---------------------------------------------------------------|
+| Vimal Kumar           | Red Hat      | vimalk78       | <vimal78@gmail.com>              | Project Lead                                                  |
+| Vibhu Prashar         | Red Hat      | vprashar2929   | <vibhu.sharma2929@gmail.com>     | Technical Committee, Release Management, Repository Oversight |
+| Kaiyi Liu             | Red Hat      | KaiyiLiu1234   | <kaliu@redhat.com>               | Technical Committee                                           |
+| Sunil Thaha           | Red Hat      | sthaha         | <gh.dev@thaha.me>                | Technical Committee                                           |
+| Peng Hui Jiang        | cogiot       | jiangphcn      | <jiangphcn@apache.org>           | Technical Committee                                           |
+| Brad McCoy            | Basiq        | bradmccoydev   | <bradmccoydev@gmail.com>         | Technical Committee                                           |
+| Yi Yuan               |              | SamYuan1990    | <yy19902439@126.com>             | Community Engagement                                          |
+| Sunyanan Choochotkaew | IBM          | sunya-ch       | <sunyanan.choochotkaew1@ibm.com> | Community Engagement                                          |
+| Niki Manoledaki       | Grafana Labs | nikimanoledaki | <niki.manoledaki@grafana.com>    | Community Engagement                                          |
+| Vasco Gervasi         |              | yellowhat      | <yellowhat@mailbox.org>          | Helm Chart Maintainer                                         |
 
 This list must be kept in sync with the
 [CNCF Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv).
@@ -25,18 +26,17 @@ See [the project Governance](GOVERNANCE.md) for how maintainers are elected.
 Emeritus maintainers are former maintainers of a project who no longer actively contribute or oversee it but are recognized for their past contributions.
 They may return to active status in a future cycle by reaffirming their commitment to active participation.
 
-| Name            | Company      | Github ID      | Email                         | Last cycle  |
-|-----------------|--------------|----------------|-------------------------------|-------------|
-| Huamin Chen     | Red Hat      | rootfs         | <hchen@redhat.com>            | Spring 2025 |
-| Ji Chen         | IBM          | jichenjc       | <jichenjc@cn.ibm.com>         | Spring 2025 |
-| Parul Singh     | Red Hat      | husky-parul    | <parsingh@redhat.com>         | Spring 2025 |
-| William Caban   | Red Hat      | williamcaban   | <wcabanba@redhat.com>         | Spring 2025 |
-| Ken Lu          | Intel        | kenplusplus    | <ken.lu@intel.com>            | Spring 2025 |
-| Marcelo Amaral  | IBM          | marceloamaral  | <marcelo.amaral@ibm.com>      | Spring 2025 |
-| Niki Manoledaki | Grafana Labs | nikimanoledaki | <niki.manoledaki@grafana.com> | Spring 2025 |
-| Ruomeng Hao     | Intel        | ruomengh       | <ruomengh@intel.com>          | Spring 2025 |
-| Chen Wang       | IBM          | wangchen615    | <chen.wang1@ibm.com>          | Spring 2025 |
-| Jie Ren         | Intel        | jiere          | <jie.ren@intel.com>           | Spring 2025 |
-| Dave Tucker     | Red Hat      | dave-tucker    | <datucker@redhat.com>         | Spring 2025 |
-| Maryam Tahhan   | Red Hat      | maryamtahhan   | <mtahhan@redhat.com>          | Spring 2025 |
-| Qi Feng Huo     | IBM          | huoqifeng      | <huoqif@cn.ibm.com>           | Fall 2025   |
+| Name           | Company | Github ID     | Email                    | Last cycle  |
+|----------------|---------|---------------|--------------------------|-------------|
+| Huamin Chen    | Red Hat | rootfs        | <hchen@redhat.com>       | Spring 2025 |
+| Ji Chen        | IBM     | jichenjc      | <jichenjc@cn.ibm.com>    | Spring 2025 |
+| Parul Singh    | Red Hat | husky-parul   | <parsingh@redhat.com>    | Spring 2025 |
+| William Caban  | Red Hat | williamcaban  | <wcabanba@redhat.com>    | Spring 2025 |
+| Ken Lu         | Intel   | kenplusplus   | <ken.lu@intel.com>       | Spring 2025 |
+| Marcelo Amaral | IBM     | marceloamaral | <marcelo.amaral@ibm.com> | Spring 2025 |
+| Ruomeng Hao    | Intel   | ruomengh      | <ruomengh@intel.com>     | Spring 2025 |
+| Chen Wang      | IBM     | wangchen615   | <chen.wang1@ibm.com>     | Spring 2025 |
+| Jie Ren        | Intel   | jiere         | <jie.ren@intel.com>      | Spring 2025 |
+| Dave Tucker    | Red Hat | dave-tucker   | <datucker@redhat.com>    | Spring 2025 |
+| Maryam Tahhan  | Red Hat | maryamtahhan  | <mtahhan@redhat.com>     | Spring 2025 |
+| Qi Feng Huo    | IBM     | huoqifeng     | <huoqif@cn.ibm.com>      | Fall 2025   |


### PR DESCRIPTION
Closes https://github.com/sustainable-computing-io/kepler/issues/2458

Move Niki Manoledaki from emeritus to active maintainer list

Nomination issue:
- https://github.com/sustainable-computing-io/kepler/issues/2458

sponsors: @sunya-ch @vimalk78 @vprashar2929 