### PR TITLE
feat(exporter): expose container CPU time metric

### DIFF
--- a/docs/user/metrics.md
+++ b/docs/user/metrics.md
@@ -185,6 +185,19 @@ These metrics provide energy and power information for containers.
 - **Constant Labels**:
   - `node_name`
 
+#### kepler_container_cpu_seconds_total
+
+- **Type**: COUNTER
+- **Description**: Total user and system time of cpu at container level in seconds
+- **Labels**:
+  - `container_id`
+  - `container_name`
+  - `runtime`
+  - `state`
+  - `pod_id`
+- **Constant Labels**:
+  - `node_name`
+
 #### kepler_container_cpu_watts
 
 - **Type**: GAUGE

--- a/internal/exporter/prometheus/collector/power_collector.go
+++ b/internal/exporter/prometheus/collector/power_collector.go
@@ -52,6 +52,7 @@ type PowerCollector struct {
 	// Container power metrics
 	containerCPUJoulesDescriptor *prometheus.Desc
 	containerCPUWattsDescriptor  *prometheus.Desc
+	containerCPUTimeDescriptor   *prometheus.Desc
 	containerGPUWattsDescriptor  *prometheus.Desc
 	containerGPUJoulesDescriptor *prometheus.Desc
 
@@ -147,6 +148,10 @@ func NewPowerCollector(monitor PowerDataProvider, nodeName string, logger *slog.
 
 		containerCPUJoulesDescriptor: joulesDesc("container", "cpu", nodeName, []string{cntrID, "container_name", "runtime", "state", zone, podID}),
 		containerCPUWattsDescriptor:  wattsDesc("container", "cpu", nodeName, []string{cntrID, "container_name", "runtime", "state", zone, podID}),
+		// Note: Unlike processCPUTimeDescriptor, containerCPUTimeDescriptor includes the "state" label.
+		// This exports distinct time series for running vs terminated containers, preserving a final
+		// sample for terminated containers to support correct power attribution.
+		containerCPUTimeDescriptor:   timeDesc("container", "cpu", nodeName, []string{cntrID, "container_name", "runtime", "state", podID}),
 		containerGPUJoulesDescriptor: joulesDesc("container", "gpu", nodeName, []string{cntrID, "container_name", "runtime", "state", podID}),
 		containerGPUWattsDescriptor:  wattsDesc("container", "gpu", nodeName, []string{cntrID, "container_name", "runtime", "state", podID}),
 
@@ -216,9 +221,9 @@ func (c *PowerCollector) Describe(ch chan<- *prometheus.Desc) {
 	if c.metricsLevel.IsContainerEnabled() {
 		ch <- c.containerCPUJoulesDescriptor
 		ch <- c.containerCPUWattsDescriptor
+		ch <- c.containerCPUTimeDescriptor
 		ch <- c.containerGPUJoulesDescriptor
 		ch <- c.containerGPUWattsDescriptor
-		// ch <- c.containerCPUTimeDescriptor // TODO: add conntainerCPUTimeDescriptor
 	}
 
 	// vm
@@ -432,6 +437,14 @@ func (c *PowerCollector) collectContainerMetrics(ch chan<- prometheus.Metric, st
 
 	// No need to lock, already done by the calling function
 	for id, container := range containers {
+		ch <- prometheus.MustNewConstMetric(
+			c.containerCPUTimeDescriptor,
+			prometheus.CounterValue,
+			container.CPUTotalTime,
+			id, container.Name, string(container.Runtime), state,
+			container.PodID,
+		)
+
 		for zone, usage := range container.Zones {
 			zoneName := zone.Name()
 

--- a/internal/exporter/prometheus/collector/power_collector.go
+++ b/internal/exporter/prometheus/collector/power_collector.go
@@ -148,6 +148,9 @@ func NewPowerCollector(monitor PowerDataProvider, nodeName string, logger *slog.
 
 		containerCPUJoulesDescriptor: joulesDesc("container", "cpu", nodeName, []string{cntrID, "container_name", "runtime", "state", zone, podID}),
 		containerCPUWattsDescriptor:  wattsDesc("container", "cpu", nodeName, []string{cntrID, "container_name", "runtime", "state", zone, podID}),
+		// Note: Unlike processCPUTimeDescriptor, containerCPUTimeDescriptor includes the "state" label.
+		// This exports distinct time series for running vs terminated containers, preserving a final
+		// sample for terminated containers to support correct power attribution.
 		containerCPUTimeDescriptor:   timeDesc("container", "cpu", nodeName, []string{cntrID, "container_name", "runtime", "state", podID}),
 		containerGPUJoulesDescriptor: joulesDesc("container", "gpu", nodeName, []string{cntrID, "container_name", "runtime", "state", podID}),
 		containerGPUWattsDescriptor:  wattsDesc("container", "gpu", nodeName, []string{cntrID, "container_name", "runtime", "state", podID}),

--- a/internal/exporter/prometheus/collector/power_collector_test.go
+++ b/internal/exporter/prometheus/collector/power_collector_test.go
@@ -237,6 +237,7 @@ func TestPowerCollector(t *testing.T) {
 			ID:             "abcd-efgh",
 			Name:           "test-container",
 			Runtime:        resource.PodmanRuntime,
+			CPUTotalTime:   10.5,
 			GPUPower:       42.5,
 			GPUEnergyTotal: 250 * device.Joule,
 			PodID:          "test-pod",
@@ -347,6 +348,7 @@ func TestPowerCollector(t *testing.T) {
 			"kepler_container_cpu_watts",
 			"kepler_container_gpu_watts",
 			"kepler_container_gpu_joules_total",
+			"kepler_container_cpu_seconds_total",
 
 			"kepler_vm_cpu_joules_total",
 			"kepler_vm_cpu_watts",
@@ -494,6 +496,16 @@ func TestPowerCollector(t *testing.T) {
 		}
 		assertMetricLabelValues(t, registry, "kepler_container_cpu_joules_total", expectedLabels, 100.0)
 		assertMetricLabelValues(t, registry, "kepler_container_cpu_watts", expectedLabels, 5.0)
+
+		expectedLabelsWithoutZone := map[string]string{
+			"node_name":      "test-node",
+			"container_id":   "abcd-efgh",
+			"container_name": "test-container",
+			"runtime":        "podman",
+			"state":          "running",
+			"pod_id":         "test-pod",
+		}
+		assertMetricLabelValues(t, registry, "kepler_container_cpu_seconds_total", expectedLabelsWithoutZone, 10.5)
 	})
 
 	t.Run("VM Metrics Labels", func(t *testing.T) {
@@ -797,6 +809,7 @@ func TestPowerCollector_MetricsLevelFiltering(t *testing.T) {
 				"kepler_node_cpu_idle_watts":          true,
 				"kepler_process_cpu_joules_total":     false,
 				"kepler_container_cpu_joules_total":   false,
+				"kepler_container_cpu_seconds_total":  false,
 				"kepler_vm_cpu_joules_total":          false,
 				"kepler_pod_cpu_joules_total":         false,
 			},
@@ -805,37 +818,40 @@ func TestPowerCollector_MetricsLevelFiltering(t *testing.T) {
 			name:         "Only Process metrics",
 			metricsLevel: config.MetricsLevelProcess,
 			expectedMetrics: map[string]bool{
-				"kepler_node_cpu_joules_total":      false,
-				"kepler_process_cpu_joules_total":   true,
-				"kepler_process_cpu_watts":          true,
-				"kepler_process_cpu_seconds_total":  true,
-				"kepler_container_cpu_joules_total": false,
-				"kepler_vm_cpu_joules_total":        false,
-				"kepler_pod_cpu_joules_total":       false,
+				"kepler_node_cpu_joules_total":       false,
+				"kepler_process_cpu_joules_total":    true,
+				"kepler_process_cpu_watts":           true,
+				"kepler_process_cpu_seconds_total":   true,
+				"kepler_container_cpu_joules_total":  false,
+				"kepler_container_cpu_seconds_total": false,
+				"kepler_vm_cpu_joules_total":         false,
+				"kepler_pod_cpu_joules_total":        false,
 			},
 		},
 		{
 			name:         "Node and Container metrics",
 			metricsLevel: config.MetricsLevelNode | config.MetricsLevelContainer,
 			expectedMetrics: map[string]bool{
-				"kepler_node_cpu_joules_total":      true,
-				"kepler_node_cpu_watts":             true,
-				"kepler_process_cpu_joules_total":   false,
-				"kepler_container_cpu_joules_total": true,
-				"kepler_container_cpu_watts":        true,
-				"kepler_vm_cpu_joules_total":        false,
-				"kepler_pod_cpu_joules_total":       false,
+				"kepler_node_cpu_joules_total":       true,
+				"kepler_node_cpu_watts":              true,
+				"kepler_process_cpu_joules_total":    false,
+				"kepler_container_cpu_joules_total":  true,
+				"kepler_container_cpu_watts":         true,
+				"kepler_container_cpu_seconds_total": true,
+				"kepler_vm_cpu_joules_total":         false,
+				"kepler_pod_cpu_joules_total":        false,
 			},
 		},
 		{
 			name:         "No metrics",
 			metricsLevel: config.Level(0),
 			expectedMetrics: map[string]bool{
-				"kepler_node_cpu_joules_total":      false,
-				"kepler_process_cpu_joules_total":   false,
-				"kepler_container_cpu_joules_total": false,
-				"kepler_vm_cpu_joules_total":        false,
-				"kepler_pod_cpu_joules_total":       false,
+				"kepler_node_cpu_joules_total":       false,
+				"kepler_process_cpu_joules_total":    false,
+				"kepler_container_cpu_joules_total":  false,
+				"kepler_container_cpu_seconds_total": false,
+				"kepler_vm_cpu_joules_total":         false,
+				"kepler_pod_cpu_joules_total":        false,
 			},
 		},
 	}
@@ -880,10 +896,11 @@ func TestPowerCollector_MetricsLevelFiltering(t *testing.T) {
 				},
 				Containers: monitor.Containers{
 					"test-container": &monitor.Container{
-						ID:      "test-container",
-						Name:    "test-container",
-						Runtime: resource.PodmanRuntime,
-						PodID:   "test-pod",
+						ID:           "test-container",
+						Name:         "test-container",
+						Runtime:      resource.PodmanRuntime,
+						PodID:        "test-pod",
+						CPUTotalTime: 1.5,
 						Zones: monitor.ZoneUsageMap{
 							packageZone: monitor.Usage{
 								EnergyTotal: 100 * device.Joule,
@@ -972,9 +989,10 @@ func TestTerminatedContainerExport(t *testing.T) {
 		Processes: monitor.Processes{},
 		Containers: monitor.Containers{
 			"running-container": &monitor.Container{
-				ID:      "running-container",
-				Name:    "running-cont",
-				Runtime: resource.DockerRuntime,
+				ID:           "running-container",
+				Name:         "running-cont",
+				Runtime:      resource.DockerRuntime,
+				CPUTotalTime: 150.0,
 				Zones: monitor.ZoneUsageMap{
 					packageZone: monitor.Usage{
 						EnergyTotal: 150 * device.Joule,
@@ -985,11 +1003,12 @@ func TestTerminatedContainerExport(t *testing.T) {
 		},
 		TerminatedContainers: monitor.Containers{
 			"terminated-container": &monitor.Container{
-				ID:       "terminated-container",
-				Name:     "terminated-cont",
-				Runtime:  resource.PodmanRuntime,
-				GPUPower: 55.0,
-				PodID:    "terminated-pod",
+				ID:           "terminated-container",
+				Name:         "terminated-cont",
+				Runtime:      resource.PodmanRuntime,
+				GPUPower:     55.0,
+				PodID:        "terminated-pod",
+				CPUTotalTime: 300.0,
 				Zones: monitor.ZoneUsageMap{
 					packageZone: monitor.Usage{
 						EnergyTotal: 300 * device.Joule,
@@ -1033,19 +1052,27 @@ func TestTerminatedContainerExport(t *testing.T) {
 			map[string]string{"container_id": "running-container", "state": "running"}, 150.0)
 		assertMetricLabelValues(t, registry, "kepler_container_cpu_watts",
 			map[string]string{"container_id": "running-container", "state": "running"}, 15.0)
+		assertMetricLabelValues(t, registry, "kepler_container_cpu_seconds_total",
+			map[string]string{"container_id": "running-container", "state": "running"}, 150.0)
 
 		// Test terminated container metrics
 		assertMetricLabelValues(t, registry, "kepler_container_cpu_joules_total",
 			map[string]string{"container_id": "terminated-container", "state": "terminated"}, 300.0)
 		assertMetricLabelValues(t, registry, "kepler_container_cpu_watts",
 			map[string]string{"container_id": "terminated-container", "state": "terminated"}, 30.0)
+		assertMetricLabelValues(t, registry, "kepler_container_cpu_seconds_total",
+			map[string]string{"container_id": "terminated-container", "state": "terminated"}, 300.0)
 
 		// Test additional labels for running container
 		assertMetricLabelValues(t, registry, "kepler_container_cpu_joules_total",
 			map[string]string{"container_id": "running-container", "container_name": "running-cont", "runtime": "docker"}, 150.0)
+		assertMetricLabelValues(t, registry, "kepler_container_cpu_seconds_total",
+			map[string]string{"container_id": "running-container", "container_name": "running-cont", "runtime": "docker"}, 150.0)
 
 		// Test additional labels for terminated container
 		assertMetricLabelValues(t, registry, "kepler_container_cpu_joules_total",
+			map[string]string{"container_id": "terminated-container", "container_name": "terminated-cont", "runtime": "podman"}, 300.0)
+		assertMetricLabelValues(t, registry, "kepler_container_cpu_seconds_total",
 			map[string]string{"container_id": "terminated-container", "container_name": "terminated-cont", "runtime": "podman"}, 300.0)
 	})
 
@@ -1060,6 +1087,12 @@ func TestTerminatedContainerExport(t *testing.T) {
 		assertMetricExists(t, registry, "kepler_container_cpu_watts",
 			map[string]string{"state": "running"})
 		assertMetricExists(t, registry, "kepler_container_cpu_watts",
+			map[string]string{"state": "terminated"})
+
+		// Also verify for seconds metrics
+		assertMetricExists(t, registry, "kepler_container_cpu_seconds_total",
+			map[string]string{"state": "running"})
+		assertMetricExists(t, registry, "kepler_container_cpu_seconds_total",
 			map[string]string{"state": "terminated"})
 	})
 

--- a/internal/exporter/prometheus/collector/power_collector_test.go
+++ b/internal/exporter/prometheus/collector/power_collector_test.go
@@ -237,6 +237,7 @@ func TestPowerCollector(t *testing.T) {
 			ID:             "abcd-efgh",
 			Name:           "test-container",
 			Runtime:        resource.PodmanRuntime,
+			CPUTotalTime:   10.5,
 			GPUPower:       42.5,
 			GPUEnergyTotal: 250 * device.Joule,
 			PodID:          "test-pod",
@@ -495,6 +496,16 @@ func TestPowerCollector(t *testing.T) {
 		}
 		assertMetricLabelValues(t, registry, "kepler_container_cpu_joules_total", expectedLabels, 100.0)
 		assertMetricLabelValues(t, registry, "kepler_container_cpu_watts", expectedLabels, 5.0)
+
+		expectedLabelsWithoutZone := map[string]string{
+			"node_name":      "test-node",
+			"container_id":   "abcd-efgh",
+			"container_name": "test-container",
+			"runtime":        "podman",
+			"state":          "running",
+			"pod_id":         "test-pod",
+		}
+		assertMetricLabelValues(t, registry, "kepler_container_cpu_seconds_total", expectedLabelsWithoutZone, 10.5)
 	})
 
 	t.Run("VM Metrics Labels", func(t *testing.T) {
@@ -798,6 +809,7 @@ func TestPowerCollector_MetricsLevelFiltering(t *testing.T) {
 				"kepler_node_cpu_idle_watts":          true,
 				"kepler_process_cpu_joules_total":     false,
 				"kepler_container_cpu_joules_total":   false,
+				"kepler_container_cpu_seconds_total":  false,
 				"kepler_vm_cpu_joules_total":          false,
 				"kepler_pod_cpu_joules_total":         false,
 			},
@@ -806,37 +818,40 @@ func TestPowerCollector_MetricsLevelFiltering(t *testing.T) {
 			name:         "Only Process metrics",
 			metricsLevel: config.MetricsLevelProcess,
 			expectedMetrics: map[string]bool{
-				"kepler_node_cpu_joules_total":      false,
-				"kepler_process_cpu_joules_total":   true,
-				"kepler_process_cpu_watts":          true,
-				"kepler_process_cpu_seconds_total":  true,
-				"kepler_container_cpu_joules_total": false,
-				"kepler_vm_cpu_joules_total":        false,
-				"kepler_pod_cpu_joules_total":       false,
+				"kepler_node_cpu_joules_total":       false,
+				"kepler_process_cpu_joules_total":    true,
+				"kepler_process_cpu_watts":           true,
+				"kepler_process_cpu_seconds_total":   true,
+				"kepler_container_cpu_joules_total":  false,
+				"kepler_container_cpu_seconds_total": false,
+				"kepler_vm_cpu_joules_total":         false,
+				"kepler_pod_cpu_joules_total":        false,
 			},
 		},
 		{
 			name:         "Node and Container metrics",
 			metricsLevel: config.MetricsLevelNode | config.MetricsLevelContainer,
 			expectedMetrics: map[string]bool{
-				"kepler_node_cpu_joules_total":      true,
-				"kepler_node_cpu_watts":             true,
-				"kepler_process_cpu_joules_total":   false,
-				"kepler_container_cpu_joules_total": true,
-				"kepler_container_cpu_watts":        true,
-				"kepler_vm_cpu_joules_total":        false,
-				"kepler_pod_cpu_joules_total":       false,
+				"kepler_node_cpu_joules_total":       true,
+				"kepler_node_cpu_watts":              true,
+				"kepler_process_cpu_joules_total":    false,
+				"kepler_container_cpu_joules_total":  true,
+				"kepler_container_cpu_watts":         true,
+				"kepler_container_cpu_seconds_total": true,
+				"kepler_vm_cpu_joules_total":         false,
+				"kepler_pod_cpu_joules_total":        false,
 			},
 		},
 		{
 			name:         "No metrics",
 			metricsLevel: config.Level(0),
 			expectedMetrics: map[string]bool{
-				"kepler_node_cpu_joules_total":      false,
-				"kepler_process_cpu_joules_total":   false,
-				"kepler_container_cpu_joules_total": false,
-				"kepler_vm_cpu_joules_total":        false,
-				"kepler_pod_cpu_joules_total":       false,
+				"kepler_node_cpu_joules_total":       false,
+				"kepler_process_cpu_joules_total":    false,
+				"kepler_container_cpu_joules_total":  false,
+				"kepler_container_cpu_seconds_total": false,
+				"kepler_vm_cpu_joules_total":         false,
+				"kepler_pod_cpu_joules_total":        false,
 			},
 		},
 	}
@@ -881,10 +896,11 @@ func TestPowerCollector_MetricsLevelFiltering(t *testing.T) {
 				},
 				Containers: monitor.Containers{
 					"test-container": &monitor.Container{
-						ID:      "test-container",
-						Name:    "test-container",
-						Runtime: resource.PodmanRuntime,
-						PodID:   "test-pod",
+						ID:           "test-container",
+						Name:         "test-container",
+						Runtime:      resource.PodmanRuntime,
+						PodID:        "test-pod",
+						CPUTotalTime: 1.5,
 						Zones: monitor.ZoneUsageMap{
 							packageZone: monitor.Usage{
 								EnergyTotal: 100 * device.Joule,
@@ -973,9 +989,10 @@ func TestTerminatedContainerExport(t *testing.T) {
 		Processes: monitor.Processes{},
 		Containers: monitor.Containers{
 			"running-container": &monitor.Container{
-				ID:      "running-container",
-				Name:    "running-cont",
-				Runtime: resource.DockerRuntime,
+				ID:           "running-container",
+				Name:         "running-cont",
+				Runtime:      resource.DockerRuntime,
+				CPUTotalTime: 150.0,
 				Zones: monitor.ZoneUsageMap{
 					packageZone: monitor.Usage{
 						EnergyTotal: 150 * device.Joule,
@@ -986,11 +1003,12 @@ func TestTerminatedContainerExport(t *testing.T) {
 		},
 		TerminatedContainers: monitor.Containers{
 			"terminated-container": &monitor.Container{
-				ID:       "terminated-container",
-				Name:     "terminated-cont",
-				Runtime:  resource.PodmanRuntime,
-				GPUPower: 55.0,
-				PodID:    "terminated-pod",
+				ID:           "terminated-container",
+				Name:         "terminated-cont",
+				Runtime:      resource.PodmanRuntime,
+				GPUPower:     55.0,
+				PodID:        "terminated-pod",
+				CPUTotalTime: 300.0,
 				Zones: monitor.ZoneUsageMap{
 					packageZone: monitor.Usage{
 						EnergyTotal: 300 * device.Joule,
@@ -1034,19 +1052,27 @@ func TestTerminatedContainerExport(t *testing.T) {
 			map[string]string{"container_id": "running-container", "state": "running"}, 150.0)
 		assertMetricLabelValues(t, registry, "kepler_container_cpu_watts",
 			map[string]string{"container_id": "running-container", "state": "running"}, 15.0)
+		assertMetricLabelValues(t, registry, "kepler_container_cpu_seconds_total",
+			map[string]string{"container_id": "running-container", "state": "running"}, 150.0)
 
 		// Test terminated container metrics
 		assertMetricLabelValues(t, registry, "kepler_container_cpu_joules_total",
 			map[string]string{"container_id": "terminated-container", "state": "terminated"}, 300.0)
 		assertMetricLabelValues(t, registry, "kepler_container_cpu_watts",
 			map[string]string{"container_id": "terminated-container", "state": "terminated"}, 30.0)
+		assertMetricLabelValues(t, registry, "kepler_container_cpu_seconds_total",
+			map[string]string{"container_id": "terminated-container", "state": "terminated"}, 300.0)
 
 		// Test additional labels for running container
 		assertMetricLabelValues(t, registry, "kepler_container_cpu_joules_total",
 			map[string]string{"container_id": "running-container", "container_name": "running-cont", "runtime": "docker"}, 150.0)
+		assertMetricLabelValues(t, registry, "kepler_container_cpu_seconds_total",
+			map[string]string{"container_id": "running-container", "container_name": "running-cont", "runtime": "docker"}, 150.0)
 
 		// Test additional labels for terminated container
 		assertMetricLabelValues(t, registry, "kepler_container_cpu_joules_total",
+			map[string]string{"container_id": "terminated-container", "container_name": "terminated-cont", "runtime": "podman"}, 300.0)
+		assertMetricLabelValues(t, registry, "kepler_container_cpu_seconds_total",
 			map[string]string{"container_id": "terminated-container", "container_name": "terminated-cont", "runtime": "podman"}, 300.0)
 	})
 
@@ -1061,6 +1087,12 @@ func TestTerminatedContainerExport(t *testing.T) {
 		assertMetricExists(t, registry, "kepler_container_cpu_watts",
 			map[string]string{"state": "running"})
 		assertMetricExists(t, registry, "kepler_container_cpu_watts",
+			map[string]string{"state": "terminated"})
+
+		// Also verify for seconds metrics
+		assertMetricExists(t, registry, "kepler_container_cpu_seconds_total",
+			map[string]string{"state": "running"})
+		assertMetricExists(t, registry, "kepler_container_cpu_seconds_total",
 			map[string]string{"state": "terminated"})
 	})
 

--- a/test/e2e-k8s/container_test.go
+++ b/test/e2e-k8s/container_test.go
@@ -28,6 +28,12 @@ func TestContainerMetricsPresent(t *testing.T) {
 				"kepler_container_cpu_watts metric should exist")
 			return ctx
 		}).
+		Assess("kepler_container_cpu_seconds_total exists", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			snapshot := takeSnapshot(t)
+			assert.True(t, snapshot.HasMetric("kepler_container_cpu_seconds_total"),
+				"kepler_container_cpu_seconds_total metric should exist")
+			return ctx
+		}).
 		Feature()
 
 	testenv.Test(t, feature)
@@ -75,6 +81,26 @@ func TestContainerMetricsHaveRequiredLabels(t *testing.T) {
 			}
 			return ctx
 		}).
+		Assess("kepler_container_cpu_seconds_total has required labels", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			snapshot := takeSnapshot(t)
+			metrics := snapshot.GetAllWithName("kepler_container_cpu_seconds_total")
+			require.NotEmpty(t, metrics,
+				"kepler_container_cpu_seconds_total metric should exist")
+
+			m := metrics[0]
+			requiredSecondsLabels := []string{
+				"container_id",
+				"container_name",
+				"runtime",
+				"state",
+				"pod_id",
+			}
+			for _, label := range requiredSecondsLabels {
+				assert.Contains(t, m.Labels, label,
+					"kepler_container_cpu_seconds_total should have %s label", label)
+			}
+			return ctx
+		}).
 		Feature()
 
 	testenv.Test(t, feature)
@@ -103,6 +129,17 @@ func TestContainerMetricsNonNegative(t *testing.T) {
 			}
 
 			t.Logf("Verified %d container watts metrics are non-negative", len(metrics))
+			return ctx
+		}).
+		Assess("kepler_container_cpu_seconds_total values are non-negative", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			snapshot := takeSnapshot(t)
+			metrics := snapshot.GetAllWithName("kepler_container_cpu_seconds_total")
+			for _, m := range metrics {
+				assert.GreaterOrEqual(t, m.Value, float64(0),
+					"Container seconds should be >= 0 (container_id=%s)", m.Labels["container_id"])
+			}
+
+			t.Logf("Verified %d container seconds metrics are non-negative", len(metrics))
 			return ctx
 		}).
 		Feature()


### PR DESCRIPTION
## Summary

Exposes the `kepler_container_cpu_seconds_total` Prometheus metric, reporting total container CPU time (user + system) in seconds.

### Changes

* **Exporter**: Declared, initialized, and registered the `containerCPUTimeDescriptor` on `PowerCollector`. Exposes `kepler_container_cpu_seconds_total` with labels (`container_id`, `container_name`, `runtime`, `state`, `pod_id`, `node_name`).
* **Tests**: Added unit tests in `power_collector_test.go` asserting metric values and labels for both running and terminated containers.
* **Docs**: Regenerated `docs/user/metrics.md` via `make gen-metrics-docs`.

### Verification

1. **Unit Tests**:
   ```bash
   go test ./internal/exporter/prometheus/collector/... -run TestPowerCollector -v
   go test ./internal/exporter/prometheus/collector/... -run TestTerminatedContainerExport -v
    ```
2. Quality Checks: gofmt -l . and go vet ./... passed.
3. Manual Smoke Test: Verified via local docker-compose run:
```bash
$ curl -s localhost:28283/metrics | grep kepler_container_cpu_seconds_total
kepler_container_cpu_seconds_total{container_id="...",container_name="...",node_name="kind-control-plane",pod_id="",runtime="docker",state="running"} 1.56
```