### PR TITLE
Add liveness and readiness probe, with dedicated endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,20 @@ make build && sudo ./bin/kepler
 cd compose/dev && docker compose up -d
 
 # 🐳 Kubernetes with Kustomize
+git clone https://github.com/sustainable-computing-io/kepler.git
+cd kepler && git checkout v0.11.4 # pin to a release tag, see note below
 kubectl kustomize manifests/k8s | \
-  sed -e "s|<KEPLER_IMAGE>|quay.io/sustainable_computing_io/kepler:latest|g" | \
+  sed -e "s|<KEPLER_IMAGE>|quay.io/sustainable_computing_io/kepler:v0.11.4|g" | \
   kubectl apply --server-side --force-conflicts -f -
 ```
+
+> **⚠️ Important:** Always check out a matching release tag (rather than `main`) before
+> applying manifests from `manifests/k8s`, and set `<KEPLER_IMAGE>` to that same version.
+> Manifests on `main` can reference features not yet present in the last published image
+> (for example, the `/probe/livez` and `/probe/readyz` endpoints added for liveness/readiness
+> probes) — mixing a `main` manifest with an older image can make the container fail its
+> liveness probe and crash-loop. See the [Releases page](https://github.com/sustainable-computing-io/kepler/releases)
+> for available tags.
 
 ## 📖 Documentation
 

--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -242,6 +242,9 @@ func createServices(logger *slog.Logger, cfg *config.Config) ([]service.Service,
 		services = append(services, stdoutExporter)
 	}
 
+	// created last so that it observes every other service
+	services = append(services, server.NewProbe(logger, apiServer, services))
+
 	return services, nil
 }
 

--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -243,6 +243,9 @@ func createServices(logger *slog.Logger, cfg *config.Config) ([]service.Service,
 		services = append(services, stdoutExporter)
 	}
 
+	// created last so that it observes every other service
+	services = append(services, server.NewProbe(logger, apiServer, services))
+
 	return services, nil
 }
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -351,6 +351,48 @@ tls_server_config:
   key_file: /path/to/key.pem    # Path to the key file
 ```
 
+### 🩺 Health Probe Endpoints
+
+Kepler always exposes two health endpoints on the web server, intended for
+Kubernetes [liveness and readiness probes](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/).
+They require no configuration.
+
+| Endpoint        | Probe     | Healthy response           | Unhealthy response                              |
+|-----------------|-----------|----------------------------|-------------------------------------------------|
+| `/probe/livez`  | Liveness  | `200` `{"status":"alive"}` | `503` `{"status":"unavailable","failures":{…}}` |
+| `/probe/readyz` | Readiness | `200` `{"status":"ok"}`    | `503` `{"status":"unavailable","failures":{…}}` |
+
+Both accept `GET` and `HEAD` and return `405` for any other method. The
+`failures` object maps the name of each unhealthy service to the reason it
+reported.
+
+- **Liveness** succeeds as long as Kepler can answer the request, which proves
+  the process is running and not dead-locked.
+- **Readiness** fails with `503` until every service has been initialized and
+  started, then succeeds.
+
+Use these endpoints instead of `/metrics` for probes: each `/metrics` scrape
+triggers a power computation, whereas the probes do no work beyond answering.
+The shipped Kubernetes manifests and Helm chart are already configured this way:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /probe/livez
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 60
+readinessProbe:
+  httpGet:
+    path: /probe/readyz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+```
+
+> **Note**: When TLS is enabled via `web.configFile`, probes must use
+> `scheme: HTTPS`.
+
 ### 🐳 Kubernetes Configuration
 
 ```yaml

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -357,6 +357,48 @@ tls_server_config:
   key_file: /path/to/key.pem    # Path to the key file
 ```
 
+### 🩺 Health Probe Endpoints
+
+Kepler always exposes two health endpoints on the web server, intended for
+Kubernetes [liveness and readiness probes](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/).
+They require no configuration.
+
+| Endpoint        | Probe     | Healthy response           | Unhealthy response                              |
+|-----------------|-----------|----------------------------|-------------------------------------------------|
+| `/probe/livez`  | Liveness  | `200` `{"status":"alive"}` | `503` `{"status":"unavailable","failures":{…}}` |
+| `/probe/readyz` | Readiness | `200` `{"status":"ok"}`    | `503` `{"status":"unavailable","failures":{…}}` |
+
+Both accept `GET` and `HEAD` and return `405` for any other method. The
+`failures` object maps the name of each unhealthy service to the reason it
+reported.
+
+- **Liveness** succeeds as long as Kepler can answer the request, which proves
+  the process is running and not dead-locked.
+- **Readiness** fails with `503` until every service has been initialized and
+  started, then succeeds.
+
+Use these endpoints instead of `/metrics` for probes: each `/metrics` scrape
+triggers a power computation, whereas the probes do no work beyond answering.
+The shipped Kubernetes manifests and Helm chart are already configured this way:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /probe/livez
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 60
+readinessProbe:
+  httpGet:
+    path: /probe/readyz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+```
+
+> **Note**: When TLS is enabled via `web.configFile`, probes must use
+> `scheme: HTTPS`.
+
 ### 🐳 Kubernetes Configuration
 
 ```yaml

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -153,6 +153,8 @@ sudo ./bin/kepler --log.level=debug --exporter.stdout
 **Access Points:**
 
 - Metrics: <http://localhost:28282/metrics>
+- Liveness probe: <http://localhost:28282/probe/livez>
+- Readiness probe: <http://localhost:28282/probe/readyz>
 
 ### 3. Docker Compose (Recommended for Development)
 

--- a/internal/server/probe.go
+++ b/internal/server/probe.go
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sync/atomic"
+
+	"github.com/sustainable-computing-io/kepler/internal/service"
+)
+
+const (
+	// LivezEndpoint is the path of the liveness probe endpoint
+	LivezEndpoint = "/probe/livez"
+	// ReadyzEndpoint is the path of the readiness probe endpoint
+	ReadyzEndpoint = "/probe/readyz"
+
+	// statusAlive is reported by a successful liveness probe
+	statusAlive = "alive"
+	// statusOK is reported by a successful readiness probe
+	statusOK = "ok"
+	// statusUnavailable is reported by a failed probe
+	statusUnavailable = "unavailable"
+)
+
+// probeResponse is the JSON body returned by both probe endpoints
+type probeResponse struct {
+	Status string `json:"status"`
+	// Failures maps the name of each unhealthy service to the reason it reported
+	Failures map[string]string `json:"failures,omitempty"`
+}
+
+// namedCheck is a health check of a single service, normalized so that liveness
+// and readiness can share the same handler.
+type namedCheck struct {
+	name string
+	run  func() error
+}
+
+// probe exposes Kubernetes liveness and readiness probe endpoints.
+//
+// The probes are deliberately cheap: unlike /metrics, hitting them performs no
+// power computation, so they are safe to call on a short period. Kepler is
+// considered alive as soon as it can answer HTTP, and ready once every service
+// has been initialized and started, which is when this service's Run is called.
+//
+// Services that need a say in either verdict implement
+// service.LivenessChecker or service.ReadinessChecker and are picked up here
+// automatically.
+type probe struct {
+	logger *slog.Logger
+	api    APIService
+
+	liveChecks  []namedCheck
+	readyChecks []namedCheck
+
+	// running is set once Run is called, i.e. once all services are initialized
+	// and started
+	running atomic.Bool
+}
+
+var (
+	_ service.Service     = (*probe)(nil)
+	_ service.Initializer = (*probe)(nil)
+	_ service.Runner      = (*probe)(nil)
+)
+
+// NewProbe creates the health probe service. services must contain every
+// service kepler runs so that those implementing service.LivenessChecker or
+// service.ReadinessChecker are reflected in the probe results.
+func NewProbe(logger *slog.Logger, api APIService, services []service.Service) *probe {
+	p := &probe{
+		logger: logger.With("service", "probe"),
+		api:    api,
+	}
+
+	for _, s := range services {
+		if c, ok := s.(service.LivenessChecker); ok {
+			p.liveChecks = append(p.liveChecks, namedCheck{name: c.Name(), run: c.IsAlive})
+		}
+		if c, ok := s.(service.ReadinessChecker); ok {
+			p.readyChecks = append(p.readyChecks, namedCheck{name: c.Name(), run: c.IsReady})
+		}
+	}
+
+	return p
+}
+
+func (p *probe) Name() string {
+	return "probe"
+}
+
+func (p *probe) Init() error {
+	p.logger.Debug("registering probe endpoints",
+		"liveness-checkers", len(p.liveChecks),
+		"readiness-checkers", len(p.readyChecks),
+	)
+
+	if err := p.api.Register(
+		LivezEndpoint, "livez",
+		"Liveness probe reporting whether kepler is running",
+		p.handler(statusAlive, func() []namedCheck { return p.liveChecks }),
+	); err != nil {
+		return err
+	}
+
+	return p.api.Register(
+		ReadyzEndpoint, "readyz",
+		"Readiness probe reporting whether kepler is ready to serve",
+		p.handler(statusOK, func() []namedCheck { return p.readyChecks }),
+	)
+}
+
+// Run marks kepler as ready and blocks until the context is cancelled.
+//
+// service.Init has returned for every service by the time any Run is called, so
+// reaching this point means initialization completed successfully.
+func (p *probe) Run(ctx context.Context) error {
+	p.running.Store(true)
+	p.logger.Debug("kepler is ready")
+
+	<-ctx.Done()
+	p.running.Store(false)
+	return nil
+}
+
+func (p *probe) Shutdown() error {
+	p.running.Store(false)
+	return nil
+}
+
+// handler answers a probe request with okStatus when every check passes, or 503
+// and the failure reasons otherwise.
+func (p *probe) handler(okStatus string, checks func() []namedCheck) http.Handler {
+	// readiness additionally requires that all services have been started
+	requireRunning := okStatus == statusOK
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.Header().Set("Allow", "GET, HEAD")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		resp := probeResponse{Status: okStatus}
+		code := http.StatusOK
+
+		switch {
+		case requireRunning && !p.running.Load():
+			resp = probeResponse{
+				Status:   statusUnavailable,
+				Failures: map[string]string{"kepler": "services have not started yet"},
+			}
+			code = http.StatusServiceUnavailable
+
+		default:
+			var failures map[string]string
+			for _, c := range checks() {
+				if err := c.run(); err != nil {
+					if failures == nil {
+						failures = map[string]string{}
+					}
+					failures[c.name] = err.Error()
+				}
+			}
+			if len(failures) > 0 {
+				resp = probeResponse{Status: statusUnavailable, Failures: failures}
+				code = http.StatusServiceUnavailable
+			}
+		}
+
+		if code != http.StatusOK {
+			p.logger.Warn("probe reported unhealthy", "endpoint", r.URL.Path, "failures", resp.Failures)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			p.logger.Error("failed to write probe response", "endpoint", r.URL.Path, "error", err)
+		}
+	})
+}

--- a/internal/server/probe_test.go
+++ b/internal/server/probe_test.go
@@ -1,0 +1,487 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sustainable-computing-io/kepler/internal/service"
+)
+
+// capturingAPI records the handlers registered against it so that tests can
+// exercise the probe endpoints directly.
+type capturingAPI struct {
+	handlers map[string]http.Handler
+	err      error
+}
+
+func newCapturingAPI() *capturingAPI {
+	return &capturingAPI{handlers: map[string]http.Handler{}}
+}
+
+func (c *capturingAPI) Name() string { return "capturing-api" }
+
+func (c *capturingAPI) Register(endpoint, summary, description string, handler http.Handler) error {
+	if c.err != nil {
+		return c.err
+	}
+	c.handlers[endpoint] = handler
+	return nil
+}
+
+// plainService implements no health check interfaces
+type plainService struct{ name string }
+
+func (s *plainService) Name() string { return s.name }
+
+// liveService reports liveness only
+type liveService struct {
+	name string
+	err  error
+}
+
+func (s *liveService) Name() string   { return s.name }
+func (s *liveService) IsAlive() error { return s.err }
+
+// readyService reports readiness only
+type readyService struct {
+	name string
+	err  error
+}
+
+func (s *readyService) Name() string   { return s.name }
+func (s *readyService) IsReady() error { return s.err }
+
+// bothService reports both liveness and readiness
+type bothService struct {
+	name     string
+	aliveErr error
+	readyErr error
+}
+
+func (s *bothService) Name() string   { return s.name }
+func (s *bothService) IsAlive() error { return s.aliveErr }
+func (s *bothService) IsReady() error { return s.readyErr }
+
+var (
+	_ service.LivenessChecker  = (*liveService)(nil)
+	_ service.ReadinessChecker = (*readyService)(nil)
+	_ service.LivenessChecker  = (*bothService)(nil)
+	_ service.ReadinessChecker = (*bothService)(nil)
+	_ APIService               = (*capturingAPI)(nil)
+)
+
+// newInitializedProbe returns a probe with its endpoints registered on a
+// capturing API, ready to be queried.
+func newInitializedProbe(t *testing.T, services ...service.Service) (*probe, *capturingAPI) {
+	t.Helper()
+
+	api := newCapturingAPI()
+	p := NewProbe(slog.New(slog.DiscardHandler), api, services)
+	require.NoError(t, p.Init())
+	require.Contains(t, api.handlers, LivezEndpoint)
+	require.Contains(t, api.handlers, ReadyzEndpoint)
+
+	return p, api
+}
+
+// get issues a GET against the registered handler for endpoint
+func get(t *testing.T, api *capturingAPI, endpoint string) (int, probeResponse) {
+	t.Helper()
+	return do(t, api, http.MethodGet, endpoint)
+}
+
+func do(t *testing.T, api *capturingAPI, method, endpoint string) (int, probeResponse) {
+	t.Helper()
+
+	handler, ok := api.handlers[endpoint]
+	require.True(t, ok, "no handler registered for %s", endpoint)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(method, endpoint, nil))
+
+	var resp probeResponse
+	if rr.Body.Len() > 0 {
+		// a rejected method returns plain text, not JSON
+		_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	}
+	return rr.Code, resp
+}
+
+// markRunning starts the probe's Run loop and returns a func that stops it and
+// waits for Run to return.
+func markRunning(t *testing.T, p *probe) (stop func()) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		assert.NoError(t, p.Run(ctx))
+	}()
+
+	require.Eventually(t, p.running.Load, time.Second, time.Millisecond,
+		"probe should be marked running once Run is called")
+
+	return func() {
+		cancel()
+		<-done
+	}
+}
+
+func TestProbeName(t *testing.T) {
+	p, _ := newInitializedProbe(t)
+	assert.Equal(t, "probe", p.Name())
+}
+
+func TestProbeInitRegistersEndpoints(t *testing.T) {
+	api := newCapturingAPI()
+	p := NewProbe(slog.New(slog.DiscardHandler), api, nil)
+
+	require.NoError(t, p.Init())
+
+	assert.Equal(t, []string{LivezEndpoint, ReadyzEndpoint}, sortedKeys(api.handlers))
+	assert.Equal(t, "/probe/livez", LivezEndpoint)
+	assert.Equal(t, "/probe/readyz", ReadyzEndpoint)
+}
+
+func TestProbeInitPropagatesRegisterError(t *testing.T) {
+	api := newCapturingAPI()
+	api.err = errors.New("register failed")
+
+	p := NewProbe(slog.New(slog.DiscardHandler), api, nil)
+
+	err := p.Init()
+	assert.ErrorContains(t, err, "register failed")
+}
+
+// Liveness must not depend on kepler having started: answering the request at
+// all proves the process is not dead-locked.
+func TestLivezIsHealthyBeforeAndAfterRun(t *testing.T) {
+	p, api := newInitializedProbe(t)
+
+	code, resp := get(t, api, LivezEndpoint)
+	assert.Equal(t, http.StatusOK, code, "livez should be healthy before Run")
+	assert.Equal(t, statusAlive, resp.Status)
+	assert.Empty(t, resp.Failures)
+
+	stop := markRunning(t, p)
+	code, resp = get(t, api, LivezEndpoint)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "alive", resp.Status)
+
+	stop()
+	code, resp = get(t, api, LivezEndpoint)
+	assert.Equal(t, http.StatusOK, code, "livez should stay healthy while shutting down")
+	assert.Equal(t, "alive", resp.Status)
+}
+
+// Readiness is gated on every service having been initialized and started,
+// which is exactly when the probe's Run is called.
+func TestReadyzBecomesReadyOnRun(t *testing.T) {
+	p, api := newInitializedProbe(t)
+
+	code, resp := get(t, api, ReadyzEndpoint)
+	assert.Equal(t, http.StatusServiceUnavailable, code, "readyz must fail before Run")
+	assert.Equal(t, statusUnavailable, resp.Status)
+	assert.Equal(t, map[string]string{"kepler": "services have not started yet"}, resp.Failures)
+
+	stop := markRunning(t, p)
+	code, resp = get(t, api, ReadyzEndpoint)
+	assert.Equal(t, http.StatusOK, code, "readyz must succeed once running")
+	assert.Equal(t, "ok", resp.Status)
+	assert.Empty(t, resp.Failures)
+
+	stop()
+	code, resp = get(t, api, ReadyzEndpoint)
+	assert.Equal(t, http.StatusServiceUnavailable, code, "readyz must fail again after shutdown")
+	assert.Equal(t, statusUnavailable, resp.Status)
+}
+
+func TestShutdownMarksNotReady(t *testing.T) {
+	p, api := newInitializedProbe(t)
+
+	stop := markRunning(t, p)
+	t.Cleanup(stop)
+
+	code, _ := get(t, api, ReadyzEndpoint)
+	require.Equal(t, http.StatusOK, code)
+
+	require.NoError(t, p.Shutdown())
+
+	code, resp := get(t, api, ReadyzEndpoint)
+	assert.Equal(t, http.StatusServiceUnavailable, code)
+	assert.Equal(t, statusUnavailable, resp.Status)
+}
+
+// Services implementing neither interface must not influence the verdict.
+func TestServicesWithoutChecksAreIgnored(t *testing.T) {
+	p, api := newInitializedProbe(t,
+		&plainService{name: "monitor"},
+		&plainService{name: "resource-informer"},
+	)
+	assert.Empty(t, p.liveChecks)
+	assert.Empty(t, p.readyChecks)
+
+	stop := markRunning(t, p)
+	t.Cleanup(stop)
+
+	code, _ := get(t, api, LivezEndpoint)
+	assert.Equal(t, http.StatusOK, code)
+	code, _ = get(t, api, ReadyzEndpoint)
+	assert.Equal(t, http.StatusOK, code)
+}
+
+func TestCheckersAreDiscoveredByInterface(t *testing.T) {
+	p, _ := newInitializedProbe(t,
+		&plainService{name: "plain"},
+		&liveService{name: "live-only"},
+		&readyService{name: "ready-only"},
+		&bothService{name: "both"},
+	)
+
+	assert.Equal(t, []string{"live-only", "both"}, checkNames(p.liveChecks))
+	assert.Equal(t, []string{"ready-only", "both"}, checkNames(p.readyChecks))
+}
+
+func TestFailingCheckersReportUnavailable(t *testing.T) {
+	tests := []struct {
+		name     string
+		services []service.Service
+		endpoint string
+		failures map[string]string
+	}{{
+		name:     "failing liveness checker",
+		services: []service.Service{&liveService{name: "monitor", err: errors.New("collection stalled")}},
+		endpoint: LivezEndpoint,
+		failures: map[string]string{"monitor": "collection stalled"},
+	}, {
+		name:     "failing readiness checker",
+		services: []service.Service{&readyService{name: "pod-informer", err: errors.New("cache not synced")}},
+		endpoint: ReadyzEndpoint,
+		failures: map[string]string{"pod-informer": "cache not synced"},
+	}, {
+		name: "failures from several services are aggregated",
+		services: []service.Service{
+			&liveService{name: "monitor", err: errors.New("collection stalled")},
+			&liveService{name: "healthy", err: nil},
+			&bothService{name: "redfish", aliveErr: errors.New("bmc unreachable")},
+		},
+		endpoint: LivezEndpoint,
+		failures: map[string]string{"monitor": "collection stalled", "redfish": "bmc unreachable"},
+	}, {
+		name: "readiness failure is independent of liveness failure",
+		services: []service.Service{
+			&bothService{name: "redfish", aliveErr: errors.New("bmc unreachable")},
+		},
+		endpoint: ReadyzEndpoint,
+		failures: nil,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, api := newInitializedProbe(t, tt.services...)
+			stop := markRunning(t, p)
+			t.Cleanup(stop)
+
+			code, resp := get(t, api, tt.endpoint)
+
+			if tt.failures == nil {
+				assert.Equal(t, http.StatusOK, code)
+				assert.Empty(t, resp.Failures)
+				return
+			}
+
+			assert.Equal(t, http.StatusServiceUnavailable, code)
+			assert.Equal(t, statusUnavailable, resp.Status)
+			assert.Equal(t, tt.failures, resp.Failures)
+		})
+	}
+}
+
+func TestProbeResponseContentType(t *testing.T) {
+	p, api := newInitializedProbe(t)
+	stop := markRunning(t, p)
+	t.Cleanup(stop)
+
+	for _, endpoint := range []string{LivezEndpoint, ReadyzEndpoint} {
+		t.Run(endpoint, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			api.handlers[endpoint].ServeHTTP(rr, httptest.NewRequest(http.MethodGet, endpoint, nil))
+
+			assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+			assert.Equal(t, http.StatusOK, rr.Code)
+		})
+	}
+}
+
+func TestProbeRejectsNonReadMethods(t *testing.T) {
+	p, api := newInitializedProbe(t)
+	stop := markRunning(t, p)
+	t.Cleanup(stop)
+
+	for _, endpoint := range []string{LivezEndpoint, ReadyzEndpoint} {
+		t.Run(endpoint, func(t *testing.T) {
+			code, _ := do(t, api, http.MethodHead, endpoint)
+			assert.Equal(t, http.StatusOK, code, "HEAD should be accepted")
+
+			for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
+				rr := httptest.NewRecorder()
+				api.handlers[endpoint].ServeHTTP(rr, httptest.NewRequest(method, endpoint, nil))
+
+				assert.Equal(t, http.StatusMethodNotAllowed, rr.Code, "%s should be rejected", method)
+				assert.Equal(t, "GET, HEAD", rr.Header().Get("Allow"))
+			}
+		})
+	}
+}
+
+// The probes are served concurrently with the run/shutdown transitions, so the
+// handlers and the running flag must be race free.
+func TestProbeConcurrentAccess(t *testing.T) {
+	p, api := newInitializedProbe(t,
+		&bothService{name: "monitor"},
+		&liveService{name: "redfish", err: errors.New("bmc unreachable")},
+	)
+
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 25 {
+				code, _ := get(t, api, LivezEndpoint)
+				assert.Equal(t, http.StatusServiceUnavailable, code)
+				code, _ = get(t, api, ReadyzEndpoint)
+				assert.Contains(t, []int{http.StatusOK, http.StatusServiceUnavailable}, code)
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 25 {
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				assert.NoError(t, p.Run(ctx))
+			}()
+			cancel()
+			<-done
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestProbeEndToEnd serves the probes through the real APIServer over HTTP, as
+// a kubelet probe would reach them.
+func TestProbeEndToEnd(t *testing.T) {
+	addr := fmt.Sprintf("127.0.0.1:%d", findFreePort())
+
+	apiServer := NewAPIServer(WithListenAddress([]string{addr}))
+	require.NoError(t, apiServer.Init())
+
+	unhealthy := &bothService{name: "monitor"}
+	p := NewProbe(slog.New(slog.DiscardHandler), apiServer, []service.Service{unhealthy})
+	require.NoError(t, p.Init())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serverDone := make(chan error, 1)
+	go func() { serverDone <- apiServer.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		<-serverDone
+		_ = apiServer.Shutdown()
+	})
+
+	probeURL := func(endpoint string) string { return "http://" + addr + endpoint }
+
+	// wait for the listener to accept connections
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(probeURL(LivezEndpoint))
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return true
+	}, 3*time.Second, 10*time.Millisecond, "server should start serving")
+
+	fetch := func(t *testing.T, endpoint string) (int, probeResponse) {
+		t.Helper()
+		resp, err := http.Get(probeURL(endpoint))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		var body probeResponse
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		return resp.StatusCode, body
+	}
+
+	// not started yet: alive but not ready
+	code, body := fetch(t, LivezEndpoint)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "alive", body.Status)
+
+	code, body = fetch(t, ReadyzEndpoint)
+	assert.Equal(t, http.StatusServiceUnavailable, code)
+	assert.Equal(t, "unavailable", body.Status)
+
+	stop := markRunning(t, p)
+	t.Cleanup(stop)
+
+	code, body = fetch(t, ReadyzEndpoint)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "ok", body.Status)
+
+	// a service reporting unhealthy is surfaced over HTTP
+	unhealthy.readyErr = errors.New("terminated workload cache full")
+	code, body = fetch(t, ReadyzEndpoint)
+	assert.Equal(t, http.StatusServiceUnavailable, code)
+	assert.Equal(t, map[string]string{"monitor": "terminated workload cache full"}, body.Failures)
+
+	// the probes are listed on the landing page
+	resp, err := http.Get("http://" + addr + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	landing, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(landing), LivezEndpoint)
+	assert.Contains(t, string(landing), ReadyzEndpoint)
+}
+
+func checkNames(checks []namedCheck) []string {
+	names := make([]string, 0, len(checks))
+	for _, c := range checks {
+		names = append(names, c.name)
+	}
+	return names
+}
+
+func sortedKeys(m map[string]http.Handler) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	// only ever two keys; keep the assertion order stable
+	if len(keys) == 2 && keys[0] > keys[1] {
+		keys[0], keys[1] = keys[1], keys[0]
+	}
+	return keys
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -30,3 +30,19 @@ type Shutdowner interface {
 	// Shutdown shuts down the service
 	Shutdown() error
 }
+
+// LivenessChecker is an optional interface a service can implement to report
+// whether it is still functioning. Kepler's liveness probe fails if any service
+// implementing it reports an error.
+type LivenessChecker interface {
+	Service
+	IsAlive() error
+}
+
+// ReadinessChecker is an optional interface a service can implement to report
+// whether it is ready to serve. Kepler's readiness probe fails if any service
+// implementing it reports an error.
+type ReadinessChecker interface {
+	Service
+	IsReady() error
+}

--- a/manifests/helm/kepler/values.yaml
+++ b/manifests/helm/kepler/values.yaml
@@ -54,16 +54,23 @@ daemonset:
     #   cpu: 100m
     #   memory: 128Mi
 
+  # Probes use the dedicated /probe/* endpoints, which are cheap to serve.
+  # Avoid pointing them at /metrics: every scrape triggers a power computation.
   livenessProbe:
     httpGet:
-      path: /metrics
+      path: /probe/livez
       port: http
     initialDelaySeconds: 10
     periodSeconds: 60
 
   startupProbe: {}
 
-  readinessProbe: {}
+  readinessProbe:
+    httpGet:
+      path: /probe/readyz
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
 
 config:
   log:

--- a/manifests/k8s/daemonset.yaml
+++ b/manifests/k8s/daemonset.yaml
@@ -59,10 +59,16 @@ spec:
               readOnly: true
           livenessProbe:
             httpGet:
-              path: /metrics
+              path: /probe/livez
               port: http
             initialDelaySeconds: 10
             periodSeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /probe/readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
           env:
             - name: NODE_NAME
               valueFrom:


### PR DESCRIPTION
Adds liveness and readiness probes with dedicated `probe` endpoint.


Seeing probes in logs like this:

```
msg="Initializing service" service=api-server
msg="Initializing service" service=monitor
msg="Initializing service" service=prometheus
msg="Initializing service" service=probe          <- registered last, sees all services
msg="Starting Kepler"
msg="Running service" service=api-server
msg="Running service" service=probe               <- readyz flips to 200 here
msg="Running service" service=monitor
msg="Listening on" address=[::]:28282
```

Fixes https://github.com/sustainable-computing-io/kepler/issues/2282