### PR TITLE
feat(Dockerfile): use a minimal base container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN CROSS_CC=""; \
       GIT_COMMIT=${GIT_COMMIT} \
       GIT_BRANCH=${GIT_BRANCH}
 
-FROM registry.access.redhat.com/ubi9:latest
+FROM quay.io/fedora/fedora-minimal:latest
 
 # Build arguments for labels
 ARG VERSION


### PR DESCRIPTION
This is a followup to https://github.com/sustainable-computing-io/kepler/pull/2255

Since the user space is only provided to ease troubleshooting, `fedora-minimal` should:
* reduce the size of the image 
* have a low CVE list 
* not require regular version bumps (RHEL8 -> RHEL9 -> RHEL10)

I think `ubi-micro` is probably the way to go, but didn't see consensus in the original PR.

If maintaining the version (8->9->10) is too concerning, `alpine:latest` might be an alternative.