### PR TITLE
fix: preserve accumulated errors in calculateNodePower/firstNodeRead

### DIFF
--- a/internal/monitor/node.go
+++ b/internal/monitor/node.go
@@ -53,7 +53,7 @@ func (pm *PowerMonitor) calculateNodePower(prevNode, newNode *Node) error {
 			absEnergy = energyReading
 
 			if energyErr != nil {
-				retErr = errors.Join(energyErr)
+				retErr = errors.Join(retErr, energyErr)
 				pm.logger.Warn("Could not read energy for zone", "zone", zone.Name(), "index", zone.Index(), "error", energyErr)
 				continue
 			}
@@ -66,7 +66,7 @@ func (pm *PowerMonitor) calculateNodePower(prevNode, newNode *Node) error {
 		} else {
 			// power sensor
 			if powerErr != nil {
-				retErr = errors.Join(powerErr)
+				retErr = errors.Join(retErr, powerErr)
 				pm.logger.Warn("Could not read power for zone", "zone", zone.Name(), "index", zone.Index(), "error", powerErr)
 				continue
 			}
@@ -211,7 +211,7 @@ func (pm *PowerMonitor) firstNodeRead(node *Node) error {
 		if isEnergySensor {
 			// energy sensor
 			if energyErr != nil {
-				retErr = errors.Join(energyErr)
+				retErr = errors.Join(retErr, energyErr)
 				pm.logger.Warn("Could not read energy for zone", "zone", zone.Name(), "index", zone.Index(), "error", energyErr)
 				continue
 			}
@@ -223,7 +223,7 @@ func (pm *PowerMonitor) firstNodeRead(node *Node) error {
 		} else {
 			// power sensor
 			if powerErr != nil {
-				retErr = errors.Join(powerErr)
+				retErr = errors.Join(retErr, powerErr)
 				pm.logger.Warn("Could not read power for zone", "zone", zone.Name(), "index", zone.Index(), "error", powerErr)
 				continue
 			}

--- a/internal/monitor/node_test.go
+++ b/internal/monitor/node_test.go
@@ -4,6 +4,7 @@
 package monitor
 
 import (
+	"errors"
 	"log/slog"
 	"os"
 	"testing"
@@ -274,6 +275,30 @@ func TestNodeErrorHandling(t *testing.T) {
 		// Should have zone info for both
 		assert.NotContains(t, current.Node.Zones, pkg)
 		assert.Contains(t, current.Node.Zones, core)
+	})
+
+	t.Run("Multiple Zone Errors Are Aggregated", func(t *testing.T) {
+		mockCPUPowerMeter.ExpectedCalls = nil
+		mockCPUPowerMeter.On("Zones").Return(testZones, nil)
+
+		pkgErr := errors.New("pkg energy read failed")
+		coreErr := errors.New("core energy read failed")
+		pkg.OnEnergy(0, pkgErr)
+		core.OnEnergy(0, coreErr)
+
+		current := NewSnapshot()
+		err := pm.firstNodeRead(current.Node)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, pkgErr, "pkg error must not be dropped")
+		assert.ErrorIs(t, err, coreErr, "core error must not be dropped")
+
+		prev := NewSnapshot()
+		err = pm.calculateNodePower(prev.Node, current.Node)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, pkgErr, "pkg error must not be dropped")
+		assert.ErrorIs(t, err, coreErr, "core error must not be dropped")
+
+		mockCPUPowerMeter.AssertExpectations(t)
 	})
 
 	mockResourceInformer.AssertExpectations(t)


### PR DESCRIPTION
## Problem
In `internal/monitor/node.go`, both `calculateNodePower` and
`firstNodeRead` accumulate per-zone read errors using
`retErr = errors.Join(energyErr)` / `errors.Join(powerErr)` inside a
loop over zones. Since `errors.Join` is called with only the new
error, each failing zone overwrites `retErr` instead of appending to
it — if multiple zones fail in the same cycle, only the last one's
error is returned to the caller.

## Fix #2482 
Changed both call sites in each function to
`errors.Join(retErr, err)` so all per-zone errors are preserved,
consistent with the accumulator pattern already used elsewhere
(e.g. `internal/resource/informer.go`).

## Testing
Added a unit test with a mock EnergyZone where two zones fail reads
in the same call, asserting the returned error unwraps to both
underlying errors.