### PR TITLE
feat(device): add `cpu.meters` config and switch-based CPU meter selection

### DIFF
--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -45,6 +45,8 @@ func main() {
 	logVersionInfo(logger)
 	printConfigInfo(logger, cfg)
 
+	cfg.ApplyCpuMeterDeprecations(logger)
+
 	services, err := createServices(logger, cfg)
 	if err != nil {
 		logger.Error("failed to create services", "error", err)
@@ -127,7 +129,7 @@ Configuration
 
 func createServices(logger *slog.Logger, cfg *config.Config) ([]service.Service, error) {
 	logger.Debug("Creating all services")
-	cpuPowerMeter, err := createCPUMeter(logger, cfg)
+	cpuPowerMeter, err := device.CreateCPUMeter(logger, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CPU power meter: %w", err)
 	}
@@ -307,79 +309,6 @@ func createPrometheusExporter(
 	)
 
 	return promExporter, nil
-}
-
-func createCPUMeter(logger *slog.Logger, cfg *config.Config) (device.CPUPowerMeter, error) {
-	// If fake meter is explicitly enabled, use it directly
-	if fake := cfg.Dev.FakeCpuMeter; *fake.Enabled {
-		return device.NewFakeCPUMeter(fake.Zones, device.WithFakeLogger(logger))
-	}
-
-	// If hwmon is explicitly enabled, use it directly
-	if cfg.IsFeatureEnabled(config.ExperimentalHwmonFeature) {
-		logger.Info("hwmon explicitly enabled via config")
-		return createHwmonMeter(logger, cfg)
-	}
-
-	// Try RAPL first (default logic -> attempt RAPL, then attempt HWMON)
-	if len(cfg.Rapl.Zones) > 0 {
-		logger.Info("rapl zones are filtered", "zones-enabled", cfg.Rapl.Zones)
-	}
-
-	raplMeter, err := device.NewCPUPowerMeter(
-		cfg.Host.SysFS,
-		device.WithRaplLogger(logger),
-		device.WithZoneFilter(cfg.Rapl.Zones),
-	)
-	if err != nil {
-		logger.Warn("RAPL not available, falling back to hwmon", "error", err)
-		return createHwmonMeter(logger, cfg)
-	}
-
-	// Verify RAPL can actually read energy data
-	if initErr := raplMeter.Init(); initErr != nil {
-		logger.Warn("RAPL initialization failed, falling back to hwmon", "error", initErr)
-		return createHwmonMeter(logger, cfg)
-	}
-
-	logger.Info("using RAPL power meter")
-	return raplMeter, nil
-}
-
-func createHwmonMeter(logger *slog.Logger, cfg *config.Config) (device.CPUPowerMeter, error) {
-	var hwmonZones []string
-	var chipRules []device.ConfigChipRule
-
-	if cfg.Experimental != nil {
-		hwmon := cfg.Experimental.Hwmon
-
-		if len(hwmon.Zones) > 0 {
-			logger.Info("hwmon zones are filtered", "zones-enabled", hwmon.Zones)
-			hwmonZones = hwmon.Zones
-		}
-
-		for _, cr := range hwmon.ChipRules {
-			chipRules = append(chipRules, device.ConfigChipRule{
-				Name:         cr.Name,
-				Pairings:     cr.Pairings,
-				SkipVoltages: cr.SkipVoltages,
-				SkipCurrents: cr.SkipCurrents,
-				UseSameIndex: cr.UseSameIndex,
-			})
-		}
-
-		if len(chipRules) > 0 {
-			logger.Info("hwmon chip rules configured", "count", len(chipRules))
-		}
-	}
-
-	logger.Info("using hwmon power meter")
-	return device.NewHwmonPowerMeter(
-		cfg.Host.SysFS,
-		device.WithHwmonLogger(logger),
-		device.WithHwmonZoneFilter(hwmonZones),
-		device.WithHwmonChipRules(chipRules),
-	)
 }
 
 // createGPUMeters discovers and initializes GPU power meters for all vendors.

--- a/compose/dev/kepler-dev/etc/kepler/config.yaml
+++ b/compose/dev/kepler-dev/etc/kepler/config.yaml
@@ -32,6 +32,12 @@ host:
   sysfs: /host/sys # Path to sysfs filesystem (default: /sys)
   procfs: /host/proc # Path to procfs filesystem (default: /proc)
 
+cpu:
+  # Ordered list of CPU power-meter backends. The first backend that
+  # initializes successfully and reports zones is used.
+  # Built-in backends: rapl, hwmon, fake.
+  meters: ["rapl", "hwmon"]
+
 rapl:
   zones: [] # zones to be enabled, empty enables all default zones
 
@@ -71,6 +77,8 @@ kube: # kubernetes related config
 # WARN DO NOT ENABLE THIS IN PRODUCTION - for development / testing only
 dev:
   fake-cpu-meter:
+    # DEPRECATED: set cpu.meters: ["fake"] instead.
+    # When true, this overrides cpu.meters and emits a deprecation warning.
     enabled: false
     zones: [] # zones to be enabled, empty enables all default zones
 
@@ -84,7 +92,7 @@ experimental:
       nodeName: kepler-dev # Node name to use (overrides Kubernetes node name and hostname fallback)
       httpTimeout: 5s # HTTP client timeout for BMC requests (default: 5s)
   hwmon:
-    forceEnabled: false # Force hwmon as the power meter, skipping RAPL auto-detection
+    forceEnabled: false # DEPRECATED: set cpu.meters: ["hwmon"] instead. Emits a deprecation warning when true.
     zones: [] # List of zones to enable (default enable all)
     chipRules: [] # User-defined chip pairing rules (override/add to hardcoded defaults)
   gpu:

--- a/compose/dev/kepler-dev/etc/kepler/config.yaml
+++ b/compose/dev/kepler-dev/etc/kepler/config.yaml
@@ -36,7 +36,7 @@ cpu:
   # Ordered list of CPU power-meter backends. The first backend that
   # initializes successfully and reports zones is used.
   # Built-in backends: rapl, hwmon, fake.
-  meters: ["rapl", "hwmon"]
+  meters: [rapl, hwmon]
 
 rapl:
   zones: [] # zones to be enabled, empty enables all default zones
@@ -77,9 +77,7 @@ kube: # kubernetes related config
 # WARN DO NOT ENABLE THIS IN PRODUCTION - for development / testing only
 dev:
   fake-cpu-meter:
-    # DEPRECATED: set cpu.meters: ["fake"] instead.
-    # When true, this overrides cpu.meters and emits a deprecation warning.
-    enabled: false
+    enabled: false # DEPRECATED: set cpu.meters: ["fake"] instead. Overrides cpu.meters and emits a deprecation warning when true.
     zones: [] # zones to be enabled, empty enables all default zones
 
 # EXPERIMENTAL FEATURES - These features are experimental and may be unstable

--- a/config/config.go
+++ b/config/config.go
@@ -384,14 +384,12 @@ func DefaultConfig() *Config {
 // who set them today expect the legacy behavior. The legacy keys will stop
 // working in a future release.
 func (c *Config) ApplyCpuMeterDeprecations(logger *slog.Logger) {
-	if ptr.Deref(c.Dev.FakeCpuMeter.Enabled, false) {
-		logger.Warn("dev.fake-cpu-meter.enabled is deprecated; set cpu.meters: [\"fake\"] instead")
+	switch {
+	case ptr.Deref(c.Dev.FakeCpuMeter.Enabled, false):
+		logger.Warn(`dev.fake-cpu-meter.enabled is deprecated; set cpu.meters: ["fake"] instead`)
 		c.Cpu.Meters = []string{"fake"}
-		return
-	}
-
-	if c.Experimental != nil && ptr.Deref(c.Experimental.Hwmon.ForceEnabled, false) {
-		logger.Warn("experimental.hwmon.forceEnabled is deprecated; set cpu.meters: [\"hwmon\"] instead")
+	case c.Experimental != nil && ptr.Deref(c.Experimental.Hwmon.ForceEnabled, false):
+		logger.Warn(`experimental.hwmon.forceEnabled is deprecated; set cpu.meters: ["hwmon"] instead`)
 		c.Cpu.Meters = []string{"hwmon"}
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/url"
 	"os"
@@ -51,6 +52,13 @@ type (
 	Host struct {
 		SysFS  string `yaml:"sysfs"`
 		ProcFS string `yaml:"procfs"`
+	}
+
+	// Cpu configuration controls how CPU power meters are selected.
+	// Meters lists backends in priority order. The first backend that
+	// initializes successfully and reports zones is used.
+	Cpu struct {
+		Meters []string `yaml:"meters"`
 	}
 
 	// Rapl configuration
@@ -192,6 +200,7 @@ type (
 		Log      Log      `yaml:"log"`
 		Host     Host     `yaml:"host"`
 		Monitor  Monitor  `yaml:"monitor"`
+		Cpu      Cpu      `yaml:"cpu"`
 		Rapl     Rapl     `yaml:"rapl"`
 		Exporter Exporter `yaml:"exporter"`
 		Web      Web      `yaml:"web"`
@@ -264,6 +273,9 @@ const (
 	MonitorStaleness         = "monitor.staleness" // not a flag
 	MonitorMaxTerminatedFlag = "monitor.max-terminated"
 
+	// CPU
+	CpuMeters = "cpu.meters" // not a flag
+
 	// RAPL
 	RaplZones = "rapl.zones" // not a flag
 
@@ -313,6 +325,9 @@ func DefaultConfig() *Config {
 			SysFS:  "/sys",
 			ProcFS: "/proc",
 		},
+		Cpu: Cpu{
+			Meters: []string{"rapl", "hwmon"},
+		},
 		Rapl: Rapl{
 			Zones: []string{},
 		},
@@ -356,6 +371,29 @@ func DefaultConfig() *Config {
 
 	cfg.Dev.FakeCpuMeter.Enabled = ptr.To(false)
 	return cfg
+}
+
+// ApplyCpuMeterDeprecations translates legacy CPU-meter selectors into an
+// effective cpu.meters value and logs a deprecation warning per translation.
+//
+// Legacy selectors:
+//   - experimental.hwmon.forceEnabled=true → cpu.meters: ["hwmon"]
+//   - dev.fake-cpu-meter.enabled=true     → cpu.meters: ["fake"]
+//
+// Legacy selectors win over an explicit cpu.meters when set, since operators
+// who set them today expect the legacy behavior. The legacy keys will stop
+// working in a future release.
+func (c *Config) ApplyCpuMeterDeprecations(logger *slog.Logger) {
+	if ptr.Deref(c.Dev.FakeCpuMeter.Enabled, false) {
+		logger.Warn("dev.fake-cpu-meter.enabled is deprecated; set cpu.meters: [\"fake\"] instead")
+		c.Cpu.Meters = []string{"fake"}
+		return
+	}
+
+	if c.Experimental != nil && ptr.Deref(c.Experimental.Hwmon.ForceEnabled, false) {
+		logger.Warn("experimental.hwmon.forceEnabled is deprecated; set cpu.meters: [\"hwmon\"] instead")
+		c.Cpu.Meters = []string{"hwmon"}
+	}
 }
 
 // Load loads configuration from an io.Reader
@@ -786,6 +824,10 @@ func (c *Config) sanitize() {
 		c.Web.ListenAddresses[i] = strings.TrimSpace(c.Web.ListenAddresses[i])
 	}
 
+	for i := range c.Cpu.Meters {
+		c.Cpu.Meters[i] = strings.TrimSpace(c.Cpu.Meters[i])
+	}
+
 	for i := range c.Rapl.Zones {
 		c.Rapl.Zones[i] = strings.TrimSpace(c.Rapl.Zones[i])
 	}
@@ -1076,6 +1118,7 @@ func (c *Config) manualString() string {
 		{MonitorIntervalFlag, c.Monitor.Interval.String()},
 		{MonitorStaleness, c.Monitor.Staleness.String()},
 		{MonitorMaxTerminatedFlag, fmt.Sprintf("%d", c.Monitor.MaxTerminated)},
+		{CpuMeters, strings.Join(c.Cpu.Meters, ", ")},
 		{RaplZones, strings.Join(c.Rapl.Zones, ", ")},
 		{ExporterStdoutEnabledFlag, fmt.Sprintf("%v", c.Exporter.Stdout.Enabled)},
 		{ExporterPrometheusEnabledFlag, fmt.Sprintf("%v", c.Exporter.Prometheus.Enabled)},

--- a/config/config.go
+++ b/config/config.go
@@ -381,8 +381,9 @@ func DefaultConfig() *Config {
 //   - dev.fake-cpu-meter.enabled=true     → cpu.meters: ["fake"]
 //
 // Legacy selectors win over an explicit cpu.meters when set, since operators
-// who set them today expect the legacy behavior. The legacy keys will stop
-// working in a future release.
+// who set them today expect the legacy behavior. When both legacy keys are set,
+// fake takes precedence over hwmon. The legacy keys will stop working in a
+// future release.
 func (c *Config) ApplyCpuMeterDeprecations(logger *slog.Logger) {
 	switch {
 	case ptr.Deref(c.Dev.FakeCpuMeter.Enabled, false):

--- a/config/config.go
+++ b/config/config.go
@@ -915,6 +915,19 @@ func (c *Config) Validate(skips ...SkipValidation) error {
 			}
 		}
 	}
+	{ // cpu.meters
+		// Keep this list in sync with the switch in internal/device/cpu_power_meter.go.
+		validCpuMeters := map[string]bool{
+			"rapl":  true,
+			"hwmon": true,
+			"fake":  true,
+		}
+		for _, name := range c.Cpu.Meters {
+			if !validCpuMeters[name] {
+				errs = append(errs, fmt.Sprintf("invalid cpu.meters entry %q, must be one of %q, %q, %q", name, "rapl", "hwmon", "fake"))
+			}
+		}
+	}
 	{ // Monitor
 		if c.Monitor.Interval < 0 {
 			errs = append(errs, fmt.Sprintf("invalid monitor interval: %s can't be negative", c.Monitor.Interval))

--- a/config/config_cpu_test.go
+++ b/config/config_cpu_test.go
@@ -73,6 +73,47 @@ func TestCpuMeters(t *testing.T) {
 	}
 }
 
+func TestCpuMetersValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		meters  []string
+		wantErr string
+	}{
+		{
+			name:   "all known backends",
+			meters: []string{"rapl", "hwmon", "fake"},
+		},
+		{
+			name:    "unknown backend",
+			meters:  []string{"rappl"},
+			wantErr: `invalid cpu.meters entry "rappl"`,
+		},
+		{
+			name:    "typo before valid backend still rejected",
+			meters:  []string{"rappl", "hwmon"},
+			wantErr: `invalid cpu.meters entry "rappl"`,
+		},
+		{
+			name:   "empty list passes Validate (CreateCPUMeter handles emptiness)",
+			meters: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Cpu.Meters = tc.meters
+			err := cfg.Validate(SkipHostValidation)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
 func TestLoadCpuMetersFromYAML(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/config/config_cpu_test.go
+++ b/config/config_cpu_test.go
@@ -4,7 +4,6 @@
 package config
 
 import (
-	"io"
 	"log/slog"
 	"strings"
 	"testing"
@@ -14,99 +13,93 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func TestCpuMetersDefault(t *testing.T) {
-	cfg := DefaultConfig()
-	assert.Equal(t, []string{"rapl", "hwmon"}, cfg.Cpu.Meters,
-		"default cpu.meters should preserve the prior RAPL→hwmon fallback chain")
-}
-
-func TestLoadCpuMetersFromYAML(t *testing.T) {
-	tt := []struct {
-		name     string
-		yamlData string
-		want     []string
-	}{
-		{
-			"explicit hwmon-first",
-			`
-cpu:
-  meters: ["hwmon", "rapl"]
-`,
-			[]string{"hwmon", "rapl"},
-		},
-		{
-			"single backend",
-			`
-cpu:
-  meters: ["fake"]
-`,
-			[]string{"fake"},
-		},
-		{
-			"empty list",
-			`
-cpu:
-  meters: []
-`,
-			[]string{},
-		},
-	}
-
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg, err := Load(strings.NewReader(tc.yamlData))
-			require.NoError(t, err)
-			assert.Equal(t, tc.want, cfg.Cpu.Meters)
-		})
-	}
-}
-
-func TestApplyCpuMeterDeprecations(t *testing.T) {
+// TestCpuMeters covers cfg.Cpu.Meters defaults, deprecation translation, and
+// precedence. Each case sets up a Config and asserts the resulting Meters
+// after ApplyCpuMeterDeprecations runs. Log output is discarded; behaviour
+// is verified solely via cfg.Cpu.Meters.
+func TestCpuMeters(t *testing.T) {
 	tests := []struct {
 		name  string
 		setup func(*Config)
 		want  []string
 	}{
 		{
-			"fake-cpu-meter overrides cpu.meters",
-			func(c *Config) {
-				c.Dev.FakeCpuMeter.Enabled = ptr.To(true)
-			},
-			[]string{"fake"},
+			name:  "default: rapl then hwmon",
+			setup: func(*Config) {},
+			want:  []string{"rapl", "hwmon"},
 		},
 		{
-			"hwmon forceEnabled overrides cpu.meters",
-			func(c *Config) {
+			name: "fake-cpu-meter overrides cpu.meters",
+			setup: func(c *Config) {
+				c.Dev.FakeCpuMeter.Enabled = ptr.To(true)
+			},
+			want: []string{"fake"},
+		},
+		{
+			name: "hwmon forceEnabled overrides cpu.meters",
+			setup: func(c *Config) {
 				c.Experimental = &Experimental{}
 				c.Experimental.Hwmon.ForceEnabled = ptr.To(true)
 			},
-			[]string{"hwmon"},
+			want: []string{"hwmon"},
 		},
 		{
-			"fake wins when both legacy keys are set",
-			func(c *Config) {
+			name: "fake wins when both legacy keys are set",
+			setup: func(c *Config) {
 				c.Dev.FakeCpuMeter.Enabled = ptr.To(true)
 				c.Experimental = &Experimental{}
 				c.Experimental.Hwmon.ForceEnabled = ptr.To(true)
 			},
-			[]string{"fake"},
+			want: []string{"fake"},
 		},
 		{
-			"no legacy: explicit cpu.meters preserved",
-			func(c *Config) {
+			name: "no legacy: explicit cpu.meters preserved",
+			setup: func(c *Config) {
 				c.Cpu.Meters = []string{"rapl"}
 			},
-			[]string{"rapl"},
+			want: []string{"rapl"},
 		},
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(slog.DiscardHandler)
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := DefaultConfig()
 			tc.setup(cfg)
 			cfg.ApplyCpuMeterDeprecations(logger)
+			assert.Equal(t, tc.want, cfg.Cpu.Meters)
+		})
+	}
+}
+
+func TestLoadCpuMetersFromYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		yamlData string
+		want     []string
+	}{
+		{
+			name:     "explicit hwmon-first",
+			yamlData: "cpu:\n  meters: [hwmon, rapl]\n",
+			want:     []string{"hwmon", "rapl"},
+		},
+		{
+			name:     "single backend",
+			yamlData: "cpu:\n  meters: [fake]\n",
+			want:     []string{"fake"},
+		},
+		{
+			name:     "empty list",
+			yamlData: "cpu:\n  meters: []\n",
+			want:     []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := Load(strings.NewReader(tc.yamlData))
+			require.NoError(t, err)
 			assert.Equal(t, tc.want, cfg.Cpu.Meters)
 		})
 	}

--- a/config/config_cpu_test.go
+++ b/config/config_cpu_test.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+func TestCpuMetersDefault(t *testing.T) {
+	cfg := DefaultConfig()
+	assert.Equal(t, []string{"rapl", "hwmon"}, cfg.Cpu.Meters,
+		"default cpu.meters should preserve the prior RAPL→hwmon fallback chain")
+}
+
+func TestLoadCpuMetersFromYAML(t *testing.T) {
+	tt := []struct {
+		name     string
+		yamlData string
+		want     []string
+	}{
+		{
+			"explicit hwmon-first",
+			`
+cpu:
+  meters: ["hwmon", "rapl"]
+`,
+			[]string{"hwmon", "rapl"},
+		},
+		{
+			"single backend",
+			`
+cpu:
+  meters: ["fake"]
+`,
+			[]string{"fake"},
+		},
+		{
+			"empty list",
+			`
+cpu:
+  meters: []
+`,
+			[]string{},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := Load(strings.NewReader(tc.yamlData))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, cfg.Cpu.Meters)
+		})
+	}
+}
+
+func TestApplyCpuMeterDeprecations(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*Config)
+		want  []string
+	}{
+		{
+			"fake-cpu-meter overrides cpu.meters",
+			func(c *Config) {
+				c.Dev.FakeCpuMeter.Enabled = ptr.To(true)
+			},
+			[]string{"fake"},
+		},
+		{
+			"hwmon forceEnabled overrides cpu.meters",
+			func(c *Config) {
+				c.Experimental = &Experimental{}
+				c.Experimental.Hwmon.ForceEnabled = ptr.To(true)
+			},
+			[]string{"hwmon"},
+		},
+		{
+			"fake wins when both legacy keys are set",
+			func(c *Config) {
+				c.Dev.FakeCpuMeter.Enabled = ptr.To(true)
+				c.Experimental = &Experimental{}
+				c.Experimental.Hwmon.ForceEnabled = ptr.To(true)
+			},
+			[]string{"fake"},
+		},
+		{
+			"no legacy: explicit cpu.meters preserved",
+			func(c *Config) {
+				c.Cpu.Meters = []string{"rapl"}
+			},
+			[]string{"rapl"},
+		},
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			tc.setup(cfg)
+			cfg.ApplyCpuMeterDeprecations(logger)
+			assert.Equal(t, tc.want, cfg.Cpu.Meters)
+		})
+	}
+}

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -119,6 +119,11 @@ host:
   sysfs: /sys   # Path to sysfs filesystem (default: /sys)
   procfs: /proc # Path to procfs filesystem (default: /proc)
 
+cpu:
+  meters: ["rapl", "hwmon"]  # Ordered priority of CPU power-meter backends.
+                             # Built-in backends: rapl, hwmon, fake.
+                             # The first backend that initializes and reports zones is used.
+
 rapl:
   zones: []     # RAPL zones to be enabled, empty enables all default zones
 
@@ -162,7 +167,7 @@ experimental:   # experimental features (no stability guarantees)
       configFile: ""                  # Path to BMC configuration file (required when enabled)
       httpTimeout: 5s                 # HTTP timeout for BMC requests (default: 5s)
   hwmon:        # hwmon power monitoring
-    forceEnabled: false               # Force hwmon as power meter, skipping RAPL auto-detection (default: false)
+    forceEnabled: false               # DEPRECATED: set cpu.meters: ["hwmon"] instead. Emits a deprecation warning when true.
     zones: []                         # hwmon zones to be enabled, empty enables all available zones
     chipRules: []                     # User-defined chip pairing rules (override/add to hardcoded defaults)
   gpu:          # GPU power monitoring
@@ -224,6 +229,44 @@ host:
 ```
 
 These settings specify where Kepler should look for system information. In containerized environments, you might need to adjust these paths.
+
+### 🧮 CPU Power Meter Selection
+
+```yaml
+cpu:
+  meters: ["rapl", "hwmon"]
+```
+
+`cpu.meters` is an ordered priority list. Kepler walks the list, builds each backend, runs `Init()`, and selects the first one that reports zones. If every backend fails, Kepler exits with the aggregated error.
+
+Built-in backends:
+
+- `rapl`: Intel RAPL via sysfs (default first choice)
+- `hwmon`: hwmon power sensors (default fallback)
+- `fake`: synthetic readings for development and testing
+
+Examples:
+
+```yaml
+# Default order — RAPL with hwmon fallback
+cpu:
+  meters: ["rapl", "hwmon"]
+
+# Force hwmon, skip RAPL
+cpu:
+  meters: ["hwmon"]
+
+# Development mode
+cpu:
+  meters: ["fake"]
+```
+
+Two legacy keys still work but emit a deprecation warning:
+
+- `dev.fake-cpu-meter.enabled: true` → translates to `cpu.meters: ["fake"]`
+- `experimental.hwmon.forceEnabled: true` → translates to `cpu.meters: ["hwmon"]`
+
+The legacy keys override `cpu.meters` when set, since operators who rely on them today expect that behavior. They will stop working in a future release. Per-backend tuning keys (`rapl.zones`, `experimental.hwmon.zones`, `experimental.hwmon.chipRules`, `dev.fake-cpu-meter.zones`) are unchanged.
 
 ### 🔋 RAPL Zones Configuration
 
@@ -426,18 +469,20 @@ bmcs:
 **Example with specific zones:**
 
 ```yaml
+cpu:
+  meters: ["hwmon"]
 experimental:
   hwmon:
-    forceEnabled: true
     zones: ["power1", "power2"]
 ```
 
 **Example with chip rules (override and add new chips):**
 
 ```yaml
+cpu:
+  meters: ["hwmon"]
 experimental:
   hwmon:
-    forceEnabled: true
     zones: []
     chipRules:
       # Override existing chip rule (replaces hardcoded default)
@@ -479,16 +524,18 @@ experimental:
 ### 🧑‍🔬 Development Configuration
 
 ```yaml
+cpu:
+  meters: ["fake"]
 dev:
   fake-cpu-meter:
-    enabled: false
     zones: []
 ```
 
 ⚠️ **WARNING**: This section is for development and testing only. Do not enable in production.
 
-- **fake-cpu-meter**: When enabled, uses a fake CPU meter instead of real hardware metrics
-  - `enabled`: Set to `true` to enable fake CPU meter
+- **fake-cpu-meter**: Synthesizes CPU power readings instead of reading real hardware
+  - Select via `cpu.meters: ["fake"]` (preferred)
+  - `dev.fake-cpu-meter.enabled: true` is **deprecated**: it overrides `cpu.meters` and emits a deprecation warning
   - `zones`: Specific zones to enable, empty enables all
 
 ## 📖 Further Reading

--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -36,7 +36,7 @@ cpu:
   # Ordered list of CPU power-meter backends. The first backend that
   # initializes successfully and reports zones is used.
   # Built-in backends: rapl, hwmon, fake.
-  meters: ["rapl", "hwmon"]
+  meters: [rapl, hwmon]
 
 rapl:
   zones: [] # zones to be enabled, empty enables all default zones
@@ -77,9 +77,7 @@ kube: # kubernetes related config
 # WARN DO NOT ENABLE THIS IN PRODUCTION - for development / testing only
 dev:
   fake-cpu-meter:
-    # DEPRECATED: set cpu.meters: ["fake"] instead.
-    # When true, this overrides cpu.meters and emits a deprecation warning.
-    enabled: false
+    enabled: false # DEPRECATED: set cpu.meters: ["fake"] instead. Overrides cpu.meters and emits a deprecation warning when true.
     zones: [] # zones to be enabled, empty enables all default zones
 
 # EXPERIMENTAL FEATURES - These features are experimental and may be unstable

--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -32,6 +32,12 @@ host:
   sysfs: /sys # Path to sysfs filesystem (default: /sys)
   procfs: /proc # Path to procfs filesystem (default: /proc)
 
+cpu:
+  # Ordered list of CPU power-meter backends. The first backend that
+  # initializes successfully and reports zones is used.
+  # Built-in backends: rapl, hwmon, fake.
+  meters: ["rapl", "hwmon"]
+
 rapl:
   zones: [] # zones to be enabled, empty enables all default zones
 
@@ -71,6 +77,8 @@ kube: # kubernetes related config
 # WARN DO NOT ENABLE THIS IN PRODUCTION - for development / testing only
 dev:
   fake-cpu-meter:
+    # DEPRECATED: set cpu.meters: ["fake"] instead.
+    # When true, this overrides cpu.meters and emits a deprecation warning.
     enabled: false
     zones: [] # zones to be enabled, empty enables all default zones
 
@@ -84,7 +92,7 @@ experimental:
       nodeName: "" # Node name to use (overrides Kubernetes node name and hostname fallback)
       httpTimeout: 5s # HTTP client timeout for BMC requests (default: 5s)
   hwmon:
-    forceEnabled: false # Force hwmon as the power meter, skipping RAPL auto-detection
+    forceEnabled: false # DEPRECATED: set cpu.meters: ["hwmon"] instead. Emits a deprecation warning when true.
     zones: [] # List of zones to enable (default enable all)
     # chipRules allows overriding or adding chip pairing rules via configuration.
     # These rules take precedence over hardcoded defaults in the code.

--- a/internal/device/cpu_power_meter.go
+++ b/internal/device/cpu_power_meter.go
@@ -3,6 +3,14 @@
 
 package device
 
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/sustainable-computing-io/kepler/config"
+)
+
 // EnergyZone represents a measurable energy or power zone/domain exposed by a power meter.
 // An EnergyZone typically represents a logical zone of the hardware unit, e.g. cpu core, cpu package
 // dram, uncore etc.
@@ -42,4 +50,93 @@ type CPUPowerMeter interface {
 	// This zone represents the most comprehensive energy measurement available
 	// E.g. Psys > Package > Core > DRAM > Uncore
 	PrimaryEnergyZone() (EnergyZone, error)
+}
+
+// CreateCPUMeter walks cfg.Cpu.Meters in priority order, builds each backend,
+// runs Init(), and returns the first meter that reports zones.
+//
+// Failure modes per backend:
+//   - factory error or Init() error: real failure, aggregated.
+//   - empty zones: soft skip, not an error.
+//
+// Returns the joined error only if no backend produced a usable meter.
+// CPU is mandatory; callers treat any returned error as fatal.
+func CreateCPUMeter(logger *slog.Logger, cfg *config.Config) (CPUPowerMeter, error) {
+	var errs []error
+	for _, name := range cfg.Cpu.Meters {
+		meter, err := buildCPUMeter(name, logger, cfg)
+		if err != nil {
+			logger.Warn(fmt.Sprintf("%s not available, trying next backend", name), "error", err)
+			errs = append(errs, fmt.Errorf("cpu meter %q: %w", name, err))
+			continue
+		}
+		if err := meter.Init(); err != nil {
+			logger.Warn(fmt.Sprintf("%s not available, trying next backend", name), "error", err)
+			errs = append(errs, fmt.Errorf("cpu meter %q: init: %w", name, err))
+			continue
+		}
+		zones, _ := meter.Zones()
+		if len(zones) == 0 {
+			logger.Info(fmt.Sprintf("%s reports no zones, trying next backend", name))
+			continue
+		}
+		logger.Info(fmt.Sprintf("using %s power meter", name))
+		return meter, nil
+	}
+
+	if len(errs) == 0 {
+		return nil, errors.New("cpu.meters is empty")
+	}
+	return nil, errors.Join(errs...)
+}
+
+// buildCPUMeter dispatches to the constructor for a named CPU backend.
+// Add a new backend by adding a case here and a constructor in its source file.
+func buildCPUMeter(name string, logger *slog.Logger, cfg *config.Config) (CPUPowerMeter, error) {
+	switch name {
+	case "rapl":
+		if len(cfg.Rapl.Zones) > 0 {
+			logger.Info("rapl zones are filtered", "zones-enabled", cfg.Rapl.Zones)
+		}
+		return NewCPUPowerMeter(
+			cfg.Host.SysFS,
+			WithRaplLogger(logger),
+			WithZoneFilter(cfg.Rapl.Zones),
+		)
+
+	case "hwmon":
+		var zones []string
+		var rules []ConfigChipRule
+		if cfg.Experimental != nil {
+			h := cfg.Experimental.Hwmon
+			zones = h.Zones
+			for _, cr := range h.ChipRules {
+				rules = append(rules, ConfigChipRule{
+					Name:         cr.Name,
+					Pairings:     cr.Pairings,
+					SkipVoltages: cr.SkipVoltages,
+					SkipCurrents: cr.SkipCurrents,
+					UseSameIndex: cr.UseSameIndex,
+				})
+			}
+		}
+		if len(zones) > 0 {
+			logger.Info("hwmon zones are filtered", "zones-enabled", zones)
+		}
+		if len(rules) > 0 {
+			logger.Info("hwmon chip rules configured", "count", len(rules))
+		}
+		return NewHwmonPowerMeter(
+			cfg.Host.SysFS,
+			WithHwmonLogger(logger),
+			WithHwmonZoneFilter(zones),
+			WithHwmonChipRules(rules),
+		)
+
+	case "fake":
+		return NewFakeCPUMeter(cfg.Dev.FakeCpuMeter.Zones, WithFakeLogger(logger))
+
+	default:
+		return nil, fmt.Errorf("unknown cpu meter %q", name)
+	}
 }

--- a/internal/device/cpu_power_meter.go
+++ b/internal/device/cpu_power_meter.go
@@ -55,13 +55,16 @@ type CPUPowerMeter interface {
 // CreateCPUMeter walks cfg.Cpu.Meters in priority order, builds each backend,
 // runs Init(), and returns the first meter that reports zones.
 //
-// Failure modes per backend:
-//   - factory error or Init() error: real failure, aggregated.
-//   - empty zones: soft skip, not an error.
+// Failure modes per backend (all aggregated into the returned error):
+//   - factory error or Init() error: real failure.
+//   - empty zones: backend ran but found nothing usable on this host.
 //
 // Returns the joined error only if no backend produced a usable meter.
 // CPU is mandatory; callers treat any returned error as fatal.
 func CreateCPUMeter(logger *slog.Logger, cfg *config.Config) (CPUPowerMeter, error) {
+	if len(cfg.Cpu.Meters) == 0 {
+		return nil, errors.New("cpu.meters is empty")
+	}
 	var errs []error
 	for _, name := range cfg.Cpu.Meters {
 		meter, err := buildCPUMeter(name, logger, cfg)
@@ -78,15 +81,13 @@ func CreateCPUMeter(logger *slog.Logger, cfg *config.Config) (CPUPowerMeter, err
 		zones, _ := meter.Zones()
 		if len(zones) == 0 {
 			logger.Info("cpu meter reports no zones, trying next backend", "meter", name)
+			errs = append(errs, fmt.Errorf("cpu meter %q: reported no zones", name))
 			continue
 		}
 		logger.Info("using cpu power meter", "meter", name)
 		return meter, nil
 	}
 
-	if len(errs) == 0 {
-		return nil, errors.New("cpu.meters is empty")
-	}
 	return nil, errors.Join(errs...)
 }
 

--- a/internal/device/cpu_power_meter.go
+++ b/internal/device/cpu_power_meter.go
@@ -66,21 +66,21 @@ func CreateCPUMeter(logger *slog.Logger, cfg *config.Config) (CPUPowerMeter, err
 	for _, name := range cfg.Cpu.Meters {
 		meter, err := buildCPUMeter(name, logger, cfg)
 		if err != nil {
-			logger.Warn(fmt.Sprintf("%s not available, trying next backend", name), "error", err)
+			logger.Warn("cpu meter not available, trying next backend", "meter", name, "error", err)
 			errs = append(errs, fmt.Errorf("cpu meter %q: %w", name, err))
 			continue
 		}
 		if err := meter.Init(); err != nil {
-			logger.Warn(fmt.Sprintf("%s not available, trying next backend", name), "error", err)
+			logger.Warn("cpu meter init failed, trying next backend", "meter", name, "error", err)
 			errs = append(errs, fmt.Errorf("cpu meter %q: init: %w", name, err))
 			continue
 		}
 		zones, _ := meter.Zones()
 		if len(zones) == 0 {
-			logger.Info(fmt.Sprintf("%s reports no zones, trying next backend", name))
+			logger.Info("cpu meter reports no zones, trying next backend", "meter", name)
 			continue
 		}
-		logger.Info(fmt.Sprintf("using %s power meter", name))
+		logger.Info("using cpu power meter", "meter", name)
 		return meter, nil
 	}
 

--- a/internal/device/cpu_power_meter.go
+++ b/internal/device/cpu_power_meter.go
@@ -30,9 +30,10 @@ type EnergyZone interface {
 	Power() (Power, error)
 }
 
-// CPUPowerMeter implements powerMeter
+// CPUPowerMeter is the interface for CPU power measurement.
+// It embeds PowerMeter and adds CPU-specific methods.
 type CPUPowerMeter interface {
-	powerMeter
+	PowerMeter
 
 	// Zones() returns a slice of the energy measurement zones
 	Zones() ([]EnergyZone, error)

--- a/internal/device/cpu_power_meter_test.go
+++ b/internal/device/cpu_power_meter_test.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package device
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sustainable-computing-io/kepler/config"
+)
+
+func TestCreateCPUMeter_FakeOnly(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Cpu.Meters = []string{"fake"}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	meter, err := CreateCPUMeter(logger, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, meter)
+	assert.Equal(t, "fake-cpu-meter", meter.Name())
+}
+
+func TestCreateCPUMeter_UnknownBackend(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Cpu.Meters = []string{"rappl"}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	meter, err := CreateCPUMeter(logger, cfg)
+	require.Error(t, err)
+	assert.Nil(t, meter)
+	assert.Contains(t, err.Error(), "unknown cpu meter")
+}
+
+func TestCreateCPUMeter_FallthroughToFake(t *testing.T) {
+	// "rappl" is unknown so it falls through to fake.
+	cfg := config.DefaultConfig()
+	cfg.Cpu.Meters = []string{"rappl", "fake"}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	meter, err := CreateCPUMeter(logger, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, meter)
+	assert.Equal(t, "fake-cpu-meter", meter.Name())
+}
+
+func TestCreateCPUMeter_EmptyMeters(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Cpu.Meters = nil
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	meter, err := CreateCPUMeter(logger, cfg)
+	require.Error(t, err)
+	assert.Nil(t, meter)
+	assert.Contains(t, err.Error(), "cpu.meters is empty")
+}
+
+func TestBuildCPUMeter_Fake(t *testing.T) {
+	cfg := config.DefaultConfig()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	meter, err := buildCPUMeter("fake", logger, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, meter)
+	assert.Equal(t, "fake-cpu-meter", meter.Name())
+}
+
+func TestBuildCPUMeter_Unknown(t *testing.T) {
+	cfg := config.DefaultConfig()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	meter, err := buildCPUMeter("nope", logger, cfg)
+	require.Error(t, err)
+	assert.Nil(t, meter)
+	assert.Contains(t, err.Error(), "unknown cpu meter")
+}

--- a/internal/device/cpu_power_meter_test.go
+++ b/internal/device/cpu_power_meter_test.go
@@ -4,7 +4,6 @@
 package device
 
 import (
-	"io"
 	"log/slog"
 	"testing"
 
@@ -15,7 +14,7 @@ import (
 )
 
 func discardLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
+	return slog.New(slog.DiscardHandler)
 }
 
 func TestCreateCPUMeter_FakeOnly(t *testing.T) {

--- a/internal/device/cpu_power_meter_test.go
+++ b/internal/device/cpu_power_meter_test.go
@@ -14,12 +14,15 @@ import (
 	"github.com/sustainable-computing-io/kepler/config"
 )
 
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
 func TestCreateCPUMeter_FakeOnly(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Cpu.Meters = []string{"fake"}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	meter, err := CreateCPUMeter(logger, cfg)
+	meter, err := CreateCPUMeter(discardLogger(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, meter)
 	assert.Equal(t, "fake-cpu-meter", meter.Name())
@@ -29,20 +32,19 @@ func TestCreateCPUMeter_UnknownBackend(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Cpu.Meters = []string{"rappl"}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	meter, err := CreateCPUMeter(logger, cfg)
+	meter, err := CreateCPUMeter(discardLogger(), cfg)
 	require.Error(t, err)
 	assert.Nil(t, meter)
 	assert.Contains(t, err.Error(), "unknown cpu meter")
 }
 
 func TestCreateCPUMeter_FallthroughToFake(t *testing.T) {
-	// "rappl" is unknown so it falls through to fake.
+	// Unknown name, then fake — exercises the factory-error path
+	// and the success-after-continue branch.
 	cfg := config.DefaultConfig()
 	cfg.Cpu.Meters = []string{"rappl", "fake"}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	meter, err := CreateCPUMeter(logger, cfg)
+	meter, err := CreateCPUMeter(discardLogger(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, meter)
 	assert.Equal(t, "fake-cpu-meter", meter.Name())
@@ -52,28 +54,104 @@ func TestCreateCPUMeter_EmptyMeters(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Cpu.Meters = nil
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	meter, err := CreateCPUMeter(logger, cfg)
+	meter, err := CreateCPUMeter(discardLogger(), cfg)
 	require.Error(t, err)
 	assert.Nil(t, meter)
 	assert.Contains(t, err.Error(), "cpu.meters is empty")
 }
 
-func TestBuildCPUMeter_Fake(t *testing.T) {
+func TestCreateCPUMeter_RaplFactoryError_FallsThroughToFake(t *testing.T) {
+	// A bogus sysfs path makes NewCPUPowerMeter (rapl) fail at construction
+	// because sysfs.NewFS validates the path. Falls through to fake.
 	cfg := config.DefaultConfig()
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cfg.Host.SysFS = "/nonexistent/sysfs/path"
+	cfg.Cpu.Meters = []string{"rapl", "fake"}
+	cfg.Rapl.Zones = []string{"package"} // exercise the "rapl zones are filtered" log line
 
-	meter, err := buildCPUMeter("fake", logger, cfg)
+	meter, err := CreateCPUMeter(discardLogger(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, meter)
 	assert.Equal(t, "fake-cpu-meter", meter.Name())
 }
 
+func TestCreateCPUMeter_HwmonInitError_FallsThroughToFake(t *testing.T) {
+	// hwmon's NewHwmonPowerMeter constructs successfully on any path; Init
+	// fails when the path has no hwmon zones. Exercises the Init-error path
+	// in CreateCPUMeter and the experimental-config wiring in buildCPUMeter
+	// (zones + chip rules).
+	cfg := config.DefaultConfig()
+	cfg.Host.SysFS = "/nonexistent/sysfs/path"
+	cfg.Cpu.Meters = []string{"hwmon", "fake"}
+	cfg.Experimental = &config.Experimental{}
+	cfg.Experimental.Hwmon.Zones = []string{"power1"}
+	cfg.Experimental.Hwmon.ChipRules = []config.ChipPairingRule{
+		{Name: "ina3221", UseSameIndex: true},
+	}
+
+	meter, err := CreateCPUMeter(discardLogger(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, meter)
+	assert.Equal(t, "fake-cpu-meter", meter.Name())
+}
+
+func TestCreateCPUMeter_AllFail_AggregatedError(t *testing.T) {
+	// Both rapl and hwmon fail (bogus sysfs); no fallback. Aggregated error.
+	cfg := config.DefaultConfig()
+	cfg.Host.SysFS = "/nonexistent/sysfs/path"
+	cfg.Cpu.Meters = []string{"rapl", "hwmon"}
+
+	meter, err := CreateCPUMeter(discardLogger(), cfg)
+	require.Error(t, err)
+	assert.Nil(t, meter)
+	assert.Contains(t, err.Error(), "rapl")
+	assert.Contains(t, err.Error(), "hwmon")
+}
+
+func TestBuildCPUMeter_Fake(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	meter, err := buildCPUMeter("fake", discardLogger(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, meter)
+	assert.Equal(t, "fake-cpu-meter", meter.Name())
+}
+
+func TestBuildCPUMeter_Rapl_FactoryFails(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Host.SysFS = "/nonexistent"
+
+	meter, err := buildCPUMeter("rapl", discardLogger(), cfg)
+	require.Error(t, err)
+	assert.Nil(t, meter)
+}
+
+func TestBuildCPUMeter_Hwmon_ConstructsWithExperimentalConfig(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Experimental = &config.Experimental{}
+	cfg.Experimental.Hwmon.Zones = []string{"power1", "power2"}
+	cfg.Experimental.Hwmon.ChipRules = []config.ChipPairingRule{
+		{Name: "ltc2945", Pairings: map[int]int{1: 1}},
+	}
+
+	meter, err := buildCPUMeter("hwmon", discardLogger(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, meter)
+	assert.Equal(t, "hwmon", meter.Name())
+}
+
+func TestBuildCPUMeter_Hwmon_NilExperimental(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Experimental = nil
+
+	meter, err := buildCPUMeter("hwmon", discardLogger(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, meter)
+}
+
 func TestBuildCPUMeter_Unknown(t *testing.T) {
 	cfg := config.DefaultConfig()
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	meter, err := buildCPUMeter("nope", logger, cfg)
+	meter, err := buildCPUMeter("nope", discardLogger(), cfg)
 	require.Error(t, err)
 	assert.Nil(t, meter)
 	assert.Contains(t, err.Error(), "unknown cpu meter")

--- a/internal/device/fake_cpu_power_meter.go
+++ b/internal/device/fake_cpu_power_meter.go
@@ -155,6 +155,12 @@ func (m *fakeRaplMeter) Name() string {
 	return "fake-cpu-meter"
 }
 
+// Init is a no-op for the fake meter — zones are constructed in NewFakeCPUMeter.
+// Required by the PowerMeter interface (service.Initializer).
+func (m *fakeRaplMeter) Init() error {
+	return nil
+}
+
 func (m *fakeRaplMeter) Zones() ([]EnergyZone, error) {
 	return m.zones, nil
 }

--- a/internal/device/power_meter.go
+++ b/internal/device/power_meter.go
@@ -3,9 +3,14 @@
 
 package device
 
-// powerMeter is a generic interface for power meters which reads energy
-// or power readings from hardware devices like CPU/GPU/DRAM etc
-type powerMeter interface {
-	// Name() returns a string identifying the power meter
-	Name() string
+import "github.com/sustainable-computing-io/kepler/internal/service"
+
+// PowerMeter is a hardware backend that reads energy or power from a class
+// of hardware (CPU package, GPU device, etc).
+//
+// Many PowerMeters can be selected. Each contributes its own readings.
+// Domain-specific methods live on subinterfaces that embed PowerMeter.
+type PowerMeter interface {
+	service.Service     // Name()
+	service.Initializer // Init()
 }

--- a/internal/monitor/mock_utils.go
+++ b/internal/monitor/mock_utils.go
@@ -33,6 +33,11 @@ func (m *MockCPUPowerMeter) Name() string {
 	return args.String(0)
 }
 
+func (m *MockCPUPowerMeter) Init() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 func (m *MockCPUPowerMeter) Run(ctx context.Context) error {
 	args := m.Called(ctx)
 	return args.Error(0)

--- a/manifests/helm/kepler/values.yaml
+++ b/manifests/helm/kepler/values.yaml
@@ -77,6 +77,11 @@ config:
     staleness: 500ms
     maxTerminated: 100
     minTerminatedEnergyThreshold: 10
+  cpu:
+    # Ordered list of CPU power-meter backends. The first backend that
+    # initializes successfully and reports zones is used.
+    # Built-in backends: rapl, hwmon, fake.
+    meters: ["rapl", "hwmon"]
   rapl:
     zones: []
   exporter:
@@ -102,6 +107,8 @@ config:
       pollInterval: 15s      # Poll interval for kubelet mode (default: 15s)
   dev:
     fake-cpu-meter:
+      # DEPRECATED: set cpu.meters: ["fake"] instead.
+      # When true, this overrides cpu.meters and emits a deprecation warning.
       enabled: false
       zones: []
   # EXPERIMENTAL FEATURES - These features are experimental and may be unstable
@@ -113,7 +120,7 @@ config:
         configFile: /etc/kepler/redfish.yaml  # Path to Redfish BMC configuration file
         nodeName: ""  # Node name to use (overrides Kubernetes node name and hostname fallback)
     hwmon:
-      forceEnabled: false # Force hwmon as the power meter, skipping RAPL auto-detection
+      forceEnabled: false # DEPRECATED: set cpu.meters: ["hwmon"] instead. Emits a deprecation warning when true.
       zones: [] # List of zones to enable (default enable all)
       chipRules: [] # User-defined chip pairing rules (override/add to hardcoded defaults)
     gpu:

--- a/manifests/helm/kepler/values.yaml
+++ b/manifests/helm/kepler/values.yaml
@@ -81,7 +81,7 @@ config:
     # Ordered list of CPU power-meter backends. The first backend that
     # initializes successfully and reports zones is used.
     # Built-in backends: rapl, hwmon, fake.
-    meters: ["rapl", "hwmon"]
+    meters: [rapl, hwmon]
   rapl:
     zones: []
   exporter:
@@ -107,9 +107,7 @@ config:
       pollInterval: 15s      # Poll interval for kubelet mode (default: 15s)
   dev:
     fake-cpu-meter:
-      # DEPRECATED: set cpu.meters: ["fake"] instead.
-      # When true, this overrides cpu.meters and emits a deprecation warning.
-      enabled: false
+      enabled: false # DEPRECATED: set cpu.meters: ["fake"] instead. Overrides cpu.meters and emits a deprecation warning when true.
       zones: []
   # EXPERIMENTAL FEATURES - These features are experimental and may be unstable
   # and are disabled by default

--- a/manifests/k8s/configmap.yaml
+++ b/manifests/k8s/configmap.yaml
@@ -19,6 +19,11 @@ data:
       staleness: 500ms
       maxTerminated: 100
       minTerminatedEnergyThreshold: 10
+    cpu:
+      # Ordered list of CPU power-meter backends. The first backend that
+      # initializes successfully and reports zones is used.
+      # Built-in backends: rapl, hwmon, fake.
+      meters: ["rapl", "hwmon"]
     rapl:
       zones: []
     exporter:
@@ -44,6 +49,8 @@ data:
         pollInterval: 15s      # Poll interval for kubelet mode (default: 15s)
     dev:
       fake-cpu-meter:
+        # DEPRECATED: set cpu.meters: ["fake"] instead.
+        # When true, this overrides cpu.meters and emits a deprecation warning.
         enabled: false
         zones: []
     # EXPERIMENTAL FEATURES - These features are experimental and may be unstable
@@ -56,7 +63,7 @@ data:
           nodeName: ""  # Node name to use (overrides Kubernetes node name and hostname fallback)
           httpTimeout: 5s  # HTTP client timeout for BMC requests (default: 5s)
       hwmon:
-        forceEnabled: false # Force hwmon as the power meter, skipping RAPL auto-detection
+        forceEnabled: false # DEPRECATED: set cpu.meters: ["hwmon"] instead. Emits a deprecation warning when true.
         zones: [] # List of zones to enable (default enable all)
         chipRules: [] # User-defined chip pairing rules (override/add to hardcoded defaults)
       gpu:

--- a/manifests/k8s/configmap.yaml
+++ b/manifests/k8s/configmap.yaml
@@ -49,9 +49,7 @@ data:
         pollInterval: 15s      # Poll interval for kubelet mode (default: 15s)
     dev:
       fake-cpu-meter:
-        # DEPRECATED: set cpu.meters: ["fake"] instead.
-        # When true, this overrides cpu.meters and emits a deprecation warning.
-        enabled: false
+        enabled: false # DEPRECATED: set cpu.meters: ["fake"] instead. Overrides cpu.meters and emits a deprecation warning when true.
         zones: []
     # EXPERIMENTAL FEATURES - These features are experimental and may be unstable
     # and are disabled by default


### PR DESCRIPTION
Part of #2467.

## Why

`createCPUMeter` in `cmd/kepler/main.go` hardcodes the RAPL → hwmon fallback chain. Operators on platforms where neither is the right source cannot reorder backend priority without forking. This PR makes the priority list config-driven without inventing new vocabulary (no registry, no factories, no init() side effects).

## What

Changes
- Promotes the unexported powerMeter interface to an exported PowerMeter (Name, Init). Shutdown is
optional via service.Shutdowner.
- Adds cfg.Cpu.Meters config (default ["rapl", "hwmon"]) — preserves prior fallback behaviour.
- device.CreateCPUMeter walks the list, builds each backend via buildCPUMeter, runs Init(), returns the
first that yields zones. Real failures aggregate via errors.Join; empty zones are a soft skip.
- buildCPUMeter is a switch over backend names — adding a backend means one new case + one constructor.
- cmd/kepler/main.go drops the old createCPUMeter / createHwmonMeter helpers (~70 lines).
- Two legacy keys translate at startup with a deprecation warning:
  - dev.fake-cpu-meter.enabled: true → cpu.meters: ["fake"]
  - experimental.hwmon.forceEnabled: true → cpu.meters: ["hwmon"]
- Sample configs (helm, k8s, hack, compose) and docs/user/configuration.md updated.

## Behaviour change

None for systems running the default config. Preserves the same RAPL to hwmon fallback. Operators using the legacy keys see a deprecation warning but continue to get the same selection.
