### PR TITLE
fix(resource): skip VM processes with nil metadata instead of panicking

### DIFF
--- a/internal/resource/informer.go
+++ b/internal/resource/informer.go
@@ -254,6 +254,14 @@ func (ri *resourceInformer) refreshVMs(vmProcs []*Process) error {
 	// Build running VMs from pre-categorized VM processes
 	for _, proc := range vmProcs {
 		vm := proc.VirtualMachine
+		if vm == nil {
+			// A malformed process should not bring the whole informer down.
+			// Containers are already skipped this way in updateContainerCache.
+			ri.logger.Error("Skipping VM process with no virtual machine metadata",
+				"pid", proc.PID, "comm", proc.Comm, "type", proc.Type)
+			continue
+		}
+
 		vmsRunning[vm.ID] = ri.updateVMCache(proc)
 	}
 
@@ -433,7 +441,7 @@ func (ri *resourceInformer) Pods() *Pods {
 func (ri *resourceInformer) updateVMCache(proc *Process) *VirtualMachine {
 	vm := proc.VirtualMachine
 	if vm == nil {
-		panic(fmt.Sprintf("process %d of type %s (%s)  has is nil virtual machine", proc.PID, proc.Type, proc.Comm))
+		return nil
 	}
 
 	cached, exists := ri.vmCache[vm.ID]

--- a/internal/resource/procfs_reader_test.go
+++ b/internal/resource/procfs_reader_test.go
@@ -1101,7 +1101,7 @@ func TestResourceInformer_InitRefreshErr(t *testing.T) {
 		mockProcFS.AssertExpectations(t)
 	})
 
-	t.Run("updateVMCache with nil VM panic", func(t *testing.T) {
+	t.Run("updateVMCache with nil VM returns nil instead of panicking", func(t *testing.T) {
 		mockProcFS := &MockProcReader{}
 		informer, err := NewInformer(WithProcReader(mockProcFS))
 		require.NoError(t, err)
@@ -1109,12 +1109,31 @@ func TestResourceInformer_InitRefreshErr(t *testing.T) {
 		proc := &Process{
 			PID:            123,
 			Type:           VMProcess,
-			VirtualMachine: nil, // This should cause panic
+			VirtualMachine: nil,
 		}
 
-		assert.Panics(t, func() {
-			informer.updateVMCache(proc)
+		assert.NotPanics(t, func() {
+			assert.Nil(t, informer.updateVMCache(proc))
 		})
+	})
+
+	t.Run("Refresh skips VM process with no virtual machine metadata", func(t *testing.T) {
+		// A process classified as a VM but carrying no VM metadata must not
+		// bring the whole informer down: it is skipped and the refresh goes on.
+		mockProcFS := &MockProcReader{}
+		informer, err := NewInformer(WithProcReader(mockProcFS))
+		require.NoError(t, err)
+
+		assert.NotPanics(t, func() {
+			require.NoError(t, informer.refreshVMs([]*Process{{
+				PID:            4242,
+				Comm:           "qemu-system-x86",
+				Type:           VMProcess,
+				VirtualMachine: nil,
+			}}))
+		})
+
+		assert.Empty(t, informer.VirtualMachines().Running)
 	})
 }
 


### PR DESCRIPTION
Closes #2507.

A process classified as a VM with no VM metadata crashed the whole informer, and with it the daemon and all metrics collection.

Worth noting the panic in `updateVMCache` was never actually reached. `refreshVMs` reads `vm.ID` one line before calling it, so the process died on a nil pointer dereference first, without the message the panic was there to give. Both are fixed:

- `refreshVMs` skips the process and logs an error with the pid, comm and type
- `updateVMCache` returns nil instead of panicking

This matches what `updateContainerCache` already does for a nil container, so VMs and containers now behave the same way.

Tests: the old test asserted the panic, so it is now an assertion that it does not panic, plus a new case covering the `refreshVMs` path. Both are red on main and green here. `go test -race ./internal/resource/...` passes.
