### PR TITLE
nvidia: propagate error when no dcgm-exporter endpoint is reachable

### DIFF
--- a/internal/device/gpu/nvidia/dcgm_exporter.go
+++ b/internal/device/gpu/nvidia/dcgm_exporter.go
@@ -181,16 +181,22 @@ func (d *DCGMExporterBackend) initLocked(ctx context.Context) error {
 	// Fallback to static endpoints. This covers cases where K8s API discovery
 	// fails (e.g., RBAC issues, dcgm-exporter in a non-standard namespace)
 	// or dcgm-exporter uses hostNetwork (localhost:9400).
+	var lastErr error
 	for _, ep := range d.fallbackEndpoints {
-		if err := d.testEndpoint(ctx, ep); err == nil {
+		err := d.testEndpoint(ctx, ep)
+		if err == nil {
 			d.endpoint = ep
 			d.markInitialized()
 			d.logger.Info("DCGM exporter backend initialized", "endpoint", ep, "discovery", "fallback")
 			return nil
 		}
-		d.logger.Debug("dcgm-exporter endpoint not reachable", "endpoint", ep)
+		lastErr = err
+		d.logger.Warn("dcgm-exporter endpoint not reachable", "endpoint", ep, "error", err)
 	}
 
+	if lastErr != nil {
+		return fmt.Errorf("no reachable dcgm-exporter endpoint found (tried %d fallback endpoints): %w", len(d.fallbackEndpoints), lastErr)
+	}
 	return fmt.Errorf("no reachable dcgm-exporter endpoint found")
 }
 

--- a/internal/device/gpu/nvidia/dcgm_exporter.go
+++ b/internal/device/gpu/nvidia/dcgm_exporter.go
@@ -6,6 +6,7 @@ package nvidia
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -181,7 +182,7 @@ func (d *DCGMExporterBackend) initLocked(ctx context.Context) error {
 	// Fallback to static endpoints. This covers cases where K8s API discovery
 	// fails (e.g., RBAC issues, dcgm-exporter in a non-standard namespace)
 	// or dcgm-exporter uses hostNetwork (localhost:9400).
-	var lastErr error
+	var errs []error
 	for _, ep := range d.fallbackEndpoints {
 		err := d.testEndpoint(ctx, ep)
 		if err == nil {
@@ -190,12 +191,16 @@ func (d *DCGMExporterBackend) initLocked(ctx context.Context) error {
 			d.logger.Info("DCGM exporter backend initialized", "endpoint", ep, "discovery", "fallback")
 			return nil
 		}
-		lastErr = err
+		errs = append(errs, fmt.Errorf("endpoint %s: %w", ep, err))
 		d.logger.Warn("dcgm-exporter endpoint not reachable", "endpoint", ep, "error", err)
 	}
 
-	if lastErr != nil {
-		return fmt.Errorf("no reachable dcgm-exporter endpoint found (tried %d fallback endpoints): %w", len(d.fallbackEndpoints), lastErr)
+	if len(errs) > 0 {
+		// Aggregate every endpoint error, not just the last one: the last
+		// failure may be unfixable (e.g. unsupported hardware) while an
+		// earlier one is actionable (e.g. an RBAC issue on another endpoint).
+		return fmt.Errorf("no reachable dcgm-exporter endpoint found (tried %d fallback endpoints): %w",
+			len(d.fallbackEndpoints), errors.Join(errs...))
 	}
 	return fmt.Errorf("no reachable dcgm-exporter endpoint found")
 }

--- a/internal/device/gpu/nvidia/dcgm_exporter_test.go
+++ b/internal/device/gpu/nvidia/dcgm_exporter_test.go
@@ -293,6 +293,22 @@ func TestDCGMExporterBackend_Init_errors(t *testing.T) {
 		err := backend.Init(ctx)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no reachable dcgm-exporter endpoint found")
+		// The underlying cause from testEndpoint must be propagated, not swallowed.
+		assert.Contains(t, err.Error(), "tried 1 fallback endpoints")
+	})
+
+	t.Run("all endpoints fail reports count and cause", func(t *testing.T) {
+		backend := NewDCGMExporterBackend(slog.Default())
+		backend.discoverEndpoint = func() string { return "" }
+		backend.fallbackEndpoints = []string{
+			"http://127.0.0.1:1/metrics",
+			"http://127.0.0.1:2/metrics",
+		}
+
+		err := backend.Init(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tried 2 fallback endpoints")
+		assert.False(t, backend.IsInitialized())
 	})
 
 	t.Run("discovery succeeds", func(t *testing.T) {

--- a/internal/device/gpu/nvidia/dcgm_exporter_test.go
+++ b/internal/device/gpu/nvidia/dcgm_exporter_test.go
@@ -308,6 +308,10 @@ func TestDCGMExporterBackend_Init_errors(t *testing.T) {
 		err := backend.Init(ctx)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "tried 2 fallback endpoints")
+		// Every failed endpoint must be reported, not just the last one, so an
+		// actionable earlier failure isn't hidden behind an unfixable last one.
+		assert.Contains(t, err.Error(), "http://127.0.0.1:1/metrics")
+		assert.Contains(t, err.Error(), "http://127.0.0.1:2/metrics")
 		assert.False(t, backend.IsInitialized())
 	})
 


### PR DESCRIPTION
The fallback endpoint loop in initLocked logged each failed endpoint at Debug level and discarded the underlying error from testEndpoint. When every fallback failed, the returned error was a generic message with no diagnostic detail, making it hard to tell why dcgm-exporter could not be reached.

Log each unreachable fallback endpoint at Warn level with its error (consistent with the sibling local-discovery path), and wrap the last error into the final failure so the root cause and the number of tried endpoints are surfaced.

Fixes #2430