### PR TITLE
refactor(config): rename `cpu.meters` to `cpu.preferredMeters`

### DIFF
--- a/compose/default/kepler/etc/kepler/config.yaml
+++ b/compose/default/kepler/etc/kepler/config.yaml
@@ -32,6 +32,12 @@ host:
   sysfs: /host/sys # Path to sysfs filesystem (default: /sys)
   procfs: /host/proc # Path to procfs filesystem (default: /proc)
 
+cpu:
+  # Ordered preference list of CPU power-meter backends. The first backend
+  # that initializes successfully and reports zones is used.
+  # Built-in backends: rapl, hwmon, fake.
+  preferredMeters: [rapl, hwmon]
+
 rapl:
   zones: [] # zones to be enabled, empty enables all default zones
 
@@ -71,7 +77,7 @@ kube: # kubernetes related config
 # WARN DO NOT ENABLE THIS IN PRODUCTION - for development / testing only
 dev:
   fake-cpu-meter:
-    enabled: false
+    enabled: false # DEPRECATED: set cpu.preferredMeters: ["fake"] instead. Overrides cpu.preferredMeters and emits a deprecation warning when true.
     zones: [] # zones to be enabled, empty enables all default zones
 
 # EXPERIMENTAL FEATURES - These features are experimental and may be unstable
@@ -84,7 +90,7 @@ experimental:
       nodeName: "" # Node name to use (overrides Kubernetes node name and hostname fallback)
       httpTimeout: 5s # HTTP client timeout for BMC requests (default: 5s)
   hwmon:
-    forceEnabled: false # Force hwmon as the power meter, skipping RAPL auto-detection
+    forceEnabled: false # DEPRECATED: set cpu.preferredMeters: ["hwmon"] instead. Emits a deprecation warning when true.
     zones: [] # List of zones to enable (default enable all)
     chipRules: [] # User-defined chip pairing rules (override/add to hardcoded defaults)
   gpu:

--- a/compose/dev/kepler-dev/etc/kepler/config.yaml
+++ b/compose/dev/kepler-dev/etc/kepler/config.yaml
@@ -33,10 +33,10 @@ host:
   procfs: /host/proc # Path to procfs filesystem (default: /proc)
 
 cpu:
-  # Ordered list of CPU power-meter backends. The first backend that
-  # initializes successfully and reports zones is used.
+  # Ordered preference list of CPU power-meter backends. The first backend
+  # that initializes successfully and reports zones is used.
   # Built-in backends: rapl, hwmon, fake.
-  meters: [rapl, hwmon]
+  preferredMeters: [rapl, hwmon]
 
 rapl:
   zones: [] # zones to be enabled, empty enables all default zones
@@ -77,7 +77,7 @@ kube: # kubernetes related config
 # WARN DO NOT ENABLE THIS IN PRODUCTION - for development / testing only
 dev:
   fake-cpu-meter:
-    enabled: false # DEPRECATED: set cpu.meters: ["fake"] instead. Overrides cpu.meters and emits a deprecation warning when true.
+    enabled: false # DEPRECATED: set cpu.preferredMeters: ["fake"] instead. Overrides cpu.preferredMeters and emits a deprecation warning when true.
     zones: [] # zones to be enabled, empty enables all default zones
 
 # EXPERIMENTAL FEATURES - These features are experimental and may be unstable
@@ -90,7 +90,7 @@ experimental:
       nodeName: kepler-dev # Node name to use (overrides Kubernetes node name and hostname fallback)
       httpTimeout: 5s # HTTP client timeout for BMC requests (default: 5s)
   hwmon:
-    forceEnabled: false # DEPRECATED: set cpu.meters: ["hwmon"] instead. Emits a deprecation warning when true.
+    forceEnabled: false # DEPRECATED: set cpu.preferredMeters: ["hwmon"] instead. Emits a deprecation warning when true.
     zones: [] # List of zones to enable (default enable all)
     chipRules: [] # User-defined chip pairing rules (override/add to hardcoded defaults)
   gpu:

--- a/config/config.go
+++ b/config/config.go
@@ -55,10 +55,10 @@ type (
 	}
 
 	// Cpu configuration controls how CPU power meters are selected.
-	// Meters lists backends in priority order. The first backend that
-	// initializes successfully and reports zones is used.
+	// PreferredMeters lists backends in preference order. The first backend
+	// that initializes successfully and reports zones is used.
 	Cpu struct {
-		Meters []string `yaml:"meters"`
+		PreferredMeters []string `yaml:"preferredMeters"`
 	}
 
 	// Rapl configuration
@@ -274,7 +274,7 @@ const (
 	MonitorMaxTerminatedFlag = "monitor.max-terminated"
 
 	// CPU
-	CpuMeters = "cpu.meters" // not a flag
+	CpuPreferredMeters = "cpu.preferredMeters" // not a flag
 
 	// RAPL
 	RaplZones = "rapl.zones" // not a flag
@@ -326,7 +326,7 @@ func DefaultConfig() *Config {
 			ProcFS: "/proc",
 		},
 		Cpu: Cpu{
-			Meters: []string{"rapl", "hwmon"},
+			PreferredMeters: []string{"rapl", "hwmon"},
 		},
 		Rapl: Rapl{
 			Zones: []string{},
@@ -374,24 +374,25 @@ func DefaultConfig() *Config {
 }
 
 // ApplyCpuMeterDeprecations translates legacy CPU-meter selectors into an
-// effective cpu.meters value and logs a deprecation warning per translation.
+// effective cpu.preferredMeters value and logs a deprecation warning per
+// translation.
 //
 // Legacy selectors:
-//   - experimental.hwmon.forceEnabled=true → cpu.meters: ["hwmon"]
-//   - dev.fake-cpu-meter.enabled=true     → cpu.meters: ["fake"]
+//   - experimental.hwmon.forceEnabled=true → cpu.preferredMeters: ["hwmon"]
+//   - dev.fake-cpu-meter.enabled=true      → cpu.preferredMeters: ["fake"]
 //
-// Legacy selectors win over an explicit cpu.meters when set, since operators
-// who set them today expect the legacy behavior. When both legacy keys are set,
-// fake takes precedence over hwmon. The legacy keys will stop working in a
-// future release.
+// Legacy selectors win over an explicit cpu.preferredMeters when set, since
+// operators who set them today expect the legacy behavior. When both legacy
+// keys are set, fake takes precedence over hwmon. The legacy keys will stop
+// working in a future release.
 func (c *Config) ApplyCpuMeterDeprecations(logger *slog.Logger) {
 	switch {
 	case ptr.Deref(c.Dev.FakeCpuMeter.Enabled, false):
-		logger.Warn(`dev.fake-cpu-meter.enabled is deprecated; set cpu.meters: ["fake"] instead`)
-		c.Cpu.Meters = []string{"fake"}
+		logger.Warn(`dev.fake-cpu-meter.enabled is deprecated; set cpu.preferredMeters: ["fake"] instead`)
+		c.Cpu.PreferredMeters = []string{"fake"}
 	case c.Experimental != nil && ptr.Deref(c.Experimental.Hwmon.ForceEnabled, false):
-		logger.Warn(`experimental.hwmon.forceEnabled is deprecated; set cpu.meters: ["hwmon"] instead`)
-		c.Cpu.Meters = []string{"hwmon"}
+		logger.Warn(`experimental.hwmon.forceEnabled is deprecated; set cpu.preferredMeters: ["hwmon"] instead`)
+		c.Cpu.PreferredMeters = []string{"hwmon"}
 	}
 }
 
@@ -823,8 +824,8 @@ func (c *Config) sanitize() {
 		c.Web.ListenAddresses[i] = strings.TrimSpace(c.Web.ListenAddresses[i])
 	}
 
-	for i := range c.Cpu.Meters {
-		c.Cpu.Meters[i] = strings.TrimSpace(c.Cpu.Meters[i])
+	for i := range c.Cpu.PreferredMeters {
+		c.Cpu.PreferredMeters[i] = strings.TrimSpace(c.Cpu.PreferredMeters[i])
 	}
 
 	for i := range c.Rapl.Zones {
@@ -916,16 +917,16 @@ func (c *Config) Validate(skips ...SkipValidation) error {
 			}
 		}
 	}
-	{ // cpu.meters
+	{ // cpu.preferredMeters
 		// Keep this list in sync with the switch in internal/device/cpu_power_meter.go.
 		validCpuMeters := map[string]bool{
 			"rapl":  true,
 			"hwmon": true,
 			"fake":  true,
 		}
-		for _, name := range c.Cpu.Meters {
+		for _, name := range c.Cpu.PreferredMeters {
 			if !validCpuMeters[name] {
-				errs = append(errs, fmt.Sprintf("invalid cpu.meters entry %q, must be one of %q, %q, %q", name, "rapl", "hwmon", "fake"))
+				errs = append(errs, fmt.Sprintf("invalid cpu.preferredMeters entry %q, must be one of %q, %q, %q", name, "rapl", "hwmon", "fake"))
 			}
 		}
 	}
@@ -1130,7 +1131,7 @@ func (c *Config) manualString() string {
 		{MonitorIntervalFlag, c.Monitor.Interval.String()},
 		{MonitorStaleness, c.Monitor.Staleness.String()},
 		{MonitorMaxTerminatedFlag, fmt.Sprintf("%d", c.Monitor.MaxTerminated)},
-		{CpuMeters, strings.Join(c.Cpu.Meters, ", ")},
+		{CpuPreferredMeters, strings.Join(c.Cpu.PreferredMeters, ", ")},
 		{RaplZones, strings.Join(c.Rapl.Zones, ", ")},
 		{ExporterStdoutEnabledFlag, fmt.Sprintf("%v", c.Exporter.Stdout.Enabled)},
 		{ExporterPrometheusEnabledFlag, fmt.Sprintf("%v", c.Exporter.Prometheus.Enabled)},

--- a/config/config_cpu_test.go
+++ b/config/config_cpu_test.go
@@ -13,11 +13,11 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// TestCpuMeters covers cfg.Cpu.Meters defaults, deprecation translation, and
-// precedence. Each case sets up a Config and asserts the resulting Meters
-// after ApplyCpuMeterDeprecations runs. Log output is discarded; behaviour
-// is verified solely via cfg.Cpu.Meters.
-func TestCpuMeters(t *testing.T) {
+// TestCpuPreferredMeters covers cfg.Cpu.PreferredMeters defaults, deprecation
+// translation, and precedence. Each case sets up a Config and asserts the
+// resulting PreferredMeters after ApplyCpuMeterDeprecations runs. Log output
+// is discarded; behaviour is verified solely via cfg.Cpu.PreferredMeters.
+func TestCpuPreferredMeters(t *testing.T) {
 	tests := []struct {
 		name  string
 		setup func(*Config)
@@ -29,14 +29,14 @@ func TestCpuMeters(t *testing.T) {
 			want:  []string{"rapl", "hwmon"},
 		},
 		{
-			name: "fake-cpu-meter overrides cpu.meters",
+			name: "fake-cpu-meter overrides cpu.preferredMeters",
 			setup: func(c *Config) {
 				c.Dev.FakeCpuMeter.Enabled = ptr.To(true)
 			},
 			want: []string{"fake"},
 		},
 		{
-			name: "hwmon forceEnabled overrides cpu.meters",
+			name: "hwmon forceEnabled overrides cpu.preferredMeters",
 			setup: func(c *Config) {
 				c.Experimental = &Experimental{}
 				c.Experimental.Hwmon.ForceEnabled = ptr.To(true)
@@ -53,9 +53,9 @@ func TestCpuMeters(t *testing.T) {
 			want: []string{"fake"},
 		},
 		{
-			name: "no legacy: explicit cpu.meters preserved",
+			name: "no legacy: explicit cpu.preferredMeters preserved",
 			setup: func(c *Config) {
-				c.Cpu.Meters = []string{"rapl"}
+				c.Cpu.PreferredMeters = []string{"rapl"}
 			},
 			want: []string{"rapl"},
 		},
@@ -68,12 +68,12 @@ func TestCpuMeters(t *testing.T) {
 			cfg := DefaultConfig()
 			tc.setup(cfg)
 			cfg.ApplyCpuMeterDeprecations(logger)
-			assert.Equal(t, tc.want, cfg.Cpu.Meters)
+			assert.Equal(t, tc.want, cfg.Cpu.PreferredMeters)
 		})
 	}
 }
 
-func TestCpuMetersValidation(t *testing.T) {
+func TestCpuPreferredMetersValidation(t *testing.T) {
 	tests := []struct {
 		name    string
 		meters  []string
@@ -86,12 +86,12 @@ func TestCpuMetersValidation(t *testing.T) {
 		{
 			name:    "unknown backend",
 			meters:  []string{"rappl"},
-			wantErr: `invalid cpu.meters entry "rappl"`,
+			wantErr: `invalid cpu.preferredMeters entry "rappl"`,
 		},
 		{
 			name:    "typo before valid backend still rejected",
 			meters:  []string{"rappl", "hwmon"},
-			wantErr: `invalid cpu.meters entry "rappl"`,
+			wantErr: `invalid cpu.preferredMeters entry "rappl"`,
 		},
 		{
 			name:   "empty list passes Validate (CreateCPUMeter handles emptiness)",
@@ -102,7 +102,7 @@ func TestCpuMetersValidation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := DefaultConfig()
-			cfg.Cpu.Meters = tc.meters
+			cfg.Cpu.PreferredMeters = tc.meters
 			err := cfg.Validate(SkipHostValidation)
 			if tc.wantErr == "" {
 				assert.NoError(t, err)
@@ -114,7 +114,7 @@ func TestCpuMetersValidation(t *testing.T) {
 	}
 }
 
-func TestLoadCpuMetersFromYAML(t *testing.T) {
+func TestLoadCpuPreferredMetersFromYAML(t *testing.T) {
 	tests := []struct {
 		name     string
 		yamlData string
@@ -122,17 +122,17 @@ func TestLoadCpuMetersFromYAML(t *testing.T) {
 	}{
 		{
 			name:     "explicit hwmon-first",
-			yamlData: "cpu:\n  meters: [hwmon, rapl]\n",
+			yamlData: "cpu:\n  preferredMeters: [hwmon, rapl]\n",
 			want:     []string{"hwmon", "rapl"},
 		},
 		{
 			name:     "single backend",
-			yamlData: "cpu:\n  meters: [fake]\n",
+			yamlData: "cpu:\n  preferredMeters: [fake]\n",
 			want:     []string{"fake"},
 		},
 		{
 			name:     "empty list",
-			yamlData: "cpu:\n  meters: []\n",
+			yamlData: "cpu:\n  preferredMeters: []\n",
 			want:     []string{},
 		},
 	}
@@ -141,7 +141,7 @@ func TestLoadCpuMetersFromYAML(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg, err := Load(strings.NewReader(tc.yamlData))
 			require.NoError(t, err)
-			assert.Equal(t, tc.want, cfg.Cpu.Meters)
+			assert.Equal(t, tc.want, cfg.Cpu.PreferredMeters)
 		})
 	}
 }

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -167,7 +167,7 @@ experimental:   # experimental features (no stability guarantees)
       configFile: ""                  # Path to BMC configuration file (required when enabled)
       httpTimeout: 5s                 # HTTP timeout for BMC requests (default: 5s)
   hwmon:        # hwmon power monitoring
-    forceEnabled: false               # DEPRECATED: set cpu.meters: ["hwmon"] instead. Emits a deprecation warning when true.
+    forceEnabled: false               # DEPRECATED: set cpu.preferredMeters: ["hwmon"] instead. Emits a deprecation warning when true.
     zones: []                         # hwmon zones to be enabled, empty enables all available zones
     chipRules: []                     # User-defined chip pairing rules (override/add to hardcoded defaults)
   gpu:          # GPU power monitoring
@@ -234,39 +234,39 @@ These settings specify where Kepler should look for system information. In conta
 
 ```yaml
 cpu:
-  meters: ["rapl", "hwmon"]
+  preferredMeters: ["rapl", "hwmon"]
 ```
 
-`cpu.meters` is an ordered priority list. Kepler walks the list, builds each backend, runs `Init()`, and selects the first one that reports zones. If every backend fails, Kepler exits with the aggregated error.
+`cpu.preferredMeters` is an ordered preference list. Kepler walks the list, builds each backend, runs `Init()`, and selects the first one that reports zones. If every backend fails, Kepler exits with the aggregated error.
 
 Built-in backends:
 
 - `rapl`: Intel RAPL via sysfs (default first choice)
-- `hwmon`: hwmon power sensors (default fallback)
+- `hwmon`: hwmon power sensors (default second choice)
 - `fake`: synthetic readings for development and testing
 
 Examples:
 
 ```yaml
-# Default order — RAPL with hwmon fallback
+# Default order — try RAPL first, then hwmon
 cpu:
-  meters: ["rapl", "hwmon"]
+  preferredMeters: ["rapl", "hwmon"]
 
 # Force hwmon, skip RAPL
 cpu:
-  meters: ["hwmon"]
+  preferredMeters: ["hwmon"]
 
 # Development mode
 cpu:
-  meters: ["fake"]
+  preferredMeters: ["fake"]
 ```
 
 Two legacy keys still work but emit a deprecation warning:
 
-- `dev.fake-cpu-meter.enabled: true` → translates to `cpu.meters: ["fake"]`
-- `experimental.hwmon.forceEnabled: true` → translates to `cpu.meters: ["hwmon"]`
+- `dev.fake-cpu-meter.enabled: true` → translates to `cpu.preferredMeters: ["fake"]`
+- `experimental.hwmon.forceEnabled: true` → translates to `cpu.preferredMeters: ["hwmon"]`
 
-The legacy keys override `cpu.meters` when set, since operators who rely on them today expect that behavior. They will stop working in a future release. Per-backend tuning keys (`rapl.zones`, `experimental.hwmon.zones`, `experimental.hwmon.chipRules`, `dev.fake-cpu-meter.zones`) are unchanged.
+The legacy keys override `cpu.preferredMeters` when set, since operators who rely on them today expect that behavior. They will stop working in a future release. Per-backend tuning keys (`rapl.zones`, `experimental.hwmon.zones`, `experimental.hwmon.chipRules`, `dev.fake-cpu-meter.zones`) are unchanged.
 
 ### 🔋 RAPL Zones Configuration
 
@@ -525,7 +525,7 @@ experimental:
 
 ```yaml
 cpu:
-  meters: ["fake"]
+  preferredMeters: ["fake"]
 dev:
   fake-cpu-meter:
     zones: []
@@ -534,8 +534,8 @@ dev:
 ⚠️ **WARNING**: This section is for development and testing only. Do not enable in production.
 
 - **fake-cpu-meter**: Synthesizes CPU power readings instead of reading real hardware
-  - Select via `cpu.meters: ["fake"]` (preferred)
-  - `dev.fake-cpu-meter.enabled: true` is **deprecated**: it overrides `cpu.meters` and emits a deprecation warning
+  - Select via `cpu.preferredMeters: ["fake"]` (preferred)
+  - `dev.fake-cpu-meter.enabled: true` is **deprecated**: it overrides `cpu.preferredMeters` and emits a deprecation warning
   - `zones`: Specific zones to enable, empty enables all
 
 ## 📖 Further Reading

--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -33,10 +33,10 @@ host:
   procfs: /proc # Path to procfs filesystem (default: /proc)
 
 cpu:
-  # Ordered list of CPU power-meter backends. The first backend that
-  # initializes successfully and reports zones is used.
+  # Ordered preference list of CPU power-meter backends. The first backend
+  # that initializes successfully and reports zones is used.
   # Built-in backends: rapl, hwmon, fake.
-  meters: [rapl, hwmon]
+  preferredMeters: [rapl, hwmon]
 
 rapl:
   zones: [] # zones to be enabled, empty enables all default zones
@@ -77,7 +77,7 @@ kube: # kubernetes related config
 # WARN DO NOT ENABLE THIS IN PRODUCTION - for development / testing only
 dev:
   fake-cpu-meter:
-    enabled: false # DEPRECATED: set cpu.meters: ["fake"] instead. Overrides cpu.meters and emits a deprecation warning when true.
+    enabled: false # DEPRECATED: set cpu.preferredMeters: ["fake"] instead. Overrides cpu.preferredMeters and emits a deprecation warning when true.
     zones: [] # zones to be enabled, empty enables all default zones
 
 # EXPERIMENTAL FEATURES - These features are experimental and may be unstable
@@ -90,7 +90,7 @@ experimental:
       nodeName: "" # Node name to use (overrides Kubernetes node name and hostname fallback)
       httpTimeout: 5s # HTTP client timeout for BMC requests (default: 5s)
   hwmon:
-    forceEnabled: false # DEPRECATED: set cpu.meters: ["hwmon"] instead. Emits a deprecation warning when true.
+    forceEnabled: false # DEPRECATED: set cpu.preferredMeters: ["hwmon"] instead. Emits a deprecation warning when true.
     zones: [] # List of zones to enable (default enable all)
     # chipRules allows overriding or adding chip pairing rules via configuration.
     # These rules take precedence over hardcoded defaults in the code.

--- a/internal/device/cpu_power_meter.go
+++ b/internal/device/cpu_power_meter.go
@@ -52,8 +52,8 @@ type CPUPowerMeter interface {
 	PrimaryEnergyZone() (EnergyZone, error)
 }
 
-// CreateCPUMeter walks cfg.Cpu.Meters in priority order, builds each backend,
-// runs Init(), and returns the first meter that reports zones.
+// CreateCPUMeter walks cfg.Cpu.PreferredMeters in preference order, builds
+// each backend, runs Init(), and returns the first meter that reports zones.
 //
 // Failure modes per backend (all aggregated into the returned error):
 //   - factory error or Init() error: real failure.
@@ -62,11 +62,11 @@ type CPUPowerMeter interface {
 // Returns the joined error only if no backend produced a usable meter.
 // CPU is mandatory; callers treat any returned error as fatal.
 func CreateCPUMeter(logger *slog.Logger, cfg *config.Config) (CPUPowerMeter, error) {
-	if len(cfg.Cpu.Meters) == 0 {
-		return nil, errors.New("cpu.meters is empty")
+	if len(cfg.Cpu.PreferredMeters) == 0 {
+		return nil, errors.New("cpu.preferredMeters is empty")
 	}
 	var errs []error
-	for _, name := range cfg.Cpu.Meters {
+	for _, name := range cfg.Cpu.PreferredMeters {
 		meter, err := buildCPUMeter(name, logger, cfg)
 		if err != nil {
 			logger.Warn("cpu meter not available, trying next backend", "meter", name, "error", err)

--- a/internal/device/cpu_power_meter_test.go
+++ b/internal/device/cpu_power_meter_test.go
@@ -19,7 +19,7 @@ func discardLogger() *slog.Logger {
 
 func TestCreateCPUMeter_FakeOnly(t *testing.T) {
 	cfg := config.DefaultConfig()
-	cfg.Cpu.Meters = []string{"fake"}
+	cfg.Cpu.PreferredMeters = []string{"fake"}
 
 	meter, err := CreateCPUMeter(discardLogger(), cfg)
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestCreateCPUMeter_FakeOnly(t *testing.T) {
 
 func TestCreateCPUMeter_UnknownBackend(t *testing.T) {
 	cfg := config.DefaultConfig()
-	cfg.Cpu.Meters = []string{"rappl"}
+	cfg.Cpu.PreferredMeters = []string{"rappl"}
 
 	meter, err := CreateCPUMeter(discardLogger(), cfg)
 	require.Error(t, err)
@@ -41,7 +41,7 @@ func TestCreateCPUMeter_FallthroughToFake(t *testing.T) {
 	// Unknown name, then fake — exercises the factory-error path
 	// and the success-after-continue branch.
 	cfg := config.DefaultConfig()
-	cfg.Cpu.Meters = []string{"rappl", "fake"}
+	cfg.Cpu.PreferredMeters = []string{"rappl", "fake"}
 
 	meter, err := CreateCPUMeter(discardLogger(), cfg)
 	require.NoError(t, err)
@@ -51,12 +51,12 @@ func TestCreateCPUMeter_FallthroughToFake(t *testing.T) {
 
 func TestCreateCPUMeter_EmptyMeters(t *testing.T) {
 	cfg := config.DefaultConfig()
-	cfg.Cpu.Meters = nil
+	cfg.Cpu.PreferredMeters = nil
 
 	meter, err := CreateCPUMeter(discardLogger(), cfg)
 	require.Error(t, err)
 	assert.Nil(t, meter)
-	assert.Contains(t, err.Error(), "cpu.meters is empty")
+	assert.Contains(t, err.Error(), "cpu.preferredMeters is empty")
 }
 
 func TestCreateCPUMeter_RaplFactoryError_FallsThroughToFake(t *testing.T) {
@@ -64,7 +64,7 @@ func TestCreateCPUMeter_RaplFactoryError_FallsThroughToFake(t *testing.T) {
 	// because sysfs.NewFS validates the path. Falls through to fake.
 	cfg := config.DefaultConfig()
 	cfg.Host.SysFS = "/nonexistent/sysfs/path"
-	cfg.Cpu.Meters = []string{"rapl", "fake"}
+	cfg.Cpu.PreferredMeters = []string{"rapl", "fake"}
 	cfg.Rapl.Zones = []string{"package"} // exercise the "rapl zones are filtered" log line
 
 	meter, err := CreateCPUMeter(discardLogger(), cfg)
@@ -80,7 +80,7 @@ func TestCreateCPUMeter_HwmonInitError_FallsThroughToFake(t *testing.T) {
 	// (zones + chip rules).
 	cfg := config.DefaultConfig()
 	cfg.Host.SysFS = "/nonexistent/sysfs/path"
-	cfg.Cpu.Meters = []string{"hwmon", "fake"}
+	cfg.Cpu.PreferredMeters = []string{"hwmon", "fake"}
 	cfg.Experimental = &config.Experimental{}
 	cfg.Experimental.Hwmon.Zones = []string{"power1"}
 	cfg.Experimental.Hwmon.ChipRules = []config.ChipPairingRule{
@@ -97,7 +97,7 @@ func TestCreateCPUMeter_AllFail_AggregatedError(t *testing.T) {
 	// Both rapl and hwmon fail (bogus sysfs); no fallback. Aggregated error.
 	cfg := config.DefaultConfig()
 	cfg.Host.SysFS = "/nonexistent/sysfs/path"
-	cfg.Cpu.Meters = []string{"rapl", "hwmon"}
+	cfg.Cpu.PreferredMeters = []string{"rapl", "hwmon"}
 
 	meter, err := CreateCPUMeter(discardLogger(), cfg)
 	require.Error(t, err)

--- a/manifests/helm/kepler/values.yaml
+++ b/manifests/helm/kepler/values.yaml
@@ -78,10 +78,10 @@ config:
     maxTerminated: 100
     minTerminatedEnergyThreshold: 10
   cpu:
-    # Ordered list of CPU power-meter backends. The first backend that
-    # initializes successfully and reports zones is used.
+    # Ordered preference list of CPU power-meter backends. The first backend
+    # that initializes successfully and reports zones is used.
     # Built-in backends: rapl, hwmon, fake.
-    meters: [rapl, hwmon]
+    preferredMeters: [rapl, hwmon]
   rapl:
     zones: []
   exporter:
@@ -107,7 +107,7 @@ config:
       pollInterval: 15s      # Poll interval for kubelet mode (default: 15s)
   dev:
     fake-cpu-meter:
-      enabled: false # DEPRECATED: set cpu.meters: ["fake"] instead. Overrides cpu.meters and emits a deprecation warning when true.
+      enabled: false # DEPRECATED: set cpu.preferredMeters: ["fake"] instead. Overrides cpu.preferredMeters and emits a deprecation warning when true.
       zones: []
   # EXPERIMENTAL FEATURES - These features are experimental and may be unstable
   # and are disabled by default
@@ -118,7 +118,7 @@ config:
         configFile: /etc/kepler/redfish.yaml  # Path to Redfish BMC configuration file
         nodeName: ""  # Node name to use (overrides Kubernetes node name and hostname fallback)
     hwmon:
-      forceEnabled: false # DEPRECATED: set cpu.meters: ["hwmon"] instead. Emits a deprecation warning when true.
+      forceEnabled: false # DEPRECATED: set cpu.preferredMeters: ["hwmon"] instead. Emits a deprecation warning when true.
       zones: [] # List of zones to enable (default enable all)
       chipRules: [] # User-defined chip pairing rules (override/add to hardcoded defaults)
     gpu:

--- a/manifests/k8s/configmap.yaml
+++ b/manifests/k8s/configmap.yaml
@@ -20,10 +20,10 @@ data:
       maxTerminated: 100
       minTerminatedEnergyThreshold: 10
     cpu:
-      # Ordered list of CPU power-meter backends. The first backend that
-      # initializes successfully and reports zones is used.
+      # Ordered preference list of CPU power-meter backends. The first backend
+      # that initializes successfully and reports zones is used.
       # Built-in backends: rapl, hwmon, fake.
-      meters: ["rapl", "hwmon"]
+      preferredMeters: ["rapl", "hwmon"]
     rapl:
       zones: []
     exporter:
@@ -49,7 +49,7 @@ data:
         pollInterval: 15s      # Poll interval for kubelet mode (default: 15s)
     dev:
       fake-cpu-meter:
-        enabled: false # DEPRECATED: set cpu.meters: ["fake"] instead. Overrides cpu.meters and emits a deprecation warning when true.
+        enabled: false # DEPRECATED: set cpu.preferredMeters: ["fake"] instead. Overrides cpu.preferredMeters and emits a deprecation warning when true.
         zones: []
     # EXPERIMENTAL FEATURES - These features are experimental and may be unstable
     # and are disabled by default
@@ -61,7 +61,7 @@ data:
           nodeName: ""  # Node name to use (overrides Kubernetes node name and hostname fallback)
           httpTimeout: 5s  # HTTP client timeout for BMC requests (default: 5s)
       hwmon:
-        forceEnabled: false # DEPRECATED: set cpu.meters: ["hwmon"] instead. Emits a deprecation warning when true.
+        forceEnabled: false # DEPRECATED: set cpu.preferredMeters: ["hwmon"] instead. Emits a deprecation warning when true.
         zones: [] # List of zones to enable (default enable all)
         chipRules: [] # User-defined chip pairing rules (override/add to hardcoded defaults)
       gpu:


### PR DESCRIPTION
Follow up to #2468. Addresses some of the [feedback on #2467](https://github.com/sustainable-computing-io/kepler/pull/2467#discussion_r3186410605).

## Why

`cpu.meters: ["rapl", "hwmon"]` doesn't show clearly that it is an ordered preference with a priority & fallback mechanism. 

However this is not exactly a `fallbackChain` since `CreateCPUMeter` selects once at startup. There is no runtime failover.

Opting for `preferredMeters` since it matches the kube-apiserver `preferredAddressTypes` pattern of having an ordered preference list with the first viable option being selected.

## What

Rename config field `cpu.meters` to `cpu.preferredMeters` and update all references.
