### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Our project adheres to the Linux Foundation's Generative AI Policy, which can be
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=sustainable-computing-io/kepler&type=Date)](https://www.star-history.com/#sustainable-computing-io/kepler&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=sustainable-computing-io/kepler&type=Date)](https://star-history.dera.page/#sustainable-computing-io/kepler&type=Date)
 
 ## 📝 License
 


### PR DESCRIPTION
The star history chart shown in the README is currently broken due to the previous provider hitting GitHub stargazer API restrictions. This switches the chart to star-history.dera.page, which uses a different data source that needs no API token, so the chart renders correctly again.