### PR TITLE
chore: upgrade CI infrastructure to support Go 1.25

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1.6
+          version: v2.12.2
           args: --timeout=3m --issues-exit-code=0 ./...
           only-new-issues: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
         exclude: go\.(sum|mod)$
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.1.6
+    rev: v2.12.2
     hooks:
       - id: golangci-lint
         args: [--timeout=5m]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the binary
-FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 
 # Build arguments for binary
 ARG VERSION


### PR DESCRIPTION
Description
This PR upgrades the Kepler Continuous Integration infrastructure to support Go 1.25 

Currently, several Dependabot and contributor PRs that bump go.mod dependencies requiring Go > 1.24 are blocked because the GitHub Actions pipeline uses a hardcoded Go 1.24 builder image, and an outdated golangci-lint version that lacks the AST parsers for newer Go language features.

This upgrade unblocks those dependency bumps and ensures future compatibility.

Changes Made
Dockerfile: Upgraded the builder base image from golang:1.24 to golang:1.25 so the binary compiles with the latest toolchain syntax.
GitHub Actions (.github/workflows/pr-checks.yaml): Bumped the golangci-lint version to v2.12.2 to support linting Go 1.25+ syntax.
Pre-commit Hooks (.pre-commit-config.yaml): Bumped the local golangci-lint hook to v2.12.2 to match the CI pipeline.
Testing
make test passes successfully.
golangci-lint passes successfully on the latest Go toolchain.
Related Issues
Part of #2491