### PR TITLE
feat(resource): detect VirtualBox, VMware and Xen VM processes

### DIFF
--- a/internal/resource/vm.go
+++ b/internal/resource/vm.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -14,11 +15,21 @@ var (
 	// QEMU/KVM patterns - matches both qemu-system-* and qemu-kvm variants
 	qemuPattern = regexp.MustCompile(`(bin/qemu-system-\w+|libexec/qemu-kvm|bin/kvm)`)
 
-	// TODO: add patterns for virtual box,  VMware, Xen
+	// VirtualBox patterns - matches the per-VM headless, SDL and GUI processes
+	virtualBoxPattern = regexp.MustCompile(`virtualbox/(VBoxHeadless|VBoxSDL|VirtualBoxVM)`)
 
-	// VM process name patterns
-	vmProcessPatterns = map[*regexp.Regexp]Hypervisor{
-		qemuPattern: KVMHypervisor,
+	// VMware patterns - vmware-vmx runs as one process per powered-on VM
+	vmwarePattern = regexp.MustCompile(`bin/vmware-vmx`)
+
+	// VM process name patterns, checked in order so that classification stays
+	// deterministic even if a command line matches more than one pattern
+	vmProcessPatterns = []struct {
+		pattern    *regexp.Regexp
+		hypervisor Hypervisor
+	}{
+		{qemuPattern, KVMHypervisor},
+		{virtualBoxPattern, VirtualBoxHypervisor},
+		{vmwarePattern, VMwareHypervisor},
 	}
 )
 
@@ -48,7 +59,11 @@ func vmInfoFromProc(proc procInfo) (*VirtualMachine, error) {
 	vm.Name = vmNameFromCmdLine(cmdline, hypervisor)
 
 	if vm.Name == "" {
-		vm.Name = fmt.Sprintf("%s-%s", hypervisor, vmID[:8])
+		shortID := vmID
+		if len(shortID) > 8 {
+			shortID = shortID[:8]
+		}
+		vm.Name = fmt.Sprintf("%s-%s", hypervisor, shortID)
 	}
 
 	return vm, nil
@@ -62,8 +77,16 @@ func vmInfoFromCmdLine(cmdline []string) (Hypervisor, string) {
 	exe := filepath.Base(cmdline[0])
 	fullCmd := strings.Join(cmdline, " ")
 
-	for pattern, hypervisor := range vmProcessPatterns {
-		if pattern.MatchString(exe) || pattern.MatchString(fullCmd) {
+	for _, p := range vmProcessPatterns {
+		if p.pattern.MatchString(exe) || p.pattern.MatchString(fullCmd) {
+			hypervisor := p.hypervisor
+
+			// Xen launches its device model through QEMU; the -xen-domid flag
+			// distinguishes it from a plain QEMU/KVM guest
+			if hypervisor == KVMHypervisor && hasXenDomID(cmdline) {
+				hypervisor = XenHypervisor
+			}
+
 			vmID := extractVMID(cmdline, hypervisor)
 
 			// If VM ID is still empty, make one up from the command line parameter hash
@@ -78,11 +101,23 @@ func vmInfoFromCmdLine(cmdline []string) (Hypervisor, string) {
 	return UnknownHypervisor, ""
 }
 
+// hasXenDomID reports whether the command line carries the -xen-domid flag
+// that Xen passes to its QEMU based device model
+func hasXenDomID(cmdline []string) bool {
+	return slices.Contains(cmdline, "-xen-domid")
+}
+
 // extractVMID extracts VM ID from command line arguments based on hypervisor
 func extractVMID(cmdline []string, hypervisor Hypervisor) string {
 	switch hypervisor {
 	case KVMHypervisor:
 		return extractQemuMachineID(cmdline)
+	case VirtualBoxHypervisor:
+		return extractVBoxMachineID(cmdline)
+	case VMwareHypervisor:
+		return vmwareVMNameFromCmdLine(cmdline)
+	case XenHypervisor:
+		return extractXenDomID(cmdline)
 	default:
 		return ""
 	}
@@ -99,6 +134,29 @@ func extractQemuMachineID(cmdline []string) string {
 	return qemuVMNameFromCmdLine(cmdline)
 }
 
+// extractVBoxMachineID extracts VM ID from VirtualBox command line arguments,
+// if present otherwise returns the VM name
+func extractVBoxMachineID(cmdline []string) string {
+	for i, arg := range cmdline {
+		if strings.TrimLeft(arg, "-") == "startvm" && i+1 < len(cmdline) {
+			return cmdline[i+1]
+		}
+	}
+	return vboxVMNameFromCmdLine(cmdline)
+}
+
+// extractXenDomID extracts the Xen domain ID from the device model command
+// line, if present otherwise returns the VM name
+func extractXenDomID(cmdline []string) string {
+	for i, arg := range cmdline {
+		if arg == "-xen-domid" && i+1 < len(cmdline) {
+			return cmdline[i+1]
+		}
+	}
+	// Xen device model uses QEMU style -name arguments
+	return qemuVMNameFromCmdLine(cmdline)
+}
+
 // generateVMID generates a VM ID when one can't be extracted
 func generateVMID(fullCmd string) string {
 	hash := fmt.Sprintf("%x", []byte(fullCmd))
@@ -111,11 +169,37 @@ func generateVMID(fullCmd string) string {
 // vmNameFromCmdLine extracts VM name from command line arguments
 func vmNameFromCmdLine(cmdline []string, hypervisor Hypervisor) string {
 	switch hypervisor {
-	case KVMHypervisor:
+	case KVMHypervisor, XenHypervisor:
 		return qemuVMNameFromCmdLine(cmdline)
+	case VirtualBoxHypervisor:
+		return vboxVMNameFromCmdLine(cmdline)
+	case VMwareHypervisor:
+		return vmwareVMNameFromCmdLine(cmdline)
 	default:
 		return ""
 	}
+}
+
+// vboxVMNameFromCmdLine extracts VM name from VirtualBox command line; the
+// per-VM processes carry the VM name in the --comment argument
+func vboxVMNameFromCmdLine(cmdline []string) string {
+	for i, arg := range cmdline {
+		if strings.TrimLeft(arg, "-") == "comment" && i+1 < len(cmdline) {
+			return cmdline[i+1]
+		}
+	}
+	return ""
+}
+
+// vmwareVMNameFromCmdLine extracts VM name from the .vmx config file path
+// that vmware-vmx receives as an argument
+func vmwareVMNameFromCmdLine(cmdline []string) string {
+	for _, arg := range cmdline {
+		if strings.HasSuffix(arg, ".vmx") {
+			return strings.TrimSuffix(filepath.Base(arg), ".vmx")
+		}
+	}
+	return ""
 }
 
 // qemuVMNameFromCmdLine extracts VM name from QEMU command line

--- a/internal/resource/vm_test.go
+++ b/internal/resource/vm_test.go
@@ -543,6 +543,51 @@ func TestVMInfoFromProc(t *testing.T) {
 			error: false,
 		},
 	}, {
+		name: "VirtualBox VM with UUID and comment",
+		cmdline: []string{
+			"/usr/lib/virtualbox/VBoxHeadless",
+			"--comment", "ubuntu-server",
+			"--startvm", "8a4c5e12-34ab-4f6f-9d51-0166868835fb",
+		},
+		expected: expect{
+			vm: &VirtualMachine{
+				ID:         "8a4c5e12-34ab-4f6f-9d51-0166868835fb",
+				Name:       "ubuntu-server",
+				Hypervisor: VirtualBoxHypervisor,
+			},
+			error: false,
+		},
+	}, {
+		name: "VMware VM with vmx path",
+		cmdline: []string{
+			"/usr/lib/vmware/bin/vmware-vmx",
+			"-s", "vmx.stdio.keep=TRUE",
+			"/home/user/vmware/UbuntuVM/UbuntuVM.vmx",
+		},
+		expected: expect{
+			vm: &VirtualMachine{
+				ID:         "UbuntuVM",
+				Name:       "UbuntuVM",
+				Hypervisor: VMwareHypervisor,
+			},
+			error: false,
+		},
+	}, {
+		name: "Xen VM without name (short domain ID generates name)",
+		cmdline: []string{
+			"/usr/local/lib/xen/bin/qemu-system-i386",
+			"-xen-domid", "5",
+			"-machine", "xenpv",
+		},
+		expected: expect{
+			vm: &VirtualMachine{
+				ID:         "5",
+				Name:       "xen-5",
+				Hypervisor: XenHypervisor,
+			},
+			error: false,
+		},
+	}, {
 		name: "Not a VM process",
 		cmdline: []string{
 			"/usr/bin/firefox",
@@ -652,10 +697,25 @@ func TestVMNameFromCmdLine(t *testing.T) {
 		hypervisor: KVMHypervisor,
 		expected:   "",
 	}, {
-		name:       "non-KVM hypervisor returns empty",
+		name:       "unknown hypervisor returns empty",
 		cmdline:    []string{"/usr/bin/qemu-system-x86_64", "-name", "test"},
 		hypervisor: UnknownHypervisor,
 		expected:   "",
+	}, {
+		name:       "VirtualBox name from comment",
+		cmdline:    []string{"/usr/lib/virtualbox/VBoxHeadless", "--comment", "vbox-vm"},
+		hypervisor: VirtualBoxHypervisor,
+		expected:   "vbox-vm",
+	}, {
+		name:       "VMware name from vmx path",
+		cmdline:    []string{"/usr/lib/vmware/bin/vmware-vmx", "/vms/TestVM/TestVM.vmx"},
+		hypervisor: VMwareHypervisor,
+		expected:   "TestVM",
+	}, {
+		name:       "Xen name from qemu style name argument",
+		cmdline:    []string{"/usr/local/lib/xen/bin/qemu-system-i386", "-name", "xen-guest"},
+		hypervisor: XenHypervisor,
+		expected:   "xen-guest",
 	}}
 
 	for _, tc := range tests {

--- a/internal/resource/vm_test.go
+++ b/internal/resource/vm_test.go
@@ -114,6 +114,74 @@ func TestVMInfoFromCmdLine(t *testing.T) {
 			vmID:       "test-vm",
 		},
 	}, {
+		name: "VirtualBox headless with UUID",
+		cmdline: []string{
+			"/usr/lib/virtualbox/VBoxHeadless",
+			"--comment", "ubuntu-server",
+			"--startvm", "8a4c5e12-34ab-4f6f-9d51-0166868835fb",
+			"--vrde", "config",
+		},
+		expected: expect{
+			hypervisor: VirtualBoxHypervisor,
+			vmID:       "8a4c5e12-34ab-4f6f-9d51-0166868835fb",
+		},
+	}, {
+		name: "VirtualBox GUI with single dash startvm",
+		cmdline: []string{
+			"/usr/lib/virtualbox/VirtualBoxVM",
+			"-comment", "win10",
+			"-startvm", "df12672f-fedb-4f6f-9d51-0166868835fb",
+		},
+		expected: expect{
+			hypervisor: VirtualBoxHypervisor,
+			vmID:       "df12672f-fedb-4f6f-9d51-0166868835fb",
+		},
+	}, {
+		name: "VirtualBox SDL without startvm (uses comment)",
+		cmdline: []string{
+			"/usr/lib/virtualbox/VBoxSDL",
+			"--comment", "sdl-vm",
+		},
+		expected: expect{
+			hypervisor: VirtualBoxHypervisor,
+			vmID:       "sdl-vm",
+		},
+	}, {
+		name: "VMware Workstation guest",
+		cmdline: []string{
+			"/usr/lib/vmware/bin/vmware-vmx",
+			"-s", "vmx.stdio.keep=TRUE",
+			"-@", "duplex=3;msgs=ui",
+			"/home/user/vmware/UbuntuVM/UbuntuVM.vmx",
+		},
+		expected: expect{
+			hypervisor: VMwareHypervisor,
+			vmID:       "UbuntuVM",
+		},
+	}, {
+		name: "Xen device model with domain ID",
+		cmdline: []string{
+			"/usr/local/lib/xen/bin/qemu-system-i386",
+			"-xen-domid", "5",
+			"-name", "debian-guest",
+			"-machine", "xenpv",
+		},
+		expected: expect{
+			hypervisor: XenHypervisor,
+			vmID:       "5",
+		},
+	}, {
+		name: "Xen device model with domid flag but no value (uses name)",
+		cmdline: []string{
+			"/usr/bin/qemu-system-i386",
+			"-name", "xen-guest",
+			"-xen-domid",
+		},
+		expected: expect{
+			hypervisor: XenHypervisor,
+			vmID:       "xen-guest",
+		},
+	}, {
 		name: "Not a VM process",
 		cmdline: []string{
 			"/usr/bin/firefox",
@@ -241,6 +309,153 @@ func TestExtractQemuMachineID(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			result := extractQemuMachineID(tc.cmdline)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestExtractVBoxMachineID(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmdline  []string
+		expected string
+	}{{
+		name: "startvm UUID present",
+		cmdline: []string{
+			"/usr/lib/virtualbox/VBoxHeadless",
+			"--startvm", "8a4c5e12-34ab-4f6f-9d51-0166868835fb",
+		},
+		expected: "8a4c5e12-34ab-4f6f-9d51-0166868835fb",
+	}, {
+		name: "no startvm, fallback to comment",
+		cmdline: []string{
+			"/usr/lib/virtualbox/VBoxHeadless",
+			"--comment", "fallback-vm",
+		},
+		expected: "fallback-vm",
+	}, {
+		name: "startvm without value",
+		cmdline: []string{
+			"/usr/lib/virtualbox/VBoxHeadless",
+			"--startvm",
+		},
+		expected: "",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := extractVBoxMachineID(tc.cmdline)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestExtractXenDomID(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmdline  []string
+		expected string
+	}{{
+		name: "domid present",
+		cmdline: []string{
+			"/usr/local/lib/xen/bin/qemu-system-i386",
+			"-xen-domid", "12",
+			"-name", "xen-guest",
+		},
+		expected: "12",
+	}, {
+		name: "no domid, fallback to name",
+		cmdline: []string{
+			"/usr/local/lib/xen/bin/qemu-system-i386",
+			"-name", "xen-guest",
+		},
+		expected: "xen-guest",
+	}, {
+		name: "domid without value, no name",
+		cmdline: []string{
+			"/usr/local/lib/xen/bin/qemu-system-i386",
+			"-xen-domid",
+		},
+		expected: "",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := extractXenDomID(tc.cmdline)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestVBoxVMNameFromCmdLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmdline  []string
+		expected string
+	}{{
+		name: "double dash comment",
+		cmdline: []string{
+			"/usr/lib/virtualbox/VBoxHeadless",
+			"--comment", "ubuntu-server",
+			"--startvm", "8a4c5e12-34ab-4f6f-9d51-0166868835fb",
+		},
+		expected: "ubuntu-server",
+	}, {
+		name: "single dash comment",
+		cmdline: []string{
+			"/usr/lib/virtualbox/VirtualBoxVM",
+			"-comment", "win10",
+		},
+		expected: "win10",
+	}, {
+		name: "no comment argument",
+		cmdline: []string{
+			"/usr/lib/virtualbox/VBoxHeadless",
+			"--startvm", "8a4c5e12-34ab-4f6f-9d51-0166868835fb",
+		},
+		expected: "",
+	}, {
+		name: "comment without value",
+		cmdline: []string{
+			"/usr/lib/virtualbox/VBoxHeadless",
+			"--comment",
+		},
+		expected: "",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := vboxVMNameFromCmdLine(tc.cmdline)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestVMwareVMNameFromCmdLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmdline  []string
+		expected string
+	}{{
+		name: "vmx path present",
+		cmdline: []string{
+			"/usr/lib/vmware/bin/vmware-vmx",
+			"-s", "vmx.stdio.keep=TRUE",
+			"/home/user/vmware/UbuntuVM/UbuntuVM.vmx",
+		},
+		expected: "UbuntuVM",
+	}, {
+		name: "no vmx path",
+		cmdline: []string{
+			"/usr/lib/vmware/bin/vmware-vmx",
+			"-s", "vmx.stdio.keep=TRUE",
+		},
+		expected: "",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := vmwareVMNameFromCmdLine(tc.cmdline)
 			assert.Equal(t, tc.expected, result)
 		})
 	}


### PR DESCRIPTION
## Summary

Closes #2514

Extends VM process detection in `internal/resource` beyond QEMU/KVM to the remaining hypervisors already declared in the `Hypervisor` type, resolving the TODO in `vm.go`:

```go
// TODO: add patterns for virtual box,  VMware, Xen
```

## Changes

- **VirtualBox**: matches the per-VM `VBoxHeadless`, `VBoxSDL` and `VirtualBoxVM` processes. VM ID comes from the `--startvm` argument (single or double dash), VM name from `--comment`.
- **VMware**: matches the per-VM `vmware-vmx` process. VM name comes from the `.vmx` config file path passed as an argument.
- **Xen**: the Xen device model runs through QEMU, so the `-xen-domid` flag distinguishes it from a plain QEMU/KVM guest. The domain ID becomes the VM ID and the QEMU style `-name` argument the VM name.

Robustness fixes in the shared detection path:

- `vmProcessPatterns` is now an ordered slice instead of a map, so classification stays deterministic when a command line matches more than one pattern.
- The generated fallback VM name no longer panics when the VM ID is shorter than 8 characters. A Xen domain ID like `5` would have hit the previous `vmID[:8]` slice.
- Patterns require a path prefix (`virtualbox/`, `bin/`) to avoid classifying unrelated processes that merely mention a hypervisor binary in their arguments.

## Testing

- Added table-driven unit tests for all new patterns and extraction helpers: VirtualBox headless/GUI/SDL variants, single and double dash arguments, VMware `.vmx` name extraction, Xen domain ID extraction and the QEMU name fallback.
- `go test -race ./internal/resource/` passes on Linux.
- `go vet` and `gofmt` clean.

## Notes

- Xen domain IDs change across guest reboots, so the VM ID label for Xen guests is stable only for the lifetime of a domain. This matches the behavior of the existing hash based fallback IDs.
- Behavior change for Xen hosts only: the Xen device model path (`lib/xen/bin/qemu-system-*`) already matched the QEMU pattern, so those guests were previously reported with `hypervisor="kvm"` and a name based VM ID. They now report `hypervisor="xen"` with the domain ID, which changes those label values. QEMU/KVM detection on non-Xen hosts is unchanged, covered by the pre-existing tests.
- VMware VM IDs derive from the `.vmx` file basename, so two powered-on VMs with identical config file names would share an ID. This mirrors the existing name based fallback for QEMU guests without a UUID.
- Xen PV guests that run without a QEMU device model have no host process and remain undetectable by design.
