### PR TITLE
docs(metrics): add more information about zones and how to work with them in the kepler rewrite

### DIFF
--- a/docs/user/metrics.md
+++ b/docs/user/metrics.md
@@ -11,6 +11,20 @@ Kepler exports metrics in Prometheus format that can be scraped by Prometheus or
 - **COUNTER**: A cumulative metric that only increases over time
 - **GAUGE**: A metric that can increase and decrease
 
+### Energy Zones
+
+CPU energy and power metrics carry a `zone` label. A zone is a hardware power domain reported by the underlying power meter. With the default RAPL (Running Average Power Limiting) meter, the following zones can appear:
+
+- `psys`: the entire platform / system on chip (SoC)
+- `package`: the whole CPU socket, including cores, cache, memory controller, and integrated GPU
+- `core`: the CPU cores only
+- `uncore`: the uncore parts of the package, such as an integrated GPU
+- `dram`: the memory attached to the memory controller
+
+Which zones are exported depends entirely on what the hardware and the kernel expose on that machine. It is common that CPUs support only a subset of these zones. A zone that is not available will not appear in the metrics. 
+
+Some zones overlap and therefore zones should not be summed. `package` already contains `core`, `uncore`, and part of what `psys` covers. It is advised to filter on a single zone in queries, for example `kepler_node_cpu_watts{zone="package"}`.
+
 ## Metrics Reference
 
 ### Node Metrics

--- a/docs/user/metrics.md
+++ b/docs/user/metrics.md
@@ -21,7 +21,7 @@ CPU energy and power metrics carry a `zone` label. A zone is a hardware power do
 - `uncore`: the uncore parts of the package, such as an integrated GPU
 - `dram`: the memory attached to the memory controller
 
-Which zones are exported depends entirely on what the hardware and the kernel expose on that machine. It is common that CPUs support only a subset of these zones. A zone that is not available will not appear in the metrics. 
+Which zones are exported depends entirely on what the hardware and the kernel expose on that machine. It is common that CPUs support only a subset of these zones. A zone that is not available will not appear in the metrics.
 
 Some zones overlap and therefore zones should not be summed. `package` already contains `core`, `uncore`, and part of what `psys` covers. It is advised to filter on a single zone in queries, for example `kepler_node_cpu_watts{zone="package"}`.
 

--- a/hack/gen-metric-docs/main.go
+++ b/hack/gen-metric-docs/main.go
@@ -212,10 +212,10 @@ func generateMarkdown(metrics []MetricInfo) string {
 	md.WriteString("- `uncore`: the uncore parts of the package, such as an integrated GPU\n")
 	md.WriteString("- `dram`: the memory attached to the memory controller\n\n")
 	md.WriteString("Which zones are exported depends entirely on what the hardware and the kernel expose on that machine. ")
-	md.WriteString("It is common that CPUs support only a subset of these zones. A zone that is not available will not appear in the metrics. \n\n")
+	md.WriteString("It is common that CPUs support only a subset of these zones. A zone that is not available will not appear in the metrics.\n\n")
 	md.WriteString("Some zones overlap and therefore zones should not be summed. `package` already contains `core`, `uncore`, and part of what `psys` covers. ")
 	md.WriteString("It is advised to filter on a single zone in queries, for example `kepler_node_cpu_watts{zone=\"package\"}`.\n\n")
-	
+
 	md.WriteString("## Metrics Reference\n\n")
 
 	nodeMetrics := []MetricInfo{}

--- a/hack/gen-metric-docs/main.go
+++ b/hack/gen-metric-docs/main.go
@@ -202,6 +202,20 @@ func generateMarkdown(metrics []MetricInfo) string {
 	md.WriteString("### Metric Types\n\n")
 	md.WriteString("- **COUNTER**: A cumulative metric that only increases over time\n")
 	md.WriteString("- **GAUGE**: A metric that can increase and decrease\n\n")
+	md.WriteString("### Energy Zones\n\n")
+	md.WriteString("CPU energy and power metrics carry a `zone` label. ")
+	md.WriteString("A zone is a hardware power domain reported by the underlying power meter. ")
+	md.WriteString("With the default RAPL (Running Average Power Limiting) meter, the following zones can appear:\n\n")
+	md.WriteString("- `psys`: the entire platform / system on chip (SoC)\n")
+	md.WriteString("- `package`: the whole CPU socket, including cores, cache, memory controller, and integrated GPU\n")
+	md.WriteString("- `core`: the CPU cores only\n")
+	md.WriteString("- `uncore`: the uncore parts of the package, such as an integrated GPU\n")
+	md.WriteString("- `dram`: the memory attached to the memory controller\n\n")
+	md.WriteString("Which zones are exported depends entirely on what the hardware and the kernel expose on that machine. ")
+	md.WriteString("It is common that CPUs support only a subset of these zones. A zone that is not available will not appear in the metrics. \n\n")
+	md.WriteString("Some zones overlap and therefore zones should not be summed. `package` already contains `core`, `uncore`, and part of what `psys` covers. ")
+	md.WriteString("It is advised to filter on a single zone in queries, for example `kepler_node_cpu_watts{zone=\"package\"}`.\n\n")
+	
 	md.WriteString("## Metrics Reference\n\n")
 
 	nodeMetrics := []MetricInfo{}


### PR DESCRIPTION
The goal of this PR is to make the role of `zones` in metrics more clear in the Kepler remake (>= 0.10.0) by shortly addressing them right in front of the metrics documentation and giving some advice and warnings. 

This hopefully resolves the existing discussion about the lacking documentation as mentioned in #2363 and thereby also closes this issue. 

Do I understand correctly that we also would have to create a PR in kepler-docs to make this go live?