### PR TITLE
feat(gpu): configure DCGM metrics cache TTL

### DIFF
--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -157,6 +157,15 @@ func createServices(logger *slog.Logger, cfg *config.Config) ([]service.Service,
 		}
 	}
 
+	// Inject configured DCGM metrics cache TTL for MIG power attribution
+	if cfg.Experimental != nil {
+		for _, m := range gpuMeters {
+			if c, ok := m.(gpu.DCGMMetricsCacheTTLConfigurable); ok {
+				c.SetDCGMMetricsCacheTTL(*cfg.Experimental.GPU.MetricsCacheTTL)
+			}
+		}
+	}
+
 	var services []service.Service
 
 	var podInformer pod.Informer

--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -158,7 +158,7 @@ func createServices(logger *slog.Logger, cfg *config.Config) ([]service.Service,
 	}
 
 	// Inject configured DCGM metrics cache TTL for MIG power attribution
-	if cfg.Experimental != nil {
+	if cfg.Experimental != nil && cfg.Experimental.GPU.MetricsCacheTTL != nil {
 		for _, m := range gpuMeters {
 			if c, ok := m.(gpu.DCGMMetricsCacheTTLConfigurable); ok {
 				c.SetDCGMMetricsCacheTTL(*cfg.Experimental.GPU.MetricsCacheTTL)

--- a/compose/default/kepler/etc/kepler/config.yaml
+++ b/compose/default/kepler/etc/kepler/config.yaml
@@ -97,3 +97,4 @@ experimental:
     enabled: false # Enable experimental GPU power monitoring
     idlePower: 0 # GPU idle power in Watts (0 = auto-detect)
     dcgmEndpoint: "" # dcgm-exporter metrics URL for MIG (auto-discovered if empty)
+    metricsCacheTTL: 2s # dcgm-exporter metrics cache TTL for MIG (0 disables cache)

--- a/compose/dev/kepler-dev/etc/kepler/config.yaml
+++ b/compose/dev/kepler-dev/etc/kepler/config.yaml
@@ -97,3 +97,4 @@ experimental:
     enabled: false # Enable experimental GPU power monitoring
     idlePower: 0 # GPU idle power in Watts (0 = auto-detect)
     dcgmEndpoint: "" # dcgm-exporter metrics URL for MIG (auto-discovered if empty)
+    metricsCacheTTL: 2s # dcgm-exporter metrics cache TTL for MIG (0 disables cache)

--- a/config/config.go
+++ b/config/config.go
@@ -187,6 +187,10 @@ type (
 		// Required for MIG power attribution. If empty, auto-discovered via K8s API.
 		// Example: "http://10.131.2.22:9400/metrics"
 		DCGMEndpoint string `yaml:"dcgmEndpoint"`
+
+		// MetricsCacheTTL controls how long dcgm-exporter metrics are cached for MIG
+		// power attribution. If nil, the NVIDIA backend default is used. 0 disables caching.
+		MetricsCacheTTL *time.Duration `yaml:"metricsCacheTTL,omitempty"`
 	}
 
 	// Experimental contains experimental features (no stability guarantees)
@@ -307,9 +311,10 @@ const (
 	ExperimentalHwmonZonesFlag        = "experimental.hwmon.zones"
 
 	// Experimental GPU flags
-	ExperimentalGPUEnabledFlag      = "experimental.gpu.enabled"
-	ExperimentalGPUIdlePowerFlag    = "experimental.gpu.idle-power"
-	ExperimentalGPUDCGMEndpointFlag = "experimental.gpu.dcgm-endpoint"
+	ExperimentalGPUEnabledFlag         = "experimental.gpu.enabled"
+	ExperimentalGPUIdlePowerFlag       = "experimental.gpu.idle-power"
+	ExperimentalGPUDCGMEndpointFlag    = "experimental.gpu.dcgm-endpoint"
+	ExperimentalGPUMetricsCacheTTLFlag = "experimental.gpu.metrics-cache-ttl"
 
 // WARN:  dev settings shouldn't be exposed as flags as flags are intended for end users
 )
@@ -499,6 +504,7 @@ func RegisterFlags(app *kingpin.Application) ConfigUpdaterFn {
 	gpuEnabled := app.Flag(ExperimentalGPUEnabledFlag, "Enable experimental GPU power monitoring").Default("false").Bool()
 	gpuIdlePower := app.Flag(ExperimentalGPUIdlePowerFlag, "GPU idle power in Watts (0 = auto-detect from idle observations)").Default("0").Float64()
 	gpuDCGMEndpoint := app.Flag(ExperimentalGPUDCGMEndpointFlag, "dcgm-exporter metrics endpoint URL for MIG power attribution (auto-discovered if empty)").Default("").String()
+	gpuMetricsCacheTTL := app.Flag(ExperimentalGPUMetricsCacheTTLFlag, "dcgm-exporter metrics cache TTL for MIG power attribution (0 to disable cache)").Default("2s").Duration()
 
 	return func(cfg *Config) error {
 		// Logging settings
@@ -573,7 +579,7 @@ func RegisterFlags(app *kingpin.Application) ConfigUpdaterFn {
 		}
 
 		// Apply experimental GPU settings
-		applyGPUConfig(cfg, flagsSet, gpuEnabled, gpuIdlePower, gpuDCGMEndpoint)
+		applyGPUConfig(cfg, flagsSet, gpuEnabled, gpuIdlePower, gpuDCGMEndpoint, gpuMetricsCacheTTL)
 
 		// Resolve Kube.Node fallback to hostname when Kubernetes is not enabled
 		// and no node name was set by flags or YAML
@@ -710,7 +716,7 @@ func applyHwmonFlags(hwmon *Hwmon, flagsSet map[string]bool, forceEnabled *bool,
 }
 
 // applyGPUConfig applies GPU configuration from flags
-func applyGPUConfig(cfg *Config, flagsSet map[string]bool, enabled *bool, idlePower *float64, dcgmEndpoint *string) {
+func applyGPUConfig(cfg *Config, flagsSet map[string]bool, enabled *bool, idlePower *float64, dcgmEndpoint *string, metricsCacheTTL *time.Duration) {
 	// Early exit if GPU enabled flag is not set and config file does not have experimental section
 	if !flagsSet[ExperimentalGPUEnabledFlag] && cfg.Experimental == nil {
 		return
@@ -733,6 +739,7 @@ func applyGPUConfig(cfg *Config, flagsSet map[string]bool, enabled *bool, idlePo
 		if flagsSet[ExperimentalGPUDCGMEndpointFlag] {
 			cfg.Experimental.GPU.DCGMEndpoint = *dcgmEndpoint
 		}
+		cfg.Experimental.GPU.MetricsCacheTTL = metricsCacheTTL
 	}
 }
 
@@ -994,6 +1001,9 @@ func (c *Config) validateExperimentalConfig(validationSkipped map[SkipValidation
 		}
 
 		errs = append(errs, validateDCGMEndpoint(c.Experimental.GPU.DCGMEndpoint)...)
+		if c.Experimental.GPU.MetricsCacheTTL != nil && *c.Experimental.GPU.MetricsCacheTTL < 0 {
+			errs = append(errs, fmt.Sprintf("invalid gpu metrics cache TTL: %s can't be negative", *c.Experimental.GPU.MetricsCacheTTL))
+		}
 	}
 
 	return errs

--- a/config/config.go
+++ b/config/config.go
@@ -316,6 +316,8 @@ const (
 	ExperimentalGPUDCGMEndpointFlag    = "experimental.gpu.dcgm-endpoint"
 	ExperimentalGPUMetricsCacheTTLFlag = "experimental.gpu.metrics-cache-ttl"
 
+	defaultGPUMetricsCacheTTL = 2 * time.Second
+
 // WARN:  dev settings shouldn't be exposed as flags as flags are intended for end users
 )
 
@@ -504,7 +506,7 @@ func RegisterFlags(app *kingpin.Application) ConfigUpdaterFn {
 	gpuEnabled := app.Flag(ExperimentalGPUEnabledFlag, "Enable experimental GPU power monitoring").Default("false").Bool()
 	gpuIdlePower := app.Flag(ExperimentalGPUIdlePowerFlag, "GPU idle power in Watts (0 = auto-detect from idle observations)").Default("0").Float64()
 	gpuDCGMEndpoint := app.Flag(ExperimentalGPUDCGMEndpointFlag, "dcgm-exporter metrics endpoint URL for MIG power attribution (auto-discovered if empty)").Default("").String()
-	gpuMetricsCacheTTL := app.Flag(ExperimentalGPUMetricsCacheTTLFlag, "dcgm-exporter metrics cache TTL for MIG power attribution (0 to disable cache)").Default("2s").Duration()
+	gpuMetricsCacheTTL := app.Flag(ExperimentalGPUMetricsCacheTTLFlag, "dcgm-exporter metrics cache TTL for MIG power attribution (0 to disable cache)").Default(defaultGPUMetricsCacheTTL.String()).Duration()
 
 	return func(cfg *Config) error {
 		// Logging settings
@@ -739,7 +741,11 @@ func applyGPUConfig(cfg *Config, flagsSet map[string]bool, enabled *bool, idlePo
 		if flagsSet[ExperimentalGPUDCGMEndpointFlag] {
 			cfg.Experimental.GPU.DCGMEndpoint = *dcgmEndpoint
 		}
-		cfg.Experimental.GPU.MetricsCacheTTL = metricsCacheTTL
+		if flagsSet[ExperimentalGPUMetricsCacheTTLFlag] {
+			cfg.Experimental.GPU.MetricsCacheTTL = metricsCacheTTL
+		} else if cfg.Experimental.GPU.MetricsCacheTTL == nil {
+			cfg.Experimental.GPU.MetricsCacheTTL = ptr.To(defaultGPUMetricsCacheTTL)
+		}
 	}
 }
 

--- a/config/config_gpu_test.go
+++ b/config/config_gpu_test.go
@@ -69,7 +69,7 @@ func TestApplyGPUConfig(t *testing.T) {
 		wantGPU: &ExperimentalGPU{
 			Enabled:         ptr.To(true),
 			IdlePower:       0,
-			MetricsCacheTTL: ptr.To(2 * time.Second),
+			MetricsCacheTTL: ptr.To(defaultGPUMetricsCacheTTL),
 		},
 	}, {
 		name: "gpu enabled and idle power flags",
@@ -84,7 +84,7 @@ func TestApplyGPUConfig(t *testing.T) {
 		wantGPU: &ExperimentalGPU{
 			Enabled:         ptr.To(true),
 			IdlePower:       50.0,
-			MetricsCacheTTL: ptr.To(2 * time.Second),
+			MetricsCacheTTL: ptr.To(defaultGPUMetricsCacheTTL),
 		},
 	}, {
 		name: "gpu disabled with idle power flag",
@@ -124,7 +124,25 @@ func TestApplyGPUConfig(t *testing.T) {
 		wantGPU: &ExperimentalGPU{
 			Enabled:         ptr.To(true), // preserved from YAML
 			IdlePower:       25.0,
-			MetricsCacheTTL: ptr.To(2 * time.Second),
+			MetricsCacheTTL: ptr.To(defaultGPUMetricsCacheTTL),
+		},
+	}, {
+		name: "yaml metrics cache TTL is preserved without CLI override",
+		cfg: &Config{
+			Experimental: &Experimental{
+				GPU: ExperimentalGPU{
+					Enabled:         ptr.To(true),
+					MetricsCacheTTL: ptr.To(time.Second),
+				},
+			},
+		},
+		flagsSet:  map[string]bool{},
+		enabled:   ptr.To(false),
+		idlePower: ptr.To(0.0),
+		cacheTTL:  ptr.To(2 * time.Second),
+		wantGPU: &ExperimentalGPU{
+			Enabled:         ptr.To(true),
+			MetricsCacheTTL: ptr.To(time.Second),
 		},
 	}, {
 		name: "enabled flag overrides yaml disabled",
@@ -142,7 +160,7 @@ func TestApplyGPUConfig(t *testing.T) {
 		wantGPU: &ExperimentalGPU{
 			Enabled:         ptr.To(true),
 			IdlePower:       0,
-			MetricsCacheTTL: ptr.To(2 * time.Second),
+			MetricsCacheTTL: ptr.To(defaultGPUMetricsCacheTTL),
 		},
 	}, {
 		name: "gpu enabled and metrics cache TTL flags",

--- a/config/config_gpu_test.go
+++ b/config/config_gpu_test.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/ptr"
@@ -47,6 +48,7 @@ func TestApplyGPUConfig(t *testing.T) {
 		flagsSet   map[string]bool
 		enabled    *bool
 		idlePower  *float64
+		cacheTTL   *time.Duration
 		wantExpNil bool
 		wantGPU    *ExperimentalGPU // nil means don't check GPU fields
 	}{{
@@ -55,6 +57,7 @@ func TestApplyGPUConfig(t *testing.T) {
 		flagsSet:   map[string]bool{},
 		enabled:    ptr.To(false),
 		idlePower:  ptr.To(0.0),
+		cacheTTL:   ptr.To(2 * time.Second),
 		wantExpNil: true,
 	}, {
 		name:      "gpu enabled flag only",
@@ -62,9 +65,11 @@ func TestApplyGPUConfig(t *testing.T) {
 		flagsSet:  map[string]bool{ExperimentalGPUEnabledFlag: true},
 		enabled:   ptr.To(true),
 		idlePower: ptr.To(0.0),
+		cacheTTL:  ptr.To(2 * time.Second),
 		wantGPU: &ExperimentalGPU{
-			Enabled:   ptr.To(true),
-			IdlePower: 0,
+			Enabled:         ptr.To(true),
+			IdlePower:       0,
+			MetricsCacheTTL: ptr.To(2 * time.Second),
 		},
 	}, {
 		name: "gpu enabled and idle power flags",
@@ -75,9 +80,11 @@ func TestApplyGPUConfig(t *testing.T) {
 		},
 		enabled:   ptr.To(true),
 		idlePower: ptr.To(50.0),
+		cacheTTL:  ptr.To(2 * time.Second),
 		wantGPU: &ExperimentalGPU{
-			Enabled:   ptr.To(true),
-			IdlePower: 50.0,
+			Enabled:         ptr.To(true),
+			IdlePower:       50.0,
+			MetricsCacheTTL: ptr.To(2 * time.Second),
 		},
 	}, {
 		name: "gpu disabled with idle power flag",
@@ -88,6 +95,7 @@ func TestApplyGPUConfig(t *testing.T) {
 		},
 		enabled:   ptr.To(false),
 		idlePower: ptr.To(50.0),
+		cacheTTL:  ptr.To(2 * time.Second),
 		wantGPU: &ExperimentalGPU{
 			Enabled:   ptr.To(false),
 			IdlePower: 0, // idle power not applied when GPU is disabled
@@ -98,6 +106,7 @@ func TestApplyGPUConfig(t *testing.T) {
 		flagsSet:   map[string]bool{ExperimentalGPUIdlePowerFlag: true},
 		enabled:    ptr.To(false),
 		idlePower:  ptr.To(50.0),
+		cacheTTL:   ptr.To(2 * time.Second),
 		wantExpNil: true, // early exit — enabled flag not in flagsSet, Experimental is nil
 	}, {
 		name: "yaml gpu enabled with idle power flag override",
@@ -111,9 +120,11 @@ func TestApplyGPUConfig(t *testing.T) {
 		flagsSet:  map[string]bool{ExperimentalGPUIdlePowerFlag: true},
 		enabled:   ptr.To(false),
 		idlePower: ptr.To(25.0),
+		cacheTTL:  ptr.To(2 * time.Second),
 		wantGPU: &ExperimentalGPU{
-			Enabled:   ptr.To(true), // preserved from YAML
-			IdlePower: 25.0,
+			Enabled:         ptr.To(true), // preserved from YAML
+			IdlePower:       25.0,
+			MetricsCacheTTL: ptr.To(2 * time.Second),
 		},
 	}, {
 		name: "enabled flag overrides yaml disabled",
@@ -127,16 +138,33 @@ func TestApplyGPUConfig(t *testing.T) {
 		flagsSet:  map[string]bool{ExperimentalGPUEnabledFlag: true},
 		enabled:   ptr.To(true),
 		idlePower: ptr.To(0.0),
+		cacheTTL:  ptr.To(2 * time.Second),
 		wantGPU: &ExperimentalGPU{
-			Enabled:   ptr.To(true),
-			IdlePower: 0,
+			Enabled:         ptr.To(true),
+			IdlePower:       0,
+			MetricsCacheTTL: ptr.To(2 * time.Second),
+		},
+	}, {
+		name: "gpu enabled and metrics cache TTL flags",
+		cfg:  &Config{},
+		flagsSet: map[string]bool{
+			ExperimentalGPUEnabledFlag:         true,
+			ExperimentalGPUMetricsCacheTTLFlag: true,
+		},
+		enabled:   ptr.To(true),
+		idlePower: ptr.To(0.0),
+		cacheTTL:  ptr.To(500 * time.Millisecond),
+		wantGPU: &ExperimentalGPU{
+			Enabled:         ptr.To(true),
+			IdlePower:       0,
+			MetricsCacheTTL: ptr.To(500 * time.Millisecond),
 		},
 	}}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			dcgmEndpoint := ""
-			applyGPUConfig(tc.cfg, tc.flagsSet, tc.enabled, tc.idlePower, &dcgmEndpoint)
+			applyGPUConfig(tc.cfg, tc.flagsSet, tc.enabled, tc.idlePower, &dcgmEndpoint, tc.cacheTTL)
 
 			if tc.wantExpNil {
 				assert.Nil(t, tc.cfg.Experimental)
@@ -146,6 +174,7 @@ func TestApplyGPUConfig(t *testing.T) {
 			assert.NotNil(t, tc.cfg.Experimental)
 			assert.Equal(t, tc.wantGPU.Enabled, tc.cfg.Experimental.GPU.Enabled)
 			assert.Equal(t, tc.wantGPU.IdlePower, tc.cfg.Experimental.GPU.IdlePower)
+			assert.Equal(t, tc.wantGPU.MetricsCacheTTL, tc.cfg.Experimental.GPU.MetricsCacheTTL)
 		})
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2535,6 +2535,37 @@ experimental:
 		assert.NotNil(t, cfg.Experimental)
 		assert.Equal(t, 45.5, cfg.Experimental.GPU.IdlePower)
 	})
+
+	t.Run("gpu metrics cache TTL via yaml", func(t *testing.T) {
+		yamlData := `
+experimental:
+  gpu:
+    enabled: true
+    metricsCacheTTL: 500ms
+`
+		reader := strings.NewReader(yamlData)
+		cfg, err := Load(reader)
+		assert.NoError(t, err)
+		assert.True(t, cfg.IsFeatureEnabled(ExperimentalGPUFeature))
+		assert.NotNil(t, cfg.Experimental)
+		assert.NotNil(t, cfg.Experimental.GPU.MetricsCacheTTL)
+		assert.Equal(t, 500*time.Millisecond, *cfg.Experimental.GPU.MetricsCacheTTL)
+	})
+
+	t.Run("gpu metrics cache disabled via yaml", func(t *testing.T) {
+		yamlData := `
+experimental:
+  gpu:
+    enabled: true
+    metricsCacheTTL: 0s
+`
+		reader := strings.NewReader(yamlData)
+		cfg, err := Load(reader)
+		assert.NoError(t, err)
+		assert.NotNil(t, cfg.Experimental)
+		assert.NotNil(t, cfg.Experimental.GPU.MetricsCacheTTL)
+		assert.Equal(t, time.Duration(0), *cfg.Experimental.GPU.MetricsCacheTTL)
+	})
 }
 
 func TestValidateExperimentalConfig(t *testing.T) {
@@ -2609,6 +2640,17 @@ func TestValidateExperimentalConfig(t *testing.T) {
 			},
 		},
 		expectedErrors: []string{"unreadable Redfish config file"},
+	}, {
+		name: "gpu metrics cache TTL negative",
+		config: &Config{
+			Experimental: &Experimental{
+				GPU: ExperimentalGPU{
+					Enabled:         ptr.To(true),
+					MetricsCacheTTL: ptr.To(-time.Second),
+				},
+			},
+		},
+		expectedErrors: []string{"invalid gpu metrics cache TTL"},
 	}}
 
 	for _, tc := range tests {

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -174,6 +174,7 @@ experimental:   # experimental features (no stability guarantees)
     enabled: false                    # Enable GPU power monitoring (default: false)
     idlePower: 0                      # GPU idle power in Watts, 0 = auto-detect (default: 0)
     dcgmEndpoint: ""                  # dcgm-exporter metrics URL for MIG (auto-discovered if empty)
+    metricsCacheTTL: 2s               # dcgm-exporter metrics cache TTL for MIG, 0 disables cache (default: 2s)
 
 # WARN: DO NOT ENABLE THIS IN PRODUCTION - for development/testing only
 dev:
@@ -511,6 +512,9 @@ experimental:
   - Required when GPUs are in MIG mode — NVML cannot provide per-instance utilization in MIG mode
   - If empty, Kepler auto-discovers the local dcgm-exporter pod via K8s API
   - **Note**: When deploying with MIG, the Kepler container must have `NVIDIA_VISIBLE_DEVICES=all` and `NVIDIA_MIG_MONITOR_DEVICES=all` environment variables set for NVML to see all MIG devices. These are included in the default manifests and Helm chart.
+- **metricsCacheTTL**: dcgm-exporter metrics cache TTL for MIG power attribution (default: 2s)
+  - Prevents HTTP request storms when querying multiple MIG instances
+  - Set to `0s` to disable caching and fetch metrics on every query
 
 **Example:**
 
@@ -519,6 +523,7 @@ experimental:
   gpu:
     enabled: true
     idlePower: 17.5  # Override idle power to 17.5W (0 = auto-detect)
+    metricsCacheTTL: 1s
 ```
 
 ### 🧑‍🔬 Development Configuration

--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -111,3 +111,4 @@ experimental:
     enabled: false # Enable experimental GPU power monitoring
     idlePower: 0 # GPU idle power in Watts (0 = auto-detect)
     dcgmEndpoint: "" # dcgm-exporter metrics URL for MIG (auto-discovered if empty)
+    metricsCacheTTL: 2s # dcgm-exporter metrics cache TTL for MIG (0 disables cache)

--- a/internal/device/gpu/interface.go
+++ b/internal/device/gpu/interface.go
@@ -84,6 +84,12 @@ type DCGMEndpointConfigurable interface {
 	SetDCGMEndpoint(endpoint string)
 }
 
+// DCGMMetricsCacheTTLConfigurable is an optional interface for GPU meters that
+// support configuring the dcgm-exporter metrics cache TTL for MIG attribution.
+type DCGMMetricsCacheTTLConfigurable interface {
+	SetDCGMMetricsCacheTTL(ttl time.Duration)
+}
+
 // ProcessGPUInfo contains per-process GPU metrics collected from the device.
 // This struct is vendor-agnostic.
 type ProcessGPUInfo struct {

--- a/internal/device/gpu/nvidia/collector.go
+++ b/internal/device/gpu/nvidia/collector.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"time"
 
 	"golang.org/x/sync/singleflight"
 
@@ -45,6 +46,7 @@ type GPUPowerCollector struct {
 	// MIG support
 	dcgm                 DCGMBackend
 	dcgmEndpoint         string // pre-configured endpoint, applied during Init() or SetDCGMEndpoint()
+	dcgmMetricsCacheTTL  *time.Duration
 	migInstancesByDevice map[int][]MIGGPUInstance
 
 	initialized bool
@@ -150,6 +152,9 @@ func (c *GPUPowerCollector) initDCGM() {
 	dcgm := NewDCGMExporterBackend(c.logger)
 	if c.dcgmEndpoint != "" {
 		dcgm.SetEndpoint(c.dcgmEndpoint)
+	}
+	if c.dcgmMetricsCacheTTL != nil {
+		dcgm.SetMetricsCacheTTL(*c.dcgmMetricsCacheTTL)
 	}
 
 	if err := dcgm.Init(context.Background()); err != nil {
@@ -469,6 +474,24 @@ func (c *GPUPowerCollector) SetDCGMEndpoint(endpoint string) {
 	if c.initialized && c.hasMIG() {
 		c.logger.Info("reinitializing DCGM backend with configured endpoint",
 			"endpoint", endpoint)
+		c.initDCGM()
+	}
+}
+
+// SetDCGMMetricsCacheTTL sets the dcgm-exporter metrics cache TTL.
+// Can be called before or after Init(). If called after Init() on a system
+// with MIG GPUs, reinitializes the DCGM backend with the new TTL.
+func (c *GPUPowerCollector) SetDCGMMetricsCacheTTL(ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if ttl < 0 {
+		ttl = 0
+	}
+	c.dcgmMetricsCacheTTL = &ttl
+
+	if c.initialized && c.hasMIG() {
+		c.logger.Info("reinitializing DCGM backend with configured metrics cache TTL",
+			"ttl", ttl)
 		c.initDCGM()
 	}
 }

--- a/internal/device/gpu/nvidia/collector.go
+++ b/internal/device/gpu/nvidia/collector.go
@@ -484,14 +484,17 @@ func (c *GPUPowerCollector) SetDCGMEndpoint(endpoint string) {
 func (c *GPUPowerCollector) SetDCGMMetricsCacheTTL(ttl time.Duration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if ttl < 0 {
-		ttl = 0
-	}
+	ttl = max(ttl, 0)
 	c.dcgmMetricsCacheTTL = &ttl
 
 	if c.initialized && c.hasMIG() {
-		c.logger.Info("reinitializing DCGM backend with configured metrics cache TTL",
+		c.logger.Info("initializing DCGM backend with configured metrics cache TTL",
 			"ttl", ttl)
+
+		if dcgm, ok := c.dcgm.(*DCGMExporterBackend); ok {
+			dcgm.SetMetricsCacheTTL(ttl)
+			return
+		}
 		c.initDCGM()
 	}
 }

--- a/internal/device/gpu/nvidia/collector_test.go
+++ b/internal/device/gpu/nvidia/collector_test.go
@@ -4,6 +4,7 @@
 package nvidia
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -1615,7 +1616,7 @@ func TestGPUPowerCollector_SetDCGMEndpoint(t *testing.T) {
 		assert.Equal(t, "", collector.dcgmEndpoint)
 	})
 
-	t.Run("after init with MIG reinitializes DCGM", func(t *testing.T) {
+	t.Run("after init with MIG initializes unavailable DCGM", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = fmt.Fprint(w, "# HELP\nDCGM_FI_PROF_GR_ENGINE_ACTIVE{gpu=\"0\",GPU_I_ID=\"1\",GPU_I_PROFILE=\"1g.5gb\"} 0.5\n")
@@ -1679,6 +1680,30 @@ func TestGPUPowerCollector_SetDCGMMetricsCacheTTL(t *testing.T) {
 
 		dcgm, ok := collector.dcgm.(*DCGMExporterBackend)
 		require.True(t, ok)
+		assert.Equal(t, 500*time.Millisecond, dcgm.metricsCacheTTL)
+	})
+
+	t.Run("after init with MIG updates DCGM in place", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, "# HELP\nDCGM_FI_PROF_GR_ENGINE_ACTIVE{gpu=\"0\",GPU_I_ID=\"1\",GPU_I_PROFILE=\"1g.5gb\"} 0.5\n")
+		}))
+		defer ts.Close()
+
+		dcgm := NewDCGMExporterBackend(slog.Default())
+		dcgm.SetEndpoint(ts.URL)
+		require.NoError(t, dcgm.Init(context.Background()))
+
+		collector := &GPUPowerCollector{
+			logger:       slog.Default(),
+			initialized:  true,
+			sharingModes: map[int]gpu.SharingMode{0: gpu.SharingModePartitioned},
+			dcgm:         dcgm,
+		}
+
+		collector.SetDCGMMetricsCacheTTL(500 * time.Millisecond)
+
+		assert.Same(t, dcgm, collector.dcgm)
 		assert.Equal(t, 500*time.Millisecond, dcgm.metricsCacheTTL)
 	})
 

--- a/internal/device/gpu/nvidia/collector_test.go
+++ b/internal/device/gpu/nvidia/collector_test.go
@@ -10,9 +10,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/sustainable-computing-io/kepler/internal/device"
 	"github.com/sustainable-computing-io/kepler/internal/device/gpu"
 )
@@ -1644,8 +1646,59 @@ func TestGPUPowerCollector_SetDCGMEndpoint(t *testing.T) {
 	})
 }
 
+func TestGPUPowerCollector_SetDCGMMetricsCacheTTL(t *testing.T) {
+	t.Run("before init stores TTL", func(t *testing.T) {
+		collector := &GPUPowerCollector{}
+
+		collector.SetDCGMMetricsCacheTTL(500 * time.Millisecond)
+		require.NotNil(t, collector.dcgmMetricsCacheTTL)
+		assert.Equal(t, 500*time.Millisecond, *collector.dcgmMetricsCacheTTL)
+
+		collector.SetDCGMMetricsCacheTTL(-time.Second)
+		require.NotNil(t, collector.dcgmMetricsCacheTTL)
+		assert.Equal(t, time.Duration(0), *collector.dcgmMetricsCacheTTL)
+	})
+
+	t.Run("after init with MIG reinitializes DCGM", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, "# HELP\nDCGM_FI_PROF_GR_ENGINE_ACTIVE{gpu=\"0\",GPU_I_ID=\"1\",GPU_I_PROFILE=\"1g.5gb\"} 0.5\n")
+		}))
+		defer ts.Close()
+
+		collector := &GPUPowerCollector{
+			logger:       slog.Default(),
+			initialized:  true,
+			sharingModes: map[int]gpu.SharingMode{0: gpu.SharingModePartitioned},
+			dcgmEndpoint: ts.URL + "/metrics",
+		}
+
+		collector.SetDCGMMetricsCacheTTL(500 * time.Millisecond)
+		require.NotNil(t, collector.dcgm, "DCGM should be initialized after SetDCGMMetricsCacheTTL")
+		assert.True(t, collector.dcgm.IsInitialized())
+
+		dcgm, ok := collector.dcgm.(*DCGMExporterBackend)
+		require.True(t, ok)
+		assert.Equal(t, 500*time.Millisecond, dcgm.metricsCacheTTL)
+	})
+
+	t.Run("after init without MIG does not init DCGM", func(t *testing.T) {
+		collector := &GPUPowerCollector{
+			logger:       slog.Default(),
+			initialized:  true,
+			sharingModes: map[int]gpu.SharingMode{0: gpu.SharingModeTimeSlicing},
+		}
+
+		collector.SetDCGMMetricsCacheTTL(500 * time.Millisecond)
+		assert.Nil(t, collector.dcgm, "DCGM should not be initialized for non-MIG GPUs")
+	})
+}
+
 // Verify DCGMEndpointConfigurable interface implementation
 var _ gpu.DCGMEndpointConfigurable = (*GPUPowerCollector)(nil)
+
+// Verify DCGMMetricsCacheTTLConfigurable interface implementation
+var _ gpu.DCGMMetricsCacheTTLConfigurable = (*GPUPowerCollector)(nil)
 
 func TestGPUPowerCollector_attributePartitioned_idleInstances(t *testing.T) {
 	mockBackend := new(MockNVMLBackend)

--- a/internal/device/gpu/nvidia/dcgm_exporter.go
+++ b/internal/device/gpu/nvidia/dcgm_exporter.go
@@ -25,10 +25,6 @@ import (
 )
 
 const (
-	// metricsCacheTTL is how long cached metrics are valid before refetching.
-	// This prevents HTTP request storms when querying multiple MIG instances.
-	metricsCacheTTL = 2 * time.Second
-
 	// maxConsecutiveFailures is how many HTTP failures before the circuit breaker trips.
 	maxConsecutiveFailures = 3
 
@@ -53,7 +49,8 @@ type DCGMExporterBackend struct {
 	mu          sync.Mutex
 
 	// Cached metrics with TTL to avoid HTTP request storms
-	cachedMetrics *dcgmMetrics
+	cachedMetrics   *dcgmMetrics
+	metricsCacheTTL time.Duration
 
 	// Circuit breaker: tracks consecutive failures and disables the backend
 	// after maxConsecutiveFailures. Re-initialization is attempted after reInitInterval.
@@ -120,6 +117,18 @@ func NewDCGMExporterBackend(logger *slog.Logger) *DCGMExporterBackend {
 	}
 	d.discoverEndpoint = d.discoverLocalDCGMExporter
 	return d
+}
+
+// SetMetricsCacheTTL sets how long fetched metrics are cached.
+// A zero duration disables caching. Negative values are clamped to zero.
+func (d *DCGMExporterBackend) SetMetricsCacheTTL(ttl time.Duration) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if ttl < 0 {
+		ttl = 0
+	}
+	d.metricsCacheTTL = ttl
+	d.cachedMetrics = nil
 }
 
 // SetEndpoint sets the dcgm-exporter endpoint URL
@@ -375,12 +384,12 @@ func (d *DCGMExporterBackend) GetMIGInstanceActivity(ctx context.Context, gpuInd
 }
 
 // fetchMetrics returns cached metrics if still valid, otherwise fetches fresh data.
-// Caller must hold d.mu. On cache miss (every ~2s per metricsCacheTTL), performs
+// Caller must hold d.mu. On cache miss (every ~2s by default), performs
 // an HTTP GET to dcgm-exporter and writes d.cachedMetrics with parsed results.
 // Tracks consecutive failures and trips the circuit breaker after maxConsecutiveFailures.
 func (d *DCGMExporterBackend) fetchMetrics(ctx context.Context) (*dcgmMetrics, error) {
 	// Return cached metrics if still valid
-	if d.cachedMetrics != nil && time.Since(d.cachedMetrics.timestamp) < metricsCacheTTL {
+	if d.metricsCacheTTL > 0 && d.cachedMetrics != nil && time.Since(d.cachedMetrics.timestamp) < d.metricsCacheTTL {
 		return d.cachedMetrics, nil
 	}
 

--- a/internal/device/gpu/nvidia/dcgm_exporter.go
+++ b/internal/device/gpu/nvidia/dcgm_exporter.go
@@ -124,9 +124,7 @@ func NewDCGMExporterBackend(logger *slog.Logger) *DCGMExporterBackend {
 func (d *DCGMExporterBackend) SetMetricsCacheTTL(ttl time.Duration) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if ttl < 0 {
-		ttl = 0
-	}
+	ttl = max(ttl, 0)
 	d.metricsCacheTTL = ttl
 	d.cachedMetrics = nil
 }

--- a/internal/device/gpu/nvidia/dcgm_exporter_test.go
+++ b/internal/device/gpu/nvidia/dcgm_exporter_test.go
@@ -98,6 +98,7 @@ func TestDCGMExporterBackend_GetMIGInstanceActivity(t *testing.T) {
 	ctx := context.Background()
 	backend := NewDCGMExporterBackend(slog.Default())
 	backend.SetEndpoint(server.URL)
+	backend.SetMetricsCacheTTL(2 * time.Second)
 
 	err := backend.Init(ctx)
 	require.NoError(t, err)
@@ -234,6 +235,10 @@ func TestDCGMExporterBackend_SetMetricsCacheTTL(t *testing.T) {
 		_, err = backend.GetMIGInstanceActivity(ctx, 0, 1)
 		require.NoError(t, err)
 		assert.Equal(t, initCalls+1, callCount)
+
+		_, err = backend.GetMIGInstanceActivity(ctx, 0, 2)
+		require.NoError(t, err)
+		assert.Equal(t, initCalls+1, callCount, "should use the configured cache")
 
 		backend.mu.Lock()
 		backend.cachedMetrics.timestamp = time.Now().Add(-150 * time.Millisecond)

--- a/internal/device/gpu/nvidia/dcgm_exporter_test.go
+++ b/internal/device/gpu/nvidia/dcgm_exporter_test.go
@@ -128,6 +128,7 @@ func TestDCGMExporterBackend_caching(t *testing.T) {
 	ctx := context.Background()
 	backend := NewDCGMExporterBackend(slog.Default())
 	backend.SetEndpoint(server.URL)
+	backend.SetMetricsCacheTTL(2 * time.Second)
 
 	err := backend.Init(ctx)
 	require.NoError(t, err)
@@ -192,6 +193,7 @@ func TestDCGMExporterBackend_cacheExpiry(t *testing.T) {
 	ctx := context.Background()
 	backend := NewDCGMExporterBackend(slog.Default())
 	backend.SetEndpoint(server.URL)
+	backend.SetMetricsCacheTTL(2 * time.Second)
 
 	err := backend.Init(ctx)
 	require.NoError(t, err)
@@ -211,12 +213,70 @@ func TestDCGMExporterBackend_cacheExpiry(t *testing.T) {
 	assert.Equal(t, initCalls+2, callCount, "should refetch after cache expiry")
 }
 
+func TestDCGMExporterBackend_SetMetricsCacheTTL(t *testing.T) {
+	t.Run("custom TTL controls expiry", func(t *testing.T) {
+		callCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			callCount++
+			_, _ = fmt.Fprint(w, sampleDCGMMetrics)
+		}))
+		defer server.Close()
+
+		ctx := context.Background()
+		backend := NewDCGMExporterBackend(slog.Default())
+		backend.SetEndpoint(server.URL)
+		backend.SetMetricsCacheTTL(100 * time.Millisecond)
+
+		err := backend.Init(ctx)
+		require.NoError(t, err)
+		initCalls := callCount
+
+		_, err = backend.GetMIGInstanceActivity(ctx, 0, 1)
+		require.NoError(t, err)
+		assert.Equal(t, initCalls+1, callCount)
+
+		backend.mu.Lock()
+		backend.cachedMetrics.timestamp = time.Now().Add(-150 * time.Millisecond)
+		backend.mu.Unlock()
+
+		_, err = backend.GetMIGInstanceActivity(ctx, 0, 1)
+		require.NoError(t, err)
+		assert.Equal(t, initCalls+2, callCount, "should refetch after configured cache expiry")
+	})
+
+	t.Run("zero disables cache", func(t *testing.T) {
+		callCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			callCount++
+			_, _ = fmt.Fprint(w, sampleDCGMMetrics)
+		}))
+		defer server.Close()
+
+		ctx := context.Background()
+		backend := NewDCGMExporterBackend(slog.Default())
+		backend.SetEndpoint(server.URL)
+		backend.SetMetricsCacheTTL(0)
+
+		err := backend.Init(ctx)
+		require.NoError(t, err)
+		initCalls := callCount
+
+		_, err = backend.GetMIGInstanceActivity(ctx, 0, 1)
+		require.NoError(t, err)
+		_, err = backend.GetMIGInstanceActivity(ctx, 0, 2)
+		require.NoError(t, err)
+
+		assert.Equal(t, initCalls+2, callCount, "should fetch on every query when cache is disabled")
+	})
+}
+
 func TestNewDCGMExporterBackend(t *testing.T) {
 	t.Run("with nil logger", func(t *testing.T) {
 		backend := NewDCGMExporterBackend(nil)
 		assert.NotNil(t, backend)
 		assert.NotNil(t, backend.logger)
 		assert.NotNil(t, backend.client)
+		assert.Zero(t, backend.metricsCacheTTL)
 	})
 
 	t.Run("with logger", func(t *testing.T) {

--- a/manifests/helm/kepler/values.yaml
+++ b/manifests/helm/kepler/values.yaml
@@ -125,6 +125,7 @@ config:
       enabled: false # Enable experimental GPU power monitoring
       idlePower: 0 # GPU idle power in Watts (0 = auto-detect)
       dcgmEndpoint: "" # dcgm-exporter metrics URL for MIG (auto-discovered if empty)
+      metricsCacheTTL: 2s # dcgm-exporter metrics cache TTL for MIG (0 disables cache)
 
 # ServiceMonitor for Prometheus Operator
 serviceMonitor:

--- a/manifests/k8s/configmap.yaml
+++ b/manifests/k8s/configmap.yaml
@@ -68,3 +68,4 @@ data:
         enabled: false
         idlePower: 0 # GPU idle power in Watts (0 = auto-detect)
         dcgmEndpoint: "" # dcgm-exporter metrics URL for MIG (auto-discovered if empty)
+        metricsCacheTTL: 2s # dcgm-exporter metrics cache TTL for MIG (0 disables cache)


### PR DESCRIPTION
## Summary

- Add the `experimental.gpu.metrics-cache-ttl` flag and `experimental.gpu.metricsCacheTTL` YAML option for DCGM metrics used in MIG power attribution.
- Use an effective default of `2s` with precedence: CLI flag > YAML value > default. Set `0s` to disable caching; reject negative values.
- Apply TTL changes to an initialized DCGM exporter backend without reinitializing it, and document the option in deployment templates.

Fixes #2429