### PR TITLE
fix: export missing container CPU time metric

### DIFF
--- a/docs/user/metrics.md
+++ b/docs/user/metrics.md
@@ -185,6 +185,19 @@ These metrics provide energy and power information for containers.
 - **Constant Labels**:
   - `node_name`
 
+#### kepler_container_cpu_seconds_total
+
+- **Type**: COUNTER
+- **Description**: Total user and system time of cpu at container level in seconds
+- **Labels**:
+  - `container_id`
+  - `container_name`
+  - `runtime`
+  - `state`
+  - `pod_id`
+- **Constant Labels**:
+  - `node_name`
+
 #### kepler_container_cpu_watts
 
 - **Type**: GAUGE

--- a/internal/exporter/prometheus/collector/power_collector.go
+++ b/internal/exporter/prometheus/collector/power_collector.go
@@ -52,6 +52,7 @@ type PowerCollector struct {
 	// Container power metrics
 	containerCPUJoulesDescriptor *prometheus.Desc
 	containerCPUWattsDescriptor  *prometheus.Desc
+	containerCPUTimeDescriptor   *prometheus.Desc
 	containerGPUWattsDescriptor  *prometheus.Desc
 	containerGPUJoulesDescriptor *prometheus.Desc
 
@@ -147,6 +148,7 @@ func NewPowerCollector(monitor PowerDataProvider, nodeName string, logger *slog.
 
 		containerCPUJoulesDescriptor: joulesDesc("container", "cpu", nodeName, []string{cntrID, "container_name", "runtime", "state", zone, podID}),
 		containerCPUWattsDescriptor:  wattsDesc("container", "cpu", nodeName, []string{cntrID, "container_name", "runtime", "state", zone, podID}),
+		containerCPUTimeDescriptor:   timeDesc("container", "cpu", nodeName, []string{cntrID, "container_name", "runtime", "state", podID}),
 		containerGPUJoulesDescriptor: joulesDesc("container", "gpu", nodeName, []string{cntrID, "container_name", "runtime", "state", podID}),
 		containerGPUWattsDescriptor:  wattsDesc("container", "gpu", nodeName, []string{cntrID, "container_name", "runtime", "state", podID}),
 
@@ -216,9 +218,9 @@ func (c *PowerCollector) Describe(ch chan<- *prometheus.Desc) {
 	if c.metricsLevel.IsContainerEnabled() {
 		ch <- c.containerCPUJoulesDescriptor
 		ch <- c.containerCPUWattsDescriptor
+		ch <- c.containerCPUTimeDescriptor
 		ch <- c.containerGPUJoulesDescriptor
 		ch <- c.containerGPUWattsDescriptor
-		// ch <- c.containerCPUTimeDescriptor // TODO: add conntainerCPUTimeDescriptor
 	}
 
 	// vm
@@ -432,6 +434,14 @@ func (c *PowerCollector) collectContainerMetrics(ch chan<- prometheus.Metric, st
 
 	// No need to lock, already done by the calling function
 	for id, container := range containers {
+		ch <- prometheus.MustNewConstMetric(
+			c.containerCPUTimeDescriptor,
+			prometheus.CounterValue,
+			container.CPUTotalTime,
+			id, container.Name, string(container.Runtime), state,
+			container.PodID,
+		)
+
 		for zone, usage := range container.Zones {
 			zoneName := zone.Name()
 

--- a/internal/exporter/prometheus/collector/power_collector_test.go
+++ b/internal/exporter/prometheus/collector/power_collector_test.go
@@ -215,7 +215,7 @@ func TestPowerCollector(t *testing.T) {
 	}
 
 	testProcesses := monitor.Processes{
-		"123": {
+		"123": &monitor.Process{
 			PID:            123,
 			Comm:           "test-process",
 			Exe:            "/usr/bin/123",
@@ -224,7 +224,7 @@ func TestPowerCollector(t *testing.T) {
 			GPUPower:       50.5,
 			GPUEnergyTotal: 250 * device.Joule,
 			Zones: monitor.ZoneUsageMap{
-				packageZone: {
+				packageZone: monitor.Usage{
 					EnergyTotal: 100 * device.Joule,
 					Power:       5 * device.Watt,
 				},
@@ -233,7 +233,7 @@ func TestPowerCollector(t *testing.T) {
 	}
 
 	testContainers := monitor.Containers{
-		"abcd-efgh": {
+		"abcd-efgh": &monitor.Container{
 			ID:             "abcd-efgh",
 			Name:           "test-container",
 			Runtime:        resource.PodmanRuntime,
@@ -241,7 +241,7 @@ func TestPowerCollector(t *testing.T) {
 			GPUEnergyTotal: 250 * device.Joule,
 			PodID:          "test-pod",
 			Zones: monitor.ZoneUsageMap{
-				packageZone: {
+				packageZone: monitor.Usage{
 					EnergyTotal: 100 * device.Joule,
 					Power:       5 * device.Watt,
 				},
@@ -250,12 +250,12 @@ func TestPowerCollector(t *testing.T) {
 	}
 
 	testVMs := monitor.VirtualMachines{
-		"abcd-efgh": {
+		"abcd-efgh": &monitor.VirtualMachine{
 			ID:         "abcd-efgh",
 			Name:       "test-vm",
 			Hypervisor: resource.KVMHypervisor,
 			Zones: monitor.ZoneUsageMap{
-				packageZone: {
+				packageZone: monitor.Usage{
 					EnergyTotal: 100 * device.Joule,
 					Power:       5 * device.Watt,
 				},
@@ -264,13 +264,13 @@ func TestPowerCollector(t *testing.T) {
 	}
 
 	testPods := monitor.Pods{
-		"test-pod": {
+		"test-pod": &monitor.Pod{
 			Name:           "test-pod",
 			Namespace:      "default",
 			GPUPower:       42.5,
 			GPUEnergyTotal: 250 * device.Joule,
 			Zones: monitor.ZoneUsageMap{
-				packageZone: {
+				packageZone: monitor.Usage{
 					EnergyTotal: 100 * device.Joule,
 					Power:       5 * device.Watt,
 				},
@@ -345,6 +345,7 @@ func TestPowerCollector(t *testing.T) {
 
 			"kepler_container_cpu_joules_total",
 			"kepler_container_cpu_watts",
+			"kepler_container_cpu_seconds_total",
 			"kepler_container_gpu_watts",
 			"kepler_container_gpu_joules_total",
 


### PR DESCRIPTION
### Description

Fixes #2500 

This PR addresses a bug where the `containerCPUTimeDescriptor` was missing from the Prometheus exporter, causing container CPU time metrics to be dropped or exported incorrectly.

**Changes made:**
- Added `containerCPUTimeDescriptor` to the `PowerCollector` struct.
- Initialized `containerCPUTimeDescriptor` in `NewPowerCollector` using the `timeDesc` helper with standard container labels (omitting `zone` since CPU time is aggregated per container).
- Removed the `TODO` and pushed the descriptor to the channel in the `Describe` method.
- Updated `collectContainerMetrics` to emit `container.CPUTotalTime` using this descriptor.

### Type of change
- [x] Bug fix

### Checklist
- [x] I have read the contributing guidelines
- [x] My commit is signed off (DCO)
