### PR TITLE
chore(config): align default staleness to 500ms in dev and compose configs

### DIFF
--- a/compose/default/kepler/etc/kepler/config.yaml
+++ b/compose/default/kepler/etc/kepler/config.yaml
@@ -18,7 +18,7 @@ monitor:
   # the same as long as the scrapes happens within the staleness duration.
   #
   # NOTE: Keep staleness shorter than the monitor interval.
-  staleness: 1000ms
+  staleness: 500ms
 
   # maximum number of terminated workloads (process, container, VM, pods)
   # to be kept in memory until the data is exported; 0 disables the limit

--- a/compose/dev/kepler-dev/etc/kepler/config.yaml
+++ b/compose/dev/kepler-dev/etc/kepler/config.yaml
@@ -18,7 +18,7 @@ monitor:
   # the same as long as the scrapes happens within the staleness duration.
   #
   # NOTE: Keep staleness shorter than the monitor interval.
-  staleness: 1000ms
+  staleness: 500ms
 
   # maximum number of terminated workloads (process, container, VM, pods)
   # to be kept in memory until the data is exported; 0 disables the limit

--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -18,7 +18,7 @@ monitor:
   # the same as long as the scrapes happens within the staleness duration.
   #
   # NOTE: Keep staleness shorter than the monitor interval.
-  staleness: 1000ms
+  staleness: 500ms
 
   # maximum number of terminated workloads (process, container, VM, pods)
   # to be kept in memory until the data is exported; 0 disables the limit


### PR DESCRIPTION
### Summary
This PR updates the default value of `monitor.staleness` from `1000ms` to `500ms` in `hack/config.yaml` and the Docker Compose config templates under `compose/`.

### Rationale
This aligns the default values in these helper configuration files with the hardcoded programmatic default of `500ms` in `config/config.go` (`DefaultConfig()`) and `internal/monitor/options.go`. 

This discrepancy was pointed out and discussed during the configuration documentation review in sustainable-computing-io/kepler-doc#201. Updating these templates resolves the inconsistency between the actual codebase defaults, the documentation, and these default config templates.

### References
* Relates to sustainable-computing-io/kepler-doc#201
