### PR TITLE
fix(helm): honor serviceAccount.create instead of rbac.create

### DIFF
--- a/manifests/helm/kepler/templates/rbac.yaml
+++ b/manifests/helm/kepler/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create}}
+{{- if .Values.serviceAccount.create}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,6 +11,8 @@ metadata:
     {{- toYaml . | nindent 4}}
   {{- end}}
 ---
+{{- end}}
+{{- if .Values.rbac.create}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
## What

The chart has a `serviceAccount.create` value, but only `kepler.serviceAccountName` reads it, to pick the name. Nothing gates creation on it. The ServiceAccount is created inside the `rbac.create` block instead, so the two toggles are wired to the wrong switch.

Two consequences. Setting `serviceAccount.create=false` still creates a ServiceAccount, and the helper then resolves the name to `serviceAccount.name`, or to `default` when that is empty. So the chart either overwrites an account managed outside it, or takes ownership of the namespace `default` account. Setting `rbac.create=false` to bring your own ClusterRole drops the ServiceAccount entirely, and the DaemonSet then references an account that does not exist.

This matters when the account is managed elsewhere, for example a GitOps-owned SA or one annotated for IRSA or Workload Identity.

## Change

Moves the ServiceAccount into its own `serviceAccount.create` block. `rbac.create` keeps owning the ClusterRole and the ClusterRoleBinding only. No default behaviour changes, both values default to true.

## Testing

All four combinations render correctly and pass `kubeconform -strict`:

| serviceAccount.create | rbac.create | SA | ClusterRole |
|---|---|---|---|
| true | true | yes | yes |
| true | false | yes | no |
| false | true | no | yes |
| false | false | no | no |

`helm lint` passes. Installed on kind with `serviceAccount.create=false` and a pre-existing `my-external-sa`. The chart leaves it alone, and the ClusterRoleBinding and the DaemonSet both point at it. On current main the same command overwrites that account.

