### PR TITLE
fix(manifests): add NVML init container for NVIDIA GPU Operator support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,3 +95,16 @@ repos:
       - id: helmlint
         name: helm-lint
         files: ^manifests/helm/[^/]+/(Chart\.yaml|values\.yaml|templates/.*)$
+
+  # GPU-enabled helm-lint: covers variants the helmlint hook above cannot
+  # run (it does not accept --set flags).
+  - repo: local
+    hooks:
+      - id: helm-lint-gpu
+        name: helm-lint (gpu enabled)
+        language: system
+        pass_filenames: false
+        files: ^manifests/helm/[^/]+/(Chart\.yaml|values\.yaml|templates/.*)$
+        entry: >
+          bash -c 'helm lint manifests/helm/kepler
+          --set config.experimental.gpu.enabled=true'

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -100,6 +100,41 @@ helm install kepler oci://quay.io/sustainable_computing_io/charts/kepler \
   --values values.yaml
 ```
 
+#### Enabling GPU Power Monitoring (NVIDIA GPU Operator)
+
+To export GPU power metrics on clusters with the [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/overview.html), enable the experimental GPU flag. The chart then adds an `nvidia-libs` init container that copies `libnvidia-ml.so*` from the host driver path into an `emptyDir`, and points `LD_LIBRARY_PATH` at it:
+
+```bash
+helm install kepler oci://quay.io/sustainable_computing_io/charts/kepler \
+  --namespace kepler \
+  --create-namespace \
+  --set config.experimental.gpu.enabled=true
+```
+
+What this changes:
+
+- Adds an `nvidia-libs` init container that copies `libnvidia-ml.so*` into a 200Mi `emptyDir` using `cp -P` (preserves the driver symlink chain; `cp -L` can exceed the size limit when leftover driver versions are present).
+- Mounts that `emptyDir` read-only at `/usr/local/nvidia/lib64` and sets `LD_LIBRARY_PATH=/usr/local/nvidia/lib64`.
+- Mounts the host driver directory (default `/run/nvidia/driver`, overridable via `daemonset.nvidia.driverPath`) with `DirectoryOrCreate` so non-GPU nodes still schedule.
+
+Defaults assume the standard GPU Operator layout. Override via `values.yaml` if needed:
+
+```yaml
+config:
+  experimental:
+    gpu:
+      enabled: true
+
+daemonset:
+  nvidia:
+    driverPath: /run/nvidia/driver
+    nvmlInitImage:
+      repository: busybox
+      tag: 1.36.1
+```
+
+Note: `config.experimental.gpu.enabled` is intentionally coupled with the chart's `daemonset.nvidia.*` plumbing. Enabling the binary flag without the init path (or the reverse) is not a supported split. Leave `enabled: false` if you do not want GPU power monitoring.
+
 #### Helm Management Commands
 
 ```bash

--- a/manifests/helm/kepler/templates/daemonset.yaml
+++ b/manifests/helm/kepler/templates/daemonset.yaml
@@ -41,6 +41,42 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.config.experimental.gpu.enabled }}
+      initContainers:
+        - name: nvidia-libs
+          image: "{{ .Values.daemonset.nvidia.nvmlInitImage.repository }}:{{ .Values.daemonset.nvidia.nvmlInitImage.tag }}"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            # Root required to read root-owned driver libs; capabilities dropped.
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              # cp -P keeps driver symlink chains (avoids 200Mi emptyDir blowup).
+              # set -e: copy failures fail init; do not mask with || true.
+              found=$(find /run-nvidia -name "libnvidia-ml.so*" 2>/dev/null | wc -l)
+              if [ "$found" -gt 0 ]; then
+                find /run-nvidia -name "libnvidia-ml.so*" -exec cp -P {} /nvml-libs/ \;
+                copied=$(ls /nvml-libs/ 2>/dev/null | wc -l)
+                echo "Copied $copied of $found NVML library file(s) to /nvml-libs"
+              else
+                echo "No NVML libraries found at /run-nvidia — GPU metrics will be unavailable on this node"
+              fi
+          volumeMounts:
+            - name: lib-nvidia
+              mountPath: /run-nvidia
+              readOnly: true
+            - name: nvml-libs
+              mountPath: /nvml-libs
+      {{- end }}
       containers:
         - name: kepler
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -66,6 +102,11 @@ spec:
               readOnly: true
             - name: cfm
               mountPath: /etc/kepler
+            {{- if .Values.config.experimental.gpu.enabled }}
+            - name: nvml-libs
+              mountPath: /usr/local/nvidia/lib64
+              readOnly: true
+            {{- end }}
           {{- with .Values.daemonset.startupProbe }}
           startupProbe:
             {{- toYaml . | nindent 12 }}
@@ -84,11 +125,16 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            # Required for NVML to see all MIG devices when running in a container
+            # Always set (independent of gpu.enabled) for runtimeClassName: nvidia.
             - name: NVIDIA_VISIBLE_DEVICES
               value: "all"
             - name: NVIDIA_MIG_MONITOR_DEVICES
               value: "all"
+            {{- if .Values.config.experimental.gpu.enabled }}
+            # Path for libnvidia-ml.so from the nvidia-libs init container.
+            - name: LD_LIBRARY_PATH
+              value: /usr/local/nvidia/lib64
+            {{- end }}
           {{- with .Values.daemonset.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -103,3 +149,13 @@ spec:
         - name: cfm
           configMap:
             name: {{ include "kepler.fullname" . }}
+        {{- if .Values.config.experimental.gpu.enabled }}
+        - name: lib-nvidia
+          hostPath:
+            path: {{ .Values.daemonset.nvidia.driverPath | quote }}
+            # DirectoryOrCreate so non-GPU nodes still schedule.
+            type: DirectoryOrCreate
+        - name: nvml-libs
+          emptyDir:
+            sizeLimit: 200Mi
+        {{- end }}

--- a/manifests/helm/kepler/values.yaml
+++ b/manifests/helm/kepler/values.yaml
@@ -65,6 +65,20 @@ daemonset:
 
   readinessProbe: {}
 
+  # Chart-only knobs for the NVML init-container pattern. These do NOT live
+  # under .Values.config because that tree is dumped verbatim into
+  # /etc/kepler/config.yaml (templates/configmap.yaml), and the Kepler binary
+  # doesn't (and shouldn't) know about driver paths or init-image names.
+  nvidia:
+    # Path on the host where the NVIDIA GPU Operator exposes the driver
+    # container root FS. Override if your GPU Operator uses a non-default path.
+    driverPath: /run/nvidia/driver
+    # Init container used to copy NVML libraries into an emptyDir.
+    # Override repository/tag for airgapped or private-registry environments.
+    nvmlInitImage:
+      repository: busybox
+      tag: 1.36.1
+
 config:
   log:
     level: debug
@@ -122,6 +136,9 @@ config:
       zones: [] # List of zones to enable (default enable all)
       chipRules: [] # User-defined chip pairing rules (override/add to hardcoded defaults)
     gpu:
+      # Enabling this also triggers the chart's NVML init container and
+      # LD_LIBRARY_PATH injection (daemonset.nvidia.*). Leave false if you
+      # do not want GPU power monitoring.
       enabled: false # Enable experimental GPU power monitoring
       idlePower: 0 # GPU idle power in Watts (0 = auto-detect)
       dcgmEndpoint: "" # dcgm-exporter metrics URL for MIG (auto-discovered if empty)

--- a/manifests/k8s/daemonset.yaml
+++ b/manifests/k8s/daemonset.yaml
@@ -26,6 +26,40 @@ spec:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule
+      initContainers:
+        - name: nvidia-libs
+          image: busybox:1.36.1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            # Root required to read root-owned driver libs; capabilities dropped.
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              # cp -P keeps driver symlink chains (avoids 200Mi emptyDir blowup).
+              # set -e: copy failures fail init; do not mask with || true.
+              found=$(find /run-nvidia -name "libnvidia-ml.so*" 2>/dev/null | wc -l)
+              if [ "$found" -gt 0 ]; then
+                find /run-nvidia -name "libnvidia-ml.so*" -exec cp -P {} /nvml-libs/ \;
+                copied=$(ls /nvml-libs/ 2>/dev/null | wc -l)
+                echo "Copied $copied of $found NVML library file(s) to /nvml-libs"
+              else
+                echo "No NVML libraries found at /run-nvidia — GPU metrics will be unavailable on this node"
+              fi
+          volumeMounts:
+            - name: lib-nvidia
+              mountPath: /run-nvidia
+              readOnly: true
+            - name: nvml-libs
+              mountPath: /nvml-libs
       containers:
         - name: kepler
           image: <KEPLER_IMAGE>
@@ -54,8 +88,9 @@ spec:
               mountPath: /etc/kepler/config.yaml
               subPath: config.yaml
               readOnly: true
-            - name: nvidia-driver
-              mountPath: /run/nvidia/driver
+            # NVML libs only (copied by init); avoids mounting driver glibc.
+            - name: nvml-libs
+              mountPath: /usr/local/nvidia/lib64
               readOnly: true
           livenessProbe:
             httpGet:
@@ -69,8 +104,9 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            # Static path; K8s cannot expand the image's existing LD_LIBRARY_PATH.
             - name: LD_LIBRARY_PATH
-              value: /run/nvidia/driver/usr/lib64
+              value: /usr/local/nvidia/lib64
             # Required for NVML to see all MIG devices when running in a container
             - name: NVIDIA_VISIBLE_DEVICES
               value: all
@@ -86,7 +122,11 @@ spec:
         - name: cfm
           configMap:
             name: kepler
-        - name: nvidia-driver
+        # lib-nvidia: host driver path; nvml-libs: init-populated emptyDir.
+        - name: lib-nvidia
           hostPath:
             path: /run/nvidia/driver
             type: DirectoryOrCreate
+        - name: nvml-libs
+          emptyDir:
+            sizeLimit: 200Mi


### PR DESCRIPTION
## Summary

On clusters with the NVIDIA GPU Operator, Kepler was mounting the whole driver-container root FS from `/run/nvidia/driver`. That path includes the driver's glibc, so dynamic linking breaks when NVML loads.

This PR switches to the usual pattern: an init container copies only `libnvidia-ml.so*` into an emptyDir, and Kepler mounts that at `/usr/local/nvidia/lib64` with `LD_LIBRARY_PATH` pointed there. NVML libs only, no driver glibc.

Closes #2484

## What changed

- `manifests/helm/kepler/values.yaml`: chart-only knobs under `daemonset.nvidia.*` (`driverPath`, `nvmlInitImage`). Not under `config.experimental.gpu.*`, because the configmap dumps the whole `config` tree into `/etc/kepler/config.yaml` and the binary only knows `enabled` / `idlePower` / `dcgmEndpoint` there.
- `manifests/helm/kepler/templates/daemonset.yaml`: when `config.experimental.gpu.enabled` is true, add the `nvidia-libs` init container, emptyDir mount, `LD_LIBRARY_PATH`, hostPath + emptyDir volumes (`sizeLimit: 200Mi`).
- `manifests/k8s/daemonset.yaml`: same pattern, always on (raw manifest has no values system).
- `.pre-commit-config.yaml`: local `helm-lint-gpu` hook for the `gpu.enabled=true` variant. Default state stays on the existing helmlint hook. No extra CI job.
- `docs/user/installation.md`: how to enable GPU power monitoring with the GPU Operator, including overrides and the flag coupling note.

## Design notes

- `config.experimental.gpu.enabled` is intentionally coupled to the chart plumbing. Flip that flag and you get both the binary path and the init container. There is no separate `daemonset.nvidia.enabled`.
- `NVIDIA_VISIBLE_DEVICES` / `NVIDIA_MIG_MONITOR_DEVICES` stay unconditional. They were always set, and the `runtimeClassName: nvidia` workaround depends on them.
- `LD_LIBRARY_PATH` is a static value. K8s only expands env vars defined earlier in the same pod spec, not the image env, so we cannot prepend whatever the image already had. The dynamic linker still searches `/lib` and `/usr/lib` by default.
- Init uses `set -e` and does not mask `cp` with `|| true`. A full emptyDir or a permission error should fail the pod at init, not start Kepler with a half-copied library.
- The copy pass globs the known driver lib dirs (`usr/lib64`, `usr/lib/x86_64-linux-gnu`, `usr/lib/aarch64-linux-gnu`) instead of running `find` over the driver root. The driver-container root FS has its own `/proc` mounted inside it, so a full walk is slow and exits nonzero on unreadable proc entries, which `set -e` (correctly) treats as fatal. An unknown future layout degrades to the same "No NVML libraries found" path as a non-GPU node instead of failing init.
- `cp -P` (preserve symlinks), not `cp -L`. Real NVIDIA drivers are a symlink chain (`libnvidia-ml.so` -> `.so.1` -> `.so.580.x`). Leftover driver versions on the host make `cp -L` blow past the 200Mi sizeLimit; `cp -P` keeps the chain cheap.
- Init runs as UID/GID 0 with capabilities dropped, so root-owned driver files are readable without depending on the busybox image's `USER`.

## Review feedback folded in

- Chart knobs moved out of `config.*` into `daemonset.nvidia.*` (Copilot).
- Explicit `runAsUser` / `runAsGroup: 0` (Copilot). Kept `readOnlyRootFilesystem: true` (mount points are created by the runtime before the remount; emptyDir writes do not need a writable rootfs).
- `cp -P` instead of `cp -L` (shellyco-code), with host numbers below.
- Dropped the dedicated helm-lint CI job; use the local pre-commit hook instead (vprashar).
- Trimmed heavy init-script comments in the chart; long rationale lives here and in the commit message (vprashar).
- User docs + flag-coupling callout (vprashar).
- Init no longer walks the driver root FS with `find`. On a real GPU Operator cluster it traversed the driver container's `/proc` for minutes and crash-looped on unreadable entries (laurall974's H100 report). The copy pass now globs the known lib dirs only.

## Testing

`helm lint` and `helm template` for both `gpu.enabled` states. Disabled render has no init container / nvml emptyDir path. Enabled ConfigMap only has `enabled` / `idlePower` / `dcgmEndpoint` under `experimental.gpu`.

### On a real cluster with a real GPU

Single-node k3s v1.36.2 (Ubuntu 24.04), NVIDIA RTX 3050, driver 580.173.02. Chart installed from this branch with `--set config.experimental.gpu.enabled=true`, kepler image `5495d5d-20260725174242`. Manifest unmodified.

**Non-GPU node path** (no `/run/nvidia/driver` on the host):

| Check | Result |
| --- | --- |
| Init container | `Completed`, exitCode 0, logs "No NVML libraries found at /run-nvidia" |
| hostPath `DirectoryOrCreate` | created `/run/nvidia/driver`, node still schedules |
| Init securityContext as applied by kubelet | `readOnlyRootFilesystem: true`, `drop: [ALL]`, `runAsUser/Group: 0` — container started and exited 0 |
| kepler | `NVML init failed: ERROR_LIBRARY_NOT_FOUND`, `no GPUs discovered` (this is the log from #2484) |
| Pod | `Running`, ready, 0 restarts, 0 GPU metrics |

**GPU node path** — `/run/nvidia/driver/usr/lib64` staged as the GPU Operator exposes the driver container root: real NVML symlink chain plus the driver's own userspace (`libc.so.6`, `ld-linux-x86-64.so.2`, `libcuda.so.580.173.02`, `libnvidia-glcore`, `libnvidia-opencl`), 218 MB total.

| Check | Result |
| --- | --- |
| Init container | `Copied 3 of 3 NVML library file(s)`, exitCode 0 |
| emptyDir at `/usr/local/nvidia/lib64` | 2.2 MB, symlink chain intact, NVML only — no glibc, no libcuda |
| NVML resolved by kepler (`/proc/<pid>/maps`) | `/usr/local/nvidia/lib64/libnvidia-ml.so.580.173.02` |
| kepler | `discovered GPU name="NVIDIA GeForce RTX 3050 Laptop GPU"`, `NVML initialized device_count=1` |
| Exported | `kepler_node_gpu_watts 3.224`, `kepler_node_gpu_joules_total 3148.016`, `kepler_node_gpu_info 1` |
| Host `nvidia-smi` at the same moment | 3.22 W |

### Second GPU, strict isolation

Tesla T4, driver 580.95.05, system NVML moved out of the loader's search path so the copied libraries were the only possible source.

| Check | Result |
| --- | --- |
| Init script from `helm template`, byte-for-byte under `busybox:1.36.1` | exit 0, `Copied 3 of 3` |
| `cp -P` vs `cp -L` on the same tree | 2.3 MB vs 6.9 MB |
| kepler with the emptyDir | `NVML initialized`, `kepler_node_gpu_watts 13.709` |
| Control, `LD_LIBRARY_PATH` unset | `ERROR_LIBRARY_NOT_FOUND`, 0 GPU metrics |

Earlier host-only validation (driver 580.159.03) agreed on the sizing: leftover multi-version host was ~152 MiB with `cp -P` vs ~307 MiB with `cp -L`.

### GPU Operator `/proc` regression, multi-node

4-node kubeadm v1.30.14 (3x Ubuntu 24.04, 1x Fedora 43), containerd. Driver root staged on one worker the way the operator exposes it, including a live procfs mounted at `/run/nvidia/driver/proc`, the mount the H100 report tripped on. Chart from this branch, `--set config.experimental.gpu.enabled=true`, no nodeSelector, so it schedules on every node including the tainted control plane.

| Check | Result |
| --- | --- |
| Previous revision (`find`), driver node | init exit 1 with `find: /run-nvidia/proc/1/task/1/fdinfo: Permission denied` (same lines as the H100 log), `Init:CrashLoopBackOff` |
| This revision (glob), driver node | exit 0 in under a second, `Copied 3 NVML library file(s)` |
| emptyDir | symlink chain intact (`.so -> .so.1 -> .so.580.65.06`) |
| kepler on driver node | `Running` 1/1, 2170 metrics, live RAPL zones |
| 3 nodes without `/run/nvidia` (incl. Fedora and control plane) | `No NVML libraries found`, exit 0, kepler `Running` |
| RHEL-style layout (`usr/lib64` instead of `x86_64-linux-gnu`) | `Copied 3`, kepler `Running` |

T4 re-check with the new script taken byte-for-byte from the manifest: real driver libs (580.95.05) staged in the operator layout, script exit 0, then NVML loaded strictly from the copied directory: `nvmlInit` SUCCESS, device discovered, live power readable.

### Not covered

- A real GPU Operator install. The driver root was staged by hand from the host driver rather than the operator's driver container, and device nodes reached the pod via `privileged: true` rather than `runtimeClassName: nvidia`. PSA is untested.

