### PR TITLE
fix(config): warn about unknown config fields instead of dropping them silently

### DIFF
--- a/cmd/kepler/main.go
+++ b/cmd/kepler/main.go
@@ -46,6 +46,7 @@ func main() {
 	printConfigInfo(logger, cfg)
 
 	cfg.ApplyCpuMeterDeprecations(logger)
+	cfg.LogUnknownFields(logger)
 
 	services, err := createServices(logger, cfg)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -212,6 +212,11 @@ type (
 		// use omitempty to suppress printing (String) Experimental configuration
 		// when it is empty
 		Experimental *Experimental `yaml:"experimental,omitempty"`
+
+		// unknownFields holds the keys present in the config file that do not
+		// map to any field above. They are dropped silently by the decoder, so
+		// they are kept here to be reported at startup.
+		unknownFields []string `yaml:"-"`
 	}
 )
 
@@ -408,6 +413,7 @@ func Load(r io.Reader) (*Config, error) {
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse config: %w", err)
 	}
+	cfg.unknownFields = unknownFields(data)
 	cfg.sanitize()
 
 	if err := cfg.Validate(); err != nil {

--- a/config/unknown.go
+++ b/config/unknown.go
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"bytes"
+	"log/slog"
+	"regexp"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+// notFoundRe matches the yaml.v3 strict-decoding message for a key that has no
+// matching struct field, e.g.
+// "line 12: field dcgmEndpoint not found in type config.GPU".
+var notFoundRe = regexp.MustCompile(`field (\S+) not found in type`)
+
+// unknownFields returns the config keys that the decoder ignored.
+//
+// Load uses a permissive decode so that an unknown key never prevents Kepler
+// from starting. That also means a typo, or an option belonging to a different
+// release, disappears without a trace. A second strict pass collects those keys
+// so they can be reported.
+func unknownFields(data []byte) []string {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+
+	err := dec.Decode(&Config{})
+	if err == nil {
+		return nil
+	}
+
+	typeErr, ok := err.(*yaml.TypeError)
+	if !ok {
+		return nil
+	}
+
+	seen := map[string]struct{}{}
+	fields := []string{}
+	for _, msg := range typeErr.Errors {
+		m := notFoundRe.FindStringSubmatch(msg)
+		if m == nil {
+			continue
+		}
+		if _, dup := seen[m[1]]; dup {
+			continue
+		}
+		seen[m[1]] = struct{}{}
+		fields = append(fields, m[1])
+	}
+	sort.Strings(fields)
+
+	return fields
+}
+
+// LogUnknownFields warns about config keys that were ignored while loading.
+// Unknown keys are not fatal, so an existing config that used to work keeps
+// working.
+func (c *Config) LogUnknownFields(logger *slog.Logger) {
+	if len(c.unknownFields) == 0 {
+		return
+	}
+	logger.Warn("ignoring unknown config fields; check for typos or options from another release",
+		"fields", c.unknownFields)
+}

--- a/config/unknown.go
+++ b/config/unknown.go
@@ -7,14 +7,14 @@ import (
 	"bytes"
 	"log/slog"
 	"regexp"
-	"sort"
+	"slices"
 
 	"gopkg.in/yaml.v3"
 )
 
 // notFoundRe matches the yaml.v3 strict-decoding message for a key that has no
 // matching struct field, e.g.
-// "line 12: field dcgmEndpoint not found in type config.GPU".
+// "line 12: field dcgmEndpoint not found in type config.ExperimentalGPU".
 var notFoundRe = regexp.MustCompile(`field (\S+) not found in type`)
 
 // unknownFields returns the config keys that the decoder ignored.
@@ -32,32 +32,17 @@ func unknownFields(data []byte) []string {
 		return nil
 	}
 
-	typeErr, ok := err.(*yaml.TypeError)
-	if !ok {
-		return nil
-	}
-
-	seen := map[string]struct{}{}
-	fields := []string{}
-	for _, msg := range typeErr.Errors {
-		m := notFoundRe.FindStringSubmatch(msg)
-		if m == nil {
-			continue
-		}
-		if _, dup := seen[m[1]]; dup {
-			continue
-		}
-		seen[m[1]] = struct{}{}
+	var fields []string
+	for _, m := range notFoundRe.FindAllStringSubmatch(err.Error(), -1) {
 		fields = append(fields, m[1])
 	}
-	sort.Strings(fields)
+	slices.Sort(fields)
 
-	return fields
+	return slices.Compact(fields)
 }
 
 // LogUnknownFields warns about config keys that were ignored while loading.
-// Unknown keys are not fatal, so an existing config that used to work keeps
-// working.
+// Unknown keys are not fatal, so a config that works today keeps working.
 func (c *Config) LogUnknownFields(logger *slog.Logger) {
 	if len(c.unknownFields) == 0 {
 		return

--- a/config/unknown_test.go
+++ b/config/unknown_test.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2025 The Kepler Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnknownFields(t *testing.T) {
+	tt := []struct {
+		name     string
+		yaml     string
+		expected []string
+	}{{
+		name: "known fields only",
+		yaml: `
+log:
+  level: debug
+monitor:
+  interval: 5s
+experimental:
+  gpu:
+    enabled: true
+    idlePower: 30
+`,
+		expected: nil,
+	}, {
+		name: "unknown nested field",
+		yaml: `
+experimental:
+  gpu:
+    enabled: true
+    dcgmEndpoints: http://127.0.0.1:9400/metrics
+`,
+		expected: []string{"dcgmEndpoints"},
+	}, {
+		name: "unknown top level field",
+		yaml: `
+log:
+  level: debug
+notASetting: 42
+`,
+		expected: []string{"notASetting"},
+	}, {
+		name: "several unknown fields are reported once each",
+		yaml: `
+log:
+  level: debug
+  levl: debug
+monitor:
+  interval: 5s
+  intervall: 5s
+`,
+		expected: []string{"intervall", "levl"},
+	}}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := Load(strings.NewReader(tc.yaml))
+			require.NoError(t, err, "unknown fields must not fail the load")
+			assert.Equal(t, tc.expected, cfg.unknownFields)
+			assert.Equal(t, tc.expected, unknownFields([]byte(tc.yaml)))
+		})
+	}
+}
+
+func TestLogUnknownFields(t *testing.T) {
+	logs := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(logs, nil))
+
+	cfg, err := Load(strings.NewReader("experimental:\n  gpu:\n    dcgmEndpoints: http://127.0.0.1:9400\n"))
+	require.NoError(t, err)
+
+	cfg.LogUnknownFields(logger)
+	assert.Contains(t, logs.String(), "dcgmEndpoints")
+
+	logs.Reset()
+	DefaultConfig().LogUnknownFields(logger)
+	assert.Empty(t, logs.String(), "a config with no unknown field must stay quiet")
+}

--- a/config/unknown_test.go
+++ b/config/unknown_test.go
@@ -49,16 +49,25 @@ notASetting: 42
 `,
 		expected: []string{"notASetting"},
 	}, {
+		name: "the same unknown key in two sections is reported once",
+		yaml: `
+log:
+  notAKey: debug
+monitor:
+  notAKey: 5s
+`,
+		expected: []string{"notAKey"},
+	}, {
 		name: "several unknown fields are reported once each",
 		yaml: `
 log:
   level: debug
-  levl: debug
+  notAKey: debug
 monitor:
   interval: 5s
-  intervall: 5s
+  alsoNotAKey: 5s
 `,
-		expected: []string{"intervall", "levl"},
+		expected: []string{"alsoNotAKey", "notAKey"},
 	}}
 
 	for _, tc := range tt {

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -102,6 +102,12 @@ kepler --monitor.max-terminated=-1
 
 Kepler can load configuration from a YAML file. The configuration file offers more extensive options than command-line flags.
 
+Keys that Kepler does not recognize are ignored rather than rejected, so a config written for a different release still starts. Each ignored key is listed in a warning at startup:
+
+```text
+level=WARN msg="ignoring unknown config fields; check for typos or options from another release" fields="[dcgmEndpoint]"
+```
+
 ### 🧾 Sample Configuration File
 
 ```yaml


### PR DESCRIPTION
Config loading uses `yaml.Unmarshal`, which ignores keys that match no struct field. A typo, or an option that only exists on main, is dropped with no feedback and never appears in the startup config dump. That is what happened to `dcgmEndpoint` on 0.11.4 in #2524.

This adds a second decode with `KnownFields(true)` to collect the ignored keys and log them as a warning at startup. cloudymax asked for a warning rather than a hard error, so unknown keys stay non fatal and existing configs keep working.

Example output:

```
level=WARN msg="ignoring unknown config fields; check for typos or options from another release" fields="[dcgmEndpoint]"
```

Refs #2524

Tests: new `config/unknown_test.go` covers a clean config, an unknown nested key, an unknown top level key, and several at once. `go test -race ./config/...` passes in a Linux container. Two failures in `TestInvalidConfigurationValues` also fail on unpatched main, they are unrelated.

AI assistance was used, mostly because my English is poor. I reviewed the change and ran the tests above.
