### PR TITLE
fix: prevent informer panic on nil virtual machine process

### DIFF
--- a/internal/resource/informer.go
+++ b/internal/resource/informer.go
@@ -254,6 +254,10 @@ func (ri *resourceInformer) refreshVMs(vmProcs []*Process) error {
 	// Build running VMs from pre-categorized VM processes
 	for _, proc := range vmProcs {
 		vm := proc.VirtualMachine
+		if vm == nil {
+			ri.logger.Error("process of type VM has nil virtual machine", "pid", proc.PID, "comm", proc.Comm)
+			continue
+		}
 		vmsRunning[vm.ID] = ri.updateVMCache(proc)
 	}
 
@@ -433,7 +437,8 @@ func (ri *resourceInformer) Pods() *Pods {
 func (ri *resourceInformer) updateVMCache(proc *Process) *VirtualMachine {
 	vm := proc.VirtualMachine
 	if vm == nil {
-		panic(fmt.Sprintf("process %d of type %s (%s)  has is nil virtual machine", proc.PID, proc.Type, proc.Comm))
+		ri.logger.Error("process of type VM has nil virtual machine", "pid", proc.PID, "comm", proc.Comm)
+		return nil
 	}
 
 	cached, exists := ri.vmCache[vm.ID]

--- a/internal/resource/procfs_reader_test.go
+++ b/internal/resource/procfs_reader_test.go
@@ -1101,7 +1101,7 @@ func TestResourceInformer_InitRefreshErr(t *testing.T) {
 		mockProcFS.AssertExpectations(t)
 	})
 
-	t.Run("updateVMCache with nil VM panic", func(t *testing.T) {
+	t.Run("updateVMCache with nil VM", func(t *testing.T) {
 		mockProcFS := &MockProcReader{}
 		informer, err := NewInformer(WithProcReader(mockProcFS))
 		require.NoError(t, err)
@@ -1109,12 +1109,11 @@ func TestResourceInformer_InitRefreshErr(t *testing.T) {
 		proc := &Process{
 			PID:            123,
 			Type:           VMProcess,
-			VirtualMachine: nil, // This should cause panic
+			VirtualMachine: nil,
 		}
 
-		assert.Panics(t, func() {
-			informer.updateVMCache(proc)
-		})
+		vm := informer.updateVMCache(proc)
+		assert.Nil(t, vm)
 	})
 }
 


### PR DESCRIPTION
Fixes #2507 

**Description**
This PR converts a hard `panic()` in `internal/resource/informer.go` into a structured log warning and a graceful skip.

Previously, if Kepler discovered a process of type Virtual Machine but the `proc.VM` struct was `nil`, it would crash the entire metrics informer during `refreshVMs()` and `updateVMCache()`. Given that transient or malformed process states can occur in production environments, crashing the daemon is dangerous. This change ensures Kepler simply logs the anomaly and moves on to the next process.

**Changes:**
- Replaced `panic(fmt.Sprintf(...))` with `ri.logger.Error(...)` in `updateVMCache` and returned `nil`.
- Added a `vm == nil` check with a `continue` in `refreshVMs` to safely skip the process.
- Updated the test `updateVMCache with nil VM` in `internal/resource/procfs_reader_test.go` to assert a `nil` return instead of a panic.

**Testing:**
- Existing unit tests updated and passing.
- Verified that the metrics informer loops correctly without panicking.
